### PR TITLE
[lsp] Reuse line index when publishing diagnostics

### DIFF
--- a/compiler-core/diagnostics/src/lib.rs
+++ b/compiler-core/diagnostics/src/lib.rs
@@ -6,4 +6,7 @@ mod render;
 pub use context::{DiagnosticsContext, ExternalQueries};
 pub use convert::ToDiagnostics;
 pub use model::{Diagnostic, DiagnosticCode, RelatedSpan, Severity, Span};
-pub use render::{format_rustc, format_rustc_with_path, format_text, to_lsp_diagnostic};
+pub use render::{
+    format_rustc, format_rustc_with_path, format_text, to_lsp_diagnostic,
+    to_lsp_diagnostic_with_line_index,
+};

--- a/compiler-core/diagnostics/src/render.rs
+++ b/compiler-core/diagnostics/src/render.rs
@@ -210,8 +210,17 @@ pub fn to_lsp_diagnostic(
 ) -> Option<lsp_types::Diagnostic> {
     let line_index = LineIndex::new(content);
 
+    to_lsp_diagnostic_with_line_index(diagnostic, &line_index, uri, encoding)
+}
+
+pub fn to_lsp_diagnostic_with_line_index(
+    diagnostic: &Diagnostic,
+    line_index: &LineIndex,
+    uri: &lsp_types::Url,
+    encoding: &lsp_types::PositionEncodingKind,
+) -> Option<lsp_types::Diagnostic> {
     let to_position =
-        |offset: u32| offset_to_lsp_position(&line_index, TextSize::from(offset), encoding);
+        |offset: u32| offset_to_lsp_position(line_index, TextSize::from(offset), encoding);
 
     let start = to_position(diagnostic.span.start)?;
     let end = to_position(diagnostic.span.end)?;

--- a/compiler-lsp/analyzer/src/diagnostics.rs
+++ b/compiler-lsp/analyzer/src/diagnostics.rs
@@ -1,6 +1,7 @@
 use building_types::QueryProxy;
 use diagnostics::{DiagnosticsContext, ToDiagnostics};
 use files::FileId;
+use line_index::LineIndex;
 use lsp_types::{Diagnostic, Url};
 
 use crate::{AnalyzerContext, AnalyzerError, AnalyzerHost, common};
@@ -56,8 +57,14 @@ where
     }
 
     let position_encoding = context.position_encoding().into();
+    let line_index = LineIndex::new(&content);
     let diagnostics = all_diagnostics.iter().filter_map(|diagnostic| {
-        diagnostics::to_lsp_diagnostic(diagnostic, &content, &uri, &position_encoding)
+        diagnostics::to_lsp_diagnostic_with_line_index(
+            diagnostic,
+            &line_index,
+            &uri,
+            &position_encoding,
+        )
     });
 
     let diagnostics = diagnostics.collect();


### PR DESCRIPTION
## Summary

- retain the content-based LSP diagnostic conversion API for one-off callers
- add a preindexed conversion path that accepts an existing `LineIndex`
- construct one line index for each analyzer diagnostics publication and reuse it across all diagnostics

## Motivation

The analyzer converts multiple diagnostics from one immutable content snapshot, but the existing conversion helper rebuilds the same line index for every diagnostic. Reusing the snapshot index avoids repeated source scans while preserving span filtering, related information, URI handling, and negotiated position encodings.

## Validation

- `cargo check -p diagnostics --tests`
- `cargo check -p analyzer --tests`
- `cargo nextest run -p diagnostics --no-tests=pass`
- `cargo nextest run -p analyzer` (37 passed)
- `just format`
- `git diff --check`