### PR TITLE
[checking] Memoize final zonking subtrees

### DIFF
--- a/compiler-core/checking/src/core/fold.rs
+++ b/compiler-core/checking/src/core/fold.rs
@@ -23,6 +23,16 @@ pub trait TypeFold {
     ) -> QueryResult<FoldAction>;
 
     fn transform_binder(&mut self, _binder: &mut ForallBinder) {}
+
+    fn complete<Q: ExternalQueries>(
+        &mut self,
+        _state: &mut CheckState,
+        _context: &CheckContext<Q>,
+        _id: TypeId,
+        result: TypeId,
+    ) -> QueryResult<TypeId> {
+        Ok(result)
+    }
 }
 
 pub fn fold_type<Q, F>(
@@ -107,7 +117,7 @@ where
         Type::Unification(_) | Type::Free(_) | Type::Unknown(_) => id,
     };
 
-    Ok(result)
+    folder.complete(state, context, id, result)
 }
 
 /// Flatten a row type into a single row.

--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -20,15 +20,30 @@ struct Zonk;
 impl TypeFold for Zonk {
     fn transform<Q>(
         &mut self,
-        _state: &mut CheckState,
+        state: &mut CheckState,
         _context: &CheckContext<Q>,
-        _id: TypeId,
+        id: TypeId,
         _t: &Type,
     ) -> QueryResult<FoldAction>
     where
         Q: ExternalQueries,
     {
-        Ok(FoldAction::Continue)
+        let cached = state.lookup_zonk_cache(id);
+        Ok(cached.map_or(FoldAction::Continue, FoldAction::Replace))
+    }
+
+    fn complete<Q>(
+        &mut self,
+        state: &mut CheckState,
+        _context: &CheckContext<Q>,
+        id: TypeId,
+        result: TypeId,
+    ) -> QueryResult<TypeId>
+    where
+        Q: ExternalQueries,
+    {
+        state.insert_zonk_cache(id, result);
+        Ok(result)
     }
 }
 

--- a/compiler-core/checking/src/lib.rs
+++ b/compiler-core/checking/src/lib.rs
@@ -221,11 +221,13 @@ fn check_source(queries: &impl ExternalQueries, file_id: FileId) -> QueryResult<
 
     source::check_type_items(&mut state, &context)?;
     source::check_term_items(&mut state, &context)?;
-    core::zonk::zonk_nodes(&mut state, &context)?;
-    core::zonk::zonk_tree(&mut state, &context)?;
-    core::zonk::zonk_evidence(&mut state, &context)?;
-    core::zonk::zonk_holes(&mut state, &context)?;
-    core::zonk::zonk_errors(&mut state, &context)?;
+    state.with_zonk_cache(|state| {
+        core::zonk::zonk_nodes(state, &context)?;
+        core::zonk::zonk_tree(state, &context)?;
+        core::zonk::zonk_evidence(state, &context)?;
+        core::zonk::zonk_holes(state, &context)?;
+        core::zonk::zonk_errors(state, &context)
+    })?;
     state.checked.evidence.assert_finished();
 
     Ok(state.checked)

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -55,10 +55,12 @@ pub struct UnificationEntry {
 pub struct Unifications {
     entries: Vec<UnificationEntry>,
     unique: u32,
+    frozen: bool,
 }
 
 impl Unifications {
     pub fn fresh(&mut self, depth: Depth, kind: TypeId) -> u32 {
+        assert!(!self.frozen, "invariant violated: fresh unification created while frozen");
         let unique = self.unique;
 
         self.unique += 1;
@@ -76,11 +78,25 @@ impl Unifications {
     }
 
     pub fn solve(&mut self, index: u32, solution: TypeId) {
+        let frozen = self.frozen;
+        let state = self.get(index).state;
+        assert!(
+            !frozen || matches!(state, UnificationState::Solved(_)),
+            "invariant violated: unification solved while frozen"
+        );
         self.get_mut(index).state = UnificationState::Solved(solution);
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &UnificationEntry> {
         self.entries.iter()
+    }
+
+    fn freeze(&mut self) {
+        self.frozen = true;
+    }
+
+    fn unfreeze(&mut self) {
+        self.frozen = false;
     }
 }
 
@@ -140,6 +156,8 @@ pub struct CheckState {
     pub bindings: Bindings,
     pub patterns: PatternInterner,
 
+    zonk_cache: Option<FxHashMap<TypeId, TypeId>>,
+
     pub unifications: Unifications,
     pub implications: Implications,
     pub canonicals: Canonicals,
@@ -158,6 +176,7 @@ impl CheckState {
             names: Names::new(file_id),
             bindings: Default::default(),
             patterns: Default::default(),
+            zonk_cache: None,
             unifications: Default::default(),
             implications: Default::default(),
             canonicals: Default::default(),
@@ -165,6 +184,31 @@ impl CheckState {
             defer_expansion: Default::default(),
             depth: Depth(0),
             crumbs: Default::default(),
+        }
+    }
+
+    /// Enables subtree memoization while preventing new unification solutions.
+    ///
+    /// Existing solutions may still be path-compressed.
+    pub fn with_zonk_cache<T>(&mut self, f: impl FnOnce(&mut CheckState) -> T) -> T {
+        assert!(self.zonk_cache.is_none(), "invariant violated: zonk cache enabled twice");
+        self.unifications.freeze();
+        self.zonk_cache = Some(FxHashMap::default());
+
+        let result = f(self);
+
+        self.zonk_cache = None;
+        self.unifications.unfreeze();
+        result
+    }
+
+    pub(crate) fn lookup_zonk_cache(&self, id: TypeId) -> Option<TypeId> {
+        self.zonk_cache.as_ref().and_then(|cache| cache.get(&id)).copied()
+    }
+
+    pub(crate) fn insert_zonk_cache(&mut self, id: TypeId, result: TypeId) {
+        if let Some(cache) = &mut self.zonk_cache {
+            cache.insert(id, result);
         }
     }
 


### PR DESCRIPTION
## Summary

Memoize fully folded type subtrees only during the consecutive final-output zonking passes.

- add a per-check normalized `TypeId -> TypeId` zonk cache
- expose a minimal generic fold completion hook so zonking can record completed subtrees
- scope cache activation to nodes, tree, evidence, holes, and errors
- freeze unifications while the cache is active, rejecting fresh variables and new solutions while permitting path compression of existing solutions

## Correctness

The cache is absent throughout inference, constraint solving, and earlier individual zonk calls. `fold_type` normalizes an input before cache lookup, and only successful completed folds are stored. Cached errors are therefore impossible, and normal `QueryResult` propagation remains unchanged.

The only work after activation beyond final-output rewriting is hole-binding refinement. That path normalizes, expands, interns, and compares types but does not introduce or solve unification variables. Runtime guards on `Unifications::fresh` and `Unifications::solve` enforce this boundary.

## Verification

- `just format`
- `git diff --check`
- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (30 passed)
- `just t checking` (all tests passed, no pending snapshots)

## Benchmark

Prepared the Core corpus first with:

```console
cargo run -p tests-compatibility --release -- prepare --preset core
```

Corpus: 59 packages, 294 PureScript files, 1,034,898 source bytes.

All measurements used:

```console
cargo bench -p tests-compatibility --bench checking_single_core -- check-core
```

Clean baseline point estimates were 698.54 ms (95% CI 689.04–712.64 ms) and 712.46 ms (95% CI 702.68–718.57 ms); Criterion found no significant drift between them (p = 0.82).

The first isolated memoized run was 610.92 ms (95% CI 580.45–631.75 ms), a significant 15.711% improvement over the latest baseline (95% comparison CI 12.750%–18.416%, p < 0.01). Subsequent memoized runs were 580.69 ms and, with runtime freeze enforcement, 548.69 ms. These later favorable shifts show environmental drift and are not attributed to the guards.

These measurements predate the rebase onto the current `main`, which now includes #274 and #276, so they isolate this change against the baseline at the start of the work rather than estimate its incremental effect over those later optimizations.