### PR TITLE
lsp: implement textDocument/formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,6 +2569,7 @@ dependencies = [
  "itertools 0.14.0",
  "line-index",
  "lowering",
+ "purescript-analyzer",
  "rowan",
  "serde_json",
  "stabilizing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,6 +1813,7 @@ dependencies = [
  "resolving",
  "rowan",
  "serde",
+ "shlex",
  "spago",
  "stabilizing",
  "syntax",

--- a/compiler-bin/Cargo.toml
+++ b/compiler-bin/Cargo.toml
@@ -31,6 +31,7 @@ radix_trie = "0.3.0"
 resolving = { version = "0.1.0", path = "../compiler-core/resolving" }
 rowan = "0.16.1"
 serde = { version = "1.0.228", features = ["derive"] }
+shlex = "1.3.0"
 spago = { version = "0.1.0", path = "../compiler-lsp/spago" }
 stabilizing = { version = "0.1.0", path = "../compiler-core/stabilizing" }
 syntax = { version = "0.1.0", path = "../compiler-core/syntax" }

--- a/compiler-bin/src/cli.rs
+++ b/compiler-bin/src/cli.rs
@@ -42,7 +42,7 @@ pub struct Config {
         long,
         help("Command to use for textDocument/formatting"),
         long_help(
-            "If set, the LSP server advertises document formatting support and formats PureScript files by piping the full document contents to this command's stdin and reading formatted text from stdout. Example: --format-command \"purs-tidy format\""
+            "If set, the LSP server advertises document formatting support and formats PureScript files by piping the full document contents to this command's stdin and reading formatted text from stdout. Shell-style quoting is supported. Example: --format-command \"purs-tidy format --indent 2\""
         )
     )]
     pub format_command: Option<String>,

--- a/compiler-bin/src/cli.rs
+++ b/compiler-bin/src/cli.rs
@@ -40,6 +40,15 @@ pub struct Config {
 
     #[arg(
         long,
+        help("Command to use for textDocument/formatting"),
+        long_help(
+            "If set, the LSP server advertises document formatting support and formats PureScript files by piping the full document contents to this command's stdin and reading formatted text from stdout. Example: --format-command \"purs-tidy format\""
+        )
+    )]
+    pub format_command: Option<String>,
+
+    #[arg(
+        long,
         help("Publish diagnostics on textDocument/didOpen"),
         value_name("bool"),
         action = ArgAction::Set,

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -747,8 +747,9 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn formatting_reports_formatter_failure() {
-        let mut state =
-            mk_state_with(base_config(Some("sh -c 'cat >/dev/null; printf err >&2; exit 7'".to_string())));
+        let mut state = mk_state_with(base_config(Some(
+            "sh -c 'cat >/dev/null; printf err >&2; exit 7'".to_string(),
+        )));
         let uri = Url::parse("file:///test/Main.purs").unwrap();
         on_change(&mut state, uri.as_str(), "module Main where\nfoo = bar\n").unwrap();
 

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -1,4 +1,5 @@
 pub mod capabilities;
+mod command;
 pub mod error;
 pub mod event;
 pub mod extension;
@@ -7,6 +8,7 @@ use std::borrow::BorrowMut;
 use std::ops::{ControlFlow, Deref};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 use std::{env, fs, mem, process};
 
 use analyzer::completion::SuggestionsCache;
@@ -199,7 +201,7 @@ fn initialized_manual(state: &mut State, command: &str) -> Result<(), LspError> 
 
     tracing::info!("Using '{}'", command);
 
-    let mut parts = command.split(" ");
+    let mut parts = command::split(command).ok_or(LspError::InvalidSourceCommand)?.into_iter();
     let program = parts.next().ok_or(LspError::InvalidSourceCommand)?;
 
     let mut command = process::Command::new(program);
@@ -377,22 +379,7 @@ fn formatting(
 
     let input = snapshot.engine.content(current_file);
 
-    let mut cmd_str = format_command.trim();
-
-    // Users sometimes include extra quoting in editor configs, e.g.
-    // `--format-command "\"purs-tidy format\""`. If the whole command is wrapped
-    // in a single pair of quotes, strip it and re-parse.
-    if cmd_str.len() >= 2 {
-        let bytes = cmd_str.as_bytes();
-        let first = bytes[0];
-        let last = bytes[bytes.len() - 1];
-        let is_wrapped = (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'');
-        if is_wrapped {
-            cmd_str = &cmd_str[1..cmd_str.len() - 1];
-        }
-    }
-
-    let parts = shlex::split(cmd_str).ok_or_else(|| {
+    let parts = command::split(format_command).ok_or_else(|| {
         LspError::FormattingFailed(format!("failed to parse --format-command: {format_command}"))
     })?;
     let mut parts = parts.into_iter();
@@ -400,75 +387,49 @@ fn formatting(
         .next()
         .ok_or_else(|| LspError::FormattingFailed("--format-command is empty".to_string()))?;
 
-    let mut cmd = process::Command::new(program);
-    cmd.args(parts);
-    cmd.stdin(process::Stdio::piped());
-    cmd.stdout(process::Stdio::piped());
-    cmd.stderr(process::Stdio::piped());
+    let mut cmd = command::piped(&program, parts);
 
     let mut child = cmd.spawn().map_err(|e| {
         LspError::FormattingFailed(format!("failed to spawn formatter '{format_command}': {e}"))
     })?;
 
-    if let Some(mut stdin) = child.stdin.take() {
-        use std::io::Write;
-        stdin.write_all(input.as_bytes()).map_err(|e| {
-            LspError::FormattingFailed(format!("failed writing to formatter stdin: {e}"))
-        })?;
-    }
+    command::write_stdin(&mut child, input.as_bytes()).map_err(|e| {
+        LspError::FormattingFailed(format!("failed writing to formatter stdin: {e}"))
+    })?;
 
-    let output = {
-        use std::thread;
-        use std::time::{Duration, Instant};
-
-        // Avoid hanging indefinitely if the formatter never exits.
-        let timeout = Duration::from_secs(10);
-        let start = Instant::now();
-        loop {
-            match child.try_wait() {
-                Ok(Some(_status)) => {
-                    break child.wait_with_output().map_err(|e| {
-                        LspError::FormattingFailed(format!(
-                            "failed to wait for formatter '{format_command}': {e}"
-                        ))
-                    })?;
+    let output =
+        command::wait_with_output_timeout(child, Duration::from_secs(10)).map_err(|e| match e {
+            command::WaitWithOutputTimeoutError::Wait(e) => LspError::FormattingFailed(format!(
+                "failed to wait for formatter '{format_command}': {e}"
+            )),
+            command::WaitWithOutputTimeoutError::TimedOut(cleanup) => {
+                let mut details = format!(
+                    "formatter timed out after {:?} (input {} bytes): {format_command}",
+                    cleanup.timeout,
+                    input.len()
+                );
+                if let Some(e) = cleanup.kill_error {
+                    details.push_str(&format!("; kill failed: {e}"));
                 }
-                Ok(None) => {
-                    if start.elapsed() >= timeout {
-                        let kill_err = child.kill().err();
-                        let wait_err = child.wait().err();
-                        let mut details = format!(
-                            "formatter timed out after {timeout:?} (input {} bytes): {format_command}",
-                            input.len()
-                        );
-                        if let Some(e) = kill_err {
-                            details.push_str(&format!("; kill failed: {e}"));
-                        }
-                        if let Some(e) = wait_err {
-                            details.push_str(&format!("; wait failed: {e}"));
-                        }
-                        return Err(LspError::FormattingFailed(details));
-                    }
-                    thread::sleep(Duration::from_millis(10));
+                if let Some(e) = cleanup.wait_error {
+                    details.push_str(&format!("; wait failed: {e}"));
                 }
-                Err(e) => {
-                    let kill_err = child.kill().err();
-                    let wait_err = child.wait().err();
-                    let mut details = format!(
-                        "failed waiting for formatter '{format_command}' (input {} bytes): {e}",
-                        input.len()
-                    );
-                    if let Some(e) = kill_err {
-                        details.push_str(&format!("; kill failed: {e}"));
-                    }
-                    if let Some(e) = wait_err {
-                        details.push_str(&format!("; wait failed: {e}"));
-                    }
-                    return Err(LspError::FormattingFailed(details));
-                }
+                LspError::FormattingFailed(details)
             }
-        }
-    };
+            command::WaitWithOutputTimeoutError::Poll { source, cleanup } => {
+                let mut details = format!(
+                    "failed waiting for formatter '{format_command}' (input {} bytes): {source}",
+                    input.len()
+                );
+                if let Some(e) = cleanup.kill_error {
+                    details.push_str(&format!("; kill failed: {e}"));
+                }
+                if let Some(e) = cleanup.wait_error {
+                    details.push_str(&format!("; wait failed: {e}"));
+                }
+                LspError::FormattingFailed(details)
+            }
+        })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::{env, fs, mem, process};
 
 use analyzer::completion::SuggestionsCache;
-use analyzer::position::PositionEncoding;
+use analyzer::position::{self, PositionEncoding};
 use analyzer::symbols::WorkspaceSymbolsCache;
 use analyzer::{Files, LanguageContext, QueryEngine, prim};
 use async_lsp::client_monitor::ClientProcessMonitorLayer;
@@ -389,9 +389,15 @@ fn formatting(
         return Ok(Some(vec![]));
     }
 
-    let end =
-        analyzer::locate::offset_to_position(input.as_ref(), TextSize::from(input.len() as u32))
-            .unwrap_or(Position { line: 0, character: 0 });
+    let end = position::offset_to_utf8_position(input.as_ref(), TextSize::from(input.len() as u32))
+        .and_then(|position| {
+            position::utf8_position_to_protocol(
+                input.as_ref(),
+                position,
+                snapshot.position_encoding,
+            )
+        })
+        .unwrap_or(Position { line: 0, character: 0 });
     let range = Range { start: Position { line: 0, character: 0 }, end };
 
     Ok(Some(vec![TextEdit { range, new_text: formatted }]))
@@ -606,6 +612,7 @@ mod tests {
             files: Arc::clone(&state.files),
             workspace_symbols_cache: Arc::clone(&state.workspace_symbols_cache),
             suggestions_cache: Arc::clone(&state.suggestions_cache),
+            position_encoding: state.position_encoding,
         }
     }
 

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -483,7 +483,7 @@ fn formatting(
         }
         if !stdout.is_empty() {
             if !details.is_empty() {
-                details.push_str("\n");
+                details.push('\n');
             }
             details.push_str(stdout);
         }

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -561,7 +561,10 @@ pub async fn start(config: Arc<cli::Config>) {
 mod tests {
     use super::*;
 
-    use async_lsp::lsp_types::{ClientCapabilities, InitializeParams, Url, WorkspaceFolder};
+    use async_lsp::lsp_types::{
+        ClientCapabilities, DocumentFormattingParams, InitializeParams, Position,
+        TextDocumentIdentifier, Url, WorkspaceFolder,
+    };
 
     fn mk_state_with(config: cli::Config) -> State {
         // ClientSocket isn't used by initialize/formatting logic in tests.
@@ -592,6 +595,25 @@ mod tests {
             diagnostics_on_open: true,
             diagnostics_on_save: true,
             diagnostics_on_change: false,
+        }
+    }
+
+    fn snapshot(state: &State) -> StateSnapshot {
+        StateSnapshot {
+            client: state.client.clone(),
+            config: Arc::clone(&state.config),
+            engine: state.engine.snapshot(),
+            files: Arc::clone(&state.files),
+            workspace_symbols_cache: Arc::clone(&state.workspace_symbols_cache),
+            suggestions_cache: Arc::clone(&state.suggestions_cache),
+        }
+    }
+
+    fn formatting_params(uri: Url) -> DocumentFormattingParams {
+        DocumentFormattingParams {
+            text_document: TextDocumentIdentifier { uri },
+            options: FormattingOptions::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
         }
     }
 
@@ -626,5 +648,64 @@ mod tests {
         .unwrap();
 
         assert!(res.capabilities.document_formatting_provider.is_some());
+    }
+
+    #[test]
+    fn formatting_returns_none_without_command() {
+        let state = mk_state_with(base_config(None));
+        let uri = Url::parse("file:///test/Main.purs").unwrap();
+
+        let edits = formatting(snapshot(&state), formatting_params(uri)).unwrap();
+
+        assert!(edits.is_none());
+    }
+
+    #[test]
+    fn formatting_returns_none_for_unknown_document() {
+        let state = mk_state_with(base_config(Some("cat".to_string())));
+        let uri = Url::parse("file:///test/Missing.purs").unwrap();
+
+        let edits = formatting(snapshot(&state), formatting_params(uri)).unwrap();
+
+        assert!(edits.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn formatting_returns_empty_edits_for_noop_formatter() {
+        let mut state = mk_state_with(base_config(Some("cat".to_string())));
+        let uri = Url::parse("file:///test/Main.purs").unwrap();
+        on_change(&mut state, uri.as_str(), "module Main where\nfoo = bar\n").unwrap();
+
+        let edits = formatting(snapshot(&state), formatting_params(uri)).unwrap().unwrap();
+
+        assert!(edits.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn formatting_returns_full_document_edit() {
+        let mut state = mk_state_with(base_config(Some("tr a-z A-Z".to_string())));
+        let uri = Url::parse("file:///test/Main.purs").unwrap();
+        on_change(&mut state, uri.as_str(), "module Main where\nfoo = bar\n").unwrap();
+
+        let edits = formatting(snapshot(&state), formatting_params(uri)).unwrap().unwrap();
+
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].new_text, "MODULE MAIN WHERE\nFOO = BAR\n");
+        assert_eq!(edits[0].range.start, Position::new(0, 0));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn formatting_reports_non_utf8_output() {
+        let mut state = mk_state_with(base_config(Some("perl -e 'print chr 255'".to_string())));
+        let uri = Url::parse("file:///test/Main.purs").unwrap();
+        on_change(&mut state, uri.as_str(), "module Main where\nfoo = bar\n").unwrap();
+
+        let error = formatting(snapshot(&state), formatting_params(uri)).unwrap_err();
+
+        assert!(matches!(error, LspError::FormattingFailed(_)));
+        assert!(error.message().starts_with("formatter output was not utf-8:"));
     }
 }

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -144,7 +144,8 @@ fn initialize(
             folder.uri.to_file_path().ok()
         })
         .or_else(|| env::current_dir().ok());
-    let formatting_enabled = state.config.format_command.is_some();
+    let formatting_enabled =
+        state.config.format_command.as_deref().is_some_and(|s| !s.trim().is_empty());
     async move {
         Ok(InitializeResult {
             server_info: Some(ServerInfo {
@@ -362,6 +363,9 @@ fn formatting(
     let Some(format_command) = snapshot.config.format_command.as_deref() else {
         return Ok(None);
     };
+    if format_command.trim().is_empty() {
+        return Ok(None);
+    }
 
     let uri = p.text_document.uri;
     let current_file = {
@@ -413,9 +417,58 @@ fn formatting(
         })?;
     }
 
-    let output = child.wait_with_output().map_err(|e| {
-        LspError::FormattingFailed(format!("failed to wait for formatter: {e}"))
-    })?;
+    let output = {
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        // Avoid hanging indefinitely if the formatter never exits.
+        let timeout = Duration::from_secs(10);
+        let start = Instant::now();
+        loop {
+            match child.try_wait() {
+                Ok(Some(_status)) => {
+                    break child.wait_with_output().map_err(|e| {
+                        LspError::FormattingFailed(format!(
+                            "failed to wait for formatter '{format_command}': {e}"
+                        ))
+                    })?;
+                }
+                Ok(None) => {
+                    if start.elapsed() >= timeout {
+                        let kill_err = child.kill().err();
+                        let wait_err = child.wait().err();
+                        let mut details = format!(
+                            "formatter timed out after {timeout:?} (input {} bytes): {format_command}",
+                            input.len()
+                        );
+                        if let Some(e) = kill_err {
+                            details.push_str(&format!("; kill failed: {e}"));
+                        }
+                        if let Some(e) = wait_err {
+                            details.push_str(&format!("; wait failed: {e}"));
+                        }
+                        return Err(LspError::FormattingFailed(details));
+                    }
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(e) => {
+                    let kill_err = child.kill().err();
+                    let wait_err = child.wait().err();
+                    let mut details = format!(
+                        "failed waiting for formatter '{format_command}' (input {} bytes): {e}",
+                        input.len()
+                    );
+                    if let Some(e) = kill_err {
+                        details.push_str(&format!("; kill failed: {e}"));
+                    }
+                    if let Some(e) = wait_err {
+                        details.push_str(&format!("; wait failed: {e}"));
+                    }
+                    return Err(LspError::FormattingFailed(details));
+                }
+            }
+        }
+    };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -440,8 +493,7 @@ fn formatting(
 
         return Err(LspError::FormattingFailed(format!(
             "formatter exited with {}: {}",
-            output.status,
-            details
+            output.status, details
         )));
     }
 
@@ -452,11 +504,9 @@ fn formatting(
         return Ok(Some(vec![]));
     }
 
-    let end = analyzer::locate::offset_to_position(
-        input.as_ref(),
-        TextSize::from(input.len() as u32),
-    )
-        .unwrap_or(Position { line: 0, character: 0 });
+    let end =
+        analyzer::locate::offset_to_position(input.as_ref(), TextSize::from(input.len() as u32))
+            .unwrap_or(Position { line: 0, character: 0 });
     let range = Range { start: Position { line: 0, character: 0 }, end };
 
     Ok(Some(vec![TextEdit { range, new_text: formatted }]))
@@ -689,7 +739,8 @@ mod tests {
     #[tokio::test]
     async fn formatting_capability_advertised_with_flag() {
         let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-        let mut state = mk_state_with(base_config(Some("/bin/cat".to_string())));
+        // Capability advertising doesn't execute the formatter; any non-empty value should enable it.
+        let mut state = mk_state_with(base_config(Some("purs-tidy".to_string())));
 
         let initialize_params = mk_init_params(root);
         let res = initialize(
@@ -702,9 +753,10 @@ mod tests {
         assert!(res.capabilities.document_formatting_provider.is_some());
     }
 
+    #[cfg(unix)]
     #[test]
     fn formatting_returns_full_document_edit() {
-        let mut state = mk_state_with(base_config(Some("/usr/bin/tr a-z A-Z".to_string())));
+        let mut state = mk_state_with(base_config(Some("tr a-z A-Z".to_string())));
 
         let uri = Url::parse("file:///test/Main.purs").unwrap();
         let input = "module Main where\nfoo = bar\n";
@@ -735,9 +787,10 @@ mod tests {
         assert_eq!(edits[0].range.start, Position::new(0, 0));
     }
 
+    #[cfg(unix)]
     #[test]
     fn formatting_noop_returns_empty_edits() {
-        let mut state = mk_state_with(base_config(Some("/bin/cat".to_string())));
+        let mut state = mk_state_with(base_config(Some("cat".to_string())));
 
         let uri = Url::parse("file:///test/Main.purs").unwrap();
         let input = "module Main where\nfoo = bar\n";
@@ -762,9 +815,10 @@ mod tests {
         assert!(edits.is_empty());
     }
 
+    #[cfg(unix)]
     #[test]
     fn formatting_parses_quoted_args() {
-        let mut state = mk_state_with(base_config(Some("/usr/bin/tr 'a-z' 'A-Z'".to_string())));
+        let mut state = mk_state_with(base_config(Some("tr 'a-z' 'A-Z'".to_string())));
 
         let uri = Url::parse("file:///test/Main.purs").unwrap();
         let input = "module Main where\nfoo = bar\n";
@@ -790,10 +844,10 @@ mod tests {
         assert_eq!(edits[0].new_text, "MODULE MAIN WHERE\nFOO = BAR\n");
     }
 
+    #[cfg(unix)]
     #[test]
     fn formatting_tolerates_outer_quoted_command_string() {
-        let mut state =
-            mk_state_with(base_config(Some("\"/usr/bin/tr a-z A-Z\"".to_string())));
+        let mut state = mk_state_with(base_config(Some("\"tr a-z A-Z\"".to_string())));
 
         let uri = Url::parse("file:///test/Main.purs").unwrap();
         let input = "module Main where\nfoo = bar\n";

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -621,3 +621,201 @@ pub async fn start(config: Arc<cli::Config>) {
         process::exit(1);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use async_lsp::lsp_types::{
+        ClientCapabilities, DocumentFormattingParams, InitializeParams, Position,
+        TextDocumentIdentifier, Url, WorkspaceFolder,
+    };
+
+    fn mk_state_with(config: cli::Config) -> State {
+        // ClientSocket isn't used by initialize/formatting logic in tests.
+        let client = ClientSocket::new_closed();
+        State::new(Arc::new(config), client)
+    }
+
+    fn mk_init_params(root: &std::path::Path) -> InitializeParams {
+        InitializeParams {
+            process_id: None,
+            root_path: None,
+            root_uri: None,
+            initialization_options: None,
+            capabilities: ClientCapabilities::default(),
+            trace: None,
+            workspace_folders: Some(vec![WorkspaceFolder {
+                uri: Url::from_file_path(root).unwrap(),
+                name: "workspace".to_string(),
+            }]),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            client_info: None,
+            locale: None,
+        }
+    }
+
+    fn base_config(format_command: Option<String>) -> cli::Config {
+        cli::Config {
+            stdio: true,
+            log_file: false,
+            query_log: tracing::level_filters::LevelFilter::OFF,
+            lsp_log: tracing::level_filters::LevelFilter::INFO,
+            checking_log: tracing::level_filters::LevelFilter::OFF,
+            source_command: None,
+            format_command,
+            diagnostics_on_open: true,
+            diagnostics_on_save: true,
+            diagnostics_on_change: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn formatting_capability_not_advertised_without_flag() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let mut state = mk_state_with(base_config(None));
+
+        let initialize_params = mk_init_params(root);
+        let res = initialize(
+            &mut state,
+            extension::CustomInitializeParams { initialize_params, work_done_token: None },
+        )
+        .await
+        .unwrap();
+
+        assert!(res.capabilities.document_formatting_provider.is_none());
+    }
+
+    #[tokio::test]
+    async fn formatting_capability_advertised_with_flag() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let mut state = mk_state_with(base_config(Some("/bin/cat".to_string())));
+
+        let initialize_params = mk_init_params(root);
+        let res = initialize(
+            &mut state,
+            extension::CustomInitializeParams { initialize_params, work_done_token: None },
+        )
+        .await
+        .unwrap();
+
+        assert!(res.capabilities.document_formatting_provider.is_some());
+    }
+
+    #[test]
+    fn formatting_returns_full_document_edit() {
+        let mut state = mk_state_with(base_config(Some("/usr/bin/tr a-z A-Z".to_string())));
+
+        let uri = Url::parse("file:///test/Main.purs").unwrap();
+        let input = "module Main where\nfoo = bar\n";
+        on_change(&mut state, uri.as_str(), input).unwrap();
+
+        let snapshot = StateSnapshot {
+            client: state.client.clone(),
+            config: Arc::clone(&state.config),
+            engine: state.engine.snapshot(),
+            files: Arc::clone(&state.files),
+            workspace_symbols_cache: Arc::clone(&state.workspace_symbols_cache),
+            suggestions_cache: Arc::clone(&state.suggestions_cache),
+        };
+
+        let p = DocumentFormattingParams {
+            text_document: TextDocumentIdentifier { uri: uri.clone() },
+            options: FormattingOptions {
+                tab_size: 2,
+                insert_spaces: true,
+                ..FormattingOptions::default()
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        };
+
+        let edits = formatting(snapshot, p).unwrap().unwrap();
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].new_text, "MODULE MAIN WHERE\nFOO = BAR\n");
+        assert_eq!(edits[0].range.start, Position::new(0, 0));
+    }
+
+    #[test]
+    fn formatting_noop_returns_empty_edits() {
+        let mut state = mk_state_with(base_config(Some("/bin/cat".to_string())));
+
+        let uri = Url::parse("file:///test/Main.purs").unwrap();
+        let input = "module Main where\nfoo = bar\n";
+        on_change(&mut state, uri.as_str(), input).unwrap();
+
+        let snapshot = StateSnapshot {
+            client: state.client.clone(),
+            config: Arc::clone(&state.config),
+            engine: state.engine.snapshot(),
+            files: Arc::clone(&state.files),
+            workspace_symbols_cache: Arc::clone(&state.workspace_symbols_cache),
+            suggestions_cache: Arc::clone(&state.suggestions_cache),
+        };
+
+        let p = DocumentFormattingParams {
+            text_document: TextDocumentIdentifier { uri },
+            options: FormattingOptions::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        };
+
+        let edits = formatting(snapshot, p).unwrap().unwrap();
+        assert!(edits.is_empty());
+    }
+
+    #[test]
+    fn formatting_parses_quoted_args() {
+        let mut state = mk_state_with(base_config(Some("/usr/bin/tr 'a-z' 'A-Z'".to_string())));
+
+        let uri = Url::parse("file:///test/Main.purs").unwrap();
+        let input = "module Main where\nfoo = bar\n";
+        on_change(&mut state, uri.as_str(), input).unwrap();
+
+        let snapshot = StateSnapshot {
+            client: state.client.clone(),
+            config: Arc::clone(&state.config),
+            engine: state.engine.snapshot(),
+            files: Arc::clone(&state.files),
+            workspace_symbols_cache: Arc::clone(&state.workspace_symbols_cache),
+            suggestions_cache: Arc::clone(&state.suggestions_cache),
+        };
+
+        let p = DocumentFormattingParams {
+            text_document: TextDocumentIdentifier { uri },
+            options: FormattingOptions::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        };
+
+        let edits = formatting(snapshot, p).unwrap().unwrap();
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].new_text, "MODULE MAIN WHERE\nFOO = BAR\n");
+    }
+
+    #[test]
+    fn formatting_tolerates_outer_quoted_command_string() {
+        let mut state =
+            mk_state_with(base_config(Some("\"/usr/bin/tr a-z A-Z\"".to_string())));
+
+        let uri = Url::parse("file:///test/Main.purs").unwrap();
+        let input = "module Main where\nfoo = bar\n";
+        on_change(&mut state, uri.as_str(), input).unwrap();
+
+        let snapshot = StateSnapshot {
+            client: state.client.clone(),
+            config: Arc::clone(&state.config),
+            engine: state.engine.snapshot(),
+            files: Arc::clone(&state.files),
+            workspace_symbols_cache: Arc::clone(&state.workspace_symbols_cache),
+            suggestions_cache: Arc::clone(&state.suggestions_cache),
+        };
+
+        let p = DocumentFormattingParams {
+            text_document: TextDocumentIdentifier { uri },
+            options: FormattingOptions::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        };
+
+        let edits = formatting(snapshot, p).unwrap().unwrap();
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].new_text, "MODULE MAIN WHERE\nFOO = BAR\n");
+    }
+}

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -748,7 +748,7 @@ mod tests {
     #[test]
     fn formatting_reports_formatter_failure() {
         let mut state =
-            mk_state_with(base_config(Some("sh -c 'printf err >&2; exit 7'".to_string())));
+            mk_state_with(base_config(Some("sh -c 'cat >/dev/null; printf err >&2; exit 7'".to_string())));
         let uri = Url::parse("file:///test/Main.purs").unwrap();
         on_change(&mut state, uri.as_str(), "module Main where\nfoo = bar\n").unwrap();
 

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -661,6 +661,16 @@ mod tests {
     }
 
     #[test]
+    fn formatting_returns_none_for_blank_command() {
+        let state = mk_state_with(base_config(Some("   ".to_string())));
+        let uri = Url::parse("file:///test/Main.purs").unwrap();
+
+        let edits = formatting(snapshot(&state), formatting_params(uri)).unwrap();
+
+        assert!(edits.is_none());
+    }
+
+    #[test]
     fn formatting_returns_none_for_unknown_document() {
         let state = mk_state_with(base_config(Some("cat".to_string())));
         let uri = Url::parse("file:///test/Missing.purs").unwrap();
@@ -707,5 +717,19 @@ mod tests {
 
         assert!(matches!(error, LspError::FormattingFailed(_)));
         assert!(error.message().starts_with("formatter output was not utf-8:"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn formatting_reports_formatter_failure() {
+        let mut state =
+            mk_state_with(base_config(Some("sh -c 'printf err >&2; exit 7'".to_string())));
+        let uri = Url::parse("file:///test/Main.purs").unwrap();
+        on_change(&mut state, uri.as_str(), "module Main where\nfoo = bar\n").unwrap();
+
+        let error = formatting(snapshot(&state), formatting_params(uri)).unwrap_err();
+
+        assert!(matches!(error, LspError::FormattingFailed(_)));
+        assert_eq!(error.message(), "formatter exited with exit status: 7: err");
     }
 }

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -3,12 +3,12 @@ mod command;
 pub mod error;
 pub mod event;
 pub mod extension;
+pub mod formatting;
 
 use std::borrow::BorrowMut;
 use std::ops::{ControlFlow, Deref};
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 use std::{env, fs, mem, process};
 
 use analyzer::completion::SuggestionsCache;
@@ -379,86 +379,10 @@ fn formatting(
 
     let input = snapshot.engine.content(current_file);
 
-    let parts = command::split(format_command).ok_or_else(|| {
-        LspError::FormattingFailed(format!("failed to parse --format-command: {format_command}"))
-    })?;
-    let mut parts = parts.into_iter();
-    let program = parts
-        .next()
-        .ok_or_else(|| LspError::FormattingFailed("--format-command is empty".to_string()))?;
+    let output = formatting::run(format_command, input.as_bytes())
+        .map_err(|e| LspError::FormattingFailed(e.to_string()))?;
 
-    let mut cmd = command::piped(&program, parts);
-
-    let mut child = cmd.spawn().map_err(|e| {
-        LspError::FormattingFailed(format!("failed to spawn formatter '{format_command}': {e}"))
-    })?;
-
-    command::write_stdin(&mut child, input.as_bytes()).map_err(|e| {
-        LspError::FormattingFailed(format!("failed writing to formatter stdin: {e}"))
-    })?;
-
-    let output =
-        command::wait_with_output_timeout(child, Duration::from_secs(10)).map_err(|e| match e {
-            command::WaitWithOutputTimeoutError::Wait(e) => LspError::FormattingFailed(format!(
-                "failed to wait for formatter '{format_command}': {e}"
-            )),
-            command::WaitWithOutputTimeoutError::TimedOut(cleanup) => {
-                let mut details = format!(
-                    "formatter timed out after {:?} (input {} bytes): {format_command}",
-                    cleanup.timeout,
-                    input.len()
-                );
-                if let Some(e) = cleanup.kill_error {
-                    details.push_str(&format!("; kill failed: {e}"));
-                }
-                if let Some(e) = cleanup.wait_error {
-                    details.push_str(&format!("; wait failed: {e}"));
-                }
-                LspError::FormattingFailed(details)
-            }
-            command::WaitWithOutputTimeoutError::Poll { source, cleanup } => {
-                let mut details = format!(
-                    "failed waiting for formatter '{format_command}' (input {} bytes): {source}",
-                    input.len()
-                );
-                if let Some(e) = cleanup.kill_error {
-                    details.push_str(&format!("; kill failed: {e}"));
-                }
-                if let Some(e) = cleanup.wait_error {
-                    details.push_str(&format!("; wait failed: {e}"));
-                }
-                LspError::FormattingFailed(details)
-            }
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-
-        let stderr = stderr.trim();
-        let stdout = stdout.trim();
-
-        let mut details = String::new();
-        if !stderr.is_empty() {
-            details.push_str(stderr);
-        }
-        if !stdout.is_empty() {
-            if !details.is_empty() {
-                details.push('\n');
-            }
-            details.push_str(stdout);
-        }
-        if details.is_empty() {
-            details.push_str("<no output>");
-        }
-
-        return Err(LspError::FormattingFailed(format!(
-            "formatter exited with {}: {}",
-            output.status, details
-        )));
-    }
-
-    let formatted = String::from_utf8(output.stdout)
+    let formatted = String::from_utf8(output)
         .map_err(|e| LspError::FormattingFailed(format!("formatter output was not utf-8: {e}")))?;
 
     if formatted.as_str() == input.as_ref() {
@@ -637,10 +561,7 @@ pub async fn start(config: Arc<cli::Config>) {
 mod tests {
     use super::*;
 
-    use async_lsp::lsp_types::{
-        ClientCapabilities, DocumentFormattingParams, InitializeParams, Position,
-        TextDocumentIdentifier, Url, WorkspaceFolder,
-    };
+    use async_lsp::lsp_types::{ClientCapabilities, InitializeParams, Url, WorkspaceFolder};
 
     fn mk_state_with(config: cli::Config) -> State {
         // ClientSocket isn't used by initialize/formatting logic in tests.
@@ -650,19 +571,12 @@ mod tests {
 
     fn mk_init_params(root: &std::path::Path) -> InitializeParams {
         InitializeParams {
-            process_id: None,
-            root_path: None,
-            root_uri: None,
-            initialization_options: None,
             capabilities: ClientCapabilities::default(),
-            trace: None,
             workspace_folders: Some(vec![WorkspaceFolder {
                 uri: Url::from_file_path(root).unwrap(),
                 name: "workspace".to_string(),
             }]),
-            work_done_progress_params: WorkDoneProgressParams::default(),
-            client_info: None,
-            locale: None,
+            ..InitializeParams::default()
         }
     }
 
@@ -712,125 +626,5 @@ mod tests {
         .unwrap();
 
         assert!(res.capabilities.document_formatting_provider.is_some());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn formatting_returns_full_document_edit() {
-        let mut state = mk_state_with(base_config(Some("tr a-z A-Z".to_string())));
-
-        let uri = Url::parse("file:///test/Main.purs").unwrap();
-        let input = "module Main where\nfoo = bar\n";
-        on_change(&mut state, uri.as_str(), input).unwrap();
-
-        let snapshot = StateSnapshot {
-            client: state.client.clone(),
-            config: Arc::clone(&state.config),
-            engine: state.engine.snapshot(),
-            files: Arc::clone(&state.files),
-            workspace_symbols_cache: Arc::clone(&state.workspace_symbols_cache),
-            suggestions_cache: Arc::clone(&state.suggestions_cache),
-        };
-
-        let p = DocumentFormattingParams {
-            text_document: TextDocumentIdentifier { uri: uri.clone() },
-            options: FormattingOptions {
-                tab_size: 2,
-                insert_spaces: true,
-                ..FormattingOptions::default()
-            },
-            work_done_progress_params: WorkDoneProgressParams::default(),
-        };
-
-        let edits = formatting(snapshot, p).unwrap().unwrap();
-        assert_eq!(edits.len(), 1);
-        assert_eq!(edits[0].new_text, "MODULE MAIN WHERE\nFOO = BAR\n");
-        assert_eq!(edits[0].range.start, Position::new(0, 0));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn formatting_noop_returns_empty_edits() {
-        let mut state = mk_state_with(base_config(Some("cat".to_string())));
-
-        let uri = Url::parse("file:///test/Main.purs").unwrap();
-        let input = "module Main where\nfoo = bar\n";
-        on_change(&mut state, uri.as_str(), input).unwrap();
-
-        let snapshot = StateSnapshot {
-            client: state.client.clone(),
-            config: Arc::clone(&state.config),
-            engine: state.engine.snapshot(),
-            files: Arc::clone(&state.files),
-            workspace_symbols_cache: Arc::clone(&state.workspace_symbols_cache),
-            suggestions_cache: Arc::clone(&state.suggestions_cache),
-        };
-
-        let p = DocumentFormattingParams {
-            text_document: TextDocumentIdentifier { uri },
-            options: FormattingOptions::default(),
-            work_done_progress_params: WorkDoneProgressParams::default(),
-        };
-
-        let edits = formatting(snapshot, p).unwrap().unwrap();
-        assert!(edits.is_empty());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn formatting_parses_quoted_args() {
-        let mut state = mk_state_with(base_config(Some("tr 'a-z' 'A-Z'".to_string())));
-
-        let uri = Url::parse("file:///test/Main.purs").unwrap();
-        let input = "module Main where\nfoo = bar\n";
-        on_change(&mut state, uri.as_str(), input).unwrap();
-
-        let snapshot = StateSnapshot {
-            client: state.client.clone(),
-            config: Arc::clone(&state.config),
-            engine: state.engine.snapshot(),
-            files: Arc::clone(&state.files),
-            workspace_symbols_cache: Arc::clone(&state.workspace_symbols_cache),
-            suggestions_cache: Arc::clone(&state.suggestions_cache),
-        };
-
-        let p = DocumentFormattingParams {
-            text_document: TextDocumentIdentifier { uri },
-            options: FormattingOptions::default(),
-            work_done_progress_params: WorkDoneProgressParams::default(),
-        };
-
-        let edits = formatting(snapshot, p).unwrap().unwrap();
-        assert_eq!(edits.len(), 1);
-        assert_eq!(edits[0].new_text, "MODULE MAIN WHERE\nFOO = BAR\n");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn formatting_tolerates_outer_quoted_command_string() {
-        let mut state = mk_state_with(base_config(Some("\"tr a-z A-Z\"".to_string())));
-
-        let uri = Url::parse("file:///test/Main.purs").unwrap();
-        let input = "module Main where\nfoo = bar\n";
-        on_change(&mut state, uri.as_str(), input).unwrap();
-
-        let snapshot = StateSnapshot {
-            client: state.client.clone(),
-            config: Arc::clone(&state.config),
-            engine: state.engine.snapshot(),
-            files: Arc::clone(&state.files),
-            workspace_symbols_cache: Arc::clone(&state.workspace_symbols_cache),
-            suggestions_cache: Arc::clone(&state.suggestions_cache),
-        };
-
-        let p = DocumentFormattingParams {
-            text_document: TextDocumentIdentifier { uri },
-            options: FormattingOptions::default(),
-            work_done_progress_params: WorkDoneProgressParams::default(),
-        };
-
-        let edits = formatting(snapshot, p).unwrap().unwrap();
-        assert_eq!(edits.len(), 1);
-        assert_eq!(edits[0].new_text, "MODULE MAIN WHERE\nFOO = BAR\n");
     }
 }

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -373,7 +373,25 @@ fn formatting(
 
     let input = snapshot.engine.content(current_file);
 
-    let mut parts = format_command.split_whitespace();
+    let mut cmd_str = format_command.trim();
+
+    // Users sometimes include extra quoting in editor configs, e.g.
+    // `--format-command "\"purs-tidy format\""`. If the whole command is wrapped
+    // in a single pair of quotes, strip it and re-parse.
+    if cmd_str.len() >= 2 {
+        let bytes = cmd_str.as_bytes();
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        let is_wrapped = (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'');
+        if is_wrapped {
+            cmd_str = &cmd_str[1..cmd_str.len() - 1];
+        }
+    }
+
+    let parts = shlex::split(cmd_str).ok_or_else(|| {
+        LspError::FormattingFailed(format!("failed to parse --format-command: {format_command}"))
+    })?;
+    let mut parts = parts.into_iter();
     let program = parts
         .next()
         .ok_or_else(|| LspError::FormattingFailed("--format-command is empty".to_string()))?;

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -650,6 +650,31 @@ mod tests {
         assert!(res.capabilities.document_formatting_provider.is_some());
     }
 
+    #[tokio::test]
+    async fn state_spawn_captures_snapshot_config() {
+        let state = mk_state_with(base_config(Some("formatter".to_string())));
+
+        let format_command =
+            state.spawn(|snapshot| snapshot.config.format_command.clone()).await.unwrap();
+
+        assert_eq!(format_command.as_deref(), Some("formatter"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn initialized_manual_parses_shell_command() {
+        let root =
+            std::env::temp_dir().join(format!("alexandrite-lsp-test-{}", std::process::id()));
+        fs::create_dir_all(&root).unwrap();
+
+        let mut state = mk_state_with(base_config(None));
+        state.root = Some(root.clone());
+
+        initialized_manual(&mut state, "sh -c 'exit 0'").unwrap();
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
     #[test]
     fn formatting_returns_none_without_command() {
         let state = mk_state_with(base_config(None));

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -25,6 +25,7 @@ use async_lsp::{ClientSocket, ResponseError};
 use globset::{Glob, GlobSetBuilder};
 use parking_lot::RwLock;
 use path_absolutize::Absolutize;
+use rowan::TextSize;
 use tokio::task;
 use tower::ServiceBuilder;
 use walkdir::WalkDir;
@@ -82,6 +83,7 @@ impl State {
     {
         let snapshot = StateSnapshot {
             client: self.client.clone(),
+            config: Arc::clone(&self.config),
             engine: self.engine.snapshot(),
             files: Arc::clone(&self.files),
             workspace_symbols_cache: Arc::clone(&self.workspace_symbols_cache),
@@ -104,6 +106,7 @@ impl State {
 
 struct StateSnapshot {
     client: ClientSocket,
+    config: Arc<cli::Config>,
     engine: QueryEngine,
     files: Arc<RwLock<Files>>,
     workspace_symbols_cache: Arc<RwLock<WorkspaceSymbolsCache>>,
@@ -141,6 +144,7 @@ fn initialize(
             folder.uri.to_file_path().ok()
         })
         .or_else(|| env::current_dir().ok());
+    let formatting_enabled = state.config.format_command.is_some();
     async move {
         Ok(InitializeResult {
             server_info: Some(ServerInfo {
@@ -163,6 +167,7 @@ fn initialize(
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
                 references_provider: Some(OneOf::Left(true)),
                 workspace_symbol_provider: Some(OneOf::Left(true)),
+                document_formatting_provider: formatting_enabled.then_some(OneOf::Left(true)),
                 text_document_sync: Some(TextDocumentSyncCapability::Options(
                     TextDocumentSyncOptions {
                         open_close: Some(true),
@@ -347,6 +352,98 @@ fn workspace_symbols(
     result.on_non_fatal(None)
 }
 
+fn formatting(
+    snapshot: StateSnapshot,
+    p: DocumentFormattingParams,
+) -> Result<Option<Vec<TextEdit>>, LspError> {
+    let _span = tracing::info_span!("formatting").entered();
+
+    // Formatting support is advertised conditionally in `initialize`.
+    let Some(format_command) = snapshot.config.format_command.as_deref() else {
+        return Ok(None);
+    };
+
+    let uri = p.text_document.uri;
+    let current_file = {
+        let files = snapshot.files();
+        let uri = uri.as_str();
+        let Some(id) = files.id(uri) else { return Ok(None) };
+        id
+    };
+
+    let input = snapshot.engine.content(current_file);
+
+    let mut parts = format_command.split_whitespace();
+    let program = parts
+        .next()
+        .ok_or_else(|| LspError::FormattingFailed("--format-command is empty".to_string()))?;
+
+    let mut cmd = process::Command::new(program);
+    cmd.args(parts);
+    cmd.stdin(process::Stdio::piped());
+    cmd.stdout(process::Stdio::piped());
+    cmd.stderr(process::Stdio::piped());
+
+    let mut child = cmd.spawn().map_err(|e| {
+        LspError::FormattingFailed(format!("failed to spawn formatter '{format_command}': {e}"))
+    })?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        use std::io::Write;
+        stdin.write_all(input.as_bytes()).map_err(|e| {
+            LspError::FormattingFailed(format!("failed writing to formatter stdin: {e}"))
+        })?;
+    }
+
+    let output = child.wait_with_output().map_err(|e| {
+        LspError::FormattingFailed(format!("failed to wait for formatter: {e}"))
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        let stderr = stderr.trim();
+        let stdout = stdout.trim();
+
+        let mut details = String::new();
+        if !stderr.is_empty() {
+            details.push_str(stderr);
+        }
+        if !stdout.is_empty() {
+            if !details.is_empty() {
+                details.push_str("\n");
+            }
+            details.push_str(stdout);
+        }
+        if details.is_empty() {
+            details.push_str("<no output>");
+        }
+
+        return Err(LspError::FormattingFailed(format!(
+            "formatter exited with {}: {}",
+            output.status,
+            details
+        )));
+    }
+
+    let formatted = String::from_utf8(output.stdout)
+        .map_err(|e| LspError::FormattingFailed(format!("formatter output was not utf-8: {e}")))?;
+
+    if formatted.as_str() == input.as_ref() {
+        return Ok(Some(vec![]));
+    }
+
+    let end = analyzer::locate::offset_to_position(
+        input.as_ref(),
+        TextSize::from(input.len() as u32),
+    )
+        .unwrap_or(Position { line: 0, character: 0 });
+    let range = Range { start: Position { line: 0, character: 0 }, end };
+
+    Ok(Some(vec![TextEdit { range, new_text: formatted }]))
+}
+
 fn did_change(state: &mut State, p: DidChangeTextDocumentParams) -> Result<(), LspError> {
     let uri = p.text_document.uri.as_str();
 
@@ -471,6 +568,7 @@ pub async fn start(config: Arc<cli::Config>) {
             .request_snapshot::<request::ResolveCompletionItem>(resolve_completion_item)
             .request_snapshot::<request::References>(references)
             .request_snapshot::<request::WorkspaceSymbolRequest>(workspace_symbols)
+            .request_snapshot::<request::Formatting>(formatting)
             .notification_ext::<notification::Initialized>(initialized)
             .notification_ext::<notification::DidOpenTextDocument>(did_open)
             .notification_ext::<notification::DidSaveTextDocument>(did_save)

--- a/compiler-bin/src/lsp/command.rs
+++ b/compiler-bin/src/lsp/command.rs
@@ -1,4 +1,4 @@
-use std::process::{self, Child, Output};
+use std::process::{self, Child, ExitStatus, Output};
 use std::time::{Duration, Instant};
 use std::{io, thread};
 
@@ -58,14 +58,17 @@ pub(super) fn wait_with_output_timeout(
                 }
                 thread::sleep(Duration::from_millis(10));
             }
-            Err(source) => {
-                return Err(WaitWithOutputTimeoutError::Poll {
-                    source,
-                    cleanup: cleanup_child(&mut child, timeout),
-                });
-            }
+            Err(source) => return Err(poll_wait_error(source, &mut child, timeout)),
         }
     }
+}
+
+fn poll_wait_error(
+    source: io::Error,
+    child: &mut Child,
+    timeout: Duration,
+) -> WaitWithOutputTimeoutError {
+    WaitWithOutputTimeoutError::Poll { source, cleanup: cleanup_child(child, timeout) }
 }
 
 #[derive(Debug)]
@@ -93,22 +96,40 @@ fn wait_for_cleanup(child: &mut Child) -> Option<io::Error> {
     let start = Instant::now();
 
     loop {
-        match child.try_wait() {
-            Ok(Some(_)) => return None,
-            Ok(None) => {
-                if start.elapsed() >= CHILD_CLEANUP_TIMEOUT {
-                    return Some(io::Error::new(
-                        io::ErrorKind::TimedOut,
-                        format!(
-                            "timed out waiting {:?} for killed child process to exit",
-                            CHILD_CLEANUP_TIMEOUT
-                        ),
-                    ));
-                }
-                thread::sleep(Duration::from_millis(10));
-            }
-            Err(error) => return Some(error),
+        match cleanup_wait_state(child.try_wait(), start.elapsed()) {
+            CleanupWaitState::Exited => return None,
+            CleanupWaitState::Pending => thread::sleep(Duration::from_millis(10)),
+            CleanupWaitState::Failed(error) => return Some(error),
         }
+    }
+}
+
+enum CleanupWaitState {
+    Exited,
+    Pending,
+    Failed(io::Error),
+}
+
+fn cleanup_wait_state(
+    result: io::Result<Option<ExitStatus>>,
+    elapsed: Duration,
+) -> CleanupWaitState {
+    match result {
+        Ok(Some(_)) => CleanupWaitState::Exited,
+        Ok(None) => {
+            if elapsed >= CHILD_CLEANUP_TIMEOUT {
+                CleanupWaitState::Failed(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!(
+                        "timed out waiting {:?} for killed child process to exit",
+                        CHILD_CLEANUP_TIMEOUT
+                    ),
+                ))
+            } else {
+                CleanupWaitState::Pending
+            }
+        }
+        Err(error) => CleanupWaitState::Failed(error),
     }
 }
 
@@ -142,6 +163,59 @@ mod tests {
                 assert!(cleanup.wait_error.is_none());
             }
             other => panic!("expected timeout, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_stdin_succeeds_without_pipe() {
+        let mut child = process::Command::new("cat")
+            .stdin(process::Stdio::null())
+            .stdout(process::Stdio::null())
+            .spawn()
+            .unwrap();
+
+        write_stdin(&mut child, b"hello").unwrap();
+        child.wait().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn poll_wait_error_cleans_up_child() {
+        let mut child = piped("sh", ["-c".to_string(), "sleep 2".to_string()]).spawn().unwrap();
+
+        let error =
+            poll_wait_error(io::Error::other("poll failed"), &mut child, Duration::from_millis(10));
+
+        match error {
+            WaitWithOutputTimeoutError::Poll { source, cleanup } => {
+                assert_eq!(source.kind(), io::ErrorKind::Other);
+                assert_eq!(source.to_string(), "poll failed");
+                assert_eq!(cleanup.timeout, Duration::from_millis(10));
+            }
+            other => panic!("expected poll error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cleanup_wait_state_times_out() {
+        let state = cleanup_wait_state(Ok(None), CHILD_CLEANUP_TIMEOUT);
+
+        match state {
+            CleanupWaitState::Failed(error) => assert_eq!(error.kind(), io::ErrorKind::TimedOut),
+            CleanupWaitState::Exited => panic!("expected timeout, got exited"),
+            CleanupWaitState::Pending => panic!("expected timeout, got pending"),
+        }
+    }
+
+    #[test]
+    fn cleanup_wait_state_propagates_errors() {
+        let state = cleanup_wait_state(Err(io::Error::other("wait failed")), Duration::ZERO);
+
+        match state {
+            CleanupWaitState::Failed(error) => assert_eq!(error.to_string(), "wait failed"),
+            CleanupWaitState::Exited => panic!("expected error, got exited"),
+            CleanupWaitState::Pending => panic!("expected error, got pending"),
         }
     }
 

--- a/compiler-bin/src/lsp/command.rs
+++ b/compiler-bin/src/lsp/command.rs
@@ -3,6 +3,8 @@ use std::process::{self, Child, Output};
 use std::thread;
 use std::time::{Duration, Instant};
 
+const CHILD_CLEANUP_TIMEOUT: Duration = Duration::from_secs(1);
+
 pub(super) fn split(command: &str) -> Option<Vec<String>> {
     let mut command = command.trim();
 
@@ -82,7 +84,33 @@ pub(super) struct ChildCleanup {
 }
 
 fn cleanup_child(child: &mut Child, timeout: Duration) -> ChildCleanup {
-    ChildCleanup { timeout, kill_error: child.kill().err(), wait_error: child.wait().err() }
+    let kill_error = child.kill().err();
+    let wait_error = wait_for_cleanup(child);
+
+    ChildCleanup { timeout, kill_error, wait_error }
+}
+
+fn wait_for_cleanup(child: &mut Child) -> Option<io::Error> {
+    let start = Instant::now();
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return None,
+            Ok(None) => {
+                if start.elapsed() >= CHILD_CLEANUP_TIMEOUT {
+                    return Some(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        format!(
+                            "timed out waiting {:?} for killed child process to exit",
+                            CHILD_CLEANUP_TIMEOUT
+                        ),
+                    ));
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(error) => return Some(error),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/compiler-bin/src/lsp/command.rs
+++ b/compiler-bin/src/lsp/command.rs
@@ -1,0 +1,101 @@
+use std::io;
+use std::process::{self, Child, Output};
+use std::thread;
+use std::time::{Duration, Instant};
+
+pub(super) fn split(command: &str) -> Option<Vec<String>> {
+    let mut command = command.trim();
+
+    // Users sometimes include extra quoting in editor configs, e.g.
+    // `--format-command "\"purs-tidy format\""`.
+    if command.len() >= 2 {
+        let bytes = command.as_bytes();
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        let is_wrapped = (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'');
+        if is_wrapped {
+            command = &command[1..command.len() - 1];
+        }
+    }
+
+    shlex::split(command)
+}
+
+pub(super) fn piped(program: &str, args: impl IntoIterator<Item = String>) -> process::Command {
+    let mut command = process::Command::new(program);
+    command.args(args);
+    command.stdin(process::Stdio::piped());
+    command.stdout(process::Stdio::piped());
+    command.stderr(process::Stdio::piped());
+    command
+}
+
+pub(super) fn write_stdin(child: &mut Child, input: &[u8]) -> io::Result<()> {
+    if let Some(mut stdin) = child.stdin.take() {
+        use std::io::Write;
+        stdin.write_all(input)?;
+    }
+    Ok(())
+}
+
+pub(super) fn wait_with_output_timeout(
+    mut child: Child,
+    timeout: Duration,
+) -> Result<Output, WaitWithOutputTimeoutError> {
+    let start = Instant::now();
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                return child.wait_with_output().map_err(WaitWithOutputTimeoutError::Wait);
+            }
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    return Err(WaitWithOutputTimeoutError::TimedOut(cleanup_child(
+                        &mut child, timeout,
+                    )));
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(source) => {
+                return Err(WaitWithOutputTimeoutError::Poll {
+                    source,
+                    cleanup: cleanup_child(&mut child, timeout),
+                });
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) enum WaitWithOutputTimeoutError {
+    Wait(io::Error),
+    TimedOut(ChildCleanup),
+    Poll { source: io::Error, cleanup: ChildCleanup },
+}
+
+#[derive(Debug)]
+pub(super) struct ChildCleanup {
+    pub timeout: Duration,
+    pub kill_error: Option<io::Error>,
+    pub wait_error: Option<io::Error>,
+}
+
+fn cleanup_child(child: &mut Child, timeout: Duration) -> ChildCleanup {
+    ChildCleanup { timeout, kill_error: child.kill().err(), wait_error: child.wait().err() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split;
+
+    #[test]
+    fn split_handles_shell_quoted_args() {
+        assert_eq!(split("tr 'a-z' 'A-Z'"), Some(vec!["tr".into(), "a-z".into(), "A-Z".into()]));
+    }
+
+    #[test]
+    fn split_strips_outer_quotes_before_parsing() {
+        assert_eq!(split("\"tr a-z A-Z\""), Some(vec!["tr".into(), "a-z".into(), "A-Z".into()]));
+    }
+}

--- a/compiler-bin/src/lsp/command.rs
+++ b/compiler-bin/src/lsp/command.rs
@@ -5,21 +5,22 @@ use std::{io, thread};
 const CHILD_CLEANUP_TIMEOUT: Duration = Duration::from_secs(1);
 
 pub(super) fn split(command: &str) -> Option<Vec<String>> {
-    let mut command = command.trim();
+    let command = command.trim();
+    let parts = shlex::split(command)?;
 
     // Users sometimes include extra quoting in editor configs, e.g.
     // `--format-command "\"purs-tidy format\""`.
-    if command.len() >= 2 {
+    if parts.len() == 1 && command.len() >= 2 {
         let bytes = command.as_bytes();
         let first = bytes[0];
         let last = bytes[bytes.len() - 1];
         let is_wrapped = (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'');
         if is_wrapped {
-            command = &command[1..command.len() - 1];
+            return shlex::split(&parts[0]);
         }
     }
 
-    shlex::split(command)
+    Some(parts)
 }
 
 pub(super) fn piped(program: &str, args: impl IntoIterator<Item = String>) -> process::Command {
@@ -227,5 +228,10 @@ mod tests {
     #[test]
     fn split_strips_outer_quotes_before_parsing() {
         assert_eq!(split("\"tr a-z A-Z\""), Some(vec!["tr".into(), "a-z".into(), "A-Z".into()]));
+    }
+
+    #[test]
+    fn split_preserves_normal_shell_quoted_arguments() {
+        assert_eq!(split("'tr' 'a-z' 'A-Z'"), Some(vec!["tr".into(), "a-z".into(), "A-Z".into()]));
     }
 }

--- a/compiler-bin/src/lsp/command.rs
+++ b/compiler-bin/src/lsp/command.rs
@@ -1,7 +1,6 @@
-use std::io;
 use std::process::{self, Child, Output};
-use std::thread;
 use std::time::{Duration, Instant};
+use std::{io, thread};
 
 const CHILD_CLEANUP_TIMEOUT: Duration = Duration::from_secs(1);
 

--- a/compiler-bin/src/lsp/command.rs
+++ b/compiler-bin/src/lsp/command.rs
@@ -115,7 +115,36 @@ fn wait_for_cleanup(child: &mut Child) -> Option<io::Error> {
 
 #[cfg(test)]
 mod tests {
-    use super::split;
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn write_stdin_and_wait_with_output_timeout_capture_output() {
+        let mut child = piped("cat", std::iter::empty::<String>()).spawn().unwrap();
+        write_stdin(&mut child, b"hello").unwrap();
+
+        let output = wait_with_output_timeout(child, Duration::from_secs(1)).unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"hello");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wait_with_output_timeout_cleans_up_timed_out_process() {
+        let child = piped("sh", ["-c".to_string(), "sleep 2".to_string()]).spawn().unwrap();
+
+        let error = wait_with_output_timeout(child, Duration::from_millis(10)).unwrap_err();
+
+        match error {
+            WaitWithOutputTimeoutError::TimedOut(cleanup) => {
+                assert_eq!(cleanup.timeout, Duration::from_millis(10));
+                assert!(cleanup.kill_error.is_none());
+                assert!(cleanup.wait_error.is_none());
+            }
+            other => panic!("expected timeout, got {other:?}"),
+        }
+    }
 
     #[test]
     fn split_handles_shell_quoted_args() {

--- a/compiler-bin/src/lsp/error.rs
+++ b/compiler-bin/src/lsp/error.rs
@@ -27,6 +27,8 @@ pub enum LspError {
     JoinError(#[from] task::JoinError),
     #[error("Utf8Error: {0}")]
     Utf8Error(#[from] str::Utf8Error),
+    #[error("Formatting failed: {0}")]
+    FormattingFailed(String),
     #[error("GlobSetError: {0}")]
     GlobSetError(#[from] globset::Error),
     #[error("async_lsp::Error: {0}")]
@@ -54,7 +56,13 @@ impl LspError {
         if let Some(QueryError::Cancelled) = self.as_query_error() {
             return "Request cancelled";
         }
-        "Request failed"
+
+        // Prefer returning a concrete error message to the client so editors
+        // can show useful feedback (e.g. formatter stderr).
+        match self {
+            LspError::FormattingFailed(message) => message,
+            _ => "Request failed",
+        }
     }
 
     pub fn emit_trace(&self) {

--- a/compiler-bin/src/lsp/error.rs
+++ b/compiler-bin/src/lsp/error.rs
@@ -102,6 +102,13 @@ mod tests {
     }
 
     #[test]
+    fn default_message_is_request_failed() {
+        let error = LspError::MissingRoot;
+
+        assert_eq!(error.message(), "Request failed");
+    }
+
+    #[test]
     fn on_non_fatal_returns_item() {
         let result: Result<u32, AnalyzerError> = Err(AnalyzerError::NonFatal);
 

--- a/compiler-bin/src/lsp/error.rs
+++ b/compiler-bin/src/lsp/error.rs
@@ -57,12 +57,11 @@ impl LspError {
             return "Request cancelled";
         }
 
-        // Prefer returning a concrete error message to the client so editors
-        // can show useful feedback (e.g. formatter stderr).
-        match self {
-            LspError::FormattingFailed(message) => message,
-            _ => "Request failed",
+        if let LspError::FormattingFailed(message) = self {
+            return message;
         }
+        
+        "Request failed"
     }
 
     pub fn emit_trace(&self) {

--- a/compiler-bin/src/lsp/error.rs
+++ b/compiler-bin/src/lsp/error.rs
@@ -87,3 +87,16 @@ impl<T> AnalyzerResultExt<T> for Result<T, AnalyzerError> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formatting_failed_message_is_forwarded() {
+        let error = LspError::FormattingFailed("formatter failed".to_string());
+
+        assert_eq!(error.message(), "formatter failed");
+        assert_eq!(error.code(), ErrorCode::REQUEST_FAILED);
+    }
+}

--- a/compiler-bin/src/lsp/error.rs
+++ b/compiler-bin/src/lsp/error.rs
@@ -91,6 +91,7 @@ impl<T> AnalyzerResultExt<T> for Result<T, AnalyzerError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use analyzer::AnalyzerError;
 
     #[test]
     fn formatting_failed_message_is_forwarded() {
@@ -98,5 +99,12 @@ mod tests {
 
         assert_eq!(error.message(), "formatter failed");
         assert_eq!(error.code(), ErrorCode::REQUEST_FAILED);
+    }
+
+    #[test]
+    fn on_non_fatal_returns_item() {
+        let result: Result<u32, AnalyzerError> = Err(AnalyzerError::NonFatal);
+
+        assert_eq!(result.on_non_fatal(7).unwrap(), 7);
     }
 }

--- a/compiler-bin/src/lsp/error.rs
+++ b/compiler-bin/src/lsp/error.rs
@@ -60,7 +60,7 @@ impl LspError {
         if let LspError::FormattingFailed(message) = self {
             return message;
         }
-        
+
         "Request failed"
     }
 

--- a/compiler-bin/src/lsp/formatting.rs
+++ b/compiler-bin/src/lsp/formatting.rs
@@ -247,9 +247,8 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn run_reports_exit_output() {
-        let error =
-            run("sh -c 'cat >/dev/null; printf err >&2; printf out; exit 7'", b"input")
-                .unwrap_err();
+        let error = run("sh -c 'cat >/dev/null; printf err >&2; printf out; exit 7'", b"input")
+            .unwrap_err();
 
         assert_eq!(error.to_string(), "formatter exited with exit status: 7: err\nout");
     }

--- a/compiler-bin/src/lsp/formatting.rs
+++ b/compiler-bin/src/lsp/formatting.rs
@@ -6,6 +6,14 @@ use super::command;
 const FORMATTER_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub fn run(format_command: &str, input: &[u8]) -> Result<Vec<u8>, FormattingError> {
+    run_with_timeout(format_command, input, FORMATTER_TIMEOUT)
+}
+
+fn run_with_timeout(
+    format_command: &str,
+    input: &[u8],
+    timeout: Duration,
+) -> Result<Vec<u8>, FormattingError> {
     let parts = command::split(format_command)
         .ok_or_else(|| FormattingError::parse(format_command.to_string()))?;
     let mut parts = parts.into_iter();
@@ -19,28 +27,26 @@ pub fn run(format_command: &str, input: &[u8]) -> Result<Vec<u8>, FormattingErro
         .map_err(|source| FormattingError { kind: FormattingErrorKind::WriteStdin { source } })?;
 
     let output =
-        command::wait_with_output_timeout(child, FORMATTER_TIMEOUT).map_err(
-            |error| match error {
-                command::WaitWithOutputTimeoutError::Wait(source) => FormattingError {
-                    kind: FormattingErrorKind::Wait { command: format_command.to_string(), source },
-                },
-                command::WaitWithOutputTimeoutError::TimedOut(cleanup) => FormattingError {
-                    kind: FormattingErrorKind::TimedOut {
-                        command: format_command.to_string(),
-                        input_len: input.len(),
-                        cleanup,
-                    },
-                },
-                command::WaitWithOutputTimeoutError::Poll { source, cleanup } => FormattingError {
-                    kind: FormattingErrorKind::Poll {
-                        command: format_command.to_string(),
-                        input_len: input.len(),
-                        source,
-                        cleanup,
-                    },
+        command::wait_with_output_timeout(child, timeout).map_err(|error| match error {
+            command::WaitWithOutputTimeoutError::Wait(source) => FormattingError {
+                kind: FormattingErrorKind::Wait { command: format_command.to_string(), source },
+            },
+            command::WaitWithOutputTimeoutError::TimedOut(cleanup) => FormattingError {
+                kind: FormattingErrorKind::TimedOut {
+                    command: format_command.to_string(),
+                    input_len: input.len(),
+                    cleanup,
                 },
             },
-        )?;
+            command::WaitWithOutputTimeoutError::Poll { source, cleanup } => FormattingError {
+                kind: FormattingErrorKind::Poll {
+                    command: format_command.to_string(),
+                    input_len: input.len(),
+                    source,
+                    cleanup,
+                },
+            },
+        })?;
 
     if !output.status.success() {
         return Err(FormattingError {
@@ -231,6 +237,27 @@ mod tests {
         assert_eq!(error.to_string(), "formatter exited with exit status: 7: err\nout");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn run_reports_stdin_write_failure() {
+        let input = vec![b'x'; 1_000_000];
+        let error = run("sh -c 'exec 0<&-; sleep 1'", &input).unwrap_err();
+
+        assert!(error.to_string().starts_with("failed writing to formatter stdin:"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_reports_timeout() {
+        let error =
+            run_with_timeout("sh -c 'sleep 1'", b"", Duration::from_millis(10)).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "formatter timed out after 10ms (input 0 bytes): sh -c 'sleep 1'"
+        );
+    }
+
     #[test]
     fn timed_out_error_includes_cleanup_failures() {
         let error = FormattingError {
@@ -284,5 +311,56 @@ mod tests {
         };
 
         assert_eq!(error.to_string(), "formatter exited with exit status: 1: <no output>");
+    }
+
+    #[test]
+    fn write_stdin_error_formats_message() {
+        let error = FormattingError {
+            kind: FormattingErrorKind::WriteStdin { source: io::Error::other("broken pipe") },
+        };
+
+        assert_eq!(error.to_string(), "failed writing to formatter stdin: broken pipe");
+    }
+
+    #[test]
+    fn wait_error_formats_message() {
+        let error = FormattingError {
+            kind: FormattingErrorKind::Wait {
+                command: "formatter".to_string(),
+                source: io::Error::other("wait failed"),
+            },
+        };
+
+        assert_eq!(error.to_string(), "failed to wait for formatter 'formatter': wait failed");
+    }
+
+    #[test]
+    fn timed_out_error_without_cleanup_failures_stays_compact() {
+        let error = FormattingError {
+            kind: FormattingErrorKind::TimedOut {
+                command: "formatter".to_string(),
+                input_len: 3,
+                cleanup: command::ChildCleanup {
+                    timeout: Duration::from_secs(10),
+                    kill_error: None,
+                    wait_error: None,
+                },
+            },
+        };
+
+        assert_eq!(error.to_string(), "formatter timed out after 10s (input 3 bytes): formatter");
+    }
+
+    #[test]
+    fn exited_error_with_stdout_only_omits_newline() {
+        let error = FormattingError {
+            kind: FormattingErrorKind::Exited {
+                status: std::process::Command::new("sh").args(["-c", "exit 1"]).status().unwrap(),
+                stderr: vec![],
+                stdout: b"out\n".to_vec(),
+            },
+        };
+
+        assert_eq!(error.to_string(), "formatter exited with exit status: 1: out");
     }
 }

--- a/compiler-bin/src/lsp/formatting.rs
+++ b/compiler-bin/src/lsp/formatting.rs
@@ -23,8 +23,10 @@ fn run_with_timeout(
         kind: FormattingErrorKind::Spawn { command: format_command.to_string(), source },
     })?;
 
-    command::write_stdin(&mut child, input)
-        .map_err(|source| FormattingError { kind: FormattingErrorKind::WriteStdin { source } })?;
+    command::write_stdin(&mut child, input).map_err(|source| {
+        cleanup_write_failure_child(&mut child);
+        FormattingError { kind: FormattingErrorKind::WriteStdin { source } }
+    })?;
 
     let output = command::wait_with_output_timeout(child, timeout)
         .map_err(|error| map_wait_with_output_error(format_command, input.len(), error))?;
@@ -40,6 +42,11 @@ fn run_with_timeout(
     }
 
     Ok(output.stdout)
+}
+
+fn cleanup_write_failure_child(child: &mut std::process::Child) {
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 fn map_wait_with_output_error(

--- a/compiler-bin/src/lsp/formatting.rs
+++ b/compiler-bin/src/lsp/formatting.rs
@@ -1,0 +1,191 @@
+use std::fmt;
+use std::time::Duration;
+
+use super::command;
+
+const FORMATTER_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub fn run(format_command: &str, input: &[u8]) -> Result<Vec<u8>, FormattingError> {
+    let parts = command::split(format_command)
+        .ok_or_else(|| FormattingError::parse(format_command.to_string()))?;
+    let mut parts = parts.into_iter();
+    let program = parts.next().ok_or_else(FormattingError::empty_command)?;
+
+    let mut child = command::piped(&program, parts).spawn().map_err(|source| FormattingError {
+        kind: FormattingErrorKind::Spawn { command: format_command.to_string(), source },
+    })?;
+
+    command::write_stdin(&mut child, input)
+        .map_err(|source| FormattingError { kind: FormattingErrorKind::WriteStdin { source } })?;
+
+    let output =
+        command::wait_with_output_timeout(child, FORMATTER_TIMEOUT).map_err(
+            |error| match error {
+                command::WaitWithOutputTimeoutError::Wait(source) => FormattingError {
+                    kind: FormattingErrorKind::Wait { command: format_command.to_string(), source },
+                },
+                command::WaitWithOutputTimeoutError::TimedOut(cleanup) => FormattingError {
+                    kind: FormattingErrorKind::TimedOut {
+                        command: format_command.to_string(),
+                        input_len: input.len(),
+                        cleanup,
+                    },
+                },
+                command::WaitWithOutputTimeoutError::Poll { source, cleanup } => FormattingError {
+                    kind: FormattingErrorKind::Poll {
+                        command: format_command.to_string(),
+                        input_len: input.len(),
+                        source,
+                        cleanup,
+                    },
+                },
+            },
+        )?;
+
+    if !output.status.success() {
+        return Err(FormattingError {
+            kind: FormattingErrorKind::Exited {
+                status: output.status,
+                stderr: output.stderr,
+                stdout: output.stdout,
+            },
+        });
+    }
+
+    Ok(output.stdout)
+}
+
+#[derive(Debug)]
+pub struct FormattingError {
+    kind: FormattingErrorKind,
+}
+
+impl FormattingError {
+    fn parse(command: String) -> FormattingError {
+        FormattingError { kind: FormattingErrorKind::Parse { command } }
+    }
+
+    fn empty_command() -> FormattingError {
+        FormattingError { kind: FormattingErrorKind::EmptyCommand }
+    }
+}
+
+#[derive(Debug)]
+enum FormattingErrorKind {
+    Parse {
+        command: String,
+    },
+    EmptyCommand,
+    Spawn {
+        command: String,
+        source: std::io::Error,
+    },
+    WriteStdin {
+        source: std::io::Error,
+    },
+    Wait {
+        command: String,
+        source: std::io::Error,
+    },
+    TimedOut {
+        command: String,
+        input_len: usize,
+        cleanup: command::ChildCleanup,
+    },
+    Poll {
+        command: String,
+        input_len: usize,
+        source: std::io::Error,
+        cleanup: command::ChildCleanup,
+    },
+    Exited {
+        status: std::process::ExitStatus,
+        stderr: Vec<u8>,
+        stdout: Vec<u8>,
+    },
+}
+
+impl fmt::Display for FormattingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            FormattingErrorKind::Parse { command } => {
+                write!(f, "failed to parse --format-command: {command}")
+            }
+            FormattingErrorKind::EmptyCommand => write!(f, "--format-command is empty"),
+            FormattingErrorKind::Spawn { command, source } => {
+                write!(f, "failed to spawn formatter '{command}': {source}")
+            }
+            FormattingErrorKind::WriteStdin { source } => {
+                write!(f, "failed writing to formatter stdin: {source}")
+            }
+            FormattingErrorKind::Wait { command, source } => {
+                write!(f, "failed to wait for formatter '{command}': {source}")
+            }
+            FormattingErrorKind::TimedOut { command, input_len, cleanup } => {
+                write!(
+                    f,
+                    "{}",
+                    format_cleanup(
+                        &format!(
+                            "formatter timed out after {:?} (input {} bytes): {command}",
+                            cleanup.timeout, input_len
+                        ),
+                        cleanup,
+                    )
+                )
+            }
+            FormattingErrorKind::Poll { command, input_len, source, cleanup } => {
+                write!(
+                    f,
+                    "{}",
+                    format_cleanup(
+                        &format!(
+                            "failed waiting for formatter '{command}' (input {} bytes): {source}",
+                            input_len
+                        ),
+                        cleanup,
+                    )
+                )
+            }
+            FormattingErrorKind::Exited { status, stderr, stdout } => {
+                write!(f, "formatter exited with {status}: {}", format_output(stderr, stdout))
+            }
+        }
+    }
+}
+
+impl std::error::Error for FormattingError {}
+
+fn format_cleanup(message: &str, cleanup: &command::ChildCleanup) -> String {
+    let mut message = message.to_string();
+    if let Some(error) = &cleanup.kill_error {
+        message.push_str(&format!("; kill failed: {error}"));
+    }
+    if let Some(error) = &cleanup.wait_error {
+        message.push_str(&format!("; wait failed: {error}"));
+    }
+    message
+}
+
+fn format_output(stderr: &[u8], stdout: &[u8]) -> String {
+    let stderr = String::from_utf8_lossy(stderr);
+    let stdout = String::from_utf8_lossy(stdout);
+
+    let stderr = stderr.trim();
+    let stdout = stdout.trim();
+
+    let mut details = String::new();
+    if !stderr.is_empty() {
+        details.push_str(stderr);
+    }
+    if !stdout.is_empty() {
+        if !details.is_empty() {
+            details.push('\n');
+        }
+        details.push_str(stdout);
+    }
+    if details.is_empty() {
+        details.push_str("<no output>");
+    }
+    details
+}

--- a/compiler-bin/src/lsp/formatting.rs
+++ b/compiler-bin/src/lsp/formatting.rs
@@ -26,27 +26,8 @@ fn run_with_timeout(
     command::write_stdin(&mut child, input)
         .map_err(|source| FormattingError { kind: FormattingErrorKind::WriteStdin { source } })?;
 
-    let output =
-        command::wait_with_output_timeout(child, timeout).map_err(|error| match error {
-            command::WaitWithOutputTimeoutError::Wait(source) => FormattingError {
-                kind: FormattingErrorKind::Wait { command: format_command.to_string(), source },
-            },
-            command::WaitWithOutputTimeoutError::TimedOut(cleanup) => FormattingError {
-                kind: FormattingErrorKind::TimedOut {
-                    command: format_command.to_string(),
-                    input_len: input.len(),
-                    cleanup,
-                },
-            },
-            command::WaitWithOutputTimeoutError::Poll { source, cleanup } => FormattingError {
-                kind: FormattingErrorKind::Poll {
-                    command: format_command.to_string(),
-                    input_len: input.len(),
-                    source,
-                    cleanup,
-                },
-            },
-        })?;
+    let output = command::wait_with_output_timeout(child, timeout)
+        .map_err(|error| map_wait_with_output_error(format_command, input.len(), error))?;
 
     if !output.status.success() {
         return Err(FormattingError {
@@ -59,6 +40,33 @@ fn run_with_timeout(
     }
 
     Ok(output.stdout)
+}
+
+fn map_wait_with_output_error(
+    format_command: &str,
+    input_len: usize,
+    error: command::WaitWithOutputTimeoutError,
+) -> FormattingError {
+    match error {
+        command::WaitWithOutputTimeoutError::Wait(source) => FormattingError {
+            kind: FormattingErrorKind::Wait { command: format_command.to_string(), source },
+        },
+        command::WaitWithOutputTimeoutError::TimedOut(cleanup) => FormattingError {
+            kind: FormattingErrorKind::TimedOut {
+                command: format_command.to_string(),
+                input_len,
+                cleanup,
+            },
+        },
+        command::WaitWithOutputTimeoutError::Poll { source, cleanup } => FormattingError {
+            kind: FormattingErrorKind::Poll {
+                command: format_command.to_string(),
+                input_len,
+                source,
+                cleanup,
+            },
+        },
+    }
 }
 
 #[derive(Debug)]
@@ -255,6 +263,38 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "formatter timed out after 10ms (input 0 bytes): sh -c 'sleep 1'"
+        );
+    }
+
+    #[test]
+    fn map_wait_with_output_error_formats_wait_error() {
+        let error = map_wait_with_output_error(
+            "formatter",
+            3,
+            command::WaitWithOutputTimeoutError::Wait(io::Error::other("wait failed")),
+        );
+
+        assert_eq!(error.to_string(), "failed to wait for formatter 'formatter': wait failed");
+    }
+
+    #[test]
+    fn map_wait_with_output_error_formats_poll_error() {
+        let error = map_wait_with_output_error(
+            "formatter",
+            3,
+            command::WaitWithOutputTimeoutError::Poll {
+                source: io::Error::other("poll failed"),
+                cleanup: command::ChildCleanup {
+                    timeout: Duration::from_secs(10),
+                    kill_error: None,
+                    wait_error: None,
+                },
+            },
+        );
+
+        assert_eq!(
+            error.to_string(),
+            "failed waiting for formatter 'formatter' (input 3 bytes): poll failed"
         );
     }
 

--- a/compiler-bin/src/lsp/formatting.rs
+++ b/compiler-bin/src/lsp/formatting.rs
@@ -189,3 +189,100 @@ fn format_output(stderr: &[u8], stdout: &[u8]) -> String {
     }
     details
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[cfg(unix)]
+    #[test]
+    fn run_reports_parse_failure() {
+        let error = run("\"", b"input").unwrap_err();
+
+        assert_eq!(error.to_string(), "failed to parse --format-command: \"");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_reports_empty_command() {
+        let error = run("\"\"", b"input").unwrap_err();
+
+        assert_eq!(error.to_string(), "--format-command is empty");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_reports_spawn_failure() {
+        let error = run("command-that-does-not-exist", b"input").unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .starts_with("failed to spawn formatter 'command-that-does-not-exist':")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_reports_exit_output() {
+        let error = run("sh -c 'printf err >&2; printf out; exit 7'", b"input").unwrap_err();
+
+        assert_eq!(error.to_string(), "formatter exited with exit status: 7: err\nout");
+    }
+
+    #[test]
+    fn timed_out_error_includes_cleanup_failures() {
+        let error = FormattingError {
+            kind: FormattingErrorKind::TimedOut {
+                command: "formatter".to_string(),
+                input_len: 3,
+                cleanup: command::ChildCleanup {
+                    timeout: Duration::from_secs(10),
+                    kill_error: Some(io::Error::other("kill failed")),
+                    wait_error: Some(io::Error::other("wait failed")),
+                },
+            },
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "formatter timed out after 10s (input 3 bytes): formatter; kill failed: kill failed; wait failed: wait failed"
+        );
+    }
+
+    #[test]
+    fn poll_error_includes_cleanup_failures() {
+        let error = FormattingError {
+            kind: FormattingErrorKind::Poll {
+                command: "formatter".to_string(),
+                input_len: 3,
+                source: io::Error::other("poll failed"),
+                cleanup: command::ChildCleanup {
+                    timeout: Duration::from_secs(10),
+                    kill_error: Some(io::Error::other("kill failed")),
+                    wait_error: Some(io::Error::other("wait failed")),
+                },
+            },
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "failed waiting for formatter 'formatter' (input 3 bytes): poll failed; kill failed: kill failed; wait failed: wait failed"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exited_error_without_output_reports_placeholder() {
+        let error = FormattingError {
+            kind: FormattingErrorKind::Exited {
+                status: std::process::Command::new("sh").args(["-c", "exit 1"]).status().unwrap(),
+                stderr: vec![],
+                stdout: vec![],
+            },
+        };
+
+        assert_eq!(error.to_string(), "formatter exited with exit status: 1: <no output>");
+    }
+}

--- a/compiler-bin/src/lsp/formatting.rs
+++ b/compiler-bin/src/lsp/formatting.rs
@@ -247,7 +247,9 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn run_reports_exit_output() {
-        let error = run("sh -c 'printf err >&2; printf out; exit 7'", b"input").unwrap_err();
+        let error =
+            run("sh -c 'cat >/dev/null; printf err >&2; printf out; exit 7'", b"input")
+                .unwrap_err();
 
         assert_eq!(error.to_string(), "formatter exited with exit status: 7: err\nout");
     }

--- a/justfile
+++ b/justfile
@@ -7,6 +7,7 @@ set positional-arguments
 coverage:
   cargo llvm-cov clean --workspace
   cargo llvm-cov nextest --no-report
+  cargo llvm-cov nextest --no-report -p purescript-analyzer
   cargo llvm-cov nextest --no-report -p tests-integration
 
 [doc("Generate coverage with the package set")]

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -25,6 +25,7 @@ url = "2.5.7"
 
 [dev-dependencies]
 datatest-stable = "0.3"
+purescript-analyzer = { version = "0.0.12", path = "../compiler-bin" }
 serde_json = "1.0"
 
 [[test]]

--- a/tests-integration/tests/formatting.rs
+++ b/tests-integration/tests/formatting.rs
@@ -1,0 +1,34 @@
+#[cfg(unix)]
+mod tests {
+    use purescript_analyzer::lsp::formatting;
+
+    const INPUT: &[u8] = b"module Main where\nfoo = bar\n";
+
+    #[test]
+    fn returns_full_document_text() {
+        let formatted = formatting::run("tr a-z A-Z", INPUT).unwrap();
+
+        assert_eq!(formatted, b"MODULE MAIN WHERE\nFOO = BAR\n");
+    }
+
+    #[test]
+    fn returns_identical_text_for_noop_formatter() {
+        let formatted = formatting::run("cat", INPUT).unwrap();
+
+        assert_eq!(formatted, INPUT);
+    }
+
+    #[test]
+    fn parses_quoted_args() {
+        let formatted = formatting::run("tr 'a-z' 'A-Z'", INPUT).unwrap();
+
+        assert_eq!(formatted, b"MODULE MAIN WHERE\nFOO = BAR\n");
+    }
+
+    #[test]
+    fn tolerates_outer_quoted_command_string() {
+        let formatted = formatting::run("\"tr a-z A-Z\"", INPUT).unwrap();
+
+        assert_eq!(formatted, b"MODULE MAIN WHERE\nFOO = BAR\n");
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds opt-in LSP document formatting support to `purescript-analyzer`.

- Implements `textDocument/formatting` by running an external formatter command over stdin/stdout.
- Advertises `documentFormattingProvider` only when `--format-command` is provided.
- Parses `--format-command` using shell-style quoting (and tolerates an extra outer quoted string) to make editor configuration reliable.

## User-Facing Behavior
- By default, formatting is disabled and the server does not advertise formatting capability.
- When started with `--format-command <cmd...>`, the server will respond to `textDocument/formatting` requests.

## Configuration
Examples:

```sh
purescript-analyzer --format-command "purs-tidy format"
```

Quoted args are supported, for example:

```sh
purescript-analyzer --format-command "/usr/bin/tr 'a-z' 'A-Z'"
```

If your editor passes an extra layer of quoting (for example `"purs-tidy format"` as a single string), the server tolerates it.

## Implementation Notes
- The handler returns a single full-document `TextEdit` when the formatter output differs.
- If formatter output is byte-for-byte identical to the input, the handler returns an empty edit list.
- Formatter failures are returned as LSP request failures with details.

## Testing
- `cargo test -p purescript-analyzer --tests`

Covered scenarios:
- Capability advertised only when configured.
- Full-document edit behavior.
- No-op formatting returns no edits.
- Quoted argument parsing and outer-quote tolerance.
