### PR TITLE
[checking] Check typed expressions against annotations

### DIFF
--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -248,6 +248,20 @@ where
     };
 
     match kind {
+        lowering::ExpressionKind::Typed { expression, type_ } => {
+            let Some(expression) = expression else {
+                return Ok(allocate_error_expression(state, unknown));
+            };
+            let Some(type_) = type_ else {
+                return Ok(allocate_error_expression(state, unknown));
+            };
+
+            let (annotation, _) = types::check_kind(state, context, *type_, context.prim.t)?;
+            let applications =
+                application::check_subsumption(state, context, annotation, expected)?;
+            let checked = check_expression(state, context, *expression, annotation)?;
+            Ok(application::materialize_implicit_applications(state, checked, applications))
+        }
         lowering::ExpressionKind::Lambda { binders, expression } => {
             forms::check_lambda(state, context, binders, *expression, expected)
         }
@@ -364,7 +378,7 @@ where
                 return Ok(allocate_error_expression(state, unknown));
             };
 
-            let (t, _) = types::infer_kind(state, context, *t)?;
+            let (t, _) = types::check_kind(state, context, *t, context.prim.t)?;
             check_expression(state, context, *e, t)
         }
 

--- a/compiler-core/checking/src/source/terms/application.rs
+++ b/compiler-core/checking/src/source/terms/application.rs
@@ -227,8 +227,20 @@ pub fn subtype_expression<Q>(
 where
     Q: ExternalQueries,
 {
-    let applications =
-        unification::subtype_with_applications(state, context, expression.type_id, expected)?;
+    let applications = check_subsumption(state, context, expression.type_id, expected)?;
+    Ok(materialize_implicit_applications(state, expression, applications))
+}
+
+pub(super) fn check_subsumption<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    inferred: TypeId,
+    expected: TypeId,
+) -> QueryResult<Vec<ImplicitApplication>>
+where
+    Q: ExternalQueries,
+{
+    let applications = unification::subtype_with_applications(state, context, inferred, expected)?;
     let applications = applications.into_iter().map(|application| match application {
         unification::SubtypeApplication::Type { argument, result } => {
             ImplicitApplication::Type { argument, result }
@@ -237,10 +249,10 @@ where
             ImplicitApplication::Evidence { evidence, result }
         }
     });
-    Ok(materialize_implicit_applications(state, expression, applications))
+    Ok(applications.collect())
 }
 
-fn materialize_implicit_applications(
+pub(super) fn materialize_implicit_applications(
     state: &mut CheckState,
     mut expression: ElaboratedExpression,
     implicit: impl IntoIterator<Item = ImplicitApplication>,

--- a/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.purs
+++ b/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.purs
@@ -1,0 +1,16 @@
+module Main where
+
+foreign import unsafeCoerce :: forall a b. a -> b
+
+class Convert :: (Type -> Type) -> (Type -> Type) -> Constraint
+class Convert f g where
+  convert :: forall a. f a -> g a
+
+data F :: Type -> Type
+data F a
+
+data G :: Type -> Type
+data G a
+
+instance Convert F G where
+  convert = (unsafeCoerce :: forall a. F a -> G a)

--- a/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.snap
+++ b/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Convert :: (Prim.Type -> Prim.Type) -> (Prim.Type -> Prim.Type) -> Prim.Constraint
+interface Convert f g where
+  convert :: forall (a :: Prim.Type). f a -> g a
+
+data F :: Prim.Type -> Prim.Type
+data F @a
+
+data G :: Prim.Type -> Prim.Type
+data G @a
+
+foreign import unsafeCoerce :: forall a b. a -> b
+
+dictionary convertG :: Main.Convert Main.F Main.G where
+  convert :: forall (a :: Prim.Type). Main.F a -> Main.G a
+  convert = (\@a -> unsafeCoerce @(Main.F a) @(Main.G a)) @a1

--- a/tests-integration/fixtures/semantic/1786336800_typed_expression_available_constraint/Main.purs
+++ b/tests-integration/fixtures/semantic/1786336800_typed_expression_available_constraint/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+class Value :: Type -> Constraint
+class Value a where
+  value :: a
+
+test :: Value Int => Int
+test = (value :: Value Int => Int)

--- a/tests-integration/fixtures/semantic/1786336800_typed_expression_available_constraint/Main.snap
+++ b/tests-integration/fixtures/semantic/1786336800_typed_expression_available_constraint/Main.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Value :: Prim.Type -> Prim.Constraint
+interface Value a where
+  value :: a
+
+test :: Main.Value Prim.Int => Prim.Int
+test = \{valueDict} -> (\{valueDict1} -> value @Prim.Int {valueDict1}) {valueDict}

--- a/tests-integration/fixtures/semantic/1786336800_typed_expression_constraint_scope/Main.purs
+++ b/tests-integration/fixtures/semantic/1786336800_typed_expression_constraint_scope/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+class Value :: Type -> Constraint
+class Value a where
+  value :: a
+
+test :: Int
+test = (value :: Value Int => Int)

--- a/tests-integration/fixtures/semantic/1786336800_typed_expression_constraint_scope/Main.snap
+++ b/tests-integration/fixtures/semantic/1786336800_typed_expression_constraint_scope/Main.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Value :: Prim.Type -> Prim.Constraint
+interface Value a where
+  value :: a
+
+test :: Prim.Int
+test = (\{valueDict} -> value @Prim.Int {valueDict}) {error}

--- a/tests-integration/fixtures/semantic/1786336800_typed_expression_nested_constraint/Main.purs
+++ b/tests-integration/fixtures/semantic/1786336800_typed_expression_nested_constraint/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+class Value :: Type -> Constraint
+class Value a
+
+constrainedIdentity :: forall a. Value a => a -> a
+constrainedIdentity value = value
+
+test :: forall a. Value a => a -> a
+test = (constrainedIdentity :: forall b. Value b => b -> b)

--- a/tests-integration/fixtures/semantic/1786336800_typed_expression_nested_constraint/Main.snap
+++ b/tests-integration/fixtures/semantic/1786336800_typed_expression_nested_constraint/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Value :: Prim.Type -> Prim.Constraint
+interface Value a where
+
+constrainedIdentity :: forall a. Main.Value a => a -> a
+constrainedIdentity = \{valueDict} -> \value -> value
+
+test :: forall a. Main.Value a => a -> a
+test = \{valueDict} -> (\@b -> \{valueDict1} -> constrainedIdentity @b {valueDict1}) @a {valueDict}


### PR DESCRIPTION
## Summary

Typed expressions now use the checking rule implemented by the reference PureScript compiler: the annotation is checked to have kind `Type`, annotation-to-context subsumption is established before checking the payload, and the resulting type or evidence applications are materialized around the checked expression.

Separate semantic fixtures record polymorphic instance members, available and missing constrained evidence, and nested type/evidence abstraction ownership.

## Motivation

Typed expressions previously fell through the generic infer-then-check path. Nested abstraction support made the original polymorphic instance example type-check, but the implementation still did not model the dedicated `Typed` checking rule or its ordering directly.

## Verification

- `cargo check -p checking --tests`
- `cargo nextest run -p checking`
- `just t checking`
- `just t semantic`
- Reference cases compiled with `purs 0.15.16`; the missing-evidence case was confirmed to fail with `NoInstanceFound`