### PR TITLE
[lsp] Highlight complete names in hover responses

### DIFF
--- a/compiler-lsp/analyzer/src/definition.rs
+++ b/compiler-lsp/analyzer/src/definition.rs
@@ -56,6 +56,12 @@ pub fn implementation(
                 lowered.tree.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             definition_file_type(context, f_id, t_id)
         }
+        locate::Located::TermReference(file_id, term_id) => {
+            definition_file_term(context, file_id, term_id)
+        }
+        locate::Located::TypeReference(file_id, type_id) => {
+            definition_file_type(context, file_id, type_id)
+        }
         locate::Located::InstanceHead(file_id, type_id) => {
             definition_file_type(context, file_id, type_id)
         }

--- a/compiler-lsp/analyzer/src/document_highlight.rs
+++ b/compiler-lsp/analyzer/src/document_highlight.rs
@@ -63,6 +63,12 @@ pub fn implementation(
         locate::Located::TypeOperator(operator_id) => {
             highlight_type_operator(context, current_file, operator_id)
         }
+        locate::Located::TermReference(file_id, term_id) => {
+            highlight_file_term(context, current_file, file_id, term_id)
+        }
+        locate::Located::TypeReference(file_id, type_id) => {
+            highlight_file_type(context, current_file, file_id, type_id)
+        }
         locate::Located::InstanceHead(file_id, type_id) => {
             highlight_file_type(context, current_file, file_id, type_id)
         }
@@ -349,6 +355,18 @@ fn highlight_file_term(
         }
     }
 
+    let ranges = locate::term_infix_reference_ranges(
+        &content,
+        &parsed,
+        &stabilized,
+        &indexed,
+        &lowered,
+        (file_id, term_id),
+    );
+    for range in ranges {
+        highlights.extend(document_highlight(&content, context.position_encoding(), range));
+    }
+
     for (pun_id, resolution) in lowered.tree.iter_expression_pun() {
         if let TermVariableResolution::Reference(f_id, t_id) = resolution
             && (f_id, t_id) == (file_id, term_id)
@@ -424,6 +442,18 @@ fn highlight_file_type(
                 }),
             );
         }
+    }
+
+    let ranges = locate::type_infix_reference_ranges(
+        &content,
+        &parsed,
+        &stabilized,
+        &indexed,
+        &lowered,
+        (file_id, type_id),
+    );
+    for range in ranges {
+        highlights.extend(document_highlight(&content, context.position_encoding(), range));
     }
 
     let ranges = locate::instance_head_ranges(

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -7,7 +7,7 @@ use lowering::{BinderKind, ExpressionKind, TermVariableResolution, TypeKind};
 use lsp_types::*;
 use smol_str::ToSmolStr;
 use syntax::ast::{AstNode, AstPtr};
-use syntax::{TextRange, cst};
+use syntax::{SyntaxToken, TextRange, TextSize, cst};
 
 use crate::extract::AnnotationSyntaxRange;
 use crate::{AnalyzerContext, AnalyzerError, AnalyzerQueries, extract, locate, position};
@@ -30,9 +30,14 @@ pub fn implementation(
         position::protocol_position_to_utf8(&content, position, context.position_encoding())
             .ok_or(AnalyzerError::NonFatal)?;
 
-    let located = locate::locate(engine, current_file, position)?;
+    let offset =
+        position::utf8_position_to_offset(&content, position).ok_or(AnalyzerError::NonFatal)?;
+    let (located, token) = locate::locate_with_token(engine, current_file, position)?;
+    let range = hover_name_range(token, offset).and_then(|range| {
+        position::text_range_to_protocol(&content, range, context.position_encoding())
+    });
 
-    match located {
+    let hover = match located {
         locate::Located::ModuleName(module_name) => {
             hover_module_name(engine, current_file, module_name)
         }
@@ -78,7 +83,28 @@ pub fn implementation(
         locate::Located::TypeItem(type_id) => hover_file_type(engine, current_file, type_id),
         locate::Located::LetBinding(let_id) => hover_let(engine, current_file, let_id),
         locate::Located::Nothing => Ok(None),
-    }
+    }?;
+
+    Ok(hover.map(|mut hover| {
+        hover.range = range;
+        hover
+    }))
+}
+
+fn hover_name_range(token: Option<SyntaxToken>, offset: TextSize) -> Option<TextRange> {
+    let token = token?;
+    let mut ancestors = token.parent_ancestors();
+    let range = ancestors.find_map(|node| {
+        let kind = node.kind();
+        if cst::ModuleName::can_cast(kind) {
+            Some(node.text_range())
+        } else if let Some(qualified) = cst::QualifiedName::cast(node) {
+            position::qualified_name_text_range(&qualified)
+        } else {
+            None
+        }
+    });
+    range.filter(|range| range.contains_inclusive(offset))
 }
 
 fn hover_module_name(

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -62,6 +62,12 @@ pub fn implementation(
                 lowered.tree.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             hover_file_type(engine, f_id, t_id)
         }
+        locate::Located::TermReference(file_id, term_id) => {
+            hover_file_term(engine, file_id, term_id)
+        }
+        locate::Located::TypeReference(file_id, type_id) => {
+            hover_file_type(engine, file_id, type_id)
+        }
         locate::Located::InstanceHead(file_id, type_id) => {
             hover_file_type(engine, file_id, type_id)
         }

--- a/compiler-lsp/analyzer/src/locate.rs
+++ b/compiler-lsp/analyzer/src/locate.rs
@@ -215,6 +215,15 @@ pub fn locate(
     id: FileId,
     position: Utf8Position,
 ) -> Result<Located, AnalyzerError> {
+    let (located, _) = locate_with_token(engine, id, position)?;
+    Ok(located)
+}
+
+pub(crate) fn locate_with_token(
+    engine: &impl AnalyzerQueries,
+    id: FileId,
+    position: Utf8Position,
+) -> Result<(Located, Option<SyntaxToken>), AnalyzerError> {
     let content = engine.content(id);
 
     let (parsed, _) = engine.parsed(id)?;
@@ -223,15 +232,18 @@ pub fn locate(
     let lowered = engine.lowered(id)?;
 
     let Some(offset) = position::utf8_position_to_offset(&content, position) else {
-        return Ok(Located::Nothing);
+        return Ok((Located::Nothing, None));
     };
 
     let node = parsed.syntax_node();
     let token = node.token_at_offset(offset);
 
     Ok(match token {
-        TokenAtOffset::None => Located::Nothing,
-        TokenAtOffset::Single(token) => locate_single(&stabilized, &indexed, &lowered, token),
+        TokenAtOffset::None => (Located::Nothing, None),
+        TokenAtOffset::Single(token) => {
+            let located = locate_single(&stabilized, &indexed, &lowered, &token);
+            (located, Some(token))
+        }
         TokenAtOffset::Between(left, right) => {
             locate_between(&stabilized, &indexed, &lowered, left, right)
         }
@@ -242,7 +254,7 @@ fn locate_single(
     stabilized: &StabilizedModule,
     indexed: &IndexedModule,
     lowered: &LoweredModule,
-    token: SyntaxToken,
+    token: &SyntaxToken,
 ) -> Located {
     token
         .parent_ancestors()
@@ -422,16 +434,16 @@ fn locate_between(
     lowered: &LoweredModule,
     left: SyntaxToken,
     right: SyntaxToken,
-) -> Located {
-    let left = locate_single(stabilized, indexed, lowered, left);
-    let right = locate_single(stabilized, indexed, lowered, right);
-    match (&left, &right) {
+) -> (Located, Option<SyntaxToken>) {
+    let left_located = locate_single(stabilized, indexed, lowered, &left);
+    let right_located = locate_single(stabilized, indexed, lowered, &right);
+    match (&left_located, &right_located) {
         // If left/right share an ancestor;
-        (_, _) if left == right => left,
-        (_, Located::Nothing) => left,
-        (Located::Nothing, _) => right,
+        (_, _) if left_located == right_located => (right_located, Some(right)),
+        (_, Located::Nothing) => (left_located, Some(left)),
+        (Located::Nothing, _) => (right_located, Some(right)),
         // otherwise, lean towards the right.
-        (_, _) => right,
+        (_, _) => (right_located, Some(right)),
     }
 }
 

--- a/compiler-lsp/analyzer/src/locate.rs
+++ b/compiler-lsp/analyzer/src/locate.rs
@@ -3,10 +3,12 @@
 use std::iter;
 
 use files::FileId;
-use indexing::{ImportItemId, IndexedModule, IndexedTermItemKind, TermItemId, TypeItemId};
+use indexing::{
+    ImportItemId, IndexedModule, IndexedTermItemKind, IndexedTypeItemKind, TermItemId, TypeItemId,
+};
 use lowering::{
     BinderId, ExpressionId, LetBindingNameGroupId, LoweredModule, RecordAccessLabelId, RecordPunId,
-    TermItemKind, TermOperatorId, TypeId, TypeOperatorId, TypeVariableBindingId,
+    TermItemKind, TermOperatorId, TypeId, TypeItemKind, TypeOperatorId, TypeVariableBindingId,
 };
 use stabilizing::{AstId, StabilizedModule};
 use syntax::ast::{AstNode, AstPtr};
@@ -67,6 +69,65 @@ pub fn instance_head_ranges(
         }
     });
     ranges.collect()
+}
+
+pub fn term_infix_reference_ranges(
+    content: &str,
+    parsed: &parsing::ParsedModule,
+    stabilized: &StabilizedModule,
+    indexed: &IndexedModule,
+    lowered: &LoweredModule,
+    target: (FileId, TermItemId),
+) -> Vec<Utf8Range> {
+    let root = parsed.syntax_node();
+    let ranges = indexed.items.iter_terms().filter_map(|(term_id, item)| {
+        let IndexedTermItemKind::Operator { id } = &item.kind else { return None };
+        let TermItemKind::Operator { resolution, .. } = lowered.tree.get_term_item_kind(term_id)?
+        else {
+            return None;
+        };
+        if resolution.as_ref() != Some(&target) {
+            return None;
+        }
+        infix_reference_range(content, &root, stabilized, *id)
+    });
+    ranges.collect()
+}
+
+pub fn type_infix_reference_ranges(
+    content: &str,
+    parsed: &parsing::ParsedModule,
+    stabilized: &StabilizedModule,
+    indexed: &IndexedModule,
+    lowered: &LoweredModule,
+    target: (FileId, TypeItemId),
+) -> Vec<Utf8Range> {
+    let root = parsed.syntax_node();
+    let ranges = indexed.items.iter_types().filter_map(|(type_id, item)| {
+        let IndexedTypeItemKind::Operator { id } = &item.kind else { return None };
+        let TypeItemKind::Operator { resolution, .. } = lowered.tree.get_type_item_kind(type_id)?
+        else {
+            return None;
+        };
+        if resolution.as_ref() != Some(&target) {
+            return None;
+        }
+        infix_reference_range(content, &root, stabilized, *id)
+    });
+    ranges.collect()
+}
+
+fn infix_reference_range(
+    content: &str,
+    root: &SyntaxNode,
+    stabilized: &StabilizedModule,
+    id: AstId<cst::InfixDeclaration>,
+) -> Option<Utf8Range> {
+    let ptr = stabilized.syntax_ptr(id)?;
+    let declaration = ptr.try_to_node(root).and_then(cst::InfixDeclaration::cast)?;
+    let qualified = declaration.qualified()?;
+    let range = position::qualified_name_text_range(&qualified)?;
+    position::text_range_to_utf8_range(content, range)
 }
 
 fn instance_head_range<T>(
@@ -139,6 +200,8 @@ pub enum Located {
     ExpressionPun(RecordPunId),
     TermOperator(TermOperatorId),
     TypeOperator(TypeOperatorId),
+    TermReference(FileId, TermItemId),
+    TypeReference(FileId, TypeItemId),
     InstanceHead(FileId, TypeItemId),
     InstanceMember(FileId, TermItemId),
     TermItem(TermItemId),
@@ -200,6 +263,8 @@ fn locate_node(
     } else if cst::ModuleName::can_cast(kind) {
         let ptr = ptr.cast()?;
         Some(Located::ModuleName(ptr))
+    } else if cst::QualifiedName::can_cast(kind) {
+        locate_infix_reference(stabilized, indexed, lowered, node)
     } else if cst::ImportItem::can_cast(kind) {
         let ptr = ptr.cast()?;
         let id = stabilized.lookup_ptr(&ptr)?;
@@ -303,6 +368,49 @@ fn locate_node(
         let id = stabilized.lookup_ptr(&ptr)?;
         let (file_id, term_id) = lowered.tree.find_instance_member_resolution(id)?;
         Some(Located::InstanceMember(file_id, term_id))
+    } else {
+        None
+    }
+}
+
+fn locate_infix_reference(
+    stabilized: &StabilizedModule,
+    indexed: &IndexedModule,
+    lowered: &LoweredModule,
+    node: SyntaxNode,
+) -> Option<Located> {
+    let parent = node.parent()?;
+    if !cst::InfixDeclaration::can_cast(parent.kind()) {
+        return None;
+    }
+    let located = resolve_infix_reference(stabilized, indexed, lowered, parent);
+    Some(located.unwrap_or(Located::Nothing))
+}
+
+fn resolve_infix_reference(
+    stabilized: &StabilizedModule,
+    indexed: &IndexedModule,
+    lowered: &LoweredModule,
+    declaration: SyntaxNode,
+) -> Option<Located> {
+    let declaration = cst::Declaration::cast(declaration)?;
+    let ptr = AstPtr::new(&declaration);
+    let declaration_id = stabilized.lookup_ptr(&ptr)?;
+
+    if let Some(term_id) = indexed.pairs.declaration_to_term(declaration_id) {
+        let TermItemKind::Operator { resolution, .. } = lowered.tree.get_term_item_kind(term_id)?
+        else {
+            return None;
+        };
+        let (file_id, term_id) = resolution.as_ref()?;
+        Some(Located::TermReference(*file_id, *term_id))
+    } else if let Some(type_id) = indexed.pairs.declaration_to_type(declaration_id) {
+        let TypeItemKind::Operator { resolution, .. } = lowered.tree.get_type_item_kind(type_id)?
+        else {
+            return None;
+        };
+        let (file_id, type_id) = resolution.as_ref()?;
+        Some(Located::TypeReference(*file_id, *type_id))
     } else {
         None
     }

--- a/compiler-lsp/analyzer/src/position.rs
+++ b/compiler-lsp/analyzer/src/position.rs
@@ -278,6 +278,25 @@ pub fn record_pun_name_range(
     text_range_to_utf8_range(content, token.text_range())
 }
 
+pub fn qualified_name_text_range(qualified: &cst::QualifiedName) -> Option<TextRange> {
+    let qualifier_range = qualified
+        .qualifier()
+        .and_then(|qualifier| qualifier.text())
+        .map(|token| token.text_range());
+    let name_range = qualified
+        .lower()
+        .or_else(|| qualified.upper())
+        .or_else(|| qualified.operator())
+        .or_else(|| qualified.operator_name())
+        .map(|token| token.text_range());
+
+    match (qualifier_range, name_range) {
+        (Some(qualifier), Some(name)) => Some(qualifier.cover(name)),
+        (Some(range), None) | (None, Some(range)) => Some(range),
+        (None, None) => None,
+    }
+}
+
 pub fn infix_operator_range(
     content: &str,
     root: &SyntaxNode,

--- a/compiler-lsp/analyzer/src/references.rs
+++ b/compiler-lsp/analyzer/src/references.rs
@@ -57,6 +57,12 @@ pub fn implementation(
                 lowered.tree.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             references_file_type(context, current_file, f_id, t_id)
         }
+        locate::Located::TermReference(file_id, term_id) => {
+            references_file_term(context, current_file, file_id, term_id)
+        }
+        locate::Located::TypeReference(file_id, type_id) => {
+            references_file_type(context, current_file, file_id, type_id)
+        }
         locate::Located::InstanceHead(file_id, type_id) => {
             references_file_type(context, current_file, file_id, type_id)
         }
@@ -343,6 +349,7 @@ fn references_file_term(
         let content = engine.content(candidate_id);
         let (parsed, _) = engine.parsed(candidate_id)?;
         let stabilized = engine.stabilized(candidate_id)?;
+        let indexed = engine.indexed(candidate_id)?;
         let lowered = engine.lowered(candidate_id)?;
 
         for (expr_id, expr_kind) in lowered.tree.iter_expression() {
@@ -396,6 +403,21 @@ fn references_file_term(
                 locations.push(Location { uri: uri.clone(), range });
             }
         }
+
+        let ranges = locate::term_infix_reference_ranges(
+            &content,
+            &parsed,
+            &stabilized,
+            &indexed,
+            &lowered,
+            (file_id, term_id),
+        );
+        for range in ranges {
+            let range =
+                position::utf8_range_to_protocol(&content, range, context.position_encoding())
+                    .ok_or(AnalyzerError::NonFatal)?;
+            locations.push(Location { uri: uri.clone(), range });
+        }
     }
 
     Ok(Some(locations))
@@ -444,6 +466,21 @@ fn references_file_type(
                     .ok_or(AnalyzerError::NonFatal)?;
                 locations.push(Location { uri: uri.clone(), range });
             }
+        }
+
+        let ranges = locate::type_infix_reference_ranges(
+            &content,
+            &parsed,
+            &stabilized,
+            &indexed,
+            &lowered,
+            (file_id, type_id),
+        );
+        for range in ranges {
+            let range =
+                position::utf8_range_to_protocol(&content, range, context.position_encoding())
+                    .ok_or(AnalyzerError::NonFatal)?;
+            locations.push(Location { uri: uri.clone(), range });
         }
 
         let ranges = locate::instance_head_ranges(

--- a/compiler-lsp/analyzer/src/rename.rs
+++ b/compiler-lsp/analyzer/src/rename.rs
@@ -625,6 +625,8 @@ fn rename_target(
 
             RenameTarget::Type(file_id, type_id)
         }
+        locate::Located::TermReference(file_id, term_id) => RenameTarget::Term(file_id, term_id),
+        locate::Located::TypeReference(file_id, type_id) => RenameTarget::Type(file_id, type_id),
         locate::Located::InstanceHead(file_id, type_id) => RenameTarget::Type(file_id, type_id),
         locate::Located::TermItem(term_id) => RenameTarget::Term(current_file, term_id),
         locate::Located::TypeItem(type_id) => RenameTarget::Type(current_file, type_id),

--- a/tests-integration/fixtures/lsp/1751367660_hover_local/Main.snap
+++ b/tests-integration/fixtures/lsp/1751367660_hover_local/Main.snap
@@ -10,7 +10,7 @@ ref = life
 --    $
 ```
 
-Range: <none>
+Range: "life"
 
 ```purescript
 life :: Int
@@ -24,7 +24,7 @@ Hover at Position { line: 17, character: 6 }
 --    $     $
 ```
 
-Range: <none>
+Range: "life"
 
 ```purescript
 Int
@@ -38,7 +38,7 @@ Hover at Position { line: 17, character: 12 }
 --    $     $
 ```
 
-Range: <none>
+Range: "value"
 
 ```purescript
 Int
@@ -52,7 +52,7 @@ just :: Maybe Int
 --       $
 ```
 
-Range: <none>
+Range: "Maybe"
 
 ```purescript
 Maybe :: Type -> Type
@@ -66,7 +66,7 @@ just = Just 42
 --      $
 ```
 
-Range: <none>
+Range: "Just"
 
 ```purescript
 Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
@@ -80,7 +80,7 @@ nothing :: Maybe Int
 --          $
 ```
 
-Range: <none>
+Range: "Maybe"
 
 ```purescript
 Maybe :: Type -> Type
@@ -94,7 +94,7 @@ nothing = Nothing
 --         $
 ```
 
-Range: <none>
+Range: "Nothing"
 
 ```purescript
 Nothing :: forall (@a :: Type). Maybe (a :: Type)
@@ -108,7 +108,7 @@ Hover at Position { line: 34, character: 3 }
 -- $
 ```
 
-Range: <none>
+Range: "Just"
 
 ```purescript
 Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
@@ -122,7 +122,7 @@ Hover at Position { line: 37, character: 3 }
 -- $
 ```
 
-Range: <none>
+Range: "Nothing"
 
 ```purescript
 Nothing :: forall (@a :: Type). Maybe (a :: Type)

--- a/tests-integration/fixtures/lsp/1751367660_hover_local/Main.snap
+++ b/tests-integration/fixtures/lsp/1751367660_hover_local/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 90
+assertion_line: 134
 expression: report
 ---
 Hover at Position { line: 6, character: 6 }
@@ -9,6 +9,8 @@ Hover at Position { line: 6, character: 6 }
 ref = life
 --    $
 ```
+
+Range: <none>
 
 ```purescript
 life :: Int
@@ -22,6 +24,8 @@ Hover at Position { line: 17, character: 6 }
 --    $     $
 ```
 
+Range: <none>
+
 ```purescript
 Int
 ```
@@ -33,6 +37,8 @@ Hover at Position { line: 17, character: 12 }
     [life, value]
 --    $     $
 ```
+
+Range: <none>
 
 ```purescript
 Int
@@ -46,6 +52,8 @@ just :: Maybe Int
 --       $
 ```
 
+Range: <none>
+
 ```purescript
 Maybe :: Type -> Type
 ```
@@ -57,6 +65,8 @@ Hover at Position { line: 24, character: 8 }
 just = Just 42
 --      $
 ```
+
+Range: <none>
 
 ```purescript
 Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
@@ -70,6 +80,8 @@ nothing :: Maybe Int
 --          $
 ```
 
+Range: <none>
+
 ```purescript
 Maybe :: Type -> Type
 ```
@@ -81,6 +93,8 @@ Hover at Position { line: 29, character: 11 }
 nothing = Nothing
 --         $
 ```
+
+Range: <none>
 
 ```purescript
 Nothing :: forall (@a :: Type). Maybe (a :: Type)
@@ -94,6 +108,8 @@ Hover at Position { line: 34, character: 3 }
 -- $
 ```
 
+Range: <none>
+
 ```purescript
 Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
 ```
@@ -105,6 +121,8 @@ Hover at Position { line: 37, character: 3 }
   Nothing -> 
 -- $
 ```
+
+Range: <none>
 
 ```purescript
 Nothing :: forall (@a :: Type). Maybe (a :: Type)

--- a/tests-integration/fixtures/lsp/1751391900_hover_import/Main.snap
+++ b/tests-integration/fixtures/lsp/1751391900_hover_import/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 90
+assertion_line: 134
 expression: report
 ---
 Hover at Position { line: 2, character: 8 }
@@ -9,6 +9,8 @@ Hover at Position { line: 2, character: 8 }
 import Lib (life, Maybe(..), (+),  type (++))
 --      $    $     $          $          $
 ```
+
+Range: <none>
 
 ```purescript
 module Lib where
@@ -22,6 +24,8 @@ import Lib (life, Maybe(..), (+),  type (++))
 --      $    $     $          $          $
 ```
 
+Range: <none>
+
 ```purescript
 life :: Int
 ```
@@ -33,6 +37,8 @@ Hover at Position { line: 2, character: 19 }
 import Lib (life, Maybe(..), (+),  type (++))
 --      $    $     $          $          $
 ```
+
+Range: <none>
 
 ```purescript
 Maybe :: Type -> Type
@@ -46,6 +52,8 @@ import Lib (life, Maybe(..), (+),  type (++))
 --      $    $     $          $          $
 ```
 
+Range: <none>
+
 ```purescript
 + :: Int -> Int -> Int
 ```
@@ -57,6 +65,8 @@ Hover at Position { line: 2, character: 41 }
 import Lib (life, Maybe(..), (+),  type (++))
 --      $    $     $          $          $
 ```
+
+Range: <none>
 
 ```purescript
 ++ :: Type -> Type -> Type
@@ -70,6 +80,8 @@ ref = life
 --     $
 ```
 
+Range: <none>
+
 ```purescript
 life :: Int
 ```
@@ -81,6 +93,8 @@ Hover at Position { line: 9, character: 24 }
 just :: forall a. a -> Maybe a
 --                      $    $
 ```
+
+Range: <none>
 
 ```purescript
 Maybe :: Type -> Type
@@ -94,6 +108,8 @@ just :: forall a. a -> Maybe a
 --                      $    $
 ```
 
+Range: <none>
+
 ```purescript
 Type
 ```
@@ -105,6 +121,8 @@ Hover at Position { line: 11, character: 8 }
 just = Just
 --      $
 ```
+
+Range: <none>
 
 ```purescript
 Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
@@ -118,6 +136,8 @@ nothing :: forall a. Maybe a
 --                    $
 ```
 
+Range: <none>
+
 ```purescript
 Maybe :: Type -> Type
 ```
@@ -129,6 +149,8 @@ Hover at Position { line: 16, character: 11 }
 nothing = Nothing
 --         $
 ```
+
+Range: <none>
 
 ```purescript
 Nothing :: forall (@a :: Type). Maybe (a :: Type)
@@ -142,6 +164,8 @@ opName = (+)
 --        $
 ```
 
+Range: <none>
+
 ```purescript
 + :: Int -> Int -> Int
 ```
@@ -154,6 +178,8 @@ opChain = 9 + 10
 --          $
 ```
 
+Range: <none>
+
 ```purescript
 + :: Int -> Int -> Int
 ```
@@ -165,6 +191,8 @@ Hover at Position { line: 27, character: 23 }
 type TypeOpChain = Int ++ Int
 --                     $
 ```
+
+Range: <none>
 
 ```purescript
 ++ :: Type -> Type -> Type

--- a/tests-integration/fixtures/lsp/1751391900_hover_import/Main.snap
+++ b/tests-integration/fixtures/lsp/1751391900_hover_import/Main.snap
@@ -10,7 +10,7 @@ import Lib (life, Maybe(..), (+),  type (++))
 --      $    $     $          $          $
 ```
 
-Range: <none>
+Range: "Lib"
 
 ```purescript
 module Lib where
@@ -80,7 +80,7 @@ ref = life
 --     $
 ```
 
-Range: <none>
+Range: "life"
 
 ```purescript
 life :: Int
@@ -94,7 +94,7 @@ just :: forall a. a -> Maybe a
 --                      $    $
 ```
 
-Range: <none>
+Range: "Maybe"
 
 ```purescript
 Maybe :: Type -> Type
@@ -122,7 +122,7 @@ just = Just
 --      $
 ```
 
-Range: <none>
+Range: "Just"
 
 ```purescript
 Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
@@ -136,7 +136,7 @@ nothing :: forall a. Maybe a
 --                    $
 ```
 
-Range: <none>
+Range: "Maybe"
 
 ```purescript
 Maybe :: Type -> Type
@@ -150,7 +150,7 @@ nothing = Nothing
 --         $
 ```
 
-Range: <none>
+Range: "Nothing"
 
 ```purescript
 Nothing :: forall (@a :: Type). Maybe (a :: Type)
@@ -164,7 +164,7 @@ opName = (+)
 --        $
 ```
 
-Range: <none>
+Range: "(+)"
 
 ```purescript
 + :: Int -> Int -> Int
@@ -178,7 +178,7 @@ opChain = 9 + 10
 --          $
 ```
 
-Range: <none>
+Range: "+"
 
 ```purescript
 + :: Int -> Int -> Int
@@ -192,7 +192,7 @@ type TypeOpChain = Int ++ Int
 --                     $
 ```
 
-Range: <none>
+Range: "++"
 
 ```purescript
 ++ :: Type -> Type -> Type

--- a/tests-integration/fixtures/lsp/1754895540_prim_implicit/Main.snap
+++ b/tests-integration/fixtures/lsp/1754895540_prim_implicit/Main.snap
@@ -20,7 +20,7 @@ type Hover = Type
 --           $
 ```
 
-Range: <none>
+Range: "Type"
 
 ```purescript
 Type :: Type

--- a/tests-integration/fixtures/lsp/1754895540_prim_implicit/Main.snap
+++ b/tests-integration/fixtures/lsp/1754895540_prim_implicit/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 90
+assertion_line: 134
 expression: report
 ---
 GotoDefinition at Position { line: 2, character: 18 }
@@ -19,6 +19,8 @@ Hover at Position { line: 5, character: 13 }
 type Hover = Type
 --           $
 ```
+
+Range: <none>
 
 ```purescript
 Type :: Type

--- a/tests-integration/fixtures/lsp/1754895600_prim_explicit/Main.snap
+++ b/tests-integration/fixtures/lsp/1754895600_prim_explicit/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 90
+assertion_line: 134
 expression: report
 ---
 GotoDefinition at Position { line: 4, character: 18 }
@@ -19,6 +19,8 @@ Hover at Position { line: 7, character: 13 }
 type Hover = Type
 --           $
 ```
+
+Range: <none>
 
 ```purescript
 Type :: Type

--- a/tests-integration/fixtures/lsp/1754895600_prim_explicit/Main.snap
+++ b/tests-integration/fixtures/lsp/1754895600_prim_explicit/Main.snap
@@ -20,7 +20,7 @@ type Hover = Type
 --           $
 ```
 
-Range: <none>
+Range: "Type"
 
 ```purescript
 Type :: Type

--- a/tests-integration/fixtures/lsp/1755255480_unicode_operators/Main.snap
+++ b/tests-integration/fixtures/lsp/1755255480_unicode_operators/Main.snap
@@ -10,7 +10,7 @@ bug ∷ ∀ a. Effect (Either a a) → Effect (Either a a)
 --                 $                     $
 ```
 
-Range: <none>
+Range: "Either"
 
 ```purescript
 Either :: Type -> Type -> Type
@@ -24,7 +24,7 @@ bug ∷ ∀ a. Effect (Either a a) → Effect (Either a a)
 --                 $                     $
 ```
 
-Range: <none>
+Range: "Either"
 
 ```purescript
 Either :: Type -> Type -> Type

--- a/tests-integration/fixtures/lsp/1755255480_unicode_operators/Main.snap
+++ b/tests-integration/fixtures/lsp/1755255480_unicode_operators/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 90
+assertion_line: 134
 expression: report
 ---
 Hover at Position { line: 6, character: 19 }
@@ -9,6 +9,8 @@ Hover at Position { line: 6, character: 19 }
 bug ∷ ∀ a. Effect (Either a a) → Effect (Either a a)
 --                 $                     $
 ```
+
+Range: <none>
 
 ```purescript
 Either :: Type -> Type -> Type
@@ -21,6 +23,8 @@ Hover at Position { line: 6, character: 41 }
 bug ∷ ∀ a. Effect (Either a a) → Effect (Either a a)
 --                 $                     $
 ```
+
+Range: <none>
 
 ```purescript
 Either :: Type -> Type -> Type

--- a/tests-integration/fixtures/lsp/1757267400_documentation_string/Main.snap
+++ b/tests-integration/fixtures/lsp/1757267400_documentation_string/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 90
+assertion_line: 134
 expression: report
 ---
 Hover at Position { line: 6, character: 7 }
@@ -9,6 +9,8 @@ Hover at Position { line: 6, character: 7 }
 test = id
 --     $
 ```
+
+Range: <none>
 
 ```purescript
 id :: forall (a :: Type). (a :: Type) -> (a :: Type)
@@ -24,6 +26,8 @@ test2 = const
 --      $
 ```
 
+Range: <none>
+
 ```purescript
 const ::
   forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
@@ -36,6 +40,8 @@ Hover at Position { line: 21, character: 8 }
 test3 = docOnly
 --      $
 ```
+
+Range: <none>
 
 ```purescript
 docOnly :: Int
@@ -50,6 +56,8 @@ Hover at Position { line: 29, character: 8 }
 test4 = multiLine
 --      $
 ```
+
+Range: <none>
 
 ```purescript
 multiLine :: Int
@@ -67,6 +75,8 @@ test5 = multiLine2
 --      $
 ```
 
+Range: <none>
+
 ```purescript
 multiLine2 :: Int
 ```
@@ -82,6 +92,8 @@ Hover at Position { line: 50, character: 8 }
 test6 = multiLine3
 --      $
 ```
+
+Range: <none>
 
 ```purescript
 multiLine3 :: Int
@@ -101,6 +113,8 @@ Hover at Position { line: 60, character: 6 }
 --    $
 ```
 
+Range: <none>
+
 ```purescript
 Int
 ```
@@ -112,6 +126,8 @@ Hover at Position { line: 62, character: 6 }
     , withSignature
 --    $
 ```
+
+Range: <none>
 
 ```purescript
 Int

--- a/tests-integration/fixtures/lsp/1757267400_documentation_string/Main.snap
+++ b/tests-integration/fixtures/lsp/1757267400_documentation_string/Main.snap
@@ -10,7 +10,7 @@ test = id
 --     $
 ```
 
-Range: <none>
+Range: "id"
 
 ```purescript
 id :: forall (a :: Type). (a :: Type) -> (a :: Type)
@@ -26,7 +26,7 @@ test2 = const
 --      $
 ```
 
-Range: <none>
+Range: "const"
 
 ```purescript
 const ::
@@ -41,7 +41,7 @@ test3 = docOnly
 --      $
 ```
 
-Range: <none>
+Range: "docOnly"
 
 ```purescript
 docOnly :: Int
@@ -57,7 +57,7 @@ test4 = multiLine
 --      $
 ```
 
-Range: <none>
+Range: "multiLine"
 
 ```purescript
 multiLine :: Int
@@ -75,7 +75,7 @@ test5 = multiLine2
 --      $
 ```
 
-Range: <none>
+Range: "multiLine2"
 
 ```purescript
 multiLine2 :: Int
@@ -93,7 +93,7 @@ test6 = multiLine3
 --      $
 ```
 
-Range: <none>
+Range: "multiLine3"
 
 ```purescript
 multiLine3 :: Int
@@ -113,7 +113,7 @@ Hover at Position { line: 60, character: 6 }
 --    $
 ```
 
-Range: <none>
+Range: "valueOnly"
 
 ```purescript
 Int
@@ -127,7 +127,7 @@ Hover at Position { line: 62, character: 6 }
 --    $
 ```
 
-Range: <none>
+Range: "withSignature"
 
 ```purescript
 Int

--- a/tests-integration/fixtures/lsp/1757532000_references_import/Main.snap
+++ b/tests-integration/fixtures/lsp/1757532000_references_import/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 90
+assertion_line: 134
 expression: report
 ---
 References at Position { line: 2, character: 12 }
@@ -22,6 +22,7 @@ import Lib (Maybe(..), plus, (+), type (:), class Eq)
 ```
 
 file:///tests-integration/fixtures/lsp/1757532000_references_import/Main.purs @ 18:8..18:12
+file:///tests-integration/fixtures/lsp/1757532000_references_import/Lib.purs @ 6:8..6:12
 
 
 References at Position { line: 2, character: 30 }

--- a/tests-integration/fixtures/lsp/1758309780_locate_declaration/Main.snap
+++ b/tests-integration/fixtures/lsp/1758309780_locate_declaration/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 90
+assertion_line: 134
 expression: report
 ---
 Hover at Position { line: 3, character: 20 }
@@ -9,6 +9,8 @@ Hover at Position { line: 3, character: 20 }
 foreign import data Effect :: Type -> Type
 --                  $ @ %
 ```
+
+Range: <none>
 
 ```purescript
 Effect :: Type -> Type
@@ -43,6 +45,8 @@ Hover at Position { line: 10, character: 3 }
 effectEffectEffect = 123
 -- $ @ %
 ```
+
+Range: <none>
 
 ```purescript
 effectEffectEffect :: Int

--- a/tests-integration/fixtures/lsp/1758309900_locate_class_member/Main.snap
+++ b/tests-integration/fixtures/lsp/1758309900_locate_class_member/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 90
+assertion_line: 134
 expression: report
 ---
 References at Position { line: 3, character: 3 }
@@ -29,6 +29,8 @@ Hover at Position { line: 3, character: 7 }
   eqEqEqEq :: a -> a -> Boolean
 -- % @ $
 ```
+
+Range: <none>
 
 ```purescript
 eqEqEqEq ::

--- a/tests-integration/fixtures/lsp/1777394160_hover_term_literal/Main.snap
+++ b/tests-integration/fixtures/lsp/1777394160_hover_term_literal/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 90
+assertion_line: 134
 expression: report
 ---
 Hover at Position { line: 2, character: 7 }
@@ -9,6 +9,8 @@ Hover at Position { line: 2, character: 7 }
 life = 42
 --     $
 ```
+
+Range: <none>
 
 ```purescript
 Int
@@ -22,6 +24,8 @@ hello = "world"
 --       $
 ```
 
+Range: <none>
+
 ```purescript
 String
 ```
@@ -33,6 +37,8 @@ Hover at Position { line: 8, character: 9 }
 colon = ':'
 --       $
 ```
+
+Range: <none>
 
 ```purescript
 Char
@@ -46,6 +52,8 @@ array = [ 1, 2, 3 ]
 --      $
 ```
 
+Range: <none>
+
 ```purescript
 Array Int
 ```
@@ -57,6 +65,8 @@ Hover at Position { line: 14, character: 9 }
 record = { life }
 --       $
 ```
+
+Range: <none>
 
 ```purescript
 { life :: Int }

--- a/tests-integration/fixtures/lsp/1777394220_hover_term_signature/Main.snap
+++ b/tests-integration/fixtures/lsp/1777394220_hover_term_signature/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 90
+assertion_line: 134
 expression: report
 ---
 Hover at Position { line: 4, character: 11 }
@@ -9,6 +9,8 @@ Hover at Position { line: 4, character: 11 }
 variable = life
 --         $
 ```
+
+Range: <none>
 
 ```purescript
 life :: Int
@@ -22,6 +24,8 @@ just = Just
 --     $
 ```
 
+Range: <none>
+
 ```purescript
 Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
 ```
@@ -33,6 +37,8 @@ Hover at Position { line: 12, character: 10 }
 nothing = Nothing
 --        $
 ```
+
+Range: <none>
 
 ```purescript
 Nothing :: forall (@a :: Type). Maybe (a :: Type)

--- a/tests-integration/fixtures/lsp/1777394220_hover_term_signature/Main.snap
+++ b/tests-integration/fixtures/lsp/1777394220_hover_term_signature/Main.snap
@@ -10,7 +10,7 @@ variable = life
 --         $
 ```
 
-Range: <none>
+Range: "life"
 
 ```purescript
 life :: Int
@@ -24,7 +24,7 @@ just = Just
 --     $
 ```
 
-Range: <none>
+Range: "Just"
 
 ```purescript
 Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
@@ -38,7 +38,7 @@ nothing = Nothing
 --        $
 ```
 
-Range: <none>
+Range: "Nothing"
 
 ```purescript
 Nothing :: forall (@a :: Type). Maybe (a :: Type)

--- a/tests-integration/fixtures/lsp/1777394640_hover_term_pun/Main.snap
+++ b/tests-integration/fixtures/lsp/1777394640_hover_term_pun/Main.snap
@@ -10,6 +10,8 @@ inferred { argument } = { argument }
 --         $              $
 ```
 
+Range: <none>
+
 ```purescript
 (t0 :: Type)
 ```
@@ -21,6 +23,8 @@ Hover at Position { line: 2, character: 26 }
 inferred { argument } = { argument }
 --         $              $
 ```
+
+Range: <none>
 
 ```purescript
 (t0 :: Type)
@@ -34,6 +38,8 @@ checked { argument } = { argument }
 --        $              $
 ```
 
+Range: <none>
+
 ```purescript
 (ofCourse :: Type)
 ```
@@ -45,6 +51,8 @@ Hover at Position { line: 6, character: 25 }
 checked { argument } = { argument }
 --        $              $
 ```
+
+Range: <none>
 
 ```purescript
 (ofCourse :: Type)

--- a/tests-integration/fixtures/lsp/1777394700_hover_term_binder/Main.snap
+++ b/tests-integration/fixtures/lsp/1777394700_hover_term_binder/Main.snap
@@ -10,6 +10,8 @@ fromBinder argument = argument
 --         $
 ```
 
+Range: <none>
+
 ```purescript
 (t0 :: Type)
 ```
@@ -21,6 +23,8 @@ Hover at Position { line: 5, character: 12 }
 fromLiteral "hello" = "hello"
 --          $
 ```
+
+Range: <none>
 
 ```purescript
 String
@@ -34,6 +38,8 @@ fromArray [ element ] = [ element ]
 --        $
 ```
 
+Range: <none>
+
 ```purescript
 Array (t0 :: Type)
 ```
@@ -45,6 +51,8 @@ Hover at Position { line: 11, character: 11 }
 fromRecord { element } = { element }
 --         $
 ```
+
+Range: <none>
 
 ```purescript
 { element :: (t0 :: Type) | (t1 :: Row Type) }

--- a/tests-integration/fixtures/lsp/1777491240_hover_term_hole_filled/Main.snap
+++ b/tests-integration/fixtures/lsp/1777491240_hover_term_hole_filled/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 90
+assertion_line: 134
 expression: report
 ---
 Hover at Position { line: 4, character: 11 }
@@ -9,6 +9,8 @@ Hover at Position { line: 4, character: 11 }
 test = add ?one ?two
 --         $    $
 ```
+
+Range: <none>
 
 ```purescript
 Int
@@ -21,6 +23,8 @@ Hover at Position { line: 4, character: 16 }
 test = add ?one ?two
 --         $    $
 ```
+
+Range: <none>
 
 ```purescript
 Int

--- a/tests-integration/fixtures/lsp/1777491300_hover_term_let/Main.snap
+++ b/tests-integration/fixtures/lsp/1777491300_hover_term_let/Main.snap
@@ -10,7 +10,7 @@ Hover at Position { line: 6, character: 4 }
 --  $
 ```
 
-Range: <none>
+Range: "identity"
 
 ```purescript
 (t0 :: Type) -> (t0 :: Type)

--- a/tests-integration/fixtures/lsp/1777491300_hover_term_let/Main.snap
+++ b/tests-integration/fixtures/lsp/1777491300_hover_term_let/Main.snap
@@ -10,6 +10,8 @@ Hover at Position { line: 6, character: 4 }
 --  $
 ```
 
+Range: <none>
+
 ```purescript
 (t0 :: Type) -> (t0 :: Type)
 ```

--- a/tests-integration/fixtures/lsp/1777536720_hover_type_constructor/Main.snap
+++ b/tests-integration/fixtures/lsp/1777536720_hover_type_constructor/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 90
+assertion_line: 134
 expression: report
 ---
 Hover at Position { line: 5, character: 23 }
@@ -9,6 +9,8 @@ Hover at Position { line: 5, character: 23 }
 foreign import main :: Effect Unit
 --                     $
 ```
+
+Range: <none>
 
 ```purescript
 Effect :: Type -> Type

--- a/tests-integration/fixtures/lsp/1777536720_hover_type_constructor/Main.snap
+++ b/tests-integration/fixtures/lsp/1777536720_hover_type_constructor/Main.snap
@@ -10,7 +10,7 @@ foreign import main :: Effect Unit
 --                     $
 ```
 
-Range: <none>
+Range: "Effect"
 
 ```purescript
 Effect :: Type -> Type

--- a/tests-integration/fixtures/lsp/1777536780_hover_type_literal/Main.snap
+++ b/tests-integration/fixtures/lsp/1777536780_hover_type_literal/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 90
+assertion_line: 134
 expression: report
 ---
 Hover at Position { line: 2, character: 12 }
@@ -9,6 +9,8 @@ Hover at Position { line: 2, character: 12 }
 type Life = 42
 --          $
 ```
+
+Range: <none>
 
 ```purescript
 Int
@@ -21,6 +23,8 @@ Hover at Position { line: 5, character: 13 }
 type Hello = "World"
 --           $
 ```
+
+Range: <none>
 
 ```purescript
 Symbol

--- a/tests-integration/fixtures/lsp/1777536840_hover_type_variable/Main.snap
+++ b/tests-integration/fixtures/lsp/1777536840_hover_type_variable/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 90
+assertion_line: 134
 expression: report
 ---
 Hover at Position { line: 2, character: 22 }
@@ -9,6 +9,8 @@ Hover at Position { line: 2, character: 22 }
 identity :: forall a. a -> a
 --                    $
 ```
+
+Range: <none>
 
 ```purescript
 Type

--- a/tests-integration/fixtures/lsp/1779134340_let_binding_hover/Main.snap
+++ b/tests-integration/fixtures/lsp/1779134340_let_binding_hover/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 101
+assertion_line: 134
 expression: report
 ---
 Hover at Position { line: 2, character: 15 }
@@ -9,6 +9,8 @@ Hover at Position { line: 2, character: 15 }
 equation = let life = 42 in life
 --             $
 ```
+
+Range: <none>
 
 ```purescript
 Int
@@ -21,6 +23,8 @@ Hover at Position { line: 7, character: 4 }
     life :: Int
 --  $
 ```
+
+Range: <none>
 
 ```purescript
 Int

--- a/tests-integration/fixtures/lsp/1780504560_document_highlight_types_and_imports/Main.snap
+++ b/tests-integration/fixtures/lsp/1780504560_document_highlight_types_and_imports/Main.snap
@@ -70,6 +70,7 @@ foreign import data Local :: Type
 ```
 
 5:20..5:25
+8:14..8:19
 17:36..17:41
 22:22..22:27
 25:31..25:36
@@ -175,8 +176,9 @@ infixr 5 plus as <+>
 --       &        &
 ```
 
-35:17..35:20
-47:29..47:32
+32:0..32:4
+33:0..33:4
+35:9..35:13
 
 
 DocumentHighlight at Position { line: 35, character: 18 }

--- a/tests-integration/fixtures/lsp/1783870980_rename_import_items_and_operators/Main.snap
+++ b/tests-integration/fixtures/lsp/1783870980_rename_import_items_and_operators/Main.snap
@@ -13,7 +13,7 @@ import Lib (value, class Example, Data(Constructor), (<?>), type (++))
 ```diff
 --- Lib.purs
 +++ Lib.purs
-@@ -1,6 +1,6 @@
+@@ -1,11 +1,11 @@
 -module Lib (value, class Example, Data(Constructor), (<?>), type (++)) where
 +module Lib (renamed, class Example, Data(Constructor), (<?>), type (++)) where
 
@@ -22,6 +22,12 @@ import Lib (value, class Example, Data(Constructor), (<?>), type (++))
 
  class Example a
 
+ data Data = Constructor
+
+-infix 5 value as <?>
++infix 5 renamed as <?>
+
+ infix 5 type Data as ++
 ```
 
 ```diff
@@ -103,7 +109,7 @@ import Lib (value, class Example, Data(Constructor), (<?>), type (++))
 ```diff
 --- Lib.purs
 +++ Lib.purs
-@@ -1,10 +1,10 @@
+@@ -1,11 +1,11 @@
 -module Lib (value, class Example, Data(Constructor), (<?>), type (++)) where
 +module Lib (value, class Example, Renamed(Constructor), (<?>), type (++)) where
 
@@ -116,6 +122,8 @@ import Lib (value, class Example, Data(Constructor), (<?>), type (++))
 
  infix 5 value as <?>
 
+-infix 5 type Data as ++
++infix 5 type Renamed as ++
 ```
 
 ```diff

--- a/tests-integration/fixtures/lsp/1784284380_rename_declaration_kinds/Main.snap
+++ b/tests-integration/fixtures/lsp/1784284380_rename_declaration_kinds/Main.snap
@@ -86,9 +86,12 @@ type Synonym = ForeignType
  --   /
 
  newtype Wrapper = Wrapper ForeignType
-@@ -28,5 +28,5 @@
+@@ -26,7 +26,7 @@
+ operatorUse = foreignValue <?> foreignValue
+ --                         /
 
- infixl 5 type Synonym as :+:
+-infixl 5 type Synonym as :+:
++infixl 5 type Renamed as :+:
 
 -type OperatorUse = Synonym :+: Synonym
 +type OperatorUse = Renamed :+: Renamed

--- a/tests-integration/fixtures/lsp/1785371460_instance_member_type_variable_names/Main.snap
+++ b/tests-integration/fixtures/lsp/1785371460_instance_member_type_variable_names/Main.snap
@@ -10,7 +10,7 @@ Hover at Position { line: 9, character: 6 }
 --    $
 ```
 
-Range: <none>
+Range: "program"
 
 ```purescript
 ((a :: Type) -> (r :: Type)) -> (r :: Type)
@@ -24,7 +24,7 @@ Hover at Position { line: 11, character: 8 }
 --      $       $
 ```
 
-Range: <none>
+Range: "return"
 
 ```purescript
 (b :: Type) -> (r :: Type)
@@ -38,7 +38,7 @@ Hover at Position { line: 11, character: 16 }
 --      $       $
 ```
 
-Range: <none>
+Range: "function"
 
 ```purescript
 (a :: Type) -> (b :: Type)

--- a/tests-integration/fixtures/lsp/1785371460_instance_member_type_variable_names/Main.snap
+++ b/tests-integration/fixtures/lsp/1785371460_instance_member_type_variable_names/Main.snap
@@ -10,6 +10,8 @@ Hover at Position { line: 9, character: 6 }
 --    $
 ```
 
+Range: <none>
+
 ```purescript
 ((a :: Type) -> (r :: Type)) -> (r :: Type)
 ```
@@ -22,6 +24,8 @@ Hover at Position { line: 11, character: 8 }
 --      $       $
 ```
 
+Range: <none>
+
 ```purescript
 (b :: Type) -> (r :: Type)
 ```
@@ -33,6 +37,8 @@ Hover at Position { line: 11, character: 16 }
         return (function a)
 --      $       $
 ```
+
+Range: <none>
 
 ```purescript
 (a :: Type) -> (b :: Type)

--- a/tests-integration/fixtures/lsp/1785763200_hover_instance_member/Main.snap
+++ b/tests-integration/fixtures/lsp/1785763200_hover_instance_member/Main.snap
@@ -10,6 +10,8 @@ Hover at Position { line: 7, character: 3 }
 -- $
 ```
 
+Range: <none>
+
 ```purescript
 map ::
   forall (@f :: Type -> Type).
@@ -28,6 +30,8 @@ Hover at Position { line: 9, character: 3 }
 -- $
 ```
 
+Range: <none>
+
 ```purescript
 map ::
   forall (@f :: Type -> Type).
@@ -45,6 +49,8 @@ Hover at Position { line: 16, character: 3 }
 value = 42
 -- $
 ```
+
+Range: <none>
 
 ```purescript
 value :: Int

--- a/tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Main.snap
+++ b/tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Main.snap
@@ -10,6 +10,8 @@ Hover at Position { line: 6, character: 3 }
 -- $ @
 ```
 
+Range: <none>
+
 ```purescript
 execute :: forall (@a :: Type). Alpha (a :: Type) => (a :: Type) -> Int
 ```
@@ -31,6 +33,8 @@ Hover at Position { line: 10, character: 3 }
   execute value = value
 -- $ @
 ```
+
+Range: <none>
 
 ```purescript
 execute :: forall (@a :: Type). Beta (a :: Type) => (a :: Type) -> Int

--- a/tests-integration/fixtures/lsp/1785823140_record_access_label_hover/Main.snap
+++ b/tests-integration/fixtures/lsp/1785823140_record_access_label_hover/Main.snap
@@ -10,6 +10,8 @@ access = record.nested.value
 --              $      $
 ```
 
+Range: <none>
+
 ```purescript
 { value :: Int }
 ```
@@ -21,6 +23,8 @@ Hover at Position { line: 5, character: 23 }
 access = record.nested.value
 --              $      $
 ```
+
+Range: <none>
 
 ```purescript
 Int

--- a/tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.snap
+++ b/tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.snap
@@ -48,7 +48,7 @@ instance Functor Identity
 --       $@%&/?
 ```
 
-Range: <none>
+Range: "Functor"
 
 ```purescript
 Functor :: forall (t0 :: Type). (t0 :: Type) -> Constraint
@@ -161,7 +161,7 @@ derive instance Functor Derived
 --              $@%
 ```
 
-Range: <none>
+Range: "Functor"
 
 ```purescript
 Functor :: forall (t0 :: Type). (t0 :: Type) -> Constraint
@@ -199,7 +199,7 @@ derive newtype instance Functor Wrapper
 --                      $@%
 ```
 
-Range: <none>
+Range: "Functor"
 
 ```purescript
 Functor :: forall (t0 :: Type). (t0 :: Type) -> Constraint
@@ -237,7 +237,7 @@ else instance Lib.ImportedFunctor ChainSecond
 --                $@%/
 ```
 
-Range: <none>
+Range: "Lib.ImportedFunctor"
 
 ```purescript
 ImportedFunctor :: forall (t0 :: Type). (t0 :: Type) -> Constraint

--- a/tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.snap
+++ b/tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.snap
@@ -10,6 +10,8 @@ class Functor f
 --    $ @ %
 ```
 
+Range: <none>
+
 ```purescript
 Functor :: forall (t0 :: Type). (t0 :: Type) -> Constraint
 ```
@@ -45,6 +47,8 @@ Hover at Position { line: 9, character: 9 }
 instance Functor Identity
 --       $@%&/?
 ```
+
+Range: <none>
 
 ```purescript
 Functor :: forall (t0 :: Type). (t0 :: Type) -> Constraint
@@ -157,6 +161,8 @@ derive instance Functor Derived
 --              $@%
 ```
 
+Range: <none>
+
 ```purescript
 Functor :: forall (t0 :: Type). (t0 :: Type) -> Constraint
 ```
@@ -193,6 +199,8 @@ derive newtype instance Functor Wrapper
 --                      $@%
 ```
 
+Range: <none>
+
 ```purescript
 Functor :: forall (t0 :: Type). (t0 :: Type) -> Constraint
 ```
@@ -228,6 +236,8 @@ Hover at Position { line: 29, character: 18 }
 else instance Lib.ImportedFunctor ChainSecond
 --                $@%/
 ```
+
+Range: <none>
 
 ```purescript
 ImportedFunctor :: forall (t0 :: Type). (t0 :: Type) -> Constraint

--- a/tests-integration/fixtures/lsp/1786252140_hover_data_declaration_type_variable_binder/Main.snap
+++ b/tests-integration/fixtures/lsp/1786252140_hover_data_declaration_type_variable_binder/Main.snap
@@ -10,6 +10,8 @@ newtype Identity a = Identity a
 --               $
 ```
 
+Range: <none>
+
 ```purescript
 Type
 ```
@@ -21,6 +23,8 @@ Hover at Position { line: 6, character: 11 }
 data Proxy a = Proxy
 --         $
 ```
+
+Range: <none>
 
 ```purescript
 (kind :: Type)

--- a/tests-integration/fixtures/lsp/1786252620_hover_type_declaration_variable_binder/Main.snap
+++ b/tests-integration/fixtures/lsp/1786252620_hover_type_declaration_variable_binder/Main.snap
@@ -10,6 +10,8 @@ type Synonym a = a
 --           $
 ```
 
+Range: <none>
+
 ```purescript
 (t0 :: Type)
 ```
@@ -21,6 +23,8 @@ Hover at Position { line: 5, character: 14 }
 class Example a
 --            $
 ```
+
+Range: <none>
 
 ```purescript
 (t0 :: Type)

--- a/tests-integration/fixtures/lsp/1786252620_hover_value_signature_type_variable_binder/Main.snap
+++ b/tests-integration/fixtures/lsp/1786252620_hover_value_signature_type_variable_binder/Main.snap
@@ -10,6 +10,8 @@ apply :: forall (constructor :: Type -> Type). constructor Int -> constructor In
 --               $
 ```
 
+Range: <none>
+
 ```purescript
 Type -> Type
 ```

--- a/tests-integration/fixtures/lsp/1786354800_hover_qualified_name_ranges/Library.Values.purs
+++ b/tests-integration/fixtures/lsp/1786354800_hover_qualified_name_ranges/Library.Values.purs
@@ -1,0 +1,11 @@
+module Library.Values where
+
+type Value = Int
+
+value :: Value
+value = 42
+
+add :: Int -> Int -> Int
+add left right = left + right
+
+infixl 6 add as +

--- a/tests-integration/fixtures/lsp/1786354800_hover_qualified_name_ranges/Main.purs
+++ b/tests-integration/fixtures/lsp/1786354800_hover_qualified_name_ranges/Main.purs
@@ -1,0 +1,20 @@
+module Main where
+
+import Library.Values as Library.Values
+--       $       $
+
+qualifiedType :: Library.Values.Value
+--                                $
+qualifiedType = Library.Values.value
+--                               $
+
+qualifiedOperator = Library.Values.(+)
+--                                  $
+
+endBoundary = Library.Values.value
+--                                $
+
+record = { value: 42 }
+
+recordAccess = record.value
+--                   $

--- a/tests-integration/fixtures/lsp/1786354800_hover_qualified_name_ranges/Main.snap
+++ b/tests-integration/fixtures/lsp/1786354800_hover_qualified_name_ranges/Main.snap
@@ -1,0 +1,101 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Hover at Position { line: 2, character: 9 }
+
+```
+import Library.Values as Library.Values
+--       $       $
+```
+
+Range: <none>
+
+```purescript
+module Library.Values where
+```
+
+
+Hover at Position { line: 2, character: 17 }
+
+```
+import Library.Values as Library.Values
+--       $       $
+```
+
+Range: <none>
+
+```purescript
+module Library.Values where
+```
+
+
+Hover at Position { line: 5, character: 34 }
+
+```
+qualifiedType :: Library.Values.Value
+--                                $
+```
+
+Range: <none>
+
+```purescript
+Value :: Type
+```
+
+
+Hover at Position { line: 7, character: 33 }
+
+```
+qualifiedType = Library.Values.value
+--                               $
+```
+
+Range: <none>
+
+```purescript
+value :: Value
+```
+
+
+Hover at Position { line: 10, character: 36 }
+
+```
+qualifiedOperator = Library.Values.(+)
+--                                  $
+```
+
+Range: <none>
+
+```purescript
++ :: Int -> Int -> Int
+```
+
+
+Hover at Position { line: 13, character: 34 }
+
+```
+endBoundary = Library.Values.value
+--                                $
+```
+
+Range: <none>
+
+```purescript
+value :: Value
+```
+
+
+Hover at Position { line: 18, character: 21 }
+
+```
+recordAccess = record.value
+--                   $
+```
+
+Range: <none>
+
+```purescript
+Int
+```

--- a/tests-integration/fixtures/lsp/1786354800_hover_qualified_name_ranges/Main.snap
+++ b/tests-integration/fixtures/lsp/1786354800_hover_qualified_name_ranges/Main.snap
@@ -10,7 +10,7 @@ import Library.Values as Library.Values
 --       $       $
 ```
 
-Range: <none>
+Range: "Library.Values"
 
 ```purescript
 module Library.Values where
@@ -24,7 +24,7 @@ import Library.Values as Library.Values
 --       $       $
 ```
 
-Range: <none>
+Range: "Library.Values"
 
 ```purescript
 module Library.Values where
@@ -38,7 +38,7 @@ qualifiedType :: Library.Values.Value
 --                                $
 ```
 
-Range: <none>
+Range: "Library.Values.Value"
 
 ```purescript
 Value :: Type
@@ -52,7 +52,7 @@ qualifiedType = Library.Values.value
 --                               $
 ```
 
-Range: <none>
+Range: "Library.Values.value"
 
 ```purescript
 value :: Value
@@ -66,7 +66,7 @@ qualifiedOperator = Library.Values.(+)
 --                                  $
 ```
 
-Range: <none>
+Range: "Library.Values.(+)"
 
 ```purescript
 + :: Int -> Int -> Int
@@ -80,7 +80,7 @@ endBoundary = Library.Values.value
 --                                $
 ```
 
-Range: <none>
+Range: "Library.Values.value"
 
 ```purescript
 value :: Value

--- a/tests-integration/fixtures/lsp/1786362960_infix_backing_references/Library.purs
+++ b/tests-integration/fixtures/lsp/1786362960_infix_backing_references/Library.purs
@@ -1,0 +1,5 @@
+module Library where
+
+combine left right = left
+
+type Wrapped = Int

--- a/tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs
+++ b/tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs
@@ -1,0 +1,25 @@
+module Main where
+
+import Library as Library
+
+combine left right = left
+
+infixl 6 combine as <+>
+--       @$%&?/     $@
+
+type Wrapped = Int
+
+infixl 6 type Wrapped as :+:
+--            @$%&?/     $@
+
+infixl 6 Library.combine as <++>
+--               @$%&?/
+
+infixl 6 type Library.Wrapped as :++:
+--                    @$%&?/
+
+infixl 6 missing as <?>
+--       @$%&?/
+
+infixl 6 type Missing as :?:
+--            @$%&?/

--- a/tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.snap
+++ b/tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.snap
@@ -1,0 +1,430 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+GotoDefinition at Position { line: 6, character: 9 }
+
+```
+infixl 6 combine as <+>
+--       @$%&?/     $@
+```
+
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 6:0..6:23
+
+
+Hover at Position { line: 6, character: 10 }
+
+```
+infixl 6 combine as <+>
+--       @$%&?/     $@
+```
+
+Range: <none>
+
+```purescript
+<+> ::
+  forall (t0 :: Type) (t1 :: Type). (t0 :: Type) -> (t1 :: Type) -> (t0 :: Type)
+```
+
+
+References at Position { line: 6, character: 11 }
+
+```
+infixl 6 combine as <+>
+--       @$%&?/     $@
+```
+
+
+
+
+DocumentHighlight at Position { line: 6, character: 12 }
+
+```
+infixl 6 combine as <+>
+--       @$%&?/     $@
+```
+
+6:20..6:23
+
+
+PrepareRename at Position { line: 6, character: 13 }
+
+```
+infixl 6 combine as <+>
+--       @$%&?/     $@
+```
+
+<empty>
+
+
+Rename at Position { line: 6, character: 14 }
+
+```
+infixl 6 combine as <+>
+--       @$%&?/     $@
+```
+
+<empty>
+
+
+Hover at Position { line: 6, character: 20 }
+
+```
+infixl 6 combine as <+>
+--       @$%&?/     $@
+```
+
+Range: <none>
+
+```purescript
+<+> ::
+  forall (t0 :: Type) (t1 :: Type). (t0 :: Type) -> (t1 :: Type) -> (t0 :: Type)
+```
+
+
+GotoDefinition at Position { line: 6, character: 21 }
+
+```
+infixl 6 combine as <+>
+--       @$%&?/     $@
+```
+
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 6:0..6:23
+
+
+GotoDefinition at Position { line: 11, character: 14 }
+
+```
+infixl 6 type Wrapped as :+:
+--            @$%&?/     $@
+```
+
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 11:0..11:28
+
+
+Hover at Position { line: 11, character: 15 }
+
+```
+infixl 6 type Wrapped as :+:
+--            @$%&?/     $@
+```
+
+Range: <none>
+
+```purescript
+:+: :: Type
+```
+
+
+References at Position { line: 11, character: 16 }
+
+```
+infixl 6 type Wrapped as :+:
+--            @$%&?/     $@
+```
+
+
+
+
+DocumentHighlight at Position { line: 11, character: 17 }
+
+```
+infixl 6 type Wrapped as :+:
+--            @$%&?/     $@
+```
+
+11:25..11:28
+
+
+PrepareRename at Position { line: 11, character: 18 }
+
+```
+infixl 6 type Wrapped as :+:
+--            @$%&?/     $@
+```
+
+<empty>
+
+
+Rename at Position { line: 11, character: 19 }
+
+```
+infixl 6 type Wrapped as :+:
+--            @$%&?/     $@
+```
+
+<empty>
+
+
+Hover at Position { line: 11, character: 25 }
+
+```
+infixl 6 type Wrapped as :+:
+--            @$%&?/     $@
+```
+
+Range: <none>
+
+```purescript
+:+: :: Type
+```
+
+
+GotoDefinition at Position { line: 11, character: 26 }
+
+```
+infixl 6 type Wrapped as :+:
+--            @$%&?/     $@
+```
+
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 11:0..11:28
+
+
+GotoDefinition at Position { line: 14, character: 17 }
+
+```
+infixl 6 Library.combine as <++>
+--               @$%&?/
+```
+
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 14:0..14:32
+
+
+Hover at Position { line: 14, character: 18 }
+
+```
+infixl 6 Library.combine as <++>
+--               @$%&?/
+```
+
+Range: <none>
+
+```purescript
+<++> ::
+  forall (t0 :: Type) (t1 :: Type). (t0 :: Type) -> (t1 :: Type) -> (t0 :: Type)
+```
+
+
+References at Position { line: 14, character: 19 }
+
+```
+infixl 6 Library.combine as <++>
+--               @$%&?/
+```
+
+
+
+
+DocumentHighlight at Position { line: 14, character: 20 }
+
+```
+infixl 6 Library.combine as <++>
+--               @$%&?/
+```
+
+14:28..14:32
+
+
+PrepareRename at Position { line: 14, character: 21 }
+
+```
+infixl 6 Library.combine as <++>
+--               @$%&?/
+```
+
+<empty>
+
+
+Rename at Position { line: 14, character: 22 }
+
+```
+infixl 6 Library.combine as <++>
+--               @$%&?/
+```
+
+<empty>
+
+
+GotoDefinition at Position { line: 17, character: 22 }
+
+```
+infixl 6 type Library.Wrapped as :++:
+--                    @$%&?/
+```
+
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 17:0..17:37
+
+
+Hover at Position { line: 17, character: 23 }
+
+```
+infixl 6 type Library.Wrapped as :++:
+--                    @$%&?/
+```
+
+Range: <none>
+
+```purescript
+:++: :: Type
+```
+
+
+References at Position { line: 17, character: 24 }
+
+```
+infixl 6 type Library.Wrapped as :++:
+--                    @$%&?/
+```
+
+
+
+
+DocumentHighlight at Position { line: 17, character: 25 }
+
+```
+infixl 6 type Library.Wrapped as :++:
+--                    @$%&?/
+```
+
+17:33..17:37
+
+
+PrepareRename at Position { line: 17, character: 26 }
+
+```
+infixl 6 type Library.Wrapped as :++:
+--                    @$%&?/
+```
+
+<empty>
+
+
+Rename at Position { line: 17, character: 27 }
+
+```
+infixl 6 type Library.Wrapped as :++:
+--                    @$%&?/
+```
+
+<empty>
+
+
+GotoDefinition at Position { line: 20, character: 9 }
+
+```
+infixl 6 missing as <?>
+--       @$%&?/
+```
+
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 20:0..20:23
+
+
+Hover at Position { line: 20, character: 10 }
+
+```
+infixl 6 missing as <?>
+--       @$%&?/
+```
+
+<empty>
+
+
+References at Position { line: 20, character: 11 }
+
+```
+infixl 6 missing as <?>
+--       @$%&?/
+```
+
+
+
+
+DocumentHighlight at Position { line: 20, character: 12 }
+
+```
+infixl 6 missing as <?>
+--       @$%&?/
+```
+
+20:20..20:23
+
+
+PrepareRename at Position { line: 20, character: 13 }
+
+```
+infixl 6 missing as <?>
+--       @$%&?/
+```
+
+<empty>
+
+
+Rename at Position { line: 20, character: 14 }
+
+```
+infixl 6 missing as <?>
+--       @$%&?/
+```
+
+<empty>
+
+
+GotoDefinition at Position { line: 23, character: 14 }
+
+```
+infixl 6 type Missing as :?:
+--            @$%&?/
+```
+
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 23:0..23:28
+
+
+Hover at Position { line: 23, character: 15 }
+
+```
+infixl 6 type Missing as :?:
+--            @$%&?/
+```
+
+<empty>
+
+
+References at Position { line: 23, character: 16 }
+
+```
+infixl 6 type Missing as :?:
+--            @$%&?/
+```
+
+
+
+
+DocumentHighlight at Position { line: 23, character: 17 }
+
+```
+infixl 6 type Missing as :?:
+--            @$%&?/
+```
+
+23:25..23:28
+
+
+PrepareRename at Position { line: 23, character: 18 }
+
+```
+infixl 6 type Missing as :?:
+--            @$%&?/
+```
+
+<empty>
+
+
+Rename at Position { line: 23, character: 19 }
+
+```
+infixl 6 type Missing as :?:
+--            @$%&?/
+```
+
+<empty>

--- a/tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.snap
+++ b/tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.snap
@@ -10,7 +10,7 @@ infixl 6 combine as <+>
 --       @$%&?/     $@
 ```
 
-file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 6:0..6:23
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 4:0..4:25
 
 
 Hover at Position { line: 6, character: 10 }
@@ -23,7 +23,7 @@ infixl 6 combine as <+>
 Range: <none>
 
 ```purescript
-<+> ::
+combine ::
   forall (t0 :: Type) (t1 :: Type). (t0 :: Type) -> (t1 :: Type) -> (t0 :: Type)
 ```
 
@@ -35,7 +35,7 @@ infixl 6 combine as <+>
 --       @$%&?/     $@
 ```
 
-
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 6:9..6:16
 
 
 DocumentHighlight at Position { line: 6, character: 12 }
@@ -45,7 +45,8 @@ infixl 6 combine as <+>
 --       @$%&?/     $@
 ```
 
-6:20..6:23
+4:0..4:7
+6:9..6:16
 
 
 PrepareRename at Position { line: 6, character: 13 }
@@ -55,7 +56,7 @@ infixl 6 combine as <+>
 --       @$%&?/     $@
 ```
 
-<empty>
+6:9..6:16 combine
 
 
 Rename at Position { line: 6, character: 14 }
@@ -65,7 +66,22 @@ infixl 6 combine as <+>
 --       @$%&?/     $@
 ```
 
-<empty>
+```diff
+--- Main.purs
++++ Main.purs
+@@ -2,9 +2,9 @@
+
+ import Library as Library
+
+-combine left right = left
++renamed left right = left
+
+-infixl 6 combine as <+>
++infixl 6 renamed as <+>
+ --       @$%&?/     $@
+
+ type Wrapped = Int
+```
 
 
 Hover at Position { line: 6, character: 20 }
@@ -100,7 +116,7 @@ infixl 6 type Wrapped as :+:
 --            @$%&?/     $@
 ```
 
-file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 11:0..11:28
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 9:0..9:18
 
 
 Hover at Position { line: 11, character: 15 }
@@ -113,7 +129,7 @@ infixl 6 type Wrapped as :+:
 Range: <none>
 
 ```purescript
-:+: :: Type
+Wrapped :: Type
 ```
 
 
@@ -124,7 +140,7 @@ infixl 6 type Wrapped as :+:
 --            @$%&?/     $@
 ```
 
-
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 11:14..11:21
 
 
 DocumentHighlight at Position { line: 11, character: 17 }
@@ -134,7 +150,8 @@ infixl 6 type Wrapped as :+:
 --            @$%&?/     $@
 ```
 
-11:25..11:28
+9:5..9:12
+11:14..11:21
 
 
 PrepareRename at Position { line: 11, character: 18 }
@@ -144,7 +161,7 @@ infixl 6 type Wrapped as :+:
 --            @$%&?/     $@
 ```
 
-<empty>
+11:14..11:21 Wrapped
 
 
 Rename at Position { line: 11, character: 19 }
@@ -154,7 +171,22 @@ infixl 6 type Wrapped as :+:
 --            @$%&?/     $@
 ```
 
-<empty>
+```diff
+--- Main.purs
++++ Main.purs
+@@ -7,9 +7,9 @@
+ infixl 6 combine as <+>
+ --       @$%&?/     $@
+
+-type Wrapped = Int
++type Renamed = Int
+
+-infixl 6 type Wrapped as :+:
++infixl 6 type Renamed as :+:
+ --            @$%&?/     $@
+
+ infixl 6 Library.combine as <++>
+```
 
 
 Hover at Position { line: 11, character: 25 }
@@ -188,7 +220,7 @@ infixl 6 Library.combine as <++>
 --               @$%&?/
 ```
 
-file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 14:0..14:32
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Library.purs @ 2:0..2:25
 
 
 Hover at Position { line: 14, character: 18 }
@@ -201,7 +233,7 @@ infixl 6 Library.combine as <++>
 Range: <none>
 
 ```purescript
-<++> ::
+combine ::
   forall (t0 :: Type) (t1 :: Type). (t0 :: Type) -> (t1 :: Type) -> (t0 :: Type)
 ```
 
@@ -213,7 +245,7 @@ infixl 6 Library.combine as <++>
 --               @$%&?/
 ```
 
-
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 14:9..14:24
 
 
 DocumentHighlight at Position { line: 14, character: 20 }
@@ -223,7 +255,7 @@ infixl 6 Library.combine as <++>
 --               @$%&?/
 ```
 
-14:28..14:32
+14:9..14:24
 
 
 PrepareRename at Position { line: 14, character: 21 }
@@ -233,7 +265,7 @@ infixl 6 Library.combine as <++>
 --               @$%&?/
 ```
 
-<empty>
+14:17..14:24 combine
 
 
 Rename at Position { line: 14, character: 22 }
@@ -243,7 +275,31 @@ infixl 6 Library.combine as <++>
 --               @$%&?/
 ```
 
-<empty>
+```diff
+--- Library.purs
++++ Library.purs
+@@ -1,5 +1,5 @@
+ module Library where
+
+-combine left right = left
++renamed left right = left
+
+ type Wrapped = Int
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -12,7 +12,7 @@
+ infixl 6 type Wrapped as :+:
+ --            @$%&?/     $@
+
+-infixl 6 Library.combine as <++>
++infixl 6 Library.renamed as <++>
+ --               @$%&?/
+
+ infixl 6 type Library.Wrapped as :++:
+```
 
 
 GotoDefinition at Position { line: 17, character: 22 }
@@ -253,7 +309,7 @@ infixl 6 type Library.Wrapped as :++:
 --                    @$%&?/
 ```
 
-file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 17:0..17:37
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Library.purs @ 4:0..4:18
 
 
 Hover at Position { line: 17, character: 23 }
@@ -266,7 +322,7 @@ infixl 6 type Library.Wrapped as :++:
 Range: <none>
 
 ```purescript
-:++: :: Type
+Wrapped :: Type
 ```
 
 
@@ -277,7 +333,7 @@ infixl 6 type Library.Wrapped as :++:
 --                    @$%&?/
 ```
 
-
+file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 17:14..17:29
 
 
 DocumentHighlight at Position { line: 17, character: 25 }
@@ -287,7 +343,7 @@ infixl 6 type Library.Wrapped as :++:
 --                    @$%&?/
 ```
 
-17:33..17:37
+17:14..17:29
 
 
 PrepareRename at Position { line: 17, character: 26 }
@@ -297,7 +353,7 @@ infixl 6 type Library.Wrapped as :++:
 --                    @$%&?/
 ```
 
-<empty>
+17:22..17:29 Wrapped
 
 
 Rename at Position { line: 17, character: 27 }
@@ -307,7 +363,30 @@ infixl 6 type Library.Wrapped as :++:
 --                    @$%&?/
 ```
 
-<empty>
+```diff
+--- Library.purs
++++ Library.purs
+@@ -2,4 +2,4 @@
+
+ combine left right = left
+
+-type Wrapped = Int
++type Renamed = Int
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -15,7 +15,7 @@
+ infixl 6 Library.combine as <++>
+ --               @$%&?/
+
+-infixl 6 type Library.Wrapped as :++:
++infixl 6 type Library.Renamed as :++:
+ --                    @$%&?/
+
+ infixl 6 missing as <?>
+```
 
 
 GotoDefinition at Position { line: 20, character: 9 }
@@ -317,7 +396,7 @@ infixl 6 missing as <?>
 --       @$%&?/
 ```
 
-file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 20:0..20:23
+<empty>
 
 
 Hover at Position { line: 20, character: 10 }
@@ -337,7 +416,7 @@ infixl 6 missing as <?>
 --       @$%&?/
 ```
 
-
+<empty>
 
 
 DocumentHighlight at Position { line: 20, character: 12 }
@@ -347,7 +426,7 @@ infixl 6 missing as <?>
 --       @$%&?/
 ```
 
-20:20..20:23
+<empty>
 
 
 PrepareRename at Position { line: 20, character: 13 }
@@ -377,7 +456,7 @@ infixl 6 type Missing as :?:
 --            @$%&?/
 ```
 
-file:///tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.purs @ 23:0..23:28
+<empty>
 
 
 Hover at Position { line: 23, character: 15 }
@@ -397,7 +476,7 @@ infixl 6 type Missing as :?:
 --            @$%&?/
 ```
 
-
+<empty>
 
 
 DocumentHighlight at Position { line: 23, character: 17 }
@@ -407,7 +486,7 @@ infixl 6 type Missing as :?:
 --            @$%&?/
 ```
 
-23:25..23:28
+<empty>
 
 
 PrepareRename at Position { line: 23, character: 18 }

--- a/tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.snap
+++ b/tests-integration/fixtures/lsp/1786362960_infix_backing_references/Main.snap
@@ -20,7 +20,7 @@ infixl 6 combine as <+>
 --       @$%&?/     $@
 ```
 
-Range: <none>
+Range: "combine"
 
 ```purescript
 combine ::
@@ -126,7 +126,7 @@ infixl 6 type Wrapped as :+:
 --            @$%&?/     $@
 ```
 
-Range: <none>
+Range: "Wrapped"
 
 ```purescript
 Wrapped :: Type
@@ -230,7 +230,7 @@ infixl 6 Library.combine as <++>
 --               @$%&?/
 ```
 
-Range: <none>
+Range: "Library.combine"
 
 ```purescript
 combine ::
@@ -319,7 +319,7 @@ infixl 6 type Library.Wrapped as :++:
 --                    @$%&?/
 ```
 
-Range: <none>
+Range: "Library.Wrapped"
 
 ```purescript
 Wrapped :: Type

--- a/tests-integration/src/generated/lsp.rs
+++ b/tests-integration/src/generated/lsp.rs
@@ -505,6 +505,8 @@ fn dispatch_cursor(
             }
         }
         CursorKind::Hover => {
+            let file_id = host.file_id(uri.as_str()).expect("hover URI references a loaded file");
+            let content = engine.content(file_id);
             if let Ok(Some(response)) = analyzer::hover::implementation(&context, uri, position) {
                 let convert = |marked: MarkedString| -> String {
                     match marked {
@@ -514,6 +516,24 @@ fn dispatch_cursor(
                         }) => format!("```{language}\n{value}\n```"),
                     }
                 };
+
+                let range = response.range.and_then(|range| {
+                    analyzer::position::protocol_position_to_utf8(&content, range.start, encoding)
+                        .zip(analyzer::position::protocol_position_to_utf8(
+                            &content, range.end, encoding,
+                        ))
+                        .and_then(|(start, end)| {
+                            let start =
+                                analyzer::position::utf8_position_to_offset(&content, start)?;
+                            let end = analyzer::position::utf8_position_to_offset(&content, end)?;
+                            content.get(usize::from(start)..usize::from(end))
+                        })
+                });
+                if let Some(range) = range {
+                    writeln!(result, "Range: {range:?}\n").unwrap();
+                } else {
+                    writeln!(result, "Range: <none>\n").unwrap();
+                }
 
                 match response.contents {
                     HoverContents::Scalar(marked) => {


### PR DESCRIPTION
## Summary

Return the complete source name range with successful LSP hover responses. Module names such as `Library.Values` now highlight as one range, while qualified types, values, and operators highlight their complete use-site syntax.

Range selection is derived from the enclosing `ModuleName` or `QualifiedName` CST node and converted using the negotiated LSP position encoding. Candidate ranges are retained only when they contain the requested position, preventing token-boundary hovers from highlighting an adjacent, unrelated name.

The LSP integration reports now render the source text covered by each hover range. A focused regression fixture covers dotted module components, qualified types, values and operators, end-exclusive name boundaries, and record-access boundaries.

## Motivation

Without an explicit hover range, editors infer a word range themselves. Since `.` is treated as a word separator, hovering a module such as `Control.Data` can highlight only one component. Returning the syntactic name range makes the intended highlight stable across editors.

## Verification

- `cargo check -p analyzer --tests`
- `just t lsp`