### PR TITLE
[parsing] Optimize parser event and tree construction

### DIFF
--- a/compiler-core/parsing/src/builder.rs
+++ b/compiler-core/parsing/src/builder.rs
@@ -1,18 +1,23 @@
 use std::sync::Arc;
 
-use lexing::Lexed;
+use lexing::{Lexed, Position};
 use syntax::{SyntaxKind, SyntaxValue, TreeOwner};
 use syntree::Builder as SyntreeBuilder;
 
 use crate::{ParseError, ParsedModule};
 
+pub(crate) struct Output {
+    pub(crate) events: Vec<Event>,
+    pub(crate) errors: Vec<ParserError>,
+}
+
 #[derive(Debug)]
-pub(crate) enum Output {
+pub(crate) enum Event {
     Start { kind: SyntaxKind },
     Annotate,
     Qualify,
     Token { kind: SyntaxKind },
-    Error { message: ParserError },
+    Error,
     Finish,
 }
 
@@ -25,6 +30,11 @@ pub(crate) enum ParserError {
 struct Builder<'l, 's> {
     lexed: &'l Lexed<'s>,
     index: usize,
+    previous_end: u32,
+    annotation_end: u32,
+    qualifier_end: u32,
+    token_end: u32,
+    position: Position,
     annotated: bool,
     qualified: bool,
     builder: SyntreeBuilder<SyntaxValue>,
@@ -33,12 +43,30 @@ struct Builder<'l, 's> {
 
 impl<'l, 's> Builder<'l, 's> {
     fn new(lexed: &'l Lexed<'s>) -> Builder<'l, 's> {
+        let info = lexed.info(0);
         let index = 0;
+        let previous_end = 0;
+        let annotation_end = info.annotation;
+        let qualifier_end = info.qualifier;
+        let token_end = info.token;
+        let position = info.position;
         let annotated = false;
         let qualified = false;
         let builder = SyntreeBuilder::new();
         let errors = vec![];
-        Builder { lexed, index, annotated, qualified, builder, errors }
+        Builder {
+            lexed,
+            index,
+            previous_end,
+            annotation_end,
+            qualifier_end,
+            token_end,
+            position,
+            annotated,
+            qualified,
+            builder,
+            errors,
+        }
     }
 
     fn build(self) -> (ParsedModule, Vec<ParseError>) {
@@ -58,12 +86,11 @@ impl<'l, 's> Builder<'l, 's> {
     }
 
     fn annotate(&mut self) {
-        if let Some(annotation) = self.lexed.annotation(self.index)
-            && !self.annotated
-        {
+        if !self.annotated && self.previous_end < self.annotation_end {
+            let length = (self.annotation_end - self.previous_end) as usize;
             self.start(SyntaxKind::Annotation);
             self.builder
-                .token(SyntaxValue::token(SyntaxKind::TEXT), annotation.len())
+                .token(SyntaxValue::token(SyntaxKind::TEXT), length)
                 .expect("critical violation: syntax tree capacity exceeded");
             self.finish();
         }
@@ -72,12 +99,11 @@ impl<'l, 's> Builder<'l, 's> {
     }
 
     fn qualify(&mut self) {
-        if let Some(qualifier) = self.lexed.qualifier(self.index)
-            && !self.qualified
-        {
+        if !self.qualified && self.annotation_end < self.qualifier_end {
+            let length = (self.qualifier_end - self.annotation_end) as usize;
             self.start(SyntaxKind::Qualifier);
             self.builder
-                .token(SyntaxValue::token(SyntaxKind::TEXT), qualifier.len())
+                .token(SyntaxValue::token(SyntaxKind::TEXT), length)
                 .expect("critical violation: syntax tree capacity exceeded");
             self.finish();
         }
@@ -102,21 +128,28 @@ impl<'l, 's> Builder<'l, 's> {
         self.qualify();
 
         if !matches!(kind, SyntaxKind::ERROR) {
-            let text = self.lexed.text(self.index);
+            let length = (self.token_end - self.qualifier_end) as usize;
             self.builder
-                .token(SyntaxValue::token(kind), text.len())
+                .token(SyntaxValue::token(kind), length)
                 .expect("critical violation: syntax tree capacity exceeded");
         }
 
+        self.previous_end = self.token_end;
         self.index += 1;
+        if self.index < self.lexed.len() {
+            let info = self.lexed.info(self.index);
+            self.annotation_end = info.annotation;
+            self.qualifier_end = info.qualifier;
+            self.token_end = info.token;
+            self.position = info.position;
+        }
         self.annotated = false;
         self.qualified = false;
     }
 
     fn error(&mut self, message: impl Into<Arc<str>>) {
-        let info = self.lexed.info(self.index);
-        let offset = info.qualifier as usize;
-        let position = self.lexed.position(self.index);
+        let offset = self.qualifier_end as usize;
+        let position = self.position;
         let message = message.into();
         self.builder
             .token_empty(SyntaxValue::token(SyntaxKind::ERROR))
@@ -131,22 +164,28 @@ impl<'l, 's> Builder<'l, 's> {
     }
 }
 
-pub(crate) fn build(lexed: &Lexed<'_>, output: Vec<Output>) -> (ParsedModule, Vec<ParseError>) {
+pub(crate) fn build(lexed: &Lexed<'_>, output: Output) -> (ParsedModule, Vec<ParseError>) {
     let mut builder = Builder::new(lexed);
+    let mut errors = output.errors.into_iter();
 
-    for event in output {
+    for event in output.events {
         match event {
-            Output::Start { kind } => builder.start(kind),
-            Output::Annotate => builder.annotate(),
-            Output::Qualify => builder.qualify(),
-            Output::Token { kind } => builder.token(kind),
-            Output::Error { message: ParserError::Message(message) } => builder.error(message),
-            Output::Error { message: ParserError::Expected(kind) } => {
-                builder.error(format!("Expected {kind:?}"));
+            Event::Start { kind } => builder.start(kind),
+            Event::Annotate => builder.annotate(),
+            Event::Qualify => builder.qualify(),
+            Event::Token { kind } => builder.token(kind),
+            Event::Error => {
+                match errors.next().expect("invariant violated: missing parser error") {
+                    ParserError::Message(message) => builder.error(message),
+                    ParserError::Expected(kind) => {
+                        builder.error(format!("Expected {kind:?}"));
+                    }
+                }
             }
-            Output::Finish => builder.finish(),
+            Event::Finish => builder.finish(),
         }
     }
+    assert!(errors.next().is_none(), "invariant violated: unconsumed parser error");
 
     builder.build()
 }

--- a/compiler-core/parsing/src/lib.rs
+++ b/compiler-core/parsing/src/lib.rs
@@ -30,7 +30,7 @@ impl ParsedModule {
     }
 
     pub fn cst(&self) -> cst::Module {
-        let node = self.syntax_node().clone();
+        let node = self.syntax_node();
         cst::Module::cast(node).expect("invariant violated: expected cst::Module")
     }
 

--- a/compiler-core/parsing/src/parser.rs
+++ b/compiler-core/parsing/src/parser.rs
@@ -7,16 +7,17 @@ mod types;
 
 use std::cell::Cell;
 
+#[cfg(debug_assertions)]
 use drop_bomb::DropBomb;
 use syntax::{SyntaxKind, TokenSet};
 
-use crate::builder::{Output, ParserError};
+use crate::builder::{Event, Output, ParserError};
 
 pub(crate) struct Parser<'t> {
     index: usize,
     tokens: &'t [SyntaxKind],
-    output: Vec<Output>,
-    errors: usize,
+    output: Vec<Event>,
+    errors: Vec<ParserError>,
     fuel: Cell<u16>,
 }
 
@@ -26,20 +27,21 @@ impl<'t> Parser<'t> {
     pub(crate) fn new(tokens: &'t [SyntaxKind]) -> Parser<'t> {
         let index = 0;
         let output = Vec::with_capacity(tokens.len());
-        let errors = 0;
+        let errors = vec![];
         let fuel = Cell::new(u16::MAX);
         Parser { index, tokens, output, errors, fuel }
     }
 
-    pub(crate) fn finish(self) -> Vec<Output> {
-        self.output
+    pub(crate) fn finish(self) -> Output {
+        Output { events: self.output, errors: self.errors }
     }
 
     fn nth(&self, index: usize) -> SyntaxKind {
-        if self.fuel.get() == 0 {
+        let fuel = self.fuel.get();
+        if fuel == 0 {
             panic!("invariant violated: fuel exhausted");
         }
-        self.fuel.set(self.fuel.get().saturating_sub(1));
+        self.fuel.set(fuel - 1);
         self.tokens.get(self.index + index).copied().unwrap_or(SyntaxKind::END_OF_FILE)
     }
 
@@ -47,73 +49,71 @@ impl<'t> Parser<'t> {
         self.fuel.set(u16::MAX);
         let kind = self.tokens[self.index];
         self.index += 1;
-        self.output.push(Output::Token { kind });
+        self.output.push(Event::Token { kind });
     }
 
     fn annotate(&mut self) {
-        self.output.push(Output::Annotate);
+        self.output.push(Event::Annotate);
     }
 
     fn qualify(&mut self) {
-        self.output.push(Output::Qualify);
+        self.output.push(Event::Qualify);
     }
 
     fn start(&mut self) -> NodeMarker {
         let index = self.output.len();
         let token_index = self.index;
-        self.output.push(Output::Start { kind: SyntaxKind::Node });
+        self.output.push(Event::Start { kind: SyntaxKind::Node });
         NodeMarker::new(index, token_index)
     }
 
     fn optional(&mut self, rule: Rule) {
         let initial_index = self.index;
         let initial_output = self.output.len();
-        let initial_errors = self.errors;
+        let initial_errors = self.errors.len();
 
         rule(self);
 
-        if self.errors != initial_errors {
+        if self.errors.len() != initial_errors {
             self.index = initial_index;
             self.output.truncate(initial_output);
-            self.errors = initial_errors;
+            self.errors.truncate(initial_errors);
         }
     }
 
     fn alternative(&mut self, rules: impl IntoIterator<Item = Rule>) {
         let initial_index = self.index;
         let initial_output = self.output.len();
-        let initial_errors = self.errors;
+        let initial_errors = self.errors.len();
+        let mut rules = rules.into_iter();
+        let fallback = rules.next().expect("invariant violated: at least one branch");
 
-        let mut fallback = None;
+        fallback(self);
+        if self.errors.len() == initial_errors {
+            return;
+        }
+        self.index = initial_index;
+        self.output.truncate(initial_output);
+        self.errors.truncate(initial_errors);
 
-        for rule in rules.into_iter() {
+        for rule in rules {
             rule(self);
 
-            if self.errors == initial_errors {
+            if self.errors.len() == initial_errors {
                 return;
             }
 
-            if fallback.is_none() {
-                let output = self.output.drain(initial_output..).collect();
-                fallback = Some((self.index, self.errors, output));
-            } else {
-                self.output.truncate(initial_output);
-            }
-
             self.index = initial_index;
-            self.errors = initial_errors;
+            self.output.truncate(initial_output);
+            self.errors.truncate(initial_errors);
         }
 
-        let (index, errors, mut output) =
-            fallback.expect("invariant violated: at least one branch");
-        self.index = index;
-        self.errors = errors;
-        self.output.append(&mut output);
+        fallback(self);
     }
 
     fn error(&mut self, message: &'static str) {
-        self.errors += 1;
-        self.output.push(Output::Error { message: ParserError::Message(message) });
+        self.errors.push(ParserError::Message(message));
+        self.output.push(Event::Error);
     }
 
     fn error_recover(&mut self, message: &'static str) {
@@ -161,7 +161,7 @@ impl<'t> Parser<'t> {
         }
         self.fuel.set(u16::MAX);
         self.index += 1;
-        self.output.push(Output::Token { kind });
+        self.output.push(Event::Token { kind });
         true
     }
 
@@ -169,8 +169,8 @@ impl<'t> Parser<'t> {
         if self.eat(kind) {
             return true;
         }
-        self.errors += 1;
-        self.output.push(Output::Error { message: ParserError::Expected(kind) });
+        self.errors.push(ParserError::Expected(kind));
+        self.output.push(Event::Error);
         false
     }
 
@@ -183,27 +183,48 @@ impl<'t> Parser<'t> {
     }
 }
 
+struct MarkerBomb {
+    #[cfg(debug_assertions)]
+    inner: DropBomb,
+}
+
+impl MarkerBomb {
+    fn new() -> MarkerBomb {
+        #[cfg(debug_assertions)]
+        let inner = DropBomb::new("critical failure: failed to call end or cancel");
+        MarkerBomb {
+            #[cfg(debug_assertions)]
+            inner,
+        }
+    }
+
+    fn defuse(&mut self) {
+        #[cfg(debug_assertions)]
+        self.inner.defuse();
+    }
+}
+
 struct NodeMarker {
     index: usize,
     token_index: usize,
-    bomb: DropBomb,
+    bomb: MarkerBomb,
 }
 
 impl NodeMarker {
     fn new(index: usize, token_index: usize) -> NodeMarker {
-        let bomb = DropBomb::new("failed to call end or cancel");
+        let bomb = MarkerBomb::new();
         NodeMarker { index, token_index, bomb }
     }
 
     fn end(&mut self, parser: &mut Parser, kind: SyntaxKind) {
         self.bomb.defuse();
         match &mut parser.output[self.index] {
-            Output::Start { kind: marker } => {
+            Event::Start { kind: marker } => {
                 *marker = kind;
             }
             _ => unreachable!(),
         }
-        parser.output.push(Output::Finish);
+        parser.output.push(Event::Finish);
     }
 
     fn end_non_empty(&mut self, parser: &mut Parser, kind: SyntaxKind) {
@@ -218,7 +239,7 @@ impl NodeMarker {
         self.bomb.defuse();
         if self.index == parser.output.len() - 1 {
             match parser.output.pop() {
-                Some(Output::Start { kind: SyntaxKind::Node }) => (),
+                Some(Event::Start { kind: SyntaxKind::Node }) => (),
                 _ => unreachable!(),
             }
         }
@@ -395,7 +416,7 @@ fn imports_and_statements(p: &mut Parser) {
         }
     };
 
-    while p.at(SyntaxKind::IMPORT) && !p.at_eof() {
+    while p.at(SyntaxKind::IMPORT) {
         import_statement(p);
         recover_until_end(p, "Unexpected tokens in import statement");
         if !p.at(SyntaxKind::LAYOUT_END) {
@@ -407,7 +428,7 @@ fn imports_and_statements(p: &mut Parser) {
 
     let mut statements = p.start();
 
-    while p.at_in(MODULE_STATEMENT_START) && !p.at_eof() {
+    while p.at_in(MODULE_STATEMENT_START) {
         module_statement(p);
         recover_until_end(p, "Unexpected tokens in module statement");
         if !p.at(SyntaxKind::LAYOUT_END) {
@@ -751,7 +772,7 @@ fn class_statements(p: &mut Parser) {
             e.end(p, SyntaxKind::ERROR);
         }
     };
-    while p.at_in(names::LOWER) && !p.at_eof() {
+    while p.at_in(names::LOWER) {
         class_statement(p);
         recover_until_end(p, "Unexpected tokens in class statement");
         if !p.at(SyntaxKind::LAYOUT_END) {
@@ -773,7 +794,7 @@ fn class_statement(p: &mut Parser) {
 fn instance_chain(p: &mut Parser) {
     let mut m = p.start();
     instance_declaration(p);
-    while p.at(SyntaxKind::ELSE) && !p.at_eof() {
+    while p.at(SyntaxKind::ELSE) {
         instance_declaration(p);
     }
     m.end(p, SyntaxKind::InstanceChain);
@@ -836,7 +857,7 @@ fn instance_constraints(p: &mut Parser) {
 fn instance_head(p: &mut Parser) {
     let mut m = p.start();
     names::upper(p);
-    while p.at_in(types::TYPE_ATOM_START) && !p.at_eof() {
+    while p.at_in(types::TYPE_ATOM_START) {
         types::type_atom(p);
     }
     m.end(p, SyntaxKind::InstanceHead);
@@ -858,7 +879,7 @@ fn instance_statements(p: &mut Parser) {
             e.end(p, SyntaxKind::ERROR);
         }
     };
-    while p.at_in(names::LOWER) && !p.at_eof() {
+    while p.at_in(names::LOWER) {
         instance_statement(p);
         recover_until_end(p, "Unexpected tokens in instance statement");
         if !p.at(SyntaxKind::LAYOUT_END) {
@@ -885,7 +906,7 @@ fn derive_declaration(p: &mut Parser) {
     p.optional(instance_name);
     p.optional(instance_constraints);
     instance_head(p);
-    while p.at_in(types::TYPE_ATOM_START) && !p.at_eof() {
+    while p.at_in(types::TYPE_ATOM_START) {
         types::type_atom(p);
     }
     m.end(p, SyntaxKind::DeriveDeclaration);
@@ -939,7 +960,7 @@ fn data_constructors(p: &mut Parser) {
 fn data_constructor(p: &mut Parser) {
     let mut m = p.start();
     p.expect(SyntaxKind::UPPER);
-    while p.at_in(types::TYPE_ATOM_START) && !p.at_eof() {
+    while p.at_in(types::TYPE_ATOM_START) {
         types::type_atom(p);
     }
     m.end(p, SyntaxKind::DataConstructor);

--- a/compiler-core/parsing/src/parser/binders.rs
+++ b/compiler-core/parsing/src/parser/binders.rs
@@ -19,7 +19,7 @@ pub(super) fn binder_1(p: &mut Parser) {
     let mut i = 0;
 
     binder_2(p);
-    while p.at_in(names::OPERATOR) && !p.at_eof() {
+    while p.at_in(names::OPERATOR) {
         let mut n = p.start();
         let mut o = p.start();
         names::operator(p);
@@ -63,7 +63,7 @@ fn binder_2(p: &mut Parser) {
 
 fn binder_constructor(p: &mut Parser, mut m: NodeMarker) {
     names::upper(p);
-    while p.at_in(BINDER_ATOM_START) && !p.at_eof() {
+    while p.at_in(BINDER_ATOM_START) {
         binder_atom(p);
     }
     m.end(p, SyntaxKind::BinderConstructor);

--- a/compiler-core/parsing/src/parser/binding.rs
+++ b/compiler-core/parsing/src/parser/binding.rs
@@ -22,7 +22,7 @@ pub(super) fn let_binding_statements(p: &mut Parser) {
         }
     };
     p.expect(SyntaxKind::LAYOUT_START);
-    while p.at_in(LET_BINDING_START) && !p.at_eof() {
+    while p.at_in(LET_BINDING_START) {
         p.alternative([let_binding_signature_or_equation, let_binding_pattern]);
         recover_until_end(p, "Unexpected tokens in let binding statement");
         if !p.at(SyntaxKind::LAYOUT_END) {

--- a/compiler-core/parsing/src/parser/expressions.rs
+++ b/compiler-core/parsing/src/parser/expressions.rs
@@ -19,7 +19,7 @@ fn expression_1(p: &mut Parser) {
     let mut i = 0;
 
     expression_2(p);
-    while p.at_in(names::OPERATOR) && !p.at_eof() {
+    while p.at_in(names::OPERATOR) {
         let mut n = p.start();
         let mut o = p.start();
         names::operator(p);
@@ -41,7 +41,7 @@ fn expression_2(p: &mut Parser) {
     let mut i = 0;
 
     expression_3(p);
-    while p.at(SyntaxKind::TICK) && !p.at_eof() {
+    while p.at(SyntaxKind::TICK) {
         let mut m = p.start();
         tick_expression(p);
         expression_3(p);
@@ -69,7 +69,7 @@ fn tick_expression_1(p: &mut Parser) {
     let mut i = 0;
 
     expression_3(p);
-    while p.at_in(names::OPERATOR) && !p.at_eof() {
+    while p.at_in(names::OPERATOR) {
         names::operator(p);
         expression_3(p);
         i += 1;
@@ -99,7 +99,7 @@ fn expression_4(p: &mut Parser) {
     let mut i = 0;
 
     expression_5(p);
-    while at_argument(p) && !p.at_eof() {
+    while at_argument(p) {
         expression_argument(p);
         i += 1;
     }
@@ -295,7 +295,7 @@ fn do_statements(p: &mut Parser) {
         }
     };
     p.expect(SyntaxKind::LAYOUT_START);
-    while p.at_in(DO_STATEMENT_START) && !p.at_eof() {
+    while p.at_in(DO_STATEMENT_START) {
         do_statement(p);
         recover_until_end(p, "Unexpected tokens in do statement");
         if !p.at(SyntaxKind::LAYOUT_END) {
@@ -402,7 +402,7 @@ fn expression_7(p: &mut Parser) {
     let mut i = 0;
 
     expression_atom(p);
-    while p.at(SyntaxKind::PERIOD) && !p.at_eof() {
+    while p.at(SyntaxKind::PERIOD) {
         let mut label = p.start();
         p.expect(SyntaxKind::PERIOD);
         names::label(p);

--- a/compiler-core/parsing/src/parser/generic.rs
+++ b/compiler-core/parsing/src/parser/generic.rs
@@ -80,7 +80,7 @@ pub(super) fn where_expression(p: &mut Parser) {
 }
 
 fn conditionals(p: &mut Parser, s: SyntaxKind) {
-    while p.at(SyntaxKind::PIPE) && !p.at_eof() {
+    while p.at(SyntaxKind::PIPE) {
         pattern_guarded(p, s);
     }
 }

--- a/compiler-core/parsing/src/parser/types.rs
+++ b/compiler-core/parsing/src/parser/types.rs
@@ -48,7 +48,7 @@ pub(super) fn type_3(p: &mut Parser) {
     let mut i = 0;
 
     type_4(p);
-    while p.at_in(names::OPERATOR) && !p.at_eof() {
+    while p.at_in(names::OPERATOR) {
         let mut n = p.start();
         let mut o = p.start();
         names::operator(p);
@@ -82,7 +82,7 @@ pub(super) fn type_5(p: &mut Parser) {
     let mut i = 0;
 
     type_atom(p);
-    while p.at_in(TYPE_ATOM_START) && !p.at_eof() {
+    while p.at_in(TYPE_ATOM_START) {
         type_atom(p);
         i += 1;
     }


### PR DESCRIPTION
## Intent

Reduce parsing time and transient parser memory without changing CST structure, source ranges, diagnostics, recovery behavior, or malformed-input termination.

## Changes

- Separate compact parser events from rare diagnostic payloads while preserving their ordering through speculative rollback.
- Avoid allocating a saved event tail for failed alternatives by deterministically rerunning the fallback only when every branch fails.
- Cache lexed annotation, qualifier, token, and position metadata while building the syntax tree, avoiding repeated lookups and source slicing.
- Keep unfinished-marker validation in debug builds while compiling its wrapper to a zero-sized type in release builds.
- Remove redundant EOF predicates from loops already guarded by positive non-EOF token sets.
- Remove an unnecessary syntax-node clone.

## Performance

The existing pre-lexed integration-fixture Criterion benchmark improved from approximately 4.32 ms to 3.7 ms, a roughly 13–14% reduction in parse time.

## Verification

- `cargo check -p parsing --tests`
- `cargo check -p parsing --release`
- `cargo nextest run -p parsing` — 405 passed
- `cargo nextest run -p parsing --release` — 405 passed
- `cargo bench -p tests-compatibility --bench parsing -- 'parsing/.*/parse-prelexed-single-core' --warm-up-time 1 --measurement-time 3 --noplot`
- `just format`
- `git diff --check`