### PR TITLE
[checking] Share checked core across module checks

### DIFF
--- a/compiler-core/building-types/src/lib.rs
+++ b/compiler-core/building-types/src/lib.rs
@@ -18,6 +18,7 @@ pub enum QueryKey {
     Resolved(FileId),
     Bracketed(FileId),
     Sectioned(FileId),
+    CheckedCore,
     Checked(FileId),
     Documented(FileId),
 }

--- a/compiler-core/building/src/engine.rs
+++ b/compiler-core/building/src/engine.rs
@@ -130,6 +130,7 @@ struct DerivedStorage {
     resolved: Shards<FileId, DerivedState<Arc<ResolvedModule>>>,
     bracketed: Shards<FileId, DerivedState<Arc<sugar::Bracketed>>>,
     sectioned: Shards<FileId, DerivedState<Arc<sugar::Sectioned>>>,
+    checked_core: Shards<(), DerivedState<Arc<checking::context::CheckedCore>>>,
     checked: Shards<FileId, DerivedState<Arc<CheckedModule>>>,
     documented: Shards<FileId, DerivedState<Arc<DocumentedModule>>>,
 }
@@ -501,6 +502,13 @@ impl QueryEngine {
                 QueryKey::Resolved(k) => derived_changed!(resolved, k),
                 QueryKey::Bracketed(k) => derived_changed!(bracketed, k),
                 QueryKey::Sectioned(k) => derived_changed!(sectioned, k),
+                QueryKey::CheckedCore => {
+                    self.checked_core()?;
+                    let shard = self.derived.checked_core.shard(&()).read();
+                    if let Some(DerivedState::Computed { trace, .. }) = shard.get(&()) {
+                        latest = latest.max(trace.changed);
+                    }
+                }
                 QueryKey::Checked(k) => derived_changed!(checked, k),
                 QueryKey::Documented(k) => derived_changed!(documented, k),
             }
@@ -852,6 +860,18 @@ impl QueryEngine {
         )
     }
 
+    pub fn checked_core(&self) -> QueryResult<Arc<checking::context::CheckedCore>> {
+        self.query(
+            QueryKey::CheckedCore,
+            (),
+            |derived| &derived.checked_core,
+            |this| {
+                let core = checking::context::CheckedCore::new(this)?;
+                Ok(Arc::new(core))
+            },
+        )
+    }
+
     pub fn checked(&self, id: FileId) -> QueryResult<Arc<CheckedModule>> {
         self.query(
             QueryKey::Checked(id),
@@ -982,6 +1002,10 @@ impl checking::PrettyQueries for QueryEngine {
 }
 
 impl checking::ExternalQueries for QueryEngine {
+    fn checked_core(&self) -> QueryResult<Arc<checking::context::CheckedCore>> {
+        QueryEngine::checked_core(self)
+    }
+
     fn intern_type(&self, t: checking::Type) -> checking::TypeId {
         self.interned.checking.intern_type(t)
     }
@@ -1133,6 +1157,113 @@ mod tests {
         let index_a = engine.indexed(id).unwrap();
         let index_b = engine.indexed(id).unwrap();
         assert!(Arc::ptr_eq(&index_a, &index_b));
+    }
+
+    #[test]
+    fn test_checked_core_sharing_and_invalidation() {
+        let mut engine = QueryEngine::default();
+        let mut files = Files::default();
+        prim::configure(&mut engine, &mut files);
+
+        let main = files.insert(
+            "Main.purs",
+            "module Main where\n\nimport Data.Eq (class Eq)\n\ndata Value = Value\n\nderive instance Eq Value",
+        );
+        engine.set_content(main, files.content(main));
+        engine.set_module_file("Main", main);
+
+        let checked_initial = engine.checked(main).unwrap();
+        let core_initial = engine.checked_core().unwrap();
+        let core_repeated = engine.checked_core().unwrap();
+        assert!(Arc::ptr_eq(&core_initial, &core_repeated));
+
+        {
+            let snapshot = engine.snapshot();
+            let core_snapshot = snapshot.checked_core().unwrap();
+            assert!(Arc::ptr_eq(&core_initial, &core_snapshot));
+        }
+
+        let unrelated = files.insert("Unrelated.purs", "module Unrelated where\n\nvalue = 2");
+        engine.set_content(unrelated, files.content(unrelated));
+        engine.set_module_file("Unrelated", unrelated);
+
+        let core_after_unrelated = engine.checked_core().unwrap();
+        let checked_after_unrelated = engine.checked(main).unwrap();
+        assert!(Arc::ptr_eq(&core_initial, &core_after_unrelated));
+        assert!(Arc::ptr_eq(&checked_initial, &checked_after_unrelated));
+
+        {
+            let data_eq_name = engine.interned.module.lookup("Data.Eq").unwrap();
+            let unrelated_name = engine.interned.module.lookup("Unrelated").unwrap();
+            let shard = engine.derived.checked_core.shard(&()).read();
+            let DerivedState::Computed { dependencies, .. } = shard.get(&()).unwrap() else {
+                unreachable!("invariant violated: expected computed query");
+            };
+            assert!(dependencies.contains(&QueryKey::Module(data_eq_name)));
+            assert!(dependencies.contains(&QueryKey::Indexed(core_initial.prim.prim_id)));
+            assert!(dependencies.contains(&QueryKey::Resolved(core_initial.prim.prim_id)));
+            assert!(!dependencies.contains(&QueryKey::Module(unrelated_name)));
+            assert!(!dependencies.contains(&QueryKey::Content(unrelated)));
+        }
+
+        let data_eq = files.insert(
+            "Data.Eq.purs",
+            "module Data.Eq where\n\nclass Eq a where\n  eq :: a -> a -> Boolean",
+        );
+        engine.set_content(data_eq, files.content(data_eq));
+        engine.set_module_file("Data.Eq", data_eq);
+
+        let core_with_eq = engine.checked_core().unwrap();
+        assert!(!Arc::ptr_eq(&core_after_unrelated, &core_with_eq));
+        assert!(core_with_eq.known_types.eq.is_some());
+        assert!(core_with_eq.known_terms.eq.is_some());
+
+        let checked_with_eq = engine.checked(main).unwrap();
+        assert!(!Arc::ptr_eq(&checked_initial, &checked_with_eq));
+        assert_ne!(checked_initial, checked_with_eq);
+
+        let checked_trace_with_eq = {
+            let shard = engine.derived.checked.shard(&main).read();
+            let DerivedState::Computed { trace, dependencies, .. } = shard.get(&main).unwrap()
+            else {
+                unreachable!("invariant violated: expected computed query");
+            };
+            assert!(dependencies.contains(&QueryKey::CheckedCore));
+            *trace
+        };
+
+        engine.set_content(
+            data_eq,
+            "module Data.Eq where\n\nclass Eq a where\n  eq :: a -> a -> Boolean\n\nclass Eq1 f where\n  eq1 :: forall a. Eq a => f a -> f a -> Boolean",
+        );
+
+        let checked_with_eq1 = engine.checked(main).unwrap();
+        let (core_with_eq1, core_trace_with_eq1) = {
+            let shard = engine.derived.checked_core.shard(&()).read();
+            let DerivedState::Computed { computed, trace, .. } = shard.get(&()).unwrap() else {
+                unreachable!("invariant violated: expected computed query");
+            };
+            (Arc::clone(computed), *trace)
+        };
+        let revision = engine.control.global.revision.load(Ordering::Relaxed);
+        assert_eq!(core_trace_with_eq1.built, revision);
+        assert!(!Arc::ptr_eq(&core_with_eq, &core_with_eq1));
+        assert!(core_with_eq1.known_types.eq1.is_some());
+        assert!(core_with_eq1.known_terms.eq1.is_some());
+
+        let core_with_eq1_repeated = engine.checked_core().unwrap();
+        assert!(Arc::ptr_eq(&core_with_eq1, &core_with_eq1_repeated));
+        assert!(Arc::ptr_eq(&checked_with_eq, &checked_with_eq1));
+
+        let checked_trace_with_eq1 = {
+            let shard = engine.derived.checked.shard(&main).read();
+            let DerivedState::Computed { trace, .. } = shard.get(&main).unwrap() else {
+                unreachable!("invariant violated: expected computed query");
+            };
+            *trace
+        };
+        assert!(checked_trace_with_eq1.built > checked_trace_with_eq.built);
+        assert_eq!(checked_trace_with_eq1.changed, checked_trace_with_eq.changed);
     }
 
     #[test]

--- a/compiler-core/checking/src/context.rs
+++ b/compiler-core/checking/src/context.rs
@@ -3,6 +3,7 @@
 //! See documentation for [`CheckContext`] for more information.
 
 use std::cell::RefCell;
+use std::ops::Deref;
 use std::sync::Arc;
 
 use building_types::QueryResult;
@@ -32,20 +33,7 @@ where
     Q: ExternalQueries,
 {
     pub queries: &'q Q,
-
-    pub prim: PrimCore,
-    pub prim_int: PrimIntCore,
-    pub prim_boolean: PrimBooleanCore,
-    pub prim_ordering: PrimOrderingCore,
-    pub prim_symbol: PrimSymbolCore,
-    pub prim_row: PrimRowCore,
-    pub prim_row_list: PrimRowListCore,
-    pub prim_coerce: PrimCoerceCore,
-    pub prim_type_error: PrimTypeErrorCore,
-    pub known_types: KnownTypesCore,
-    pub known_terms: KnownTermsCore,
-    pub known_reflectable: KnownReflectableCore,
-    pub known_generic: Option<KnownGeneric>,
+    pub core: Arc<CheckedCore>,
 
     pub id: FileId,
     pub stabilized: Arc<StabilizedModule>,
@@ -56,11 +44,19 @@ where
     pub sectioned: Arc<Sectioned>,
     pub resolved: Arc<ResolvedModule>,
 
-    pub prim_indexed: Arc<IndexedModule>,
-    pub prim_resolved: Arc<ResolvedModule>,
-
     checked_dependencies: RefCell<FxHashMap<FileId, Arc<CheckedModule>>>,
     checked_synonyms: RefCell<FxHashMap<(FileId, TypeItemId), Option<CheckedSynonym>>>,
+}
+
+impl<'q, Q> Deref for CheckContext<'q, Q>
+where
+    Q: ExternalQueries,
+{
+    type Target = CheckedCore;
+
+    fn deref(&self) -> &CheckedCore {
+        &self.core
+    }
 }
 
 impl<'q, Q> CheckContext<'q, Q>
@@ -68,6 +64,7 @@ where
     Q: ExternalQueries,
 {
     pub fn new(queries: &'q Q, id: FileId) -> QueryResult<CheckContext<'q, Q>> {
+        let core = queries.checked_core()?;
         let stabilized = queries.stabilized(id)?;
         let indexed = queries.indexed(id)?;
         let lowered = queries.lowered(id)?;
@@ -76,39 +73,9 @@ where
         let sectioned = queries.sectioned(id)?;
         let resolved = queries.resolved(id)?;
 
-        let prim = PrimCore::collect(queries)?;
-        let prim_int = PrimIntCore::collect(queries)?;
-        let prim_boolean = PrimBooleanCore::collect(queries)?;
-        let prim_ordering = PrimOrderingCore::collect(queries)?;
-        let prim_symbol = PrimSymbolCore::collect(queries)?;
-        let prim_row = PrimRowCore::collect(queries)?;
-        let prim_row_list = PrimRowListCore::collect(queries)?;
-        let prim_coerce = PrimCoerceCore::collect(queries)?;
-        let prim_type_error = PrimTypeErrorCore::collect(queries)?;
-        let known_types = KnownTypesCore::collect(queries)?;
-        let known_terms = KnownTermsCore::collect(queries)?;
-        let known_reflectable = KnownReflectableCore::collect(queries)?;
-        let known_generic = KnownGeneric::collect(queries)?;
-
-        let prim_id = queries.prim_id();
-        let prim_indexed = queries.indexed(prim_id)?;
-        let prim_resolved = queries.resolved(prim_id)?;
-
         Ok(CheckContext {
             queries,
-            prim,
-            prim_int,
-            prim_boolean,
-            prim_ordering,
-            prim_symbol,
-            prim_row,
-            prim_row_list,
-            prim_coerce,
-            prim_type_error,
-            known_types,
-            known_terms,
-            known_reflectable,
-            known_generic,
+            core,
             id,
             stabilized,
             indexed,
@@ -117,8 +84,6 @@ where
             bracketed,
             sectioned,
             resolved,
-            prim_indexed,
-            prim_resolved,
             checked_dependencies: RefCell::default(),
             checked_synonyms: RefCell::default(),
         })
@@ -154,6 +119,65 @@ where
         let checked_synonym = checked.lookup_synonym(type_id);
         self.checked_synonyms.borrow_mut().insert(key, checked_synonym.clone());
         Ok(checked_synonym)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct CheckedCore {
+    pub prim: PrimCore,
+    pub prim_int: PrimIntCore,
+    pub prim_boolean: PrimBooleanCore,
+    pub prim_ordering: PrimOrderingCore,
+    pub prim_symbol: PrimSymbolCore,
+    pub prim_row: PrimRowCore,
+    pub prim_row_list: PrimRowListCore,
+    pub prim_coerce: PrimCoerceCore,
+    pub prim_type_error: PrimTypeErrorCore,
+    pub known_types: KnownTypesCore,
+    pub known_terms: KnownTermsCore,
+    pub known_reflectable: KnownReflectableCore,
+    pub known_generic: Option<KnownGeneric>,
+    pub prim_indexed: Arc<IndexedModule>,
+    pub prim_resolved: Arc<ResolvedModule>,
+}
+
+impl CheckedCore {
+    pub fn new(queries: &impl ExternalQueries) -> QueryResult<CheckedCore> {
+        let prim = PrimCore::collect(queries)?;
+        let prim_int = PrimIntCore::collect(queries)?;
+        let prim_boolean = PrimBooleanCore::collect(queries)?;
+        let prim_ordering = PrimOrderingCore::collect(queries)?;
+        let prim_symbol = PrimSymbolCore::collect(queries)?;
+        let prim_row = PrimRowCore::collect(queries)?;
+        let prim_row_list = PrimRowListCore::collect(queries)?;
+        let prim_coerce = PrimCoerceCore::collect(queries)?;
+        let prim_type_error = PrimTypeErrorCore::collect(queries)?;
+        let known_types = KnownTypesCore::collect(queries)?;
+        let known_terms = KnownTermsCore::collect(queries)?;
+        let known_reflectable = KnownReflectableCore::collect(queries)?;
+        let known_generic = KnownGeneric::collect(queries)?;
+
+        let prim_id = queries.prim_id();
+        let prim_indexed = queries.indexed(prim_id)?;
+        let prim_resolved = queries.resolved(prim_id)?;
+
+        Ok(CheckedCore {
+            prim,
+            prim_int,
+            prim_boolean,
+            prim_ordering,
+            prim_symbol,
+            prim_row,
+            prim_row_list,
+            prim_coerce,
+            prim_type_error,
+            known_types,
+            known_terms,
+            known_reflectable,
+            known_generic,
+            prim_indexed,
+            prim_resolved,
+        })
     }
 }
 
@@ -357,6 +381,7 @@ impl<'r, 'q, Q: ExternalQueries> PrimLookup<'r, 'q, Q> {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct PrimCore {
     pub prim_id: FileId,
     pub t: TypeId,
@@ -414,6 +439,7 @@ impl PrimCore {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct PrimIntCore {
     pub file_id: FileId,
     pub add: TypeItemId,
@@ -441,6 +467,7 @@ impl PrimIntCore {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct PrimBooleanCore {
     pub true_: TypeId,
     pub false_: TypeId,
@@ -462,6 +489,7 @@ impl PrimBooleanCore {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct PrimOrderingCore {
     pub lt: TypeId,
     pub eq: TypeId,
@@ -485,6 +513,7 @@ impl PrimOrderingCore {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct PrimSymbolCore {
     pub file_id: FileId,
     pub append: TypeItemId,
@@ -510,6 +539,7 @@ impl PrimSymbolCore {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct PrimRowCore {
     pub file_id: FileId,
     pub union: TypeItemId,
@@ -537,6 +567,7 @@ impl PrimRowCore {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct PrimRowListCore {
     pub file_id: FileId,
     pub row_to_list: TypeItemId,
@@ -562,6 +593,7 @@ impl PrimRowListCore {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct PrimCoerceCore {
     pub file_id: FileId,
     pub coercible: TypeItemId,
@@ -583,6 +615,7 @@ impl PrimCoerceCore {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct PrimTypeErrorCore {
     pub file_id: FileId,
     pub warn: TypeItemId,
@@ -661,6 +694,7 @@ fn fetch_known_constructor(
     Ok(Some(queries.intern_type(Type::Constructor(file_id, type_id))))
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct KnownTypesCore {
     pub eq: Option<(FileId, TypeItemId)>,
     pub eq1: Option<(FileId, TypeItemId)>,
@@ -714,6 +748,7 @@ impl KnownTypesCore {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct KnownReflectableCore {
     pub is_symbol: Option<(FileId, TypeItemId)>,
     pub reflectable: Option<(FileId, TypeItemId)>,
@@ -729,6 +764,7 @@ impl KnownReflectableCore {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct KnownGeneric {
     pub no_constructors: TypeId,
     pub constructor: TypeId,
@@ -776,6 +812,7 @@ impl KnownGeneric {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct KnownTermsCore {
     pub otherwise: Option<(FileId, TermItemId)>,
     pub map: Option<(FileId, TermItemId)>,

--- a/compiler-core/checking/src/lib.rs
+++ b/compiler-core/checking/src/lib.rs
@@ -44,6 +44,14 @@ pub trait ExternalQueries:
         Checked = Arc<CheckedModule>,
     > + core::pretty::PrettyQueries
 {
+    fn checked_core(&self) -> QueryResult<Arc<context::CheckedCore>>
+    where
+        Self: Sized,
+    {
+        let core = context::CheckedCore::new(self)?;
+        Ok(Arc::new(core))
+    }
+
     fn intern_type(&self, t: Type) -> TypeId;
 
     fn intern_forall_binder(&self, b: ForallBinder) -> ForallBinderId;


### PR DESCRIPTION
## Problem

Every source-module check reconstructed the same primitive bundles and optional known type, term, and symbol lookups. Besides repeated resolution work, those bundles contain engine-local interned type IDs, so they cannot be safely cached in static process state.

## Changes

- collect the immutable engine-wide checker values in an `Arc<CheckedCore>`
- expose an uncached `ExternalQueries::checked_core` default for non-native query engines
- cache `CheckedCore` in the native `QueryEngine` as a dependency-tracked singleton derived query
- include the query key in dependency verification so snapshots, known-module registration, and known-module source changes invalidate correctly
- test Arc sharing, unrelated-module stability, `Data.Eq` invalidation, and downstream checked-query semantics

No generic folds, substitution, matching, zonking, renaming stacks, or other checker paths are optimized.

## Benchmark

Command:

```text
cargo bench -p tests-compatibility --bench checking_single_core -- check-core
```

Real Core compatibility corpus: 59 packages, 294 PureScript files.

- baseline: 665.50 ms, 95% CI [660.48 ms, 674.34 ms]
- optimized: 642.07 ms, 95% CI [622.11 ms, 660.12 ms]
- change: -5.8875%, 95% CI [-8.0888%, -3.3794%], p = 0.00 < 0.05

Criterion reported that performance improved.

## Validation

- `just format`
- `git diff --check`
- `cargo check -p checking --tests`
- `cargo nextest run -p checking -p building` (59 tests passed)
- `cargo check -p docs-lib --tests`
- `just t checking` (all tests passed, no pending snapshots)