### PR TITLE
[meta] Prepare 0.0.17 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "purescript-alexandrite"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "analyzer",
  "async-lsp",

--- a/compiler-bin/Cargo.toml
+++ b/compiler-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "purescript-alexandrite"
-version = "0.0.16"
+version = "0.0.17"
 edition = "2024"
 authors = ["Justin Garcia <git@purefunctor.me>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

- bump the `purescript-alexandrite` package version to 0.0.17
- update the lockfile package version

## Validation

- `cargo check -p purescript-alexandrite --tests --locked`
- `cargo run -p purescript-alexandrite --locked --bin purescript-alexandrite -- --version` → `purescript-alexandrite 0.0.17`
- `git diff --check`
