### PR TITLE
[documenting] Avoid copying annotation token text

### DIFF
--- a/compiler-core/documenting/benches/documenting.rs
+++ b/compiler-core/documenting/benches/documenting.rs
@@ -11,8 +11,7 @@ struct Fixture {
     indexed: Arc<indexing::IndexedModule>,
 }
 
-fn fixture(item_count: usize) -> Fixture {
-    let source = synthetic_module(item_count);
+fn fixture_from_source(source: String) -> Fixture {
     let lexed = lexing::lex(&source);
     let tokens = lexing::layout(&lexed);
     let (parsed, _) = parsing::parse(&lexed, &tokens);
@@ -51,10 +50,43 @@ fn synthetic_module(item_count: usize) -> String {
     source
 }
 
+fn annotation_heavy_module(item_count: usize) -> String {
+    let mut source = String::from("-- | Module documentation.\nmodule Bench.Documenting where\n\n");
+
+    for index in 0..item_count {
+        for line in 0..16 {
+            writeln!(
+                source,
+                "-- | Documentation line {line} for value {index} has enough deterministic text to make annotation copies measurable."
+            )
+            .unwrap();
+        }
+        writeln!(source, "value{index} :: Int").unwrap();
+        writeln!(source, "value{index} = {index}").unwrap();
+        writeln!(source).unwrap();
+    }
+
+    source
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
-    let fixture = fixture(400);
+    let fixture = fixture_from_source(synthetic_module(400));
 
     c.bench_function("document-module-synthetic", |b| {
+        b.iter(|| {
+            let documented = documenting::document_module(
+                black_box(&fixture.source),
+                black_box(&fixture.parsed),
+                black_box(&fixture.stabilized),
+                black_box(&fixture.indexed),
+            );
+            black_box(documented);
+        });
+    });
+
+    let fixture = fixture_from_source(annotation_heavy_module(400));
+
+    c.bench_function("document-module-annotation-heavy", |b| {
         b.iter(|| {
             let documented = documenting::document_module(
                 black_box(&fixture.source),

--- a/compiler-core/documenting/src/annotation.rs
+++ b/compiler-core/documenting/src/annotation.rs
@@ -185,8 +185,8 @@ fn annotation_documentation(source: &str, node: &SyntaxNode) -> Option<String> {
         return None;
     }
 
-    let text = node.first_token()?.text(source).to_owned();
-    extract_annotation(&text)
+    let text = node.first_token()?.text(source);
+    extract_annotation(text)
 }
 
 fn documentation_line_content(line: &str) -> Option<&str> {
@@ -223,6 +223,23 @@ mod tests {
     use indexing::IndexedTermItemKind;
 
     use super::*;
+
+    #[test]
+    fn multiline_annotation_extraction_preserves_line_semantics() {
+        let text = concat!(
+            "  -- | First line.  \n",
+            "    -- |  Indented second line.\n",
+            "    -- Ordinary comment.\n",
+            "    -- | Third line.\n",
+        );
+
+        let documentation = extract_annotation(text);
+
+        assert_eq!(
+            documentation.as_deref(),
+            Some("First line.\n Indented second line.\nThird line.")
+        );
+    }
 
     #[test]
     fn value_equation_documentation_used_when_signature_has_no_documentation() {


### PR DESCRIPTION
## Summary

- add a deterministic annotation-heavy stress case to the existing documenting Criterion benchmark
- pass borrowed syntax-token text directly into annotation extraction instead of allocating an intermediate `String`
- cover multiline extraction semantics, including trimming, preserved indentation, ignored non-documentation lines, and newline joining

## Motivation

`annotation_documentation` previously copied the complete first token text before `extract_annotation` allocated the final documentation string. Passing the borrowed token slice removes that redundant allocation without changing `AnnotationIndex`, syntax traversal, or extraction behavior.

## Measurements

The committed stress benchmark uses 400 values with 16 documentation lines each. With:

```console
cargo bench -p documenting --bench documenting -- document-module-annotation-heavy
```

Criterion reported:

- before: `[1.9168 ms, 1.9518 ms, 1.9941 ms]`
- after: `[1.8226 ms, 1.8364 ms, 1.8562 ms]`
- change: `[−8.0444%, −6.0244%, −4.2730%]` (`p < 0.05`)

This is intentionally a stress/regression case, not a representative throughput claim.

A separate uncommitted corpus harness measured the real `tests-compatibility` Core preset from package set 80.3.1: 59 packages, 294 modules, and 1,914 documentation annotations. Two baseline/optimized Criterion runs averaged 85.616 ms versus 84.288 ms for a complete serial `document_module` pass, an absolute reduction of 1.329 ms (1.55%). The observed full-corpus confidence-interval envelopes did not overlap. The effect was not distinguishable from noise in the parallel docs query-warming stage, so this change should be understood as a small allocation cleanup rather than a user-visible docs performance improvement.

## Validation

```console
cargo check -p documenting --tests
cargo nextest run -p documenting
cargo bench -p documenting --bench documenting -- document-module-annotation-heavy
just format --package documenting
```

All checks pass; the documenting test suite runs 3 tests.
