### PR TITLE
[checking] Reuse node map allocations during zonking

### DIFF
--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -45,19 +45,21 @@ where
 {
     macro_rules! zonk_type_map {
         ($field:ident) => {
-            for (node_id, type_id) in mem::take(&mut state.checked.node_types.$field) {
-                let type_id = zonk(state, context, type_id)?;
-                state.checked.node_types.$field.insert(node_id, type_id);
+            let mut node_types = mem::take(&mut state.checked.node_types.$field);
+            for type_id in node_types.values_mut() {
+                *type_id = zonk(state, context, *type_id)?;
             }
+            state.checked.node_types.$field = node_types;
         };
     }
 
     macro_rules! zonk_operator_map {
         ($field:ident) => {
-            for (node_id, branch_types) in mem::take(&mut state.checked.node_types.$field) {
-                let branch_types = zonk_operator_branch(state, context, branch_types)?;
-                state.checked.node_types.$field.insert(node_id, branch_types);
+            let mut operator_types = mem::take(&mut state.checked.node_types.$field);
+            for branch_types in operator_types.values_mut() {
+                *branch_types = zonk_operator_branch(state, context, *branch_types)?;
             }
+            state.checked.node_types.$field = operator_types;
         };
     }
 


### PR DESCRIPTION
## Intent

Final zonking currently consumes each checked node/operator map and rebuilds it through repeated insertion. This pull request keeps ownership separate from `CheckState` while zonking, mutates map values in place, and restores the original map allocation after successful traversal.

Keys, value transformations, traversal coverage, and query-error propagation remain unchanged. If zonking fails before restoration, the local map is dropped and the current field remains empty; this state is not observable because the sole caller discards its local `CheckState` when propagating that error.

## Performance

The Core compatibility corpus was prepared before timing (59 packages, 294 PureScript files, 1,034,898 source bytes). Six Criterion runs showed substantial contradictory run-to-run drift, including statistically significant improvements and regressions. The benchmark therefore does not establish an end-to-end speedup or slowdown; the concrete benefit is avoiding eleven map allocation/reinsertion cycles.

## Validation

- `just format`
- `git diff --check`
- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (30 passed)
- `just t checking` (all tests passed, no pending snapshots)