### PR TITLE
[lsp] Exclude annotations from record pun highlights

### DIFF
--- a/compiler-lsp/analyzer/src/definition.rs
+++ b/compiler-lsp/analyzer/src/definition.rs
@@ -10,9 +10,8 @@ use lowering::{
 use lsp_types::*;
 use smol_str::ToSmolStr;
 use syntax::ast::{AstNode, AstPtr};
-use syntax::{SyntaxNode, SyntaxNodePtr, cst};
+use syntax::cst;
 
-use crate::extract::AnnotationSyntaxRange;
 use crate::position::Utf8Range;
 use crate::{AnalyzerContext, AnalyzerError, common, locate, position};
 
@@ -277,7 +276,7 @@ fn definition_expression(
                 TermVariableResolution::RecordPun(id) => {
                     let root = parsed.syntax_node();
                     let ptr = stabilized.syntax_ptr(*id).ok_or(AnalyzerError::NonFatal)?;
-                    let range = record_pun_name_range(&content, &root, &ptr)
+                    let range = position::record_pun_name_range(&content, &root, &ptr)
                         .ok_or(AnalyzerError::NonFatal)?;
                     let range = position::utf8_range_to_protocol(
                         &content,
@@ -298,21 +297,6 @@ fn definition_expression(
         }
         _ => Ok(None),
     }
-}
-
-fn record_pun_name_range(
-    content: &str,
-    root: &SyntaxNode,
-    ptr: &SyntaxNodePtr,
-) -> Option<Utf8Range> {
-    let node = ptr.try_to_node(root)?;
-    let pun = cst::RecordPun::cast(node)?;
-
-    let name = pun.name()?;
-    let name = name.syntax();
-    let range = AnnotationSyntaxRange::from_node(name).syntax?;
-
-    position::text_range_to_utf8_range(content, range)
 }
 
 fn definition_type(

--- a/compiler-lsp/analyzer/src/document_highlight.rs
+++ b/compiler-lsp/analyzer/src/document_highlight.rs
@@ -15,6 +15,7 @@ use stabilizing::AstId;
 use syntax::ast::AstNode;
 use syntax::{SyntaxNode, SyntaxNodePtr, cst};
 
+use crate::extract::AnnotationSyntaxRange;
 use crate::position::{PositionEncoding, Utf8Range};
 use crate::{AnalyzerContext, AnalyzerError, locate, position};
 
@@ -223,9 +224,11 @@ fn highlight_binder(
         } = expr_kind
             && *id == binder_id
         {
-            highlights.extend(locate::id_range(&content, &parsed, &stabilized, expr_id).and_then(
-                |range| document_highlight(&content, context.position_encoding(), range),
-            ));
+            highlights.extend(
+                highlight_id_range(&content, &parsed, &stabilized, expr_id).and_then(|range| {
+                    document_highlight(&content, context.position_encoding(), range)
+                }),
+            );
         }
     }
 
@@ -233,7 +236,7 @@ fn highlight_binder(
         if let TermVariableResolution::Binder(id) = resolution
             && id == binder_id
         {
-            highlights.extend(locate::id_range(&content, &parsed, &stabilized, pun_id).and_then(
+            highlights.extend(highlight_id_range(&content, &parsed, &stabilized, pun_id).and_then(
                 |range| document_highlight(&content, context.position_encoding(), range),
             ));
         }
@@ -316,9 +319,9 @@ fn highlight_file_term(
             && (*f_id, *t_id) == (file_id, term_id)
         {
             highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, expression_id).and_then(|range| {
-                    document_highlight(&content, context.position_encoding(), range)
-                }),
+                highlight_id_range(&content, &parsed, &stabilized, expression_id).and_then(
+                    |range| document_highlight(&content, context.position_encoding(), range),
+                ),
             );
         }
     }
@@ -328,7 +331,7 @@ fn highlight_file_term(
             && (*f_id, *t_id) == (file_id, term_id)
         {
             highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, binder_id).and_then(|range| {
+                highlight_id_range(&content, &parsed, &stabilized, binder_id).and_then(|range| {
                     document_highlight(&content, context.position_encoding(), range)
                 }),
             );
@@ -338,7 +341,7 @@ fn highlight_file_term(
     for (operator_id, f_id, t_id) in lowered.tree.iter_term_operator() {
         if (f_id, t_id) == (file_id, term_id) {
             highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, operator_id).and_then(|range| {
+                highlight_id_range(&content, &parsed, &stabilized, operator_id).and_then(|range| {
                     document_highlight(&content, context.position_encoding(), range)
                 }),
             );
@@ -349,7 +352,7 @@ fn highlight_file_term(
         if let TermVariableResolution::Reference(f_id, t_id) = resolution
             && (f_id, t_id) == (file_id, term_id)
         {
-            highlights.extend(locate::id_range(&content, &parsed, &stabilized, pun_id).and_then(
+            highlights.extend(highlight_id_range(&content, &parsed, &stabilized, pun_id).and_then(
                 |range| document_highlight(&content, context.position_encoding(), range),
             ));
         }
@@ -406,7 +409,7 @@ fn highlight_file_type(
         | TypeKind::Operator { resolution: Some((f_id, t_id)) } = ty_kind
             && (*f_id, *t_id) == (file_id, type_id)
         {
-            highlights.extend(locate::id_range(&content, &parsed, &stabilized, ty_id).and_then(
+            highlights.extend(highlight_id_range(&content, &parsed, &stabilized, ty_id).and_then(
                 |range| document_highlight(&content, context.position_encoding(), range),
             ));
         }
@@ -415,7 +418,7 @@ fn highlight_file_type(
     for (operator_id, f_id, t_id) in lowered.tree.iter_type_operator() {
         if (f_id, t_id) == (file_id, type_id) {
             highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, operator_id).and_then(|range| {
+                highlight_id_range(&content, &parsed, &stabilized, operator_id).and_then(|range| {
                     document_highlight(&content, context.position_encoding(), range)
                 }),
             );
@@ -522,9 +525,11 @@ fn highlight_let(
         } = expr_kind
             && *id == let_binding_id
         {
-            highlights.extend(locate::id_range(&content, &parsed, &stabilized, expr_id).and_then(
-                |range| document_highlight(&content, context.position_encoding(), range),
-            ));
+            highlights.extend(
+                highlight_id_range(&content, &parsed, &stabilized, expr_id).and_then(|range| {
+                    document_highlight(&content, context.position_encoding(), range)
+                }),
+            );
         }
     }
 
@@ -532,7 +537,7 @@ fn highlight_let(
         if let TermVariableResolution::Let(id) = resolution
             && id == let_binding_id
         {
-            highlights.extend(locate::id_range(&content, &parsed, &stabilized, pun_id).and_then(
+            highlights.extend(highlight_id_range(&content, &parsed, &stabilized, pun_id).and_then(
                 |range| document_highlight(&content, context.position_encoding(), range),
             ));
         }
@@ -554,7 +559,7 @@ fn highlight_binder_pun(
     let mut highlights = vec![];
 
     highlights.extend(
-        locate::id_range(&content, &parsed, &stabilized, pun_id)
+        highlight_id_range(&content, &parsed, &stabilized, pun_id)
             .and_then(|range| document_highlight(&content, context.position_encoding(), range)),
     );
 
@@ -565,9 +570,9 @@ fn highlight_binder_pun(
             && *candidate_id == pun_id
         {
             highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, expression_id).and_then(|range| {
-                    document_highlight(&content, context.position_encoding(), range)
-                }),
+                highlight_id_range(&content, &parsed, &stabilized, expression_id).and_then(
+                    |range| document_highlight(&content, context.position_encoding(), range),
+                ),
             );
         }
     }
@@ -577,7 +582,7 @@ fn highlight_binder_pun(
             && candidate_id == pun_id
         {
             highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, expression_pun_id).and_then(
+                highlight_id_range(&content, &parsed, &stabilized, expression_pun_id).and_then(
                     |range| document_highlight(&content, context.position_encoding(), range),
                 ),
             );
@@ -770,6 +775,53 @@ where
     }));
 
     Ok(())
+}
+
+trait DocumentHighlightRange: AstNode {
+    fn annotation_syntax_range(&self) -> AnnotationSyntaxRange;
+}
+
+macro_rules! impl_document_highlight_range {
+    ($($target:ty),+ $(,)?) => {
+        $(
+            impl DocumentHighlightRange for $target {
+                fn annotation_syntax_range(&self) -> AnnotationSyntaxRange {
+                    AnnotationSyntaxRange::from_node(self.syntax())
+                }
+            }
+        )+
+    };
+}
+
+impl_document_highlight_range!(
+    cst::Binder,
+    cst::Expression,
+    cst::TermOperator,
+    cst::Type,
+    cst::TypeOperator,
+);
+
+impl DocumentHighlightRange for cst::RecordPun {
+    fn annotation_syntax_range(&self) -> AnnotationSyntaxRange {
+        self.name().map(|name| AnnotationSyntaxRange::from_node(name.syntax())).unwrap_or_default()
+    }
+}
+
+fn highlight_id_range<T>(
+    content: &str,
+    parsed: &parsing::ParsedModule,
+    stabilized: &stabilizing::StabilizedModule,
+    item_id: AstId<T>,
+) -> Option<Utf8Range>
+where
+    T: DocumentHighlightRange,
+{
+    let root = parsed.syntax_node();
+    let ptr = stabilized.syntax_ptr(item_id)?;
+    let node = ptr.try_to_node(&root)?;
+    let target = T::cast(node)?;
+    let range = target.annotation_syntax_range().syntax?;
+    position::text_range_to_utf8_range(content, range)
 }
 
 fn document_highlight(

--- a/compiler-lsp/analyzer/src/position.rs
+++ b/compiler-lsp/analyzer/src/position.rs
@@ -267,6 +267,17 @@ pub fn instance_declaration_name_range(
     text_range_to_utf8_range(content, token.text_range())
 }
 
+pub fn record_pun_name_range(
+    content: &str,
+    root: &SyntaxNode,
+    ptr: &SyntaxNodePtr,
+) -> Option<Utf8Range> {
+    let node = ptr.try_to_node(root)?;
+    let pun = cst::RecordPun::cast(node)?;
+    let token = pun.name()?.text()?;
+    text_range_to_utf8_range(content, token.text_range())
+}
+
 pub fn infix_operator_range(
     content: &str,
     root: &SyntaxNode,

--- a/tests-integration/fixtures/lsp/1778600820_document_highlight_record_pun/Main.snap
+++ b/tests-integration/fixtures/lsp/1778600820_document_highlight_record_pun/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 101
+assertion_line: 134
 expression: report
 ---
 DocumentHighlight at Position { line: 2, character: 9 }
@@ -10,8 +10,8 @@ binder { bar } = { bar }
 --       &         &
 ```
 
-2:8..2:12
-2:18..2:22
+2:9..2:12
+2:19..2:22
 
 
 DocumentHighlight at Position { line: 2, character: 19 }
@@ -21,8 +21,8 @@ binder { bar } = { bar }
 --       &         &
 ```
 
-2:8..2:12
-2:18..2:22
+2:9..2:12
+2:19..2:22
 
 
 DocumentHighlight at Position { line: 7, character: 11 }
@@ -33,4 +33,4 @@ record = { value }
 ```
 
 5:0..5:5
-7:10..7:16
+7:11..7:16

--- a/tests-integration/fixtures/lsp/1780512780_document_highlight_uncovered_cases/Main.snap
+++ b/tests-integration/fixtures/lsp/1780512780_document_highlight_uncovered_cases/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 101
+assertion_line: 134
 expression: report
 ---
 DocumentHighlight at Position { line: 6, character: 16 }
@@ -21,7 +21,7 @@ binderPun = \binder -> { binder }
 ```
 
 9:13..9:19
-9:24..9:31
+9:25..9:31
 
 
 DocumentHighlight at Position { line: 12, character: 30 }
@@ -32,7 +32,7 @@ letPun = let local = Box in { local }
 ```
 
 12:13..12:18
-12:29..12:35
+12:30..12:35
 
 
 DocumentHighlight at Position { line: 15, character: 21 }
@@ -42,7 +42,7 @@ recordPunReference { field } = field
 --                   &         &
 ```
 
-15:20..15:26
+15:21..15:26
 15:31..15:36
 
 
@@ -53,7 +53,7 @@ recordPunReference { field } = field
 --                   &         &
 ```
 
-15:20..15:26
+15:21..15:26
 15:31..15:36
 
 

--- a/tests-integration/fixtures/lsp/1786069320_document_highlight_record_pun_annotations/Main.purs
+++ b/tests-integration/fixtures/lsp/1786069320_document_highlight_record_pun_annotations/Main.purs
@@ -5,3 +5,6 @@ extract { value } = value
 
 extractComment { {- thing -} value } = value
 --                               &         &
+
+wrap value = { {- thing -} value }
+--                         &

--- a/tests-integration/fixtures/lsp/1786069320_document_highlight_record_pun_annotations/Main.purs
+++ b/tests-integration/fixtures/lsp/1786069320_document_highlight_record_pun_annotations/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+extract { value } = value
+--        &         &
+
+extractComment { {- thing -} value } = value
+--                               &         &

--- a/tests-integration/fixtures/lsp/1786069320_document_highlight_record_pun_annotations/Main.snap
+++ b/tests-integration/fixtures/lsp/1786069320_document_highlight_record_pun_annotations/Main.snap
@@ -10,7 +10,7 @@ extract { value } = value
 --        &         &
 ```
 
-2:9..2:15
+2:10..2:15
 2:20..2:25
 
 
@@ -21,7 +21,7 @@ extract { value } = value
 --        &         &
 ```
 
-2:9..2:15
+2:10..2:15
 2:20..2:25
 
 
@@ -32,7 +32,7 @@ extractComment { {- thing -} value } = value
 --                               &         &
 ```
 
-5:16..5:34
+5:29..5:34
 5:39..5:44
 
 
@@ -43,5 +43,16 @@ extractComment { {- thing -} value } = value
 --                               &         &
 ```
 
-5:16..5:34
+5:29..5:34
 5:39..5:44
+
+
+DocumentHighlight at Position { line: 8, character: 27 }
+
+```
+wrap value = { {- thing -} value }
+--                         &
+```
+
+8:5..8:10
+8:27..8:32

--- a/tests-integration/fixtures/lsp/1786069320_document_highlight_record_pun_annotations/Main.snap
+++ b/tests-integration/fixtures/lsp/1786069320_document_highlight_record_pun_annotations/Main.snap
@@ -1,0 +1,47 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+DocumentHighlight at Position { line: 2, character: 10 }
+
+```
+extract { value } = value
+--        &         &
+```
+
+2:9..2:15
+2:20..2:25
+
+
+DocumentHighlight at Position { line: 2, character: 20 }
+
+```
+extract { value } = value
+--        &         &
+```
+
+2:9..2:15
+2:20..2:25
+
+
+DocumentHighlight at Position { line: 5, character: 33 }
+
+```
+extractComment { {- thing -} value } = value
+--                               &         &
+```
+
+5:16..5:34
+5:39..5:44
+
+
+DocumentHighlight at Position { line: 5, character: 43 }
+
+```
+extractComment { {- thing -} value } = value
+--                               &         &
+```
+
+5:16..5:34
+5:39..5:44


### PR DESCRIPTION
## Summary

Document highlights for record puns currently use the entire stabilized record-pun range. Because a record pun's label carries leading annotations, highlighting a pun also highlights preceding whitespace or comments.

Make document-highlight range selection depend on the stabilized AST ID type. Most syntax types retain their existing annotation/syntax range, while record puns select the nested label name range. This applies consistently to binder and expression puns while preserving annotation ranges for features that need them.

The first commit records the incorrect whitespace and comment ranges; the second updates those snapshots to the exact pun name ranges.

## Verification

- `cargo check -p analyzer --tests`
- `just t lsp`