### PR TITLE
[checking] Represent polymorphic expression abstractions

### DIFF
--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -83,8 +83,12 @@ where
     let mut expressions = mem::take(&mut state.checked.tree.arena.expressions);
     for (_, expression) in expressions.iter_mut() {
         expression.type_id = zonk(state, context, expression.type_id)?;
-        if let ExpressionKind::TypeApplication { argument, .. } = &mut expression.kind {
-            *argument = zonk(state, context, *argument)?;
+        match &mut expression.kind {
+            ExpressionKind::TypeApplication { argument, .. }
+            | ExpressionKind::TypeAbstraction { parameter: argument, .. } => {
+                *argument = zonk(state, context, *argument)?;
+            }
+            _ => {}
         }
     }
     state.checked.tree.arena.expressions = expressions;

--- a/compiler-core/checking/src/source/operator.rs
+++ b/compiler-core/checking/src/source/operator.rs
@@ -103,10 +103,7 @@ where
         OperatorTree::Leaf(Some(type_id)) => match mode {
             OperatorKindMode::Infer => E::infer_surface(state, context, *type_id),
             OperatorKindMode::Check { expected_type } => {
-                // Peel constraints from the expected type as givens,
-                // so operator arguments like `unsafePartial $ expr`
-                // can discharge constraints like Partial properly.
-                let expected_type = toolkit::collect_givens(state, context, expected_type)?;
+                let expected_type = E::prepare_expected_surface(state, context, expected_type)?;
                 E::check_surface(state, context, *type_id, expected_type)
             }
         },
@@ -125,15 +122,33 @@ where
 
             let operator_type = E::lookup_item(state, context, file_id, item_id)?;
 
-            traverse_operator_branch(
-                state,
-                context,
-                *operator_id,
-                (file_id, item_id),
-                operator_type,
-                children,
-                mode,
-            )
+            match mode {
+                OperatorKindMode::Infer => traverse_operator_branch(
+                    state,
+                    context,
+                    *operator_id,
+                    (file_id, item_id),
+                    operator_type,
+                    children,
+                    mode,
+                ),
+                OperatorKindMode::Check { expected_type } => E::check_operator_branch(
+                    state,
+                    context,
+                    expected_type,
+                    |state, expected_type| {
+                        traverse_operator_branch(
+                            state,
+                            context,
+                            *operator_id,
+                            (file_id, item_id),
+                            operator_type,
+                            children,
+                            OperatorKindMode::Check { expected_type },
+                        )
+                    },
+                ),
+            }
         }
     }
 }
@@ -204,10 +219,7 @@ where
     };
 
     if let OperatorKindMode::Check { expected_type } = mode {
-        // Peel constraints from the expected type as givens,
-        // so operator result constraints can be discharged.
-        let expected_type = toolkit::collect_givens(state, context, expected_type)?;
-        let _ = unification::subtype(state, context, result_type, expected_type)?;
+        E::check_branch_result(state, context, result_type, expected_type)?;
     }
 
     let branch = OperatorBranch {
@@ -224,7 +236,13 @@ where
             result_type,
         },
     };
-    E::build(state, context, branch)
+    let built = E::build(state, context, branch)?;
+    match mode {
+        OperatorKindMode::Infer => Ok(built),
+        OperatorKindMode::Check { expected_type } => {
+            E::adapt_branch_result(state, context, built, expected_type)
+        }
+    }
 }
 
 pub trait IsOperator<Q: ExternalQueries>: IsElement {
@@ -262,6 +280,43 @@ pub trait IsOperator<Q: ExternalQueries>: IsElement {
         id: Self,
         expected: TypeId,
     ) -> QueryResult<(Self::Elaborated, TypeId)>;
+
+    fn prepare_expected_surface(
+        state: &mut CheckState,
+        context: &CheckContext<Q>,
+        expected: TypeId,
+    ) -> QueryResult<TypeId> {
+        toolkit::collect_givens(state, context, expected)
+    }
+
+    fn check_operator_branch(
+        state: &mut CheckState,
+        context: &CheckContext<Q>,
+        expected: TypeId,
+        check: impl FnOnce(&mut CheckState, TypeId) -> QueryResult<(Self::Elaborated, TypeId)>,
+    ) -> QueryResult<(Self::Elaborated, TypeId)> {
+        let expected = toolkit::collect_givens(state, context, expected)?;
+        check(state, expected)
+    }
+
+    fn check_branch_result(
+        state: &mut CheckState,
+        context: &CheckContext<Q>,
+        inferred: TypeId,
+        expected: TypeId,
+    ) -> QueryResult<()> {
+        unification::subtype(state, context, inferred, expected)?;
+        Ok(())
+    }
+
+    fn adapt_branch_result(
+        _state: &mut CheckState,
+        _context: &CheckContext<Q>,
+        built: (Self::Elaborated, TypeId),
+        _expected: TypeId,
+    ) -> QueryResult<(Self::Elaborated, TypeId)> {
+        Ok(built)
+    }
 
     fn should_defer_expansion(
         _state: &CheckState,
@@ -333,6 +388,54 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
         expected: TypeId,
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
         let checked = terms::check_expression(state, context, id, expected)?;
+        Ok((Some(checked), checked.type_id))
+    }
+
+    fn prepare_expected_surface(
+        _state: &mut CheckState,
+        _context: &CheckContext<Q>,
+        expected: TypeId,
+    ) -> QueryResult<TypeId> {
+        Ok(expected)
+    }
+
+    fn check_operator_branch(
+        state: &mut CheckState,
+        context: &CheckContext<Q>,
+        expected: TypeId,
+        check: impl FnOnce(&mut CheckState, TypeId) -> QueryResult<(Self::Elaborated, TypeId)>,
+    ) -> QueryResult<(Self::Elaborated, TypeId)> {
+        let checked =
+            terms::check_expected_expression(state, context, expected, |state, expected| {
+                let (expression, inferred) = check(state, expected)?;
+                let expression = expression.unwrap_or_else(|| {
+                    terms::allocate_expression(state, inferred, tree::ExpressionKind::Error)
+                });
+                Ok(expression)
+            })?;
+        Ok((Some(checked), checked.type_id))
+    }
+
+    fn check_branch_result(
+        _state: &mut CheckState,
+        _context: &CheckContext<Q>,
+        _inferred: TypeId,
+        _expected: TypeId,
+    ) -> QueryResult<()> {
+        Ok(())
+    }
+
+    fn adapt_branch_result(
+        state: &mut CheckState,
+        context: &CheckContext<Q>,
+        (expression, inferred): (Self::Elaborated, TypeId),
+        expected: TypeId,
+    ) -> QueryResult<(Self::Elaborated, TypeId)> {
+        let Some(expression) = expression else {
+            unification::subtype(state, context, inferred, expected)?;
+            return Ok((None, inferred));
+        };
+        let checked = terms::application::subtype_expression(state, context, expression, expected)?;
         Ok((Some(checked), checked.type_id))
     }
 

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -18,8 +18,10 @@ use rustc_hash::FxHashSet;
 use smol_str::SmolStr;
 
 use crate::context::CheckContext;
-use crate::core::{TypeId, normalise, toolkit, unification};
+use crate::core::substitute::{RigidRenaming, SubstituteName};
+use crate::core::{Type, TypeId, normalise, toolkit, unification};
 use crate::error::{ErrorCrumb, ErrorKind};
+use crate::evidence::EvidenceBinderId;
 use crate::holes::{HoleBinding, TermHole};
 use crate::source::{operator, types};
 use crate::state::CheckState;
@@ -100,26 +102,98 @@ fn check_expression_quiet<Q>(
 where
     Q: ExternalQueries,
 {
-    let expected = prepare_expected_expression(state, context, expected)?;
-
-    if let Some(section_result) = context.sectioned.expressions.get(&expression) {
-        check_sectioned_expression(state, context, expression, section_result, expected)
-    } else {
-        check_expression_core(state, context, expression, expected)
-    }
+    check_expected_expression(state, context, expected, |state, expected| {
+        if let Some(section_result) = context.sectioned.expressions.get(&expression) {
+            check_sectioned_expression(state, context, expression, section_result, expected)
+        } else {
+            check_expression_core(state, context, expression, expected)
+        }
+    })
 }
 
-fn prepare_expected_expression<Q>(
+enum AbstractionLayer {
+    Type { outer: TypeId, parameter: TypeId },
+    Evidence { outer: TypeId, binder: EvidenceBinderId },
+}
+
+pub(super) fn check_expected_expression<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     expected: TypeId,
-) -> QueryResult<TypeId>
+    check: impl FnOnce(&mut CheckState, TypeId) -> QueryResult<ElaboratedExpression>,
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
     let expected = normalise::normalise(state, context, expected)?;
-    let expected = toolkit::skolemise_forall(state, context, expected)?;
-    toolkit::collect_givens(state, context, expected)
+    let head = normalise::expand(state, context, expected)?;
+    if !matches!(context.lookup_type(head), Type::Forall(_, _) | Type::Constrained(_, _)) {
+        return check(state, expected);
+    }
+
+    state.with_depth(|state| {
+        state.with_implication(|state| {
+            let mut current = expected;
+            let mut layers = vec![];
+            let mut renaming = RigidRenaming::default();
+
+            loop {
+                current = normalise::expand(state, context, current)?;
+                match context.lookup_type(current) {
+                    Type::Forall(binder_id, body) => {
+                        let binder = context.lookup_forall_binder(binder_id);
+                        let kind = renaming.substitute(state, context, binder.kind)?;
+                        let text = state.checked.lookup_name(binder.name);
+                        let parameter = state.fresh_rigid_named(context.queries, kind, text);
+                        renaming.insert(context, binder.name, parameter);
+                        let body =
+                            SubstituteName::one(state, context, binder.name, parameter, body)?;
+                        layers.push(AbstractionLayer::Type { outer: current, parameter });
+                        current = body;
+                    }
+                    Type::Constrained(constraint, body) => {
+                        let constraint = renaming.substitute(state, context, constraint)?;
+                        let binder = state.push_given(constraint);
+                        layers.push(AbstractionLayer::Evidence { outer: current, binder });
+                        current = body;
+                    }
+                    _ => break,
+                }
+            }
+
+            let renaming = Arc::new(renaming);
+            let checked =
+                state.with_source_type_renaming(&renaming, |state| check(state, current))?;
+            Ok(wrap_abstractions(state, checked, layers))
+        })
+    })
+}
+
+fn wrap_abstractions(
+    state: &mut CheckState,
+    mut expression: ElaboratedExpression,
+    layers: Vec<AbstractionLayer>,
+) -> ElaboratedExpression {
+    for layer in layers.into_iter().rev() {
+        let (type_id, kind) = match layer {
+            AbstractionLayer::Type { outer, parameter } => {
+                let kind = tree::ExpressionKind::TypeAbstraction {
+                    parameter,
+                    expression: expression.expression,
+                };
+                (outer, kind)
+            }
+            AbstractionLayer::Evidence { outer, binder } => {
+                let kind = tree::ExpressionKind::EvidenceAbstraction {
+                    binder,
+                    expression: expression.expression,
+                };
+                (outer, kind)
+            }
+        };
+        expression = allocate_expression(state, type_id, kind);
+    }
+    expression
 }
 
 pub(super) fn check_elaborated_expression<Q>(
@@ -131,8 +205,9 @@ pub(super) fn check_elaborated_expression<Q>(
 where
     Q: ExternalQueries,
 {
-    let expected = prepare_expected_expression(state, context, expected)?;
-    check_elaborated_expression_quiet(state, context, inferred, expected)
+    check_expected_expression(state, context, expected, |state, expected| {
+        check_elaborated_expression_quiet(state, context, inferred, expected)
+    })
 }
 
 fn check_elaborated_expression_quiet<Q>(
@@ -144,9 +219,7 @@ fn check_elaborated_expression_quiet<Q>(
 where
     Q: ExternalQueries,
 {
-    let inferred = application::instantiate_expression(state, context, inferred)?;
-    unification::subtype(state, context, inferred.type_id, expected)?;
-    Ok(inferred)
+    application::subtype_expression(state, context, inferred, expected)
 }
 
 fn check_sectioned_expression<Q>(
@@ -221,10 +294,11 @@ where
                 return Ok(allocate_error_expression(state, unknown));
             };
 
-            let (annotation, _) = types::infer_kind(state, context, *type_)?;
-            unification::subtype(state, context, annotation, expected)?;
+            let (annotation, _) = types::check_kind(state, context, *type_, context.prim.t)?;
+            let applications =
+                application::check_subsumption(state, context, annotation, expected)?;
             let checked = check_expression(state, context, *expression, annotation)?;
-            Ok(ElaboratedExpression { type_id: expected, ..checked })
+            Ok(application::materialize_implicit_applications(state, checked, applications))
         }
         lowering::ExpressionKind::Lambda { binders, expression } => {
             forms::check_lambda(state, context, binders, *expression, expected)
@@ -342,9 +416,9 @@ where
                 return Ok(allocate_error_expression(state, unknown));
             };
 
-            let (t, _) = types::infer_kind(state, context, *t)?;
+            let (t, _) = types::check_kind(state, context, *t, context.prim.t)?;
             let checked = check_expression(state, context, *e, t)?;
-            Ok(ElaboratedExpression { type_id: t, ..checked })
+            Ok(checked)
         }
 
         lowering::ExpressionKind::OperatorChain { .. } => {

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -213,6 +213,19 @@ where
     };
 
     match kind {
+        lowering::ExpressionKind::Typed { expression, type_ } => {
+            let Some(expression) = expression else {
+                return Ok(allocate_error_expression(state, unknown));
+            };
+            let Some(type_) = type_ else {
+                return Ok(allocate_error_expression(state, unknown));
+            };
+
+            let (annotation, _) = types::infer_kind(state, context, *type_)?;
+            unification::subtype(state, context, annotation, expected)?;
+            let checked = check_expression(state, context, *expression, annotation)?;
+            Ok(ElaboratedExpression { type_id: expected, ..checked })
+        }
         lowering::ExpressionKind::Lambda { binders, expression } => {
             forms::check_lambda(state, context, binders, *expression, expected)
         }
@@ -330,7 +343,8 @@ where
             };
 
             let (t, _) = types::infer_kind(state, context, *t)?;
-            check_expression(state, context, *e, t)
+            let checked = check_expression(state, context, *e, t)?;
+            Ok(ElaboratedExpression { type_id: t, ..checked })
         }
 
         lowering::ExpressionKind::OperatorChain { .. } => {

--- a/compiler-core/checking/src/source/terms/application.rs
+++ b/compiler-core/checking/src/source/terms/application.rs
@@ -227,8 +227,20 @@ pub fn subtype_expression<Q>(
 where
     Q: ExternalQueries,
 {
-    let applications =
-        unification::subtype_with_applications(state, context, expression.type_id, expected)?;
+    let applications = check_subsumption(state, context, expression.type_id, expected)?;
+    Ok(materialize_implicit_applications(state, expression, applications))
+}
+
+pub(super) fn check_subsumption<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    inferred: TypeId,
+    expected: TypeId,
+) -> QueryResult<Vec<ImplicitApplication>>
+where
+    Q: ExternalQueries,
+{
+    let applications = unification::subtype_with_applications(state, context, inferred, expected)?;
     let applications = applications.into_iter().map(|application| match application {
         unification::SubtypeApplication::Type { argument, result } => {
             ImplicitApplication::Type { argument, result }
@@ -237,10 +249,10 @@ where
             ImplicitApplication::Evidence { evidence, result }
         }
     });
-    Ok(materialize_implicit_applications(state, expression, applications))
+    Ok(applications.collect())
 }
 
-fn materialize_implicit_applications(
+pub(super) fn materialize_implicit_applications(
     state: &mut CheckState,
     mut expression: ElaboratedExpression,
     implicit: impl IntoIterator<Item = ImplicitApplication>,

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -17,7 +17,7 @@ use smol_str::SmolStr;
 
 use crate::TypeId;
 use crate::core::{ForallBinderId, Role, SmolStrId};
-use crate::evidence::{Evidence, EvidenceVarId, SuperclassId};
+use crate::evidence::{Evidence, EvidenceBinderId, EvidenceVarId, SuperclassId};
 
 pub type ExpressionId = Idx<Expression>;
 pub type BinderId = Idx<Binder>;
@@ -352,6 +352,8 @@ pub enum ExpressionKind {
     TermApplication { function: ExpressionId, argument: ExpressionId },
     TypeApplication { function: ExpressionId, argument: TypeId },
     EvidenceApplication { function: ExpressionId, evidence: EvidenceVarId },
+    TypeAbstraction { parameter: TypeId, expression: ExpressionId },
+    EvidenceAbstraction { binder: EvidenceBinderId, expression: ExpressionId },
     Lambda { binders: Arc<[BinderId]>, expression: ExpressionId },
     IfThenElse { condition: ExpressionId, then: ExpressionId, else_: ExpressionId },
     Case { scrutinees: Arc<[ExpressionId]>, alternatives: Arc<[CaseAlternative]> },

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -1262,6 +1262,8 @@ where
         let expression = &self.checked.tree[expression_id];
         let precedence = match &expression.kind {
             ExpressionKind::Lambda { .. }
+            | ExpressionKind::TypeAbstraction { .. }
+            | ExpressionKind::EvidenceAbstraction { .. }
             | ExpressionKind::IfThenElse { .. }
             | ExpressionKind::Case { .. }
             | ExpressionKind::Let { .. } => ExpressionPrecedence::Abstraction,
@@ -1500,6 +1502,16 @@ where
                 )?;
                 let evidence = self.evidence_variable_name(evidence_names, *evidence)?;
                 Ok(function.append(self.arena.text(format!(" {{{evidence}}}"))))
+            }
+            ExpressionKind::TypeAbstraction { parameter, expression } => {
+                let parameter = type_pretty.render_atom(*parameter);
+                let expression = self.expression(*expression, evidence_names, type_pretty)?;
+                Ok(self.arena.text(format!("\\@{parameter} -> ")).append(expression))
+            }
+            ExpressionKind::EvidenceAbstraction { binder, expression } => {
+                let binder = self.evidence_binder_name(evidence_names, *binder)?;
+                let expression = self.expression(*expression, evidence_names, type_pretty)?;
+                Ok(self.arena.text(format!("\\{{{binder}}} -> ")).append(expression))
             }
             ExpressionKind::Lambda { binders, expression } => {
                 let mut lambda = self.arena.text("\\");

--- a/tests-integration/fixtures/checking/1786284960_typed_expression_forall_parity/Main.purs
+++ b/tests-integration/fixtures/checking/1786284960_typed_expression_forall_parity/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+foreign import unsafeCoerce :: forall a b. a -> b
+
+class Convert f g where
+  convert :: forall a. f a -> g a
+
+data F a
+data G a
+
+instance Convert F G where
+  convert = (unsafeCoerce :: forall a. F a -> G a)

--- a/tests-integration/fixtures/checking/1786284960_typed_expression_forall_parity/Main.snap
+++ b/tests-integration/fixtures/checking/1786284960_typed_expression_forall_parity/Main.snap
@@ -1,0 +1,57 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+unsafeCoerce :: forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type)
+convert ::
+  forall (t0 :: Prim.Type) (@f :: (t0 :: Prim.Type) -> Prim.Type)
+    (@g :: (t0 :: Prim.Type) -> Prim.Type).
+    Main.Convert @(t0 :: Prim.Type)
+      (f :: (t0 :: Prim.Type) -> Prim.Type)
+      (g :: (t0 :: Prim.Type) -> Prim.Type) =>
+    (forall (a :: (t0 :: Prim.Type)).
+      (f :: (t0 :: Prim.Type) -> Prim.Type) (a :: (t0 :: Prim.Type)) ->
+      (g :: (t0 :: Prim.Type) -> Prim.Type) (a :: (t0 :: Prim.Type)))
+
+Types
+Convert ::
+  forall (t0 :: Prim.Type).
+    ((t0 :: Prim.Type) -> Prim.Type) -> ((t0 :: Prim.Type) -> Prim.Type) -> Prim.Constraint
+F :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> Prim.Type
+G :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> Prim.Type
+
+Classes
+class forall (t0 :: Prim.Type) (f :: (t0 :: Prim.Type) -> Prim.Type) (g :: (t0 :: Prim.Type) -> Prim.Type). Main.Convert @(t0 :: Prim.Type)
+  (f :: (t0 :: Prim.Type) -> Prim.Type)
+  (g :: (t0 :: Prim.Type) -> Prim.Type)
+  convert ::
+  forall (t0 :: Prim.Type) (@f :: (t0 :: Prim.Type) -> Prim.Type)
+    (@g :: (t0 :: Prim.Type) -> Prim.Type).
+    Main.Convert @(t0 :: Prim.Type)
+      (f :: (t0 :: Prim.Type) -> Prim.Type)
+      (g :: (t0 :: Prim.Type) -> Prim.Type) =>
+    (forall (a :: (t0 :: Prim.Type)).
+      (f :: (t0 :: Prim.Type) -> Prim.Type) (a :: (t0 :: Prim.Type)) ->
+      (g :: (t0 :: Prim.Type) -> Prim.Type) (a :: (t0 :: Prim.Type)))
+
+Instances
+instance forall (t0 :: Prim.Type).
+  Main.Convert @(t0 :: Prim.Type) (Main.F @(t0 :: Prim.Type)) (Main.G @(t0 :: Prim.Type))
+
+Roles
+F = [Phantom]
+G = [Phantom]
+
+Diagnostics
+error[CannotUnify]: Cannot unify '(a :: (t0 :: Type))' with '(a1 :: (t0 :: Type))'
+  --> 12:14..12:50
+   |
+12 |   convert = (unsafeCoerce :: forall a. F a -> G a)
+   |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify 'F @(t0 :: Type) (a :: (t0 :: Type))' with 'F @(t0 :: Type) (a1 :: (t0 :: Type))'
+  --> 12:14..12:50
+   |
+12 |   convert = (unsafeCoerce :: forall a. F a -> G a)
+   |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786284960_typed_expression_forall_parity/Main.snap
+++ b/tests-integration/fixtures/checking/1786284960_typed_expression_forall_parity/Main.snap
@@ -43,15 +43,3 @@ instance forall (t0 :: Prim.Type).
 Roles
 F = [Phantom]
 G = [Phantom]
-
-Diagnostics
-error[CannotUnify]: Cannot unify '(a :: (t0 :: Type))' with '(a1 :: (t0 :: Type))'
-  --> 12:14..12:50
-   |
-12 |   convert = (unsafeCoerce :: forall a. F a -> G a)
-   |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'F @(t0 :: Type) (a :: (t0 :: Type))' with 'F @(t0 :: Type) (a1 :: (t0 :: Type))'
-  --> 12:14..12:50
-   |
-12 |   convert = (unsafeCoerce :: forall a. F a -> G a)
-   |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786291440_typed_expression_abstraction_evidence/Main.purs
+++ b/tests-integration/fixtures/checking/1786291440_typed_expression_abstraction_evidence/Main.purs
@@ -1,0 +1,13 @@
+module Main where
+
+class Missing a where
+  missing :: a
+
+bad :: Int
+bad = (missing :: Missing Int => Int)
+
+class Supplied a where
+  supplied :: a
+
+good :: Supplied Int => Int
+good = (supplied :: Supplied Int => Int)

--- a/tests-integration/fixtures/checking/1786291440_typed_expression_abstraction_evidence/Main.snap
+++ b/tests-integration/fixtures/checking/1786291440_typed_expression_abstraction_evidence/Main.snap
@@ -1,0 +1,27 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+missing :: forall (@a :: Prim.Type). Main.Missing (a :: Prim.Type) => (a :: Prim.Type)
+bad :: Prim.Int
+supplied :: forall (@a :: Prim.Type). Main.Supplied (a :: Prim.Type) => (a :: Prim.Type)
+good :: Main.Supplied Prim.Int => Prim.Int
+
+Types
+Missing :: Prim.Type -> Prim.Constraint
+Supplied :: Prim.Type -> Prim.Constraint
+
+Classes
+class forall (a :: Prim.Type). Main.Missing (a :: Prim.Type)
+  missing :: forall (@a :: Prim.Type). Main.Missing (a :: Prim.Type) => (a :: Prim.Type)
+class forall (a :: Prim.Type). Main.Supplied (a :: Prim.Type)
+  supplied :: forall (@a :: Prim.Type). Main.Supplied (a :: Prim.Type) => (a :: Prim.Type)
+
+Diagnostics
+error[NoInstanceFound]: No instance found for: Missing Int
+  --> 6:1..6:11
+  |
+6 | bad :: Int
+  | ^~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786291800_typed_expression_higher_rank/Main.purs
+++ b/tests-integration/fixtures/checking/1786291800_typed_expression_higher_rank/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+identity :: forall a. a -> a
+identity value = value
+
+consume :: (forall a. a -> a) -> Int
+consume _ = 0
+
+higherRank :: Int
+higherRank = consume (identity :: forall a. a -> a)

--- a/tests-integration/fixtures/checking/1786291800_typed_expression_higher_rank/Main.snap
+++ b/tests-integration/fixtures/checking/1786291800_typed_expression_higher_rank/Main.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+identity :: forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)
+consume :: (forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)) -> Prim.Int
+higherRank :: Prim.Int
+
+Types

--- a/tests-integration/fixtures/checking/1786291800_typed_expression_polymorphic_specialization/Main.purs
+++ b/tests-integration/fixtures/checking/1786291800_typed_expression_polymorphic_specialization/Main.purs
@@ -1,0 +1,16 @@
+module Main where
+
+identity :: forall a. a -> a
+identity value = value
+
+implicit :: Int
+implicit = (identity :: forall a. a -> a) 0
+
+monomorphic :: Int -> Int
+monomorphic = (identity :: forall a. a -> a)
+
+visibleIdentity :: forall @a. a -> a
+visibleIdentity value = value
+
+explicit :: Int
+explicit = (visibleIdentity :: forall @a. a -> a) @Int 0

--- a/tests-integration/fixtures/checking/1786291800_typed_expression_polymorphic_specialization/Main.snap
+++ b/tests-integration/fixtures/checking/1786291800_typed_expression_polymorphic_specialization/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+identity :: forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)
+implicit :: Prim.Int
+monomorphic :: Prim.Int -> Prim.Int
+visibleIdentity :: forall (@a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)
+explicit :: Prim.Int
+
+Types

--- a/tests-integration/fixtures/checking/1786292340_typed_expression_operator_evidence/Main.purs
+++ b/tests-integration/fixtures/checking/1786292340_typed_expression_operator_evidence/Main.purs
@@ -1,0 +1,37 @@
+module Main where
+
+class Supplied a where
+  supplied :: a
+
+consume :: (Supplied Int => Int) -> Int
+consume _ = 0
+
+identity :: forall a. a -> a
+identity value = value
+
+apply :: forall a b. (a -> b) -> a -> b
+apply function argument = function argument
+
+infixr 0 apply as <|
+
+throughOperator :: Int
+throughOperator = consume <| (supplied :: Supplied Int => Int)
+
+throughNestedOperator :: Int
+throughNestedOperator = consume <| identity <| (supplied :: Supplied Int => Int)
+
+polymorphicResult :: Int -> Int -> forall a. a -> a
+polymorphicResult _ _ value = value
+
+infixr 0 polymorphicResult as <@>
+
+throughPolymorphicResult :: forall a. a -> a
+throughPolymorphicResult = 0 <@> 0
+
+constrainedResult :: Int -> Int -> (Supplied Int => Int)
+constrainedResult _ _ = supplied
+
+infixr 0 constrainedResult as <#>
+
+throughConstrainedResult :: Supplied Int => Int
+throughConstrainedResult = 0 <#> 0

--- a/tests-integration/fixtures/checking/1786292340_typed_expression_operator_evidence/Main.snap
+++ b/tests-integration/fixtures/checking/1786292340_typed_expression_operator_evidence/Main.snap
@@ -1,0 +1,31 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+supplied :: forall (@a :: Prim.Type). Main.Supplied (a :: Prim.Type) => (a :: Prim.Type)
+consume :: (Main.Supplied Prim.Int => Prim.Int) -> Prim.Int
+identity :: forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)
+apply ::
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) -> (a :: Prim.Type) -> (b :: Prim.Type)
+<| ::
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) -> (a :: Prim.Type) -> (b :: Prim.Type)
+throughOperator :: Prim.Int
+throughNestedOperator :: Prim.Int
+polymorphicResult ::
+  Prim.Int -> Prim.Int -> (forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type))
+<@> :: Prim.Int -> Prim.Int -> (forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type))
+throughPolymorphicResult :: forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)
+constrainedResult :: Prim.Int -> Prim.Int -> (Main.Supplied Prim.Int => Prim.Int)
+<#> :: Prim.Int -> Prim.Int -> (Main.Supplied Prim.Int => Prim.Int)
+throughConstrainedResult :: Main.Supplied Prim.Int => Prim.Int
+
+Types
+Supplied :: Prim.Type -> Prim.Constraint
+
+Classes
+class forall (a :: Prim.Type). Main.Supplied (a :: Prim.Type)
+  supplied :: forall (@a :: Prim.Type). Main.Supplied (a :: Prim.Type) => (a :: Prim.Type)

--- a/tests-integration/fixtures/semantic/1784779800_record_pun_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784779800_record_pun_applications/Main.snap
@@ -34,7 +34,7 @@ inferredAliasExplicit = { aliased: aliased }
 foreign import fetch :: forall m. Main.Capability m => Prim.Int -> m Prim.Int
 
 expectedPun :: Main.Setup
-expectedPun = { fetch: fetch @m {capabilityDict} }
+expectedPun = { fetch: \@m -> \{capabilityDict} -> fetch @m {capabilityDict} }
 
 expectedExplicit :: Main.Setup
-expectedExplicit = { fetch: fetch @m {capabilityDict} }
+expectedExplicit = { fetch: \@m -> \{capabilityDict} -> fetch @m {capabilityDict} }

--- a/tests-integration/fixtures/semantic/1786284960_typed_expression_forall_parity/Main.purs
+++ b/tests-integration/fixtures/semantic/1786284960_typed_expression_forall_parity/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+foreign import unsafeCoerce :: forall a b. a -> b
+
+class Convert f g where
+  convert :: forall a. f a -> g a
+
+data F a
+data G a
+
+instance Convert F G where
+  convert = (unsafeCoerce :: forall a. F a -> G a)

--- a/tests-integration/fixtures/semantic/1786284960_typed_expression_forall_parity/Main.snap
+++ b/tests-integration/fixtures/semantic/1786284960_typed_expression_forall_parity/Main.snap
@@ -17,4 +17,4 @@ foreign import unsafeCoerce :: forall a b. a -> b
 
 dictionary convertG :: forall t0. Main.Convert @t0 (Main.F @t0) (Main.G @t0) where
   convert :: forall (a :: t0). Main.F @t0 a -> Main.G @t0 a
-  convert = unsafeCoerce @(Main.F @t0 a) @(Main.G @t0 a)
+  convert = (\@a -> unsafeCoerce @(Main.F @t0 a) @(Main.G @t0 a)) @a1

--- a/tests-integration/fixtures/semantic/1786284960_typed_expression_forall_parity/Main.snap
+++ b/tests-integration/fixtures/semantic/1786284960_typed_expression_forall_parity/Main.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Convert :: forall (k0 :: Prim.Type). (k0 -> Prim.Type) -> (k0 -> Prim.Type) -> Prim.Constraint
+interface Convert f g where
+  convert :: forall (a :: t0). f a -> g a
+
+data F :: forall (k0 :: Prim.Type). k0 -> Prim.Type
+data F @a
+
+data G :: forall (k0 :: Prim.Type). k0 -> Prim.Type
+data G @a
+
+foreign import unsafeCoerce :: forall a b. a -> b
+
+dictionary convertG :: forall t0. Main.Convert @t0 (Main.F @t0) (Main.G @t0) where
+  convert :: forall (a :: t0). Main.F @t0 a -> Main.G @t0 a
+  convert = unsafeCoerce @(Main.F @t0 a) @(Main.G @t0 a)

--- a/tests-integration/fixtures/semantic/1786291440_typed_expression_abstraction_evidence/Main.purs
+++ b/tests-integration/fixtures/semantic/1786291440_typed_expression_abstraction_evidence/Main.purs
@@ -1,0 +1,13 @@
+module Main where
+
+class Missing a where
+  missing :: a
+
+bad :: Int
+bad = (missing :: Missing Int => Int)
+
+class Supplied a where
+  supplied :: a
+
+good :: Supplied Int => Int
+good = (supplied :: Supplied Int => Int)

--- a/tests-integration/fixtures/semantic/1786291440_typed_expression_abstraction_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1786291440_typed_expression_abstraction_evidence/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Missing :: Prim.Type -> Prim.Constraint
+interface Missing a where
+  missing :: a
+
+interface Supplied :: Prim.Type -> Prim.Constraint
+interface Supplied a where
+  supplied :: a
+
+bad :: Prim.Int
+bad = (\{missingDict} -> missing @Prim.Int {missingDict}) {error}
+
+good :: Main.Supplied Prim.Int => Prim.Int
+good = \{suppliedDict} -> (\{suppliedDict1} -> supplied @Prim.Int {suppliedDict1}) {suppliedDict}

--- a/tests-integration/fixtures/semantic/1786291800_typed_expression_higher_rank/Main.purs
+++ b/tests-integration/fixtures/semantic/1786291800_typed_expression_higher_rank/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+identity :: forall a. a -> a
+identity value = value
+
+consume :: (forall a. a -> a) -> Int
+consume _ = 0
+
+higherRank :: Int
+higherRank = consume (identity :: forall a. a -> a)

--- a/tests-integration/fixtures/semantic/1786291800_typed_expression_higher_rank/Main.snap
+++ b/tests-integration/fixtures/semantic/1786291800_typed_expression_higher_rank/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+identity :: forall a. a -> a
+identity = \value -> value
+
+consume :: (forall a. a -> a) -> Prim.Int
+consume = \_ -> 0
+
+higherRank :: Prim.Int
+higherRank = consume (\@a -> (\@a1 -> identity @a1) @a)

--- a/tests-integration/fixtures/semantic/1786291800_typed_expression_polymorphic_specialization/Main.purs
+++ b/tests-integration/fixtures/semantic/1786291800_typed_expression_polymorphic_specialization/Main.purs
@@ -1,0 +1,16 @@
+module Main where
+
+identity :: forall a. a -> a
+identity value = value
+
+implicit :: Int
+implicit = (identity :: forall a. a -> a) 0
+
+monomorphic :: Int -> Int
+monomorphic = (identity :: forall a. a -> a)
+
+visibleIdentity :: forall @a. a -> a
+visibleIdentity value = value
+
+explicit :: Int
+explicit = (visibleIdentity :: forall @a. a -> a) @Int 0

--- a/tests-integration/fixtures/semantic/1786291800_typed_expression_polymorphic_specialization/Main.snap
+++ b/tests-integration/fixtures/semantic/1786291800_typed_expression_polymorphic_specialization/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+identity :: forall a. a -> a
+identity = \value -> value
+
+implicit :: Prim.Int
+implicit = (\@a -> identity @a) @Prim.Int 0
+
+monomorphic :: Prim.Int -> Prim.Int
+monomorphic = (\@a -> identity @a) @Prim.Int
+
+visibleIdentity :: forall @a. a -> a
+visibleIdentity = \value -> value
+
+explicit :: Prim.Int
+explicit = (\@a -> visibleIdentity @a) @Prim.Int 0

--- a/tests-integration/fixtures/semantic/1786292340_typed_expression_operator_evidence/Main.purs
+++ b/tests-integration/fixtures/semantic/1786292340_typed_expression_operator_evidence/Main.purs
@@ -1,0 +1,37 @@
+module Main where
+
+class Supplied a where
+  supplied :: a
+
+consume :: (Supplied Int => Int) -> Int
+consume _ = 0
+
+identity :: forall a. a -> a
+identity value = value
+
+apply :: forall a b. (a -> b) -> a -> b
+apply function argument = function argument
+
+infixr 0 apply as <|
+
+throughOperator :: Int
+throughOperator = consume <| (supplied :: Supplied Int => Int)
+
+throughNestedOperator :: Int
+throughNestedOperator = consume <| identity <| (supplied :: Supplied Int => Int)
+
+polymorphicResult :: Int -> Int -> forall a. a -> a
+polymorphicResult _ _ value = value
+
+infixr 0 polymorphicResult as <@>
+
+throughPolymorphicResult :: forall a. a -> a
+throughPolymorphicResult = 0 <@> 0
+
+constrainedResult :: Int -> Int -> (Supplied Int => Int)
+constrainedResult _ _ = supplied
+
+infixr 0 constrainedResult as <#>
+
+throughConstrainedResult :: Supplied Int => Int
+throughConstrainedResult = 0 <#> 0

--- a/tests-integration/fixtures/semantic/1786292340_typed_expression_operator_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1786292340_typed_expression_operator_evidence/Main.snap
@@ -1,0 +1,40 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Supplied :: Prim.Type -> Prim.Constraint
+interface Supplied a where
+  supplied :: a
+
+consume :: (Main.Supplied Prim.Int => Prim.Int) -> Prim.Int
+consume = \_ -> 0
+
+identity :: forall a. a -> a
+identity = \value -> value
+
+apply :: forall a b. (a -> b) -> a -> b
+apply = \function -> \argument -> function argument
+
+throughOperator :: Prim.Int
+throughOperator =
+  apply @(Main.Supplied Prim.Int => Prim.Int) @Prim.Int consume
+    (\{suppliedDict} -> (\{suppliedDict1} -> supplied @Prim.Int {suppliedDict1}) {suppliedDict})
+
+throughNestedOperator :: Prim.Int
+throughNestedOperator =
+  apply @(Main.Supplied Prim.Int => Prim.Int) @Prim.Int consume
+    (\{suppliedDict} -> apply @Prim.Int @Prim.Int (identity @Prim.Int)
+      ((\{suppliedDict1} -> supplied @Prim.Int {suppliedDict1}) {suppliedDict}))
+
+polymorphicResult :: Prim.Int -> Prim.Int -> (forall a. a -> a)
+polymorphicResult = \_ -> \_ -> \value -> value
+
+throughPolymorphicResult :: forall a. a -> a
+throughPolymorphicResult = polymorphicResult 0 0 @a
+
+constrainedResult :: Prim.Int -> Prim.Int -> (Main.Supplied Prim.Int => Prim.Int)
+constrainedResult = \{suppliedDict} -> \_ -> \_ -> supplied @Prim.Int {suppliedDict}
+
+throughConstrainedResult :: Main.Supplied Prim.Int => Prim.Int
+throughConstrainedResult = \{suppliedDict} -> constrainedResult 0 0 {suppliedDict}


### PR DESCRIPTION
## Summary

- Preserve explicitly typed expressions as sound type and evidence abstraction boundaries during checking.
- Isolate annotation-local evidence so it cannot discharge constraints required by the surrounding context.
- Apply saved subsumption elaboration after the payload is checked, including type and dictionary applications.
- Add focused checking and semantic fixtures for constraint ownership, polymorphic specialization, higher-rank values, and operator chains.

## Problem

The typed-expression rule returned the result of checking the payload against its annotation. For a polymorphic annotation, that result had the annotation opened with rigid skolems rather than the annotation type itself. This caused alpha-equivalent polymorphic types to fail when independent skolems were compared.

Changing only the returned type was not sound. It allowed annotation-local givens to solve parent wanteds and produced semantic expressions with duplicate type applications or free evidence variables.

## Implementation

The checked expression tree now has generic `TypeAbstraction` and `EvidenceAbstraction` introduction forms. Expected `forall` and constrained layers are opened in a child implication, the payload is checked under scoped rigid renaming and local evidence, and the layers are reconstructed around the checked payload.

Typed-expression checking computes annotation-to-expected subsumption before opening the payload scope. It then checks the payload against the annotation and materializes the saved type and evidence applications. Operator-chain operands and results use the same expected-expression abstraction path, including concrete rank-n and constrained result types.

This supplies the introduction-side counterparts to the existing `TypeApplication` and `EvidenceApplication` nodes and improves the semantic representation of rank-n expressions.

## Verification

- `cargo check -p checking --tests`
- `cargo nextest run -p checking` — 30 tests passed
- `just t checking` — all fixtures passed with no pending snapshots
- `just t semantic` — all fixtures passed with no pending snapshots
- Compared adversarial constraint and polymorphism cases with `purs` 0.15.16