### PR TITLE
[checking] Represent nested type and evidence abstractions

### DIFF
--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -83,8 +83,14 @@ where
     let mut expressions = mem::take(&mut state.checked.tree.arena.expressions);
     for (_, expression) in expressions.iter_mut() {
         expression.type_id = zonk(state, context, expression.type_id)?;
-        if let ExpressionKind::TypeApplication { argument, .. } = &mut expression.kind {
-            *argument = zonk(state, context, *argument)?;
+        match &mut expression.kind {
+            ExpressionKind::TypeApplication { argument, .. } => {
+                *argument = zonk(state, context, *argument)?;
+            }
+            ExpressionKind::TypeAbstraction { binder, .. } => {
+                *binder = zonk(state, context, *binder)?;
+            }
+            _ => {}
         }
     }
     state.checked.tree.arena.expressions = expressions;

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -18,7 +18,8 @@ use rustc_hash::FxHashSet;
 use smol_str::SmolStr;
 
 use crate::context::CheckContext;
-use crate::core::{TypeId, normalise, toolkit, unification};
+use crate::core::substitute::SubstituteName;
+use crate::core::{Type, TypeId, normalise, toolkit, unification};
 use crate::error::{ErrorCrumb, ErrorKind};
 use crate::holes::{HoleBinding, TermHole};
 use crate::source::{operator, types};
@@ -100,26 +101,14 @@ fn check_expression_quiet<Q>(
 where
     Q: ExternalQueries,
 {
-    let expected = prepare_expected_expression(state, context, expected)?;
-
-    if let Some(section_result) = context.sectioned.expressions.get(&expression) {
-        check_sectioned_expression(state, context, expression, section_result, expected)
-    } else {
-        check_expression_core(state, context, expression, expected)
-    }
-}
-
-fn prepare_expected_expression<Q>(
-    state: &mut CheckState,
-    context: &CheckContext<Q>,
-    expected: TypeId,
-) -> QueryResult<TypeId>
-where
-    Q: ExternalQueries,
-{
     let expected = normalise::normalise(state, context, expected)?;
-    let expected = toolkit::skolemise_forall(state, context, expected)?;
-    toolkit::collect_givens(state, context, expected)
+    check_expected_expression(state, context, expected, |state, expected| {
+        if let Some(section_result) = context.sectioned.expressions.get(&expression) {
+            check_sectioned_expression(state, context, expression, section_result, expected)
+        } else {
+            check_expression_core(state, context, expression, expected)
+        }
+    })
 }
 
 pub(super) fn check_elaborated_expression<Q>(
@@ -131,8 +120,54 @@ pub(super) fn check_elaborated_expression<Q>(
 where
     Q: ExternalQueries,
 {
-    let expected = prepare_expected_expression(state, context, expected)?;
-    check_elaborated_expression_quiet(state, context, inferred, expected)
+    let expected = normalise::normalise(state, context, expected)?;
+    check_expected_expression(state, context, expected, |state, expected| {
+        check_elaborated_expression_quiet(state, context, inferred, expected)
+    })
+}
+
+fn check_expected_expression<Q, F>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    expected: TypeId,
+    check: F,
+) -> QueryResult<ElaboratedExpression>
+where
+    Q: ExternalQueries,
+    F: FnOnce(&mut CheckState, TypeId) -> QueryResult<ElaboratedExpression>,
+{
+    let expected = normalise::expand(state, context, expected)?;
+    match context.lookup_type(expected) {
+        Type::Forall(binder_id, inner) => state.with_depth(|state| {
+            let binder = context.lookup_forall_binder(binder_id);
+
+            let kind = normalise::normalise(state, context, binder.kind)?;
+            let text = state.checked.lookup_name(binder.name);
+            let rigid = state.fresh_rigid_named(context.queries, kind, text);
+
+            let inner = SubstituteName::one(state, context, binder.name, rigid, inner)?;
+            let checked = check_expected_expression(state, context, inner, check)?;
+
+            let kind = tree::ExpressionKind::TypeAbstraction {
+                binder: rigid,
+                expression: checked.expression,
+            };
+
+            Ok(allocate_expression(state, expected, kind))
+        }),
+        Type::Constrained(constraint, constrained) => state.with_implication(|state| {
+            let binder = state.push_given(constraint);
+            let checked = check_expected_expression(state, context, constrained, check)?;
+
+            let kind = tree::ExpressionKind::EvidenceAbstraction {
+                binder,
+                expression: checked.expression,
+            };
+
+            Ok(allocate_expression(state, expected, kind))
+        }),
+        _ => check(state, expected),
+    }
 }
 
 fn check_elaborated_expression_quiet<Q>(

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -17,7 +17,7 @@ use smol_str::SmolStr;
 
 use crate::TypeId;
 use crate::core::{ForallBinderId, Role, SmolStrId};
-use crate::evidence::{Evidence, EvidenceVarId, SuperclassId};
+use crate::evidence::{Evidence, EvidenceBinderId, EvidenceVarId, SuperclassId};
 
 pub type ExpressionId = Idx<Expression>;
 pub type BinderId = Idx<Binder>;
@@ -352,6 +352,8 @@ pub enum ExpressionKind {
     TermApplication { function: ExpressionId, argument: ExpressionId },
     TypeApplication { function: ExpressionId, argument: TypeId },
     EvidenceApplication { function: ExpressionId, evidence: EvidenceVarId },
+    TypeAbstraction { binder: TypeId, expression: ExpressionId },
+    EvidenceAbstraction { binder: EvidenceBinderId, expression: ExpressionId },
     Lambda { binders: Arc<[BinderId]>, expression: ExpressionId },
     IfThenElse { condition: ExpressionId, then: ExpressionId, else_: ExpressionId },
     Case { scrutinees: Arc<[ExpressionId]>, alternatives: Arc<[CaseAlternative]> },

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -1125,7 +1125,9 @@ where
     fn expression_is_block_argument(&self, expression_id: ExpressionId) -> bool {
         matches!(
             &self.checked.tree[expression_id].kind,
-            ExpressionKind::Lambda { .. }
+            ExpressionKind::TypeAbstraction { .. }
+                | ExpressionKind::EvidenceAbstraction { .. }
+                | ExpressionKind::Lambda { .. }
                 | ExpressionKind::IfThenElse { .. }
                 | ExpressionKind::Case { .. }
                 | ExpressionKind::Let { .. }
@@ -1261,7 +1263,9 @@ where
     ) -> QueryResult<Doc<'arena>> {
         let expression = &self.checked.tree[expression_id];
         let precedence = match &expression.kind {
-            ExpressionKind::Lambda { .. }
+            ExpressionKind::TypeAbstraction { .. }
+            | ExpressionKind::EvidenceAbstraction { .. }
+            | ExpressionKind::Lambda { .. }
             | ExpressionKind::IfThenElse { .. }
             | ExpressionKind::Case { .. }
             | ExpressionKind::Let { .. } => ExpressionPrecedence::Abstraction,
@@ -1500,6 +1504,26 @@ where
                 )?;
                 let evidence = self.evidence_variable_name(evidence_names, *evidence)?;
                 Ok(function.append(self.arena.text(format!(" {{{evidence}}}"))))
+            }
+            ExpressionKind::TypeAbstraction { binder, expression } => {
+                let binder = type_pretty.render_atom(*binder);
+                let abstraction = self.arena.text(format!("\\@{binder} ->"));
+                let body = self.expression(*expression, evidence_names, type_pretty)?;
+                if self.expression_requires_body_break(*expression) {
+                    Ok(abstraction.append(self.arena.hardline().append(body).nest(2)))
+                } else {
+                    Ok(breakable_continuation(self.arena, abstraction, body))
+                }
+            }
+            ExpressionKind::EvidenceAbstraction { binder, expression } => {
+                let binder = self.evidence_binder_name(evidence_names, *binder)?;
+                let abstraction = self.arena.text(format!("\\{{{binder}}} ->"));
+                let body = self.expression(*expression, evidence_names, type_pretty)?;
+                if self.expression_requires_body_break(*expression) {
+                    Ok(abstraction.append(self.arena.hardline().append(body).nest(2)))
+                } else {
+                    Ok(breakable_continuation(self.arena, abstraction, body))
+                }
             }
             ExpressionKind::Lambda { binders, expression } => {
                 let mut lambda = self.arena.text("\\");

--- a/tests-integration/fixtures/checking/1786297500_nested_abstraction_scoping/Main.purs
+++ b/tests-integration/fixtures/checking/1786297500_nested_abstraction_scoping/Main.purs
@@ -1,0 +1,19 @@
+module Main where
+
+class Eq :: Type -> Constraint
+class Eq a where
+  show :: a -> String
+
+evidenceDoesNotEscape
+  :: forall a
+   . { scoped :: Eq a => a -> String
+     , leaked :: a -> String
+     }
+evidenceDoesNotEscape = { scoped: show, leaked: show }
+
+foreign import consume
+  :: forall result
+   . { value :: forall a. a -> result }
+  -> result
+
+typeDoesNotEscape = consume { value: \value -> value }

--- a/tests-integration/fixtures/checking/1786297500_nested_abstraction_scoping/Main.snap
+++ b/tests-integration/fixtures/checking/1786297500_nested_abstraction_scoping/Main.snap
@@ -14,7 +14,7 @@ consume ::
   forall (result :: Prim.Type).
     { value :: forall (a :: Prim.Type). (a :: Prim.Type) -> (result :: Prim.Type) } ->
     (result :: Prim.Type)
-typeDoesNotEscape :: (a :: Prim.Type)
+typeDoesNotEscape :: forall (t0 :: Prim.Type). (t0 :: Prim.Type)
 
 Types
 Eq :: Prim.Type -> Prim.Constraint
@@ -22,3 +22,15 @@ Eq :: Prim.Type -> Prim.Constraint
 Classes
 class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
   show :: forall (@a :: Prim.Type). Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
+
+Diagnostics
+error[NoInstanceFound]: No instance found for: Eq (a :: Type)
+  --> 7:1..11:7
+  |
+7 | evidenceDoesNotEscape
+  | ^~~~~~~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify '(t0 :: Type)' with '(a1 :: Type)'
+  --> 19:48..19:53
+   |
+19 | typeDoesNotEscape = consume { value: \value -> value }
+   |                                                ^~~~~

--- a/tests-integration/fixtures/checking/1786297500_nested_abstraction_scoping/Main.snap
+++ b/tests-integration/fixtures/checking/1786297500_nested_abstraction_scoping/Main.snap
@@ -1,0 +1,24 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+show :: forall (@a :: Prim.Type). Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
+evidenceDoesNotEscape ::
+  forall (a :: Prim.Type).
+    { leaked :: (a :: Prim.Type) -> Prim.String
+    , scoped :: Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
+    }
+consume ::
+  forall (result :: Prim.Type).
+    { value :: forall (a :: Prim.Type). (a :: Prim.Type) -> (result :: Prim.Type) } ->
+    (result :: Prim.Type)
+typeDoesNotEscape :: (a :: Prim.Type)
+
+Types
+Eq :: Prim.Type -> Prim.Constraint
+
+Classes
+class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
+  show :: forall (@a :: Prim.Type). Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String

--- a/tests-integration/fixtures/semantic/1784779800_record_pun_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784779800_record_pun_applications/Main.snap
@@ -34,7 +34,7 @@ inferredAliasExplicit = { aliased: aliased }
 foreign import fetch :: forall m. Main.Capability m => Prim.Int -> m Prim.Int
 
 expectedPun :: Main.Setup
-expectedPun = { fetch: fetch @m {capabilityDict} }
+expectedPun = { fetch: \@m -> \{capabilityDict} -> fetch @m {capabilityDict} }
 
 expectedExplicit :: Main.Setup
-expectedExplicit = { fetch: fetch @m {capabilityDict} }
+expectedExplicit = { fetch: \@m -> \{capabilityDict} -> fetch @m {capabilityDict} }

--- a/tests-integration/fixtures/semantic/1786296720_nested_type_and_evidence_abstractions/Main.purs
+++ b/tests-integration/fixtures/semantic/1786296720_nested_type_and_evidence_abstractions/Main.purs
@@ -1,0 +1,19 @@
+module Main where
+
+class Eq :: Type -> Constraint
+class Eq a where
+  show :: a -> String
+
+record :: { show :: forall a. Eq a => a -> String }
+record = { show }
+
+class First :: Type -> Constraint
+class First a where
+  interleaved :: forall b. Second b => a -> b
+
+class Second :: Type -> Constraint
+class Second b
+
+interleavedRecord
+  :: { interleaved :: forall a. First a => (forall b. Second b => a -> b) }
+interleavedRecord = { interleaved }

--- a/tests-integration/fixtures/semantic/1786296720_nested_type_and_evidence_abstractions/Main.snap
+++ b/tests-integration/fixtures/semantic/1786296720_nested_type_and_evidence_abstractions/Main.snap
@@ -15,7 +15,9 @@ interface Second :: Prim.Type -> Prim.Constraint
 interface Second b where
 
 record :: { show :: forall a. Main.Eq a => a -> Prim.String }
-record = { show: show @a {eqDict} }
+record = { show: \@a -> \{eqDict} -> show @a {eqDict} }
 
 interleavedRecord :: { interleaved :: forall a. Main.First a => (forall b. Main.Second b => a -> b) }
-interleavedRecord = { interleaved: interleaved @?7 {error} @?8 {error} }
+interleavedRecord =
+  { interleaved: \@a ->
+    \{firstDict} -> \@b -> \{secondDict} -> interleaved @a {firstDict} @b {secondDict} }

--- a/tests-integration/fixtures/semantic/1786296720_nested_type_and_evidence_abstractions/Main.snap
+++ b/tests-integration/fixtures/semantic/1786296720_nested_type_and_evidence_abstractions/Main.snap
@@ -1,0 +1,21 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Eq :: Prim.Type -> Prim.Constraint
+interface Eq a where
+  show :: a -> Prim.String
+
+interface First :: Prim.Type -> Prim.Constraint
+interface First a where
+  interleaved :: forall (b :: Prim.Type). Main.Second b => a -> b
+
+interface Second :: Prim.Type -> Prim.Constraint
+interface Second b where
+
+record :: { show :: forall a. Main.Eq a => a -> Prim.String }
+record = { show: show @a {eqDict} }
+
+interleavedRecord :: { interleaved :: forall a. Main.First a => (forall b. Main.Second b => a -> b) }
+interleavedRecord = { interleaved: interleaved @?7 {error} @?8 {error} }


### PR DESCRIPTION
## Summary

- represent nested rank-n and constrained expected types with explicit type and evidence abstractions in the checked semantic tree
- align abstraction nodes with skolem-depth and implication scopes while preserving interleaved binder order
- zonk and render the new nodes, including record puns and explicit record fields

## Motivation

Nested polymorphic record fields previously contained type and evidence applications whose variables had no enclosing semantic-tree binders. The same preparation path also allowed nested dictionaries and skolems to escape their lexical scopes.

## Regression history

- `Add failing test case for nested abstractions` records the free variables, unresolved interleaved applications, and scope escapes
- `Represent nested type and evidence abstractions` implements the fix and updates the same snapshots

## Verification

- `cargo check -p checking --tests`
- `cargo nextest run -p checking`
- `just t checking`
- `just t semantic`
- `just format`
- `git diff --check`