### PR TITLE
[lsp] Show kinds for type variable binder hovers

### DIFF
--- a/compiler-lsp/analyzer/src/definition.rs
+++ b/compiler-lsp/analyzer/src/definition.rs
@@ -70,6 +70,7 @@ pub fn implementation(
         locate::Located::BinderPun(_) => Ok(None),
         locate::Located::ExpressionPun(_) => Ok(None),
         locate::Located::RecordAccessLabel(_) => Ok(None),
+        locate::Located::TypeVariableBinding(_) => Ok(None),
         locate::Located::Nothing => Ok(None),
     }
 }

--- a/compiler-lsp/analyzer/src/document_highlight.rs
+++ b/compiler-lsp/analyzer/src/document_highlight.rs
@@ -69,6 +69,7 @@ pub fn implementation(
         locate::Located::ModuleName(_)
         | locate::Located::InstanceMember(_, _)
         | locate::Located::RecordAccessLabel(_)
+        | locate::Located::TypeVariableBinding(_)
         | locate::Located::Nothing => Ok(None),
     }
 }

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -45,6 +45,9 @@ pub fn implementation(
             hover_record_access_label(engine, current_file, label_id)
         }
         locate::Located::Type(type_id) => hover_type(engine, current_file, type_id),
+        locate::Located::TypeVariableBinding(binding_id) => {
+            hover_type_variable_binding(engine, current_file, binding_id)
+        }
         locate::Located::BinderPun(pun_id) => hover_pun(engine, current_file, pun_id),
         locate::Located::ExpressionPun(pun_id) => hover_pun(engine, current_file, pun_id),
         locate::Located::TermOperator(operator_id) => {
@@ -297,6 +300,18 @@ fn hover_type(
             hover_checked_type(engine, current_file, type_kind)
         }
     }
+}
+
+fn hover_type_variable_binding(
+    engine: &impl AnalyzerQueries,
+    current_file: FileId,
+    binding_id: lowering::TypeVariableBindingId,
+) -> Result<Option<Hover>, AnalyzerError> {
+    let checked = engine.checked(current_file)?;
+    let binding_kind = checked.node_types.lookup_forall_binding(binding_id);
+    let binding_kind = binding_kind.ok_or(AnalyzerError::NonFatal)?;
+
+    hover_checked_type(engine, current_file, binding_kind)
 }
 
 fn hover_checked_type(

--- a/compiler-lsp/analyzer/src/locate.rs
+++ b/compiler-lsp/analyzer/src/locate.rs
@@ -6,7 +6,7 @@ use files::FileId;
 use indexing::{ImportItemId, IndexedModule, IndexedTermItemKind, TermItemId, TypeItemId};
 use lowering::{
     BinderId, ExpressionId, LetBindingNameGroupId, LoweredModule, RecordAccessLabelId, RecordPunId,
-    TermItemKind, TermOperatorId, TypeId, TypeOperatorId,
+    TermItemKind, TermOperatorId, TypeId, TypeOperatorId, TypeVariableBindingId,
 };
 use stabilizing::{AstId, StabilizedModule};
 use syntax::ast::{AstNode, AstPtr};
@@ -134,6 +134,7 @@ pub enum Located {
     Expression(ExpressionId),
     RecordAccessLabel(RecordAccessLabelId),
     Type(TypeId),
+    TypeVariableBinding(TypeVariableBindingId),
     BinderPun(RecordPunId),
     ExpressionPun(RecordPunId),
     TermOperator(TermOperatorId),
@@ -215,6 +216,10 @@ fn locate_node(
         let ptr = ptr.cast()?;
         let id = stabilized.lookup_ptr(&ptr)?;
         Some(Located::Expression(id))
+    } else if cst::TypeVariableBinding::can_cast(kind) {
+        let ptr = ptr.cast()?;
+        let id = stabilized.lookup_ptr(&ptr)?;
+        Some(Located::TypeVariableBinding(id))
     } else if cst::Type::can_cast(kind) {
         let ptr = ptr.cast()?;
         let id = stabilized.lookup_ptr(&ptr)?;

--- a/compiler-lsp/analyzer/src/references.rs
+++ b/compiler-lsp/analyzer/src/references.rs
@@ -73,6 +73,7 @@ pub fn implementation(
         }
         locate::Located::InstanceMember(_, _) => Ok(None),
         locate::Located::RecordAccessLabel(_) => Ok(None),
+        locate::Located::TypeVariableBinding(_) => Ok(None),
         locate::Located::Nothing => Ok(None),
     }
 }

--- a/tests-integration/fixtures/lsp/1786252140_hover_data_declaration_type_variable_binder/Main.purs
+++ b/tests-integration/fixtures/lsp/1786252140_hover_data_declaration_type_variable_binder/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+newtype Identity a = Identity a
+--               $
+
+data Proxy :: forall kind. kind -> Type
+data Proxy a = Proxy
+--         $

--- a/tests-integration/fixtures/lsp/1786252140_hover_data_declaration_type_variable_binder/Main.snap
+++ b/tests-integration/fixtures/lsp/1786252140_hover_data_declaration_type_variable_binder/Main.snap
@@ -1,0 +1,27 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Hover at Position { line: 2, character: 17 }
+
+```
+newtype Identity a = Identity a
+--               $
+```
+
+```purescript
+Identity :: Type -> Type
+```
+
+
+Hover at Position { line: 6, character: 11 }
+
+```
+data Proxy a = Proxy
+--         $
+```
+
+```purescript
+Proxy :: forall (kind :: Type). (kind :: Type) -> Type
+```

--- a/tests-integration/fixtures/lsp/1786252140_hover_data_declaration_type_variable_binder/Main.snap
+++ b/tests-integration/fixtures/lsp/1786252140_hover_data_declaration_type_variable_binder/Main.snap
@@ -11,7 +11,7 @@ newtype Identity a = Identity a
 ```
 
 ```purescript
-Identity :: Type -> Type
+Type
 ```
 
 
@@ -23,5 +23,5 @@ data Proxy a = Proxy
 ```
 
 ```purescript
-Proxy :: forall (kind :: Type). (kind :: Type) -> Type
+(kind :: Type)
 ```

--- a/tests-integration/fixtures/lsp/1786252620_hover_type_declaration_variable_binder/Main.purs
+++ b/tests-integration/fixtures/lsp/1786252620_hover_type_declaration_variable_binder/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+type Synonym a = a
+--           $
+
+class Example a
+--            $

--- a/tests-integration/fixtures/lsp/1786252620_hover_type_declaration_variable_binder/Main.snap
+++ b/tests-integration/fixtures/lsp/1786252620_hover_type_declaration_variable_binder/Main.snap
@@ -1,0 +1,27 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Hover at Position { line: 2, character: 13 }
+
+```
+type Synonym a = a
+--           $
+```
+
+```purescript
+Synonym :: forall (t0 :: Type). (t0 :: Type) -> (t0 :: Type)
+```
+
+
+Hover at Position { line: 5, character: 14 }
+
+```
+class Example a
+--            $
+```
+
+```purescript
+Example :: forall (t0 :: Type). (t0 :: Type) -> Constraint
+```

--- a/tests-integration/fixtures/lsp/1786252620_hover_type_declaration_variable_binder/Main.snap
+++ b/tests-integration/fixtures/lsp/1786252620_hover_type_declaration_variable_binder/Main.snap
@@ -11,7 +11,7 @@ type Synonym a = a
 ```
 
 ```purescript
-Synonym :: forall (t0 :: Type). (t0 :: Type) -> (t0 :: Type)
+(t0 :: Type)
 ```
 
 
@@ -23,5 +23,5 @@ class Example a
 ```
 
 ```purescript
-Example :: forall (t0 :: Type). (t0 :: Type) -> Constraint
+(t0 :: Type)
 ```

--- a/tests-integration/fixtures/lsp/1786252620_hover_value_signature_type_variable_binder/Main.purs
+++ b/tests-integration/fixtures/lsp/1786252620_hover_value_signature_type_variable_binder/Main.purs
@@ -1,0 +1,5 @@
+module Main where
+
+apply :: forall (constructor :: Type -> Type). constructor Int -> constructor Int
+--               $
+apply value = value

--- a/tests-integration/fixtures/lsp/1786252620_hover_value_signature_type_variable_binder/Main.snap
+++ b/tests-integration/fixtures/lsp/1786252620_hover_value_signature_type_variable_binder/Main.snap
@@ -11,5 +11,5 @@ apply :: forall (constructor :: Type -> Type). constructor Int -> constructor In
 ```
 
 ```purescript
-Type
+Type -> Type
 ```

--- a/tests-integration/fixtures/lsp/1786252620_hover_value_signature_type_variable_binder/Main.snap
+++ b/tests-integration/fixtures/lsp/1786252620_hover_value_signature_type_variable_binder/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Hover at Position { line: 2, character: 17 }
+
+```
+apply :: forall (constructor :: Type -> Type). constructor Int -> constructor Int
+--               $
+```
+
+```purescript
+Type
+```


### PR DESCRIPTION
## Summary

Type-variable binders in data, newtype, type synonym, and class declarations currently fall through to the enclosing type declaration during hover lookup. This makes the editor show the declaration's complete kind rather than the kind assigned to the binder itself.

Identify `TypeVariableBinding` syntax directly during location lookup and render its checked kind from `forall_bindings`. This also gives explicit `forall` binders in value signatures the same location behavior.

## Examples

- `newtype Identity a = Identity a` reports `Type` for `a`.
- A `Proxy` parameter governed by `forall kind. kind -> Type` reports `(kind :: Type)`.
- `forall (constructor :: Type -> Type)` reports `Type -> Type` for `constructor`.

## Tests

The first commit records the previous enclosing-declaration hover behavior. The implementation commit updates those snapshots to the binder kinds.

- `cargo check -p analyzer --tests`
- `just t lsp`