### PR TITLE
[checking] Retain declaration type parameter ownership

### DIFF
--- a/compiler-core/checking/src/core/generalise.rs
+++ b/compiler-core/checking/src/core/generalise.rs
@@ -173,11 +173,35 @@ pub fn generalise_unsolved<Q>(
 where
     Q: ExternalQueries,
 {
+    let generalised = generalise_unsolved_with_parameters(state, context, id, unsolved)?;
+    Ok(generalised.type_id)
+}
+
+pub struct GeneralisedType {
+    pub type_id: TypeId,
+    pub parameters: Vec<GeneralisedParameter>,
+}
+
+pub struct GeneralisedParameter {
+    pub binder: crate::core::ForallBinderId,
+    pub rigid: TypeId,
+}
+
+pub fn generalise_unsolved_with_parameters<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    id: TypeId,
+    unsolved: &[u32],
+) -> QueryResult<GeneralisedType>
+where
+    Q: ExternalQueries,
+{
     if unsolved.is_empty() {
-        return Ok(id);
+        return Ok(GeneralisedType { type_id: id, parameters: vec![] });
     }
 
     let mut quantified = id;
+    let mut parameters = Vec::with_capacity(unsolved.len());
 
     // All rigid type variables in a single generalisation share the same
     // depth, one level deeper than the ambient scope. Note that the depth
@@ -205,28 +229,31 @@ where
         let UnificationEntry { kind, state: unification_state, .. } =
             *state.unifications.get(unification_id);
 
-        let (name, kind) = match unification_state {
+        let (rigid, name, kind) = match unification_state {
             UnificationState::Unsolved => {
                 let name = state.names.fresh();
                 let rigid = context.intern_rigid(name, depth, kind);
                 state.unifications.solve(unification_id, rigid);
-                (name, kind)
+                (rigid, name, kind)
             }
             UnificationState::Solved(solution) => {
                 let solution = normalise::expand(state, context, solution)?;
                 let Type::Rigid(name, _, kind) = context.lookup_type(solution) else {
                     continue;
                 };
-                (name, kind)
+                (solution, name, kind)
             }
         };
 
         let binder = ForallBinder { visible: false, name, kind };
         let binder = context.intern_forall_binder(binder);
         quantified = context.intern_forall(binder, quantified);
+        parameters.push(GeneralisedParameter { binder, rigid });
     }
 
-    zonk::zonk(state, context, quantified)
+    parameters.reverse();
+    let type_id = zonk::zonk(state, context, quantified)?;
+    Ok(GeneralisedType { type_id, parameters })
 }
 
 /// Generalises a given type. See also module-level documentation.
@@ -250,6 +277,7 @@ pub struct ConstraintErrors {
 
 pub struct ConstrainedByResiduals {
     pub type_id: TypeId,
+    pub constraints: Vec<TypeId>,
     pub evidences: Vec<Evidence>,
 }
 
@@ -264,7 +292,11 @@ where
     Q: ExternalQueries,
 {
     if residuals.is_empty() {
-        return Ok(ConstrainedByResiduals { type_id: unconstrained, evidences: vec![] });
+        return Ok(ConstrainedByResiduals {
+            type_id: unconstrained,
+            constraints: vec![],
+            evidences: vec![],
+        });
     }
 
     for residual in residuals.iter_mut() {
@@ -279,14 +311,17 @@ where
     let generalised = residuals.sorted_by_key(|constraint| constraint.key.wanted).collect_vec();
     let generalised = finalise_generalised_constraints(state, context, generalised)?;
 
-    let constrained = generalised.iter().rfold(unconstrained, |inner, generalised| {
-        let constraint = state.canonicals.type_id(context, generalised.constraint);
-        context.intern_constrained(constraint, inner)
-    });
+    let constraints = generalised
+        .iter()
+        .map(|generalised| state.canonicals.type_id(context, generalised.constraint));
+    let constraints = constraints.collect::<Vec<_>>();
+    let constrained = constraints
+        .iter()
+        .rfold(unconstrained, |inner, &constraint| context.intern_constrained(constraint, inner));
     let evidences = generalised.into_iter().map(|generalised| generalised.evidence);
     let evidences = evidences.collect();
 
-    Ok(ConstrainedByResiduals { type_id: constrained, evidences })
+    Ok(ConstrainedByResiduals { type_id: constrained, constraints, evidences })
 }
 
 type PrunedPartial = (Vec<ConstraintInScope>, Option<ConstraintInScope>);

--- a/compiler-core/checking/src/core/pretty.rs
+++ b/compiler-core/checking/src/core/pretty.rs
@@ -44,7 +44,7 @@ pub trait PrettyQueries:
     fn lookup_smol_str(&self, id: SmolStrId) -> SmolStr;
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PrettyNames {
     display_by_name: FxHashMap<Name, SmolStr>,
     next_suffix: FxHashMap<SmolStr, NonZeroU32>,
@@ -263,6 +263,15 @@ impl<'a, Q> PrettyState<'a, Q>
 where
     Q: PrettyQueries + ?Sized,
 {
+    pub(crate) fn fork(&self) -> PrettyState<'a, Q> {
+        PrettyState {
+            queries: self.queries,
+            checked: self.checked,
+            config: self.config,
+            names: self.names.clone(),
+        }
+    }
+
     pub fn display_name(&mut self, name: Name) -> SmolStr {
         self.names.set_default_name("t");
         self.names.display_name(self.queries, &self.checked.names, name)

--- a/compiler-core/checking/src/core/signature.rs
+++ b/compiler-core/checking/src/core/signature.rs
@@ -6,21 +6,32 @@ use lowering::TypeVariableBinding;
 
 use crate::context::CheckContext;
 use crate::core::substitute::RigidRenaming;
-use crate::core::{ForallBinder, Type, TypeId, normalise, toolkit, unification};
+use crate::core::{ForallBinderId, Type, TypeId, normalise, toolkit, unification};
 use crate::error::ErrorKind;
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecomposedAbstraction {
+    Type { binder: ForallBinderId },
+    Constraint { constraint: TypeId },
+}
+
 pub struct DecomposedSignature {
-    pub binders: Vec<ForallBinder>,
-    pub constraints: Vec<TypeId>,
+    pub abstractions: Vec<DecomposedAbstraction>,
     pub arguments: Vec<TypeId>,
     pub result: TypeId,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkolemisedAbstraction {
+    Type { binder: ForallBinderId, rigid: TypeId },
+    Constraint { constraint: TypeId },
+}
+
 pub struct SkolemisedSignature {
     pub renaming: Arc<RigidRenaming>,
-    pub constraints: Vec<TypeId>,
+    pub abstractions: Vec<SkolemisedAbstraction>,
     pub arguments: Vec<TypeId>,
     pub result: TypeId,
 }
@@ -40,8 +51,7 @@ pub fn decompose_signature<Q>(
 where
     Q: ExternalQueries,
 {
-    let mut binders = vec![];
-    let mut constraints = vec![];
+    let mut abstractions = vec![];
     let mut arguments = vec![];
 
     safe_loop! {
@@ -49,12 +59,12 @@ where
 
         match context.lookup_type(current) {
             Type::Forall(binder_id, inner) => {
-                binders.push(context.lookup_forall_binder(binder_id));
+                abstractions.push(DecomposedAbstraction::Type { binder: binder_id });
                 current = inner;
             }
 
             Type::Constrained(constraint, constrained) => {
-                constraints.push(constraint);
+                abstractions.push(DecomposedAbstraction::Constraint { constraint });
                 current = constrained;
             }
 
@@ -62,7 +72,7 @@ where
                 if let DecomposeSignatureMode::Patterns { required } = mode
                     && arguments.len() >= required
                 {
-                    return Ok(DecomposedSignature { binders, constraints, arguments, result: current });
+                    return Ok(DecomposedSignature { abstractions, arguments, result: current });
                 }
 
                 arguments.push(argument);
@@ -73,7 +83,7 @@ where
                 if let DecomposeSignatureMode::Patterns { required } = mode
                     && arguments.len() >= required
                 {
-                    return Ok(DecomposedSignature { binders, constraints, arguments, result: current });
+                    return Ok(DecomposedSignature { abstractions, arguments, result: current });
                 }
 
                 let function_argument =
@@ -81,7 +91,7 @@ where
 
                 let Type::Application(function, argument) = context.lookup_type(function_argument)
                 else {
-                    return Ok(DecomposedSignature { binders, constraints, arguments, result: current });
+                    return Ok(DecomposedSignature { abstractions, arguments, result: current });
                 };
 
                 let function = normalise::expand(state, context, function)?;
@@ -89,11 +99,11 @@ where
                     arguments.push(argument);
                     current = result;
                 } else {
-                    return Ok(DecomposedSignature { binders, constraints, arguments, result: current });
+                    return Ok(DecomposedSignature { abstractions, arguments, result: current });
                 }
             }
 
-            _ => return Ok(DecomposedSignature { binders, constraints, arguments, result: current }),
+            _ => return Ok(DecomposedSignature { abstractions, arguments, result: current }),
         }
     }
 }
@@ -125,12 +135,7 @@ where
     let arguments = remaining.by_ref().take(actual as usize).collect();
     let result = context.intern_function_iter(remaining, signature.result);
 
-    Ok(DecomposedSignature {
-        binders: signature.binders,
-        constraints: signature.constraints,
-        arguments,
-        result,
-    })
+    Ok(DecomposedSignature { abstractions: signature.abstractions, arguments, result })
 }
 
 pub fn expect_term_signature<Q>(
@@ -145,7 +150,7 @@ where
     let signature =
         decompose_signature(state, context, signature_type, DecomposeSignatureMode::Full)?;
 
-    let SkolemisedSignature { renaming, constraints, arguments, result } =
+    let SkolemisedSignature { renaming, abstractions, arguments, result } =
         skolemise_decomposed_signature(state, context, signature)?;
 
     let mut remaining = arguments.into_iter();
@@ -154,7 +159,7 @@ where
     let mut result = context.intern_function_iter(remaining, result);
     synthesise_functions(state, context, &mut arguments, &mut result, required)?;
 
-    Ok(SkolemisedSignature { renaming, constraints, arguments, result })
+    Ok(SkolemisedSignature { renaming, abstractions, arguments, result })
 }
 
 fn synthesise_functions<Q>(
@@ -198,19 +203,24 @@ where
     Q: ExternalQueries,
 {
     let mut renaming = RigidRenaming::default();
+    let mut abstractions = Vec::with_capacity(signature.abstractions.len());
 
-    for binder in &signature.binders {
-        let kind = renaming.substitute(state, context, binder.kind)?;
-        let text = toolkit::lookup_name(state, context, binder.name)?;
-        let rigid = state.fresh_rigid_named(context.queries, kind, text);
-        renaming.insert(context, binder.name, rigid);
+    for abstraction in signature.abstractions {
+        match abstraction {
+            DecomposedAbstraction::Type { binder } => {
+                let forall_binder = context.lookup_forall_binder(binder);
+                let kind = renaming.substitute(state, context, forall_binder.kind)?;
+                let text = toolkit::lookup_name(state, context, forall_binder.name)?;
+                let rigid = state.fresh_rigid_named(context.queries, kind, text);
+                renaming.insert(context, forall_binder.name, rigid);
+                abstractions.push(SkolemisedAbstraction::Type { binder, rigid });
+            }
+            DecomposedAbstraction::Constraint { constraint } => {
+                let constraint = renaming.substitute(state, context, constraint)?;
+                abstractions.push(SkolemisedAbstraction::Constraint { constraint });
+            }
+        }
     }
-
-    let constraints = signature
-        .constraints
-        .iter()
-        .map(|&constraint| renaming.substitute(state, context, constraint))
-        .collect::<QueryResult<Vec<_>>>()?;
 
     let arguments = signature
         .arguments
@@ -221,5 +231,5 @@ where
     let result = renaming.substitute(state, context, signature.result)?;
     let renaming = Arc::new(renaming);
 
-    Ok(SkolemisedSignature { renaming, constraints, arguments, result })
+    Ok(SkolemisedSignature { renaming, abstractions, arguments, result })
 }

--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -11,7 +11,8 @@ use crate::error::{CheckingError, ErrorKind};
 use crate::holes::{HoleBinding, TermHole, TypeHole};
 use crate::state::CheckState;
 use crate::tree::{
-    BinderKind, ExpressionKind, InstanceImplementation, TermDeclarationKind, TypeDeclarationKind,
+    BinderKind, DeclarationAbstraction, ExpressionKind, InstanceImplementation,
+    TermDeclarationKind, TypeDeclarationKind,
 };
 use crate::{ExternalQueries, OperatorBranchTypes, holes};
 
@@ -52,6 +53,30 @@ where
     Q: ExternalQueries,
 {
     fold_type(state, context, id, &mut Zonk)
+}
+
+fn zonk_declaration_abstractions<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    abstractions: &mut Arc<[DeclarationAbstraction]>,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    for abstraction in Arc::make_mut(abstractions) {
+        match abstraction {
+            DeclarationAbstraction::Type { binder, rigid } => {
+                let mut forall_binder = context.lookup_forall_binder(*binder);
+                forall_binder.kind = zonk(state, context, forall_binder.kind)?;
+                *binder = context.intern_forall_binder(forall_binder);
+                *rigid = zonk(state, context, *rigid)?;
+            }
+            DeclarationAbstraction::Evidence { constraint, .. } => {
+                *constraint = zonk(state, context, *constraint)?;
+            }
+        }
+    }
+    Ok(())
 }
 
 pub fn zonk_nodes<Q>(state: &mut CheckState, context: &CheckContext<Q>) -> QueryResult<()>
@@ -124,6 +149,7 @@ where
     let mut local_declarations = mem::take(&mut state.checked.tree.arena.lets);
     for (_, declaration) in local_declarations.iter_mut() {
         declaration.type_id = zonk(state, context, declaration.type_id)?;
+        zonk_declaration_abstractions(state, context, &mut declaration.value.abstractions)?;
     }
     state.checked.tree.arena.lets = local_declarations;
 
@@ -131,7 +157,10 @@ where
     for (_, declaration) in term_declarations.iter_mut() {
         declaration.type_id = zonk(state, context, declaration.type_id)?;
         match &mut declaration.kind {
-            TermDeclarationKind::Value(_) | TermDeclarationKind::Foreign => {}
+            TermDeclarationKind::Value(value) => {
+                zonk_declaration_abstractions(state, context, &mut value.abstractions)?;
+            }
+            TermDeclarationKind::Foreign => {}
             TermDeclarationKind::Constructor(constructor) => {
                 let arguments =
                     constructor.arguments.iter().map(|&argument| zonk(state, context, argument));
@@ -152,6 +181,11 @@ where
                         for member in Arc::make_mut(members) {
                             member.implementation_type =
                                 zonk(state, context, member.implementation_type)?;
+                            zonk_declaration_abstractions(
+                                state,
+                                context,
+                                &mut member.abstractions,
+                            )?;
                         }
                     }
                     InstanceImplementation::Delegate { constraint, .. } => {

--- a/compiler-core/checking/src/source/derive/generate.rs
+++ b/compiler-core/checking/src/source/derive/generate.rs
@@ -9,7 +9,7 @@ use crate::source::derive::builder::DerivedTreeBuilder;
 use crate::source::term_items::{
     emit_instance_superclass_constraints, freshen_instance_rigids, instantiate_class_member_type,
 };
-use crate::source::terms::ElaboratedExpression;
+use crate::source::terms::{ElaboratedExpression, equations};
 use crate::state::CheckState;
 use crate::{ExternalQueries, tree};
 
@@ -373,14 +373,10 @@ where
             return Ok(None);
         };
 
-        let signature::SkolemisedSignature { renaming, constraints, result: body_type, .. } =
+        let signature::SkolemisedSignature { renaming, abstractions, result: body_type, .. } =
             signature::expect_term_signature(state, context, member.implementation_type, 0)?;
 
-        let mut evidences = Vec::with_capacity(constraints.len());
-        for constraint in constraints {
-            let evidence = Evidence::Given(state.push_given(constraint));
-            evidences.push(evidence);
-        }
+        let abstractions = equations::bind_signature_abstractions(state, &abstractions);
 
         let body = state.with_source_type_renaming(&renaming, |state| {
             let mut builder = DerivedTreeBuilder::new(state, context, result.derive_id);
@@ -392,7 +388,7 @@ where
             result.derive_id,
             (member.file_id, member.item_id),
             member.implementation_type,
-            evidences,
+            abstractions,
             body,
         );
         Ok(Some(member))
@@ -403,7 +399,7 @@ pub(super) fn generated_member(
     derive_id: indexing::DeriveId,
     resolution: (files::FileId, indexing::TermItemId),
     implementation_type: TypeId,
-    evidences: Vec<Evidence>,
+    abstractions: Vec<tree::DeclarationAbstraction>,
     body: ElaboratedExpression,
 ) -> tree::InstanceMember {
     let where_expression = tree::WhereExpression::new(body.expression);
@@ -413,7 +409,7 @@ pub(super) fn generated_member(
     tree::InstanceMember {
         resolution,
         implementation_type,
-        evidences: Arc::from(evidences),
+        abstractions: Arc::from(abstractions),
         equations: Arc::from([equation]),
     }
 }

--- a/compiler-core/checking/src/source/derive/generate/contravariant.rs
+++ b/compiler-core/checking/src/source/derive/generate/contravariant.rs
@@ -7,14 +7,13 @@ use smol_str::format_smolstr;
 use crate::context::CheckContext;
 use crate::core::substitute::RigidRenaming;
 use crate::core::{ApplicationArgument, RowType, Type, TypeId, normalise, signature, toolkit};
-use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
 use crate::source::derive::field;
 use crate::source::derive::variance::{
     ConstructorRecipe, RecordFieldRecipe, TraversalOperation, TraversalParameter, Variance,
     VarianceRecipe,
 };
-use crate::source::terms::ElaboratedExpression;
+use crate::source::terms::{ElaboratedExpression, equations};
 use crate::state::CheckState;
 use crate::{ExternalQueries, tree};
 
@@ -51,7 +50,7 @@ impl Mappings<ElaboratedExpression> {
 struct DecodedTraversalMember {
     member: ResolvedMember,
     renaming: Arc<RigidRenaming>,
-    constraints: Vec<TypeId>,
+    abstractions: Vec<signature::SkolemisedAbstraction>,
     implementation_type: TypeId,
     function_type: TypeId,
     mappings: Mappings<TypeId>,
@@ -75,7 +74,7 @@ impl DecodedTraversalMember {
             TraversalKind::Contravariant => 2,
             TraversalKind::Profunctor => 3,
         };
-        let signature::SkolemisedSignature { renaming, constraints, arguments, result } =
+        let signature::SkolemisedSignature { renaming, abstractions, arguments, result } =
             signature::expect_term_signature(
                 state,
                 context,
@@ -102,7 +101,7 @@ impl DecodedTraversalMember {
             implementation_type: member.implementation_type,
             member,
             renaming,
-            constraints,
+            abstractions,
             function_type,
             mappings,
             data_file,
@@ -143,10 +142,7 @@ where
             return Ok(None);
         };
 
-        let mut evidences = Vec::with_capacity(member.constraints.len());
-        for &constraint in &member.constraints {
-            evidences.push(Evidence::Given(state.push_given(constraint)));
-        }
+        let abstractions = equations::bind_signature_abstractions(state, &member.abstractions);
 
         let body = state.with_source_type_renaming(&member.renaming, |state| {
             emit_variance_traversal(state, context, result.derive_id, &member, recipe)
@@ -157,7 +153,7 @@ where
             result.derive_id,
             (member.member.file_id, member.member.item_id),
             member.implementation_type,
-            evidences,
+            abstractions,
             body,
         )))
     })

--- a/compiler-core/checking/src/source/derive/generate/foldable.rs
+++ b/compiler-core/checking/src/source/derive/generate/foldable.rs
@@ -7,13 +7,12 @@ use smol_str::format_smolstr;
 use crate::context::CheckContext;
 use crate::core::substitute::RigidRenaming;
 use crate::core::{ApplicationArgument, RowType, Type, TypeId, normalise, signature, toolkit};
-use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
 use crate::source::derive::field;
 use crate::source::derive::variance::{
     ConstructorRecipe, RecordFieldRecipe, TraversalOperation, TraversalParameter, VarianceRecipe,
 };
-use crate::source::terms::ElaboratedExpression;
+use crate::source::terms::{ElaboratedExpression, equations};
 use crate::state::CheckState;
 use crate::{ExternalQueries, tree};
 
@@ -59,7 +58,7 @@ impl Mappings<ElaboratedExpression> {
 struct DecodedFoldMember {
     member: ResolvedMember,
     renaming: Arc<RigidRenaming>,
-    constraints: Vec<TypeId>,
+    abstractions: Vec<signature::SkolemisedAbstraction>,
     implementation_type: TypeId,
     function_type: TypeId,
     mappings: Mappings<TypeId>,
@@ -101,7 +100,7 @@ impl DecodedFoldMember {
             (TraversalKind::Foldable, FoldOperation::Map) => 2,
             (TraversalKind::Bifoldable, FoldOperation::Map) => 3,
         };
-        let signature::SkolemisedSignature { renaming, constraints, arguments, result } =
+        let signature::SkolemisedSignature { renaming, abstractions, arguments, result } =
             signature::expect_term_signature(
                 state,
                 context,
@@ -138,7 +137,7 @@ impl DecodedFoldMember {
             implementation_type: member.implementation_type,
             member,
             renaming,
-            constraints,
+            abstractions,
             function_type,
             mappings,
             accumulator_type,
@@ -280,10 +279,7 @@ where
             return Ok(None);
         };
 
-        let mut evidences = Vec::with_capacity(member.constraints.len());
-        for &constraint in &member.constraints {
-            evidences.push(Evidence::Given(state.push_given(constraint)));
-        }
+        let abstractions = equations::bind_signature_abstractions(state, &member.abstractions);
 
         let body = state.with_source_type_renaming(&member.renaming, |state| {
             emit_variance_fold(state, context, result.derive_id, &member, recipe, operation)
@@ -294,7 +290,7 @@ where
             result.derive_id,
             (member.member.file_id, member.member.item_id),
             member.implementation_type,
-            evidences,
+            abstractions,
             body,
         )))
     })

--- a/compiler-core/checking/src/source/derive/generate/functor.rs
+++ b/compiler-core/checking/src/source/derive/generate/functor.rs
@@ -7,14 +7,13 @@ use smol_str::format_smolstr;
 use crate::context::CheckContext;
 use crate::core::substitute::RigidRenaming;
 use crate::core::{ApplicationArgument, RowType, Type, TypeId, normalise, signature, toolkit};
-use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
 use crate::source::derive::field;
 use crate::source::derive::variance::{
     ConstructorRecipe, RecordFieldRecipe, TraversalOperation, TraversalParameter, Variance,
     VarianceRecipe,
 };
-use crate::source::terms::ElaboratedExpression;
+use crate::source::terms::{ElaboratedExpression, equations};
 use crate::state::CheckState;
 use crate::{ExternalQueries, tree};
 
@@ -51,7 +50,7 @@ impl Mappings<ElaboratedExpression> {
 struct DecodedTraversalMember {
     member: ResolvedMember,
     renaming: Arc<RigidRenaming>,
-    constraints: Vec<TypeId>,
+    abstractions: Vec<signature::SkolemisedAbstraction>,
     implementation_type: TypeId,
     function_type: TypeId,
     mappings: Mappings<TypeId>,
@@ -75,7 +74,7 @@ impl DecodedTraversalMember {
             TraversalKind::Functor => 2,
             TraversalKind::Bifunctor => 3,
         };
-        let signature::SkolemisedSignature { renaming, constraints, arguments, result } =
+        let signature::SkolemisedSignature { renaming, abstractions, arguments, result } =
             signature::expect_term_signature(
                 state,
                 context,
@@ -100,7 +99,7 @@ impl DecodedTraversalMember {
             implementation_type: member.implementation_type,
             member,
             renaming,
-            constraints,
+            abstractions,
             function_type,
             mappings,
             data_file,
@@ -141,10 +140,7 @@ where
             return Ok(None);
         };
 
-        let mut evidences = Vec::with_capacity(member.constraints.len());
-        for &constraint in &member.constraints {
-            evidences.push(Evidence::Given(state.push_given(constraint)));
-        }
+        let abstractions = equations::bind_signature_abstractions(state, &member.abstractions);
 
         let body = state.with_source_type_renaming(&member.renaming, |state| {
             emit_variance_traversal(state, context, result.derive_id, &member, recipe)
@@ -155,7 +151,7 @@ where
             result.derive_id,
             (member.member.file_id, member.member.item_id),
             member.implementation_type,
-            evidences,
+            abstractions,
             body,
         )))
     })

--- a/compiler-core/checking/src/source/derive/generate/traversable.rs
+++ b/compiler-core/checking/src/source/derive/generate/traversable.rs
@@ -7,13 +7,12 @@ use smol_str::format_smolstr;
 use crate::context::CheckContext;
 use crate::core::substitute::RigidRenaming;
 use crate::core::{ApplicationArgument, RowType, Type, TypeId, normalise, signature, toolkit};
-use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
 use crate::source::derive::field;
 use crate::source::derive::variance::{
     ConstructorRecipe, RecordFieldRecipe, TraversalOperation, TraversalParameter, VarianceRecipe,
 };
-use crate::source::terms::ElaboratedExpression;
+use crate::source::terms::{ElaboratedExpression, equations};
 use crate::state::CheckState;
 use crate::{ExternalQueries, tree};
 
@@ -52,7 +51,7 @@ impl Mappings<ElaboratedExpression> {
 struct DecodedTraversalMember {
     member: ResolvedMember,
     renaming: Arc<RigidRenaming>,
-    constraints: Vec<TypeId>,
+    abstractions: Vec<signature::SkolemisedAbstraction>,
     implementation_type: TypeId,
     function_type: TypeId,
     mappings: Mappings<TypeId>,
@@ -93,7 +92,7 @@ impl DecodedTraversalMember {
             TraversalKind::Traversable => 2,
             TraversalKind::Bitraversable => 3,
         };
-        let signature::SkolemisedSignature { renaming, constraints, arguments, result } =
+        let signature::SkolemisedSignature { renaming, abstractions, arguments, result } =
             signature::expect_term_signature(
                 state,
                 context,
@@ -162,7 +161,7 @@ impl DecodedTraversalMember {
             implementation_type: member.implementation_type,
             member,
             renaming,
-            constraints,
+            abstractions,
             function_type,
             mappings,
             effect,
@@ -278,10 +277,7 @@ where
             return Ok(None);
         };
 
-        let mut evidences = Vec::with_capacity(member.constraints.len());
-        for &constraint in &member.constraints {
-            evidences.push(Evidence::Given(state.push_given(constraint)));
-        }
+        let abstractions = equations::bind_signature_abstractions(state, &member.abstractions);
 
         let body = state.with_source_type_renaming(&member.renaming, |state| {
             emit_variance_traversal(state, context, result.derive_id, &member, recipe)
@@ -292,7 +288,7 @@ where
             result.derive_id,
             (member.member.file_id, member.member.item_id),
             member.implementation_type,
-            evidences,
+            abstractions,
             body,
         )))
     })
@@ -324,7 +320,12 @@ where
         else {
             return Ok(None);
         };
-        let signature::SkolemisedSignature { renaming, constraints, arguments, result: body_type } =
+        let signature::SkolemisedSignature {
+            renaming,
+            abstractions,
+            arguments,
+            result: body_type,
+        } =
             signature::expect_term_signature(state, context, member.implementation_type, 1)?;
         let [source_type] = arguments.as_slice() else {
             return Ok(None);
@@ -368,10 +369,7 @@ where
             _ => return Ok(None),
         };
 
-        let mut evidences = Vec::with_capacity(constraints.len());
-        for constraint in constraints {
-            evidences.push(Evidence::Given(state.push_given(constraint)));
-        }
+        let abstractions = equations::bind_signature_abstractions(state, &abstractions);
 
         let body = state.with_source_type_renaming(&renaming, |state| {
             let mut builder = DerivedTreeBuilder::new(state, context, result.derive_id);
@@ -415,7 +413,7 @@ where
             result.derive_id,
             (member.file_id, member.item_id),
             member.implementation_type,
-            evidences,
+            abstractions,
             body,
         )))
     })

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -28,7 +28,7 @@ struct TermSccState {
 enum PendingValueGroup {
     Checked {
         residuals: Vec<ConstraintInScope>,
-        evidences: Vec<Evidence>,
+        abstractions: Vec<tree::DeclarationAbstraction>,
         equations: Vec<equations::ElaboratedEquation>,
     },
     Inferred {
@@ -490,7 +490,7 @@ fn record_instance_member(
     Some(tree::InstanceMember {
         resolution,
         implementation_type,
-        evidences: Arc::from(checked.evidences),
+        abstractions: Arc::from(checked.abstractions),
         equations: Arc::from(equations),
     })
 }
@@ -773,9 +773,9 @@ where
     if let Some(signature_id) = signature
         && let Some(signature_type) = state.checked.lookup_term_item_type(item_id)
     {
-        let (residuals, evidences, equations) =
+        let (residuals, abstractions, equations) =
             check_value_group_core_check(state, context, signature_id, signature_type, equations)?;
-        Ok(Some(PendingValueGroup::Checked { residuals, evidences, equations }))
+        Ok(Some(PendingValueGroup::Checked { residuals, abstractions, equations }))
     } else {
         let (residuals, equations) =
             check_value_group_core_infer(state, context, item_id, equations)?;
@@ -789,7 +789,11 @@ fn check_value_group_core_check<Q>(
     signature_id: lowering::TypeId,
     signature_type: TypeId,
     equations: &[lowering::Equation],
-) -> QueryResult<(Vec<ConstraintInScope>, Vec<Evidence>, Vec<equations::ElaboratedEquation>)>
+) -> QueryResult<(
+    Vec<ConstraintInScope>,
+    Vec<tree::DeclarationAbstraction>,
+    Vec<equations::ElaboratedEquation>,
+)>
 where
     Q: ExternalQueries,
 {
@@ -808,7 +812,7 @@ where
     )?;
     state.report_exhaustiveness(exhaustiveness);
     let residuals = state.solve_constraints(context)?;
-    Ok((residuals, checked_equations.evidences, checked_equations.equations))
+    Ok((residuals, checked_equations.abstractions, checked_equations.equations))
 }
 
 fn check_value_group_core_infer<Q>(
@@ -854,7 +858,7 @@ where
         marker: TypeId,
         unsolved: Vec<u32>,
         errors: generalise::ConstraintErrors,
-        evidences: Vec<Evidence>,
+        abstractions: Vec<tree::DeclarationAbstraction>,
         equations: Vec<equations::ElaboratedEquation>,
         inferred_constraints: bool,
     }
@@ -871,10 +875,10 @@ where
 
         let mut errors = generalise::ConstraintErrors::default();
 
-        let (marker, evidences, equations, inferred_constraints) = match group {
-            Some(PendingValueGroup::Checked { residuals, evidences, equations }) => {
+        let (marker, abstractions, equations, inferred_constraints) = match group {
+            Some(PendingValueGroup::Checked { residuals, abstractions, equations }) => {
                 errors.unsatisfied.extend(residuals);
-                (marker, evidences, equations, false)
+                (marker, abstractions, equations, false)
             }
             Some(PendingValueGroup::Inferred { residuals, equations }) => {
                 let constrained = generalise::constrain_using_residuals(
@@ -885,7 +889,13 @@ where
                     &mut errors,
                 )?;
                 let inferred_constraints = !constrained.evidences.is_empty();
-                (constrained.type_id, constrained.evidences, equations, inferred_constraints)
+                let abstractions = std::iter::zip(constrained.constraints, constrained.evidences)
+                    .map(|(constraint, evidence)| tree::DeclarationAbstraction::Evidence {
+                        constraint,
+                        evidence,
+                    });
+                let abstractions = abstractions.collect();
+                (constrained.type_id, abstractions, equations, inferred_constraints)
             }
             None => (marker, vec![], vec![], false),
         };
@@ -894,17 +904,25 @@ where
         let unsolved = generalise::unsolved_unifications(state, context, marker)?;
 
         let pending_group =
-            Pending { marker, unsolved, errors, evidences, equations, inferred_constraints };
+            Pending { marker, unsolved, errors, abstractions, equations, inferred_constraints };
         pending.push((item_id, pending_group));
     }
 
     for (
         item_id,
-        Pending { marker, unsolved, errors, evidences, equations, inferred_constraints },
+        Pending { marker, unsolved, errors, abstractions, equations, inferred_constraints },
     ) in pending
     {
-        let marker = generalise::generalise_unsolved(state, context, marker, &unsolved)?;
+        let generalised =
+            generalise::generalise_unsolved_with_parameters(state, context, marker, &unsolved)?;
+        let marker = generalised.type_id;
         state.checked.term_item_types.insert(item_id, marker);
+
+        let type_abstractions = generalised.parameters.into_iter().map(|parameter| {
+            tree::DeclarationAbstraction::Type { binder: parameter.binder, rigid: parameter.rigid }
+        });
+        let abstractions = type_abstractions.chain(abstractions);
+        let abstractions = abstractions.collect();
 
         if recursive && inferred_constraints {
             // Keep constraint evidence consistent with the candidate type used for error recovery.
@@ -915,7 +933,7 @@ where
             });
         }
 
-        record_value_declaration(state, context, item_id, marker, evidences, equations);
+        record_value_declaration(state, context, item_id, marker, abstractions, equations);
 
         for error in errors.ambiguous {
             let constraint = state.canonicals.type_id(context, error);
@@ -952,7 +970,7 @@ fn record_value_declaration<Q>(
     context: &CheckContext<Q>,
     item_id: TermItemId,
     type_id: TypeId,
-    evidences: Vec<Evidence>,
+    abstractions: Vec<tree::DeclarationAbstraction>,
     equations: Vec<equations::ElaboratedEquation>,
 ) where
     Q: ExternalQueries,
@@ -977,8 +995,10 @@ fn record_value_declaration<Q>(
         return;
     }
 
-    let declaration =
-        tree::ValueDeclaration { evidences: Arc::from(evidences), equations: Arc::from(equations) };
+    let declaration = tree::ValueDeclaration {
+        abstractions: Arc::from(abstractions),
+        equations: Arc::from(equations),
+    };
     let declaration =
         tree::TermDeclaration { type_id, kind: tree::TermDeclarationKind::Value(declaration) };
     state.checked.tree.insert_term(item_id, declaration);

--- a/compiler-core/checking/src/source/terms/equations.rs
+++ b/compiler-core/checking/src/source/terms/equations.rs
@@ -34,7 +34,7 @@ pub type ValueEquationPatterns = Vec<TypeId>;
 
 pub struct CheckedValueEquations {
     pub patterns: ValueEquationPatterns,
-    pub evidences: Vec<Evidence>,
+    pub abstractions: Vec<tree::DeclarationAbstraction>,
     pub equations: Vec<ElaboratedEquation>,
 }
 
@@ -72,14 +72,10 @@ where
 {
     let required = equations.iter().map(|equation| equation.binders.len()).max().unwrap_or(0);
 
-    let signature::SkolemisedSignature { renaming, constraints, arguments, result } =
+    let signature::SkolemisedSignature { renaming, abstractions, arguments, result } =
         signature::expect_term_signature(state, context, expected_type, required)?;
 
-    let mut evidences = vec![];
-    for &constraint in &constraints {
-        let evidence = state.push_given(constraint);
-        evidences.push(Evidence::Given(evidence));
-    }
+    let abstractions = bind_signature_abstractions(state, &abstractions);
 
     let signature = context.intern_function_list(&arguments, result);
     let signature = ValueEquationSignature { signature, arguments, result };
@@ -91,7 +87,7 @@ where
         check_equations(state, context, origin, &signature, &arguments, equations)
     })?;
 
-    Ok(CheckedValueEquations { patterns: arguments, evidences, equations })
+    Ok(CheckedValueEquations { patterns: arguments, abstractions, equations })
 }
 
 /// Infers a group of [`lowering::Equation`].
@@ -146,9 +142,28 @@ where
 
     Ok(CheckedValueEquations {
         patterns: arguments,
-        evidences: vec![],
+        abstractions: vec![],
         equations: elaborated_equations,
     })
+}
+
+pub fn bind_signature_abstractions(
+    state: &mut CheckState,
+    abstractions: &[signature::SkolemisedAbstraction],
+) -> Vec<tree::DeclarationAbstraction> {
+    let abstractions = abstractions.iter().map(|abstraction| match *abstraction {
+        signature::SkolemisedAbstraction::Type { binder, rigid } => {
+            tree::DeclarationAbstraction::Type { binder, rigid }
+        }
+        signature::SkolemisedAbstraction::Constraint { constraint } => {
+            let evidence = state.push_given(constraint);
+            tree::DeclarationAbstraction::Evidence {
+                constraint,
+                evidence: Evidence::Given(evidence),
+            }
+        }
+    });
+    abstractions.collect()
 }
 
 fn check_equations<Q>(

--- a/compiler-core/checking/src/source/terms/form_let.rs
+++ b/compiler-core/checking/src/source/terms/form_let.rs
@@ -290,7 +290,7 @@ where
         .map(|(source, equation)| equation.into_local_tree(source));
 
     let equations = equations.collect();
-    let evidences = checked_equations.evidences.into();
+    let abstractions = checked_equations.abstractions.into();
 
-    Ok(tree::LocalDeclaration::new(id, name_type, evidences, equations))
+    Ok(tree::LocalDeclaration::new(id, name_type, abstractions, equations))
 }

--- a/compiler-core/checking/src/source/type_items.rs
+++ b/compiler-core/checking/src/source/type_items.rs
@@ -507,16 +507,20 @@ where
             continue;
         };
 
-        let signature::DecomposedSignature {
-            binders: kind_binders,
-            arguments: parameter_kinds,
-            ..
-        } = signature::decompose_signature(
-            state,
-            context,
-            constructor_kind,
-            signature::DecomposeSignatureMode::Full,
-        )?;
+        let signature::DecomposedSignature { abstractions, arguments: parameter_kinds, .. } =
+            signature::decompose_signature(
+                state,
+                context,
+                constructor_kind,
+                signature::DecomposeSignatureMode::Full,
+            )?;
+        let kind_binders = abstractions.into_iter().filter_map(|abstraction| {
+            let signature::DecomposedAbstraction::Type { binder } = abstraction else {
+                return None;
+            };
+            Some(context.lookup_forall_binder(binder))
+        });
+        let kind_binders = kind_binders.collect::<Vec<_>>();
 
         // parameter_kinds is the post-generalisation kind for each parameter;
         // we want to replace pre-generalisation kinds carried by parameters
@@ -870,16 +874,20 @@ where
             continue;
         };
 
-        let signature::DecomposedSignature {
-            binders: class_binders,
-            arguments: class_parameters,
-            ..
-        } = signature::decompose_signature(
-            state,
-            context,
-            class_kind,
-            signature::DecomposeSignatureMode::Full,
-        )?;
+        let signature::DecomposedSignature { abstractions, arguments: class_parameters, .. } =
+            signature::decompose_signature(
+                state,
+                context,
+                class_kind,
+                signature::DecomposeSignatureMode::Full,
+            )?;
+        let class_binders = abstractions.into_iter().filter_map(|abstraction| {
+            let signature::DecomposedAbstraction::Type { binder } = abstraction else {
+                return None;
+            };
+            Some(context.lookup_forall_binder(binder))
+        });
+        let class_binders = class_binders.collect::<Vec<_>>();
 
         let get_parameter_kind = |index: usize| {
             if let Some(kind) = class_parameters.get(index) {

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -59,8 +59,14 @@ pub enum TermDeclarationKind {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ValueDeclaration {
-    pub evidences: Arc<[Evidence]>,
+    pub abstractions: Arc<[DeclarationAbstraction]>,
     pub equations: Arc<[Equation]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeclarationAbstraction {
+    Type { binder: ForallBinderId, rigid: TypeId },
+    Evidence { constraint: TypeId, evidence: Evidence },
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -74,10 +80,10 @@ impl LocalDeclaration {
     pub fn new(
         source: LetBindingNameGroupId,
         type_id: TypeId,
-        evidences: Arc<[Evidence]>,
+        abstractions: Arc<[DeclarationAbstraction]>,
         equations: Arc<[Equation]>,
     ) -> LocalDeclaration {
-        let value = ValueDeclaration { evidences, equations };
+        let value = ValueDeclaration { abstractions, equations };
         LocalDeclaration { source, type_id, value }
     }
 
@@ -129,7 +135,7 @@ pub struct InstanceSuperclass {
 pub struct InstanceMember {
     pub resolution: (FileId, TermItemId),
     pub implementation_type: TypeId,
-    pub evidences: Arc<[Evidence]>,
+    pub abstractions: Arc<[DeclarationAbstraction]>,
     pub equations: Arc<[Equation]>,
 }
 

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -21,11 +21,11 @@ use crate::evidence::{
     ReflectableEvidence, ReflectableOrdering, SuperclassId, SynthesizedEvidence,
 };
 use crate::tree::{
-    BinderId, BinderKind, BinderSource, CaseAlternative, Equation, ExpressionId, ExpressionKind,
-    GuardedAlternative, GuardedExpression, InstanceDeclaration, InstanceImplementation,
-    InstanceMember, LetBindingChunk, LetBindings, LocalDeclarationId, PatternGuard,
-    RecordBinderField, RecordExpressionField, RecordExpressionUpdate, TermDeclarationKind,
-    TypeDeclarationKind, VariableResolution, WhereExpression,
+    BinderId, BinderKind, BinderSource, CaseAlternative, DeclarationAbstraction, Equation,
+    ExpressionId, ExpressionKind, GuardedAlternative, GuardedExpression, InstanceDeclaration,
+    InstanceImplementation, InstanceMember, LetBindingChunk, LetBindings, LocalDeclarationId,
+    PatternGuard, RecordBinderField, RecordExpressionField, RecordExpressionUpdate,
+    TermDeclarationKind, TypeDeclarationKind, VariableResolution, WhereExpression,
 };
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
@@ -456,23 +456,29 @@ where
             unreachable!("invariant violated: term declaration is not a value");
         };
 
-        let type_id = self.signature_type_pretty.render(declaration.type_id);
+        let mut signature_pretty = self.signature_type_pretty.state();
+        let type_id = signature_pretty.render(declaration.type_id);
         let signature = self.arena.text(format!("{name} :: {type_id}"));
+        let rigid_names = self.declaration_rigid_names(&mut signature_pretty, &value.abstractions);
 
         let mut evidence_names = EvidenceNames::new();
-        for evidence in value.evidences.iter() {
-            if let Evidence::Given(binder) = evidence {
+        for abstraction in value.abstractions.iter() {
+            if let DeclarationAbstraction::Evidence { evidence: Evidence::Given(binder), .. } =
+                abstraction
+            {
                 self.evidence_binder_name(&mut evidence_names, *binder)?;
             }
         }
+        let mut equation_type_pretty = self.type_pretty.state();
+        self.assign_rigid_names(&mut equation_type_pretty, &rigid_names);
 
         let Some(equations) = self.equation_declarations(
             name,
             "",
-            &value.evidences,
+            &value.abstractions,
             &value.equations,
             &mut evidence_names,
-            &[],
+            &mut equation_type_pretty,
         )?
         else {
             return Ok(None);
@@ -538,26 +544,36 @@ where
                     let mut evidence_names = EvidenceNames::new();
                     let instance_evidences =
                         instance.evidences.iter().map(|evidence| &evidence.evidence);
-                    for evidence in instance_evidences.chain(member.evidences.iter()) {
+                    let member_evidences =
+                        member.abstractions.iter().filter_map(|abstraction| match abstraction {
+                            DeclarationAbstraction::Evidence { evidence, .. } => Some(evidence),
+                            DeclarationAbstraction::Type { .. } => None,
+                        });
+                    for evidence in instance_evidences.chain(member_evidences) {
                         if let Evidence::Given(binder) = evidence {
                             self.evidence_binder_name(&mut evidence_names, *binder)?;
                         }
                     }
 
+                    let (signature, member_rigid_names) =
+                        self.instance_member_signature(member, &member_name, &rigid_names)?;
+                    let equation_rigid_names =
+                        rigid_names.iter().cloned().chain(member_rigid_names);
+                    let equation_rigid_names = equation_rigid_names.collect::<Vec<_>>();
+                    let mut equation_type_pretty = self.type_pretty.state();
+                    self.assign_rigid_names(&mut equation_type_pretty, &equation_rigid_names);
                     let Some(equations) = self.equation_declarations(
                         &member_name,
                         "  ",
-                        &member.evidences,
+                        &member.abstractions,
                         &member.equations,
                         &mut evidence_names,
-                        &rigid_names,
+                        &mut equation_type_pretty,
                     )?
                     else {
                         continue;
                     };
 
-                    let signature =
-                        self.instance_member_signature(member, &member_name, &rigid_names)?;
                     fields.push(signature.append(self.arena.hardline()).append(equations));
                 }
             }
@@ -582,7 +598,7 @@ where
         member: &InstanceMember,
         name: &str,
         rigid_names: &[(crate::TypeId, SmolStr)],
-    ) -> QueryResult<Doc<'arena>> {
+    ) -> QueryResult<(Doc<'arena>, Vec<(crate::TypeId, SmolStr)>)> {
         let mut type_pretty = self.type_pretty.state();
 
         for (rigid, display) in rigid_names {
@@ -591,9 +607,11 @@ where
             }
         }
 
-        let mut remaining_type = member.implementation_type;
-        while let Type::Forall(binder, inner) = self.queries.lookup_type(remaining_type) {
-            let binder = self.queries.lookup_forall_binder(binder);
+        for abstraction in member.abstractions.iter() {
+            let DeclarationAbstraction::Type { binder, .. } = abstraction else {
+                continue;
+            };
+            let binder = self.queries.lookup_forall_binder(*binder);
             let text = if member.resolution.0 == self.file_id {
                 self.checked.lookup_name(binder.name)
             } else {
@@ -603,11 +621,40 @@ where
                 let text = self.queries.lookup_smol_str(text);
                 type_pretty.allocate_display_name(binder.name, text);
             }
-            remaining_type = inner;
         }
 
         let type_id = type_pretty.render(member.implementation_type);
-        Ok(self.arena.text(format!("  {name} :: {type_id}")))
+        let rigid_names = self.declaration_rigid_names(&mut type_pretty, &member.abstractions);
+        let signature = self.arena.text(format!("  {name} :: {type_id}"));
+        Ok((signature, rigid_names))
+    }
+
+    fn declaration_rigid_names(
+        &self,
+        type_pretty: &mut TypePrettyState<'context, Q>,
+        abstractions: &[DeclarationAbstraction],
+    ) -> Vec<(crate::TypeId, SmolStr)> {
+        let rigid_names = abstractions.iter().filter_map(|abstraction| {
+            let DeclarationAbstraction::Type { binder, rigid } = abstraction else {
+                return None;
+            };
+            let binder = self.queries.lookup_forall_binder(*binder);
+            let display = type_pretty.display_name(binder.name);
+            Some((*rigid, display))
+        });
+        rigid_names.collect()
+    }
+
+    fn assign_rigid_names(
+        &self,
+        type_pretty: &mut TypePrettyState<'context, Q>,
+        rigid_names: &[(crate::TypeId, SmolStr)],
+    ) {
+        for (rigid, display) in rigid_names {
+            if let Type::Rigid(name, _, _) = self.queries.lookup_type(*rigid) {
+                type_pretty.assign_display_name(name, SmolStr::clone(display));
+            }
+        }
     }
 
     fn dictionary_signature(
@@ -745,27 +792,22 @@ where
         &self,
         name: &str,
         prefix: &str,
-        evidences: &[Evidence],
+        declaration_abstractions: &[DeclarationAbstraction],
         equations: &[Equation],
         evidence_names: &mut EvidenceNames,
-        rigid_names: &[(crate::TypeId, SmolStr)],
+        type_pretty: &mut TypePrettyState<'context, Q>,
     ) -> QueryResult<Option<Doc<'arena>>> {
         let mut rendered_equations = vec![];
-        let mut type_pretty = self.type_pretty.state();
-        for (rigid, display) in rigid_names {
-            if let Type::Rigid(name, _, _) = self.queries.lookup_type(*rigid) {
-                type_pretty.assign_display_name(name, SmolStr::clone(display));
-            }
-        }
         for equation in equations.iter() {
-            let has_abstraction = !equation.binders.is_empty() || !evidences.is_empty();
+            let has_abstraction =
+                !equation.binders.is_empty() || !declaration_abstractions.is_empty();
             let (mut expression, where_bindings, force_body_break, is_lambda) = if let [alternative] =
                 equation.guarded_expression.alternatives.as_ref()
                 && alternative.pattern_guards.is_empty()
             {
                 let where_expression = &alternative.where_expression;
                 let expression =
-                    self.expression(where_expression.expression, evidence_names, &mut type_pretty)?;
+                    self.expression(where_expression.expression, evidence_names, type_pretty)?;
                 let bindings = (!where_expression.bindings.chunks.is_empty())
                     .then_some(&where_expression.bindings);
                 let force_body_break =
@@ -779,18 +821,26 @@ where
                 let expression = self.guarded_expression(
                     &equation.guarded_expression,
                     evidence_names,
-                    &mut type_pretty,
+                    type_pretty,
                 )?;
                 (expression, None, false, false)
             };
 
             let mut abstractions = vec![];
-            for evidence in evidences.iter() {
-                let binder = self.evidence_name(evidence_names, evidence)?;
-                abstractions.push(self.arena.text(format!("\\{{{binder}}} ->")));
+            for abstraction in declaration_abstractions {
+                match abstraction {
+                    DeclarationAbstraction::Type { rigid, .. } => {
+                        let binder = type_pretty.render_atom(*rigid);
+                        abstractions.push(self.arena.text(format!("\\@{binder} ->")));
+                    }
+                    DeclarationAbstraction::Evidence { evidence, .. } => {
+                        let binder = self.evidence_name(evidence_names, evidence)?;
+                        abstractions.push(self.arena.text(format!("\\{{{binder}}} ->")));
+                    }
+                }
             }
             for &binder in equation.binders.iter() {
-                let binder = self.binder(binder)?;
+                let binder = self.binder(binder, type_pretty)?;
                 let abstraction =
                     self.arena.text("\\").append(binder).append(self.arena.text(" ->"));
                 abstractions.push(abstraction);
@@ -824,7 +874,7 @@ where
                     .group()
             };
             if let Some(bindings) = where_bindings {
-                let where_clause = self.where_clause(bindings, evidence_names, &mut type_pretty)?;
+                let where_clause = self.where_clause(bindings, evidence_names, type_pretty)?;
                 equation = equation.append(self.arena.hardline().append(where_clause).nest(2));
             }
             if !prefix.is_empty() {
@@ -847,14 +897,21 @@ where
         &self,
         declaration_id: LocalDeclarationId,
         evidence_names: &mut EvidenceNames,
+        type_pretty: &mut TypePrettyState<'context, Q>,
     ) -> QueryResult<Doc<'arena>> {
         let declaration = &self.checked.tree[declaration_id];
         let name = self.local_declaration_name(declaration.source);
-        let type_id = self.signature_type_pretty.render(declaration.type_id);
+        let type_pretty = &mut type_pretty.fork();
+        let type_id = type_pretty.render(declaration.type_id);
         let signature = self.arena.text(format!("{name} :: {type_id}"));
+        let rigid_names =
+            self.declaration_rigid_names(type_pretty, &declaration.value.abstractions);
+        self.assign_rigid_names(type_pretty, &rigid_names);
 
-        for evidence in declaration.value.evidences.iter() {
-            if let Evidence::Given(binder) = evidence {
+        for abstraction in declaration.value.abstractions.iter() {
+            if let DeclarationAbstraction::Evidence { evidence: Evidence::Given(binder), .. } =
+                abstraction
+            {
                 self.evidence_binder_name(evidence_names, *binder)?;
             }
         }
@@ -862,10 +919,10 @@ where
         let equations = self.equation_declarations(
             &name,
             "",
-            &declaration.value.evidences,
+            &declaration.value.abstractions,
             &declaration.value.equations,
             evidence_names,
-            &[],
+            type_pretty,
         )?;
         let equations = equations.unwrap_or_else(|| self.arena.text(format!("{name} = <error>")));
         Ok(signature.append(self.arena.hardline()).append(equations))
@@ -881,7 +938,7 @@ where
         for chunk in bindings.chunks.iter() {
             match chunk {
                 LetBindingChunk::Pattern { binder, where_expression, .. } => {
-                    let binder = self.binder(*binder)?;
+                    let binder = self.binder(*binder, type_pretty)?;
                     let expression =
                         self.where_expression(where_expression, evidence_names, type_pretty)?;
                     rendered.push(
@@ -907,7 +964,11 @@ where
                 }
                 LetBindingChunk::Names { declarations, .. } => {
                     for &declaration in declarations.iter() {
-                        rendered.push(self.local_declaration(declaration, evidence_names)?);
+                        rendered.push(self.local_declaration(
+                            declaration,
+                            evidence_names,
+                            type_pretty,
+                        )?);
                     }
                 }
             }
@@ -1028,7 +1089,7 @@ where
                 self.expression(expression, evidence_names, type_pretty)
             }
             PatternGuard::Pattern { binder, expression } => {
-                let binder = self.binder(binder)?;
+                let binder = self.binder(binder, type_pretty)?;
                 let expression = self.expression(expression, evidence_names, type_pretty)?;
                 Ok(binder.append(self.arena.text(" <- ")).append(expression))
             }
@@ -1085,7 +1146,7 @@ where
     ) -> QueryResult<Doc<'arena>> {
         let mut rendered_binders = vec![];
         for &binder in alternative.binders.iter() {
-            rendered_binders.push(self.binder(binder)?);
+            rendered_binders.push(self.binder(binder, type_pretty)?);
         }
 
         let mut rendered_binders = rendered_binders.into_iter();
@@ -1134,13 +1195,17 @@ where
         )
     }
 
-    fn binder(&self, binder_id: BinderId) -> QueryResult<Doc<'arena>> {
+    fn binder(
+        &self,
+        binder_id: BinderId,
+        type_pretty: &mut TypePrettyState<'context, Q>,
+    ) -> QueryResult<Doc<'arena>> {
         let binder = &self.checked.tree[binder_id];
         match &binder.kind {
             BinderKind::Error => Ok(self.arena.text("<error>")),
             BinderKind::Typed { binder, annotation } => {
-                let binder = self.binder(*binder)?;
-                let annotation = self.type_pretty.render(*annotation);
+                let binder = self.binder(*binder, type_pretty)?;
+                let annotation = type_pretty.render(*annotation);
                 Ok(self
                     .arena
                     .text("(")
@@ -1179,7 +1244,7 @@ where
                 }
             },
             BinderKind::Named { name, binder } => {
-                let binder = self.binder(*binder)?;
+                let binder = self.binder(*binder, type_pretty)?;
                 Ok(self.arena.text(format!("{name}@")).append(binder))
             }
             BinderKind::Wildcard => Ok(self.arena.text("_")),
@@ -1201,7 +1266,7 @@ where
                     if position > 0 {
                         array = array.append(self.arena.text(", "));
                     }
-                    array = array.append(self.binder(element)?);
+                    array = array.append(self.binder(element, type_pretty)?);
                 }
                 Ok(array.append(self.arena.text("]")))
             }
@@ -1213,7 +1278,7 @@ where
                     }
                     match field {
                         RecordBinderField::Field { label, binder } => {
-                            let binder = self.binder(*binder)?;
+                            let binder = self.binder(*binder, type_pretty)?;
                             record =
                                 record.append(self.arena.text(format!("{label}: "))).append(binder);
                         }
@@ -1232,7 +1297,7 @@ where
                     return Ok(constructor);
                 }
                 for &argument in arguments.iter() {
-                    let argument = self.binder(argument)?;
+                    let argument = self.binder(argument, type_pretty)?;
                     constructor = constructor.append(self.arena.space()).append(argument);
                 }
                 Ok(self.arena.text("(").append(constructor).append(self.arena.text(")")))
@@ -1534,7 +1599,7 @@ where
                         if position > 0 {
                             lambda = lambda.append(self.arena.space());
                         }
-                        lambda = lambda.append(self.binder(binder)?);
+                        lambda = lambda.append(self.binder(binder, type_pretty)?);
                     }
                 }
 

--- a/tests-integration/fixtures/semantic/1784643600_constructor_binder_value_declaration/Main.snap
+++ b/tests-integration/fixtures/semantic/1784643600_constructor_binder_value_declaration/Main.snap
@@ -9,5 +9,5 @@ data Maybe @a
   | Nothing :: Main.Maybe a
 
 fromMaybe :: forall t0. t0 -> Main.Maybe t0 -> t0
-fromMaybe = \default -> \(Just value) -> value
-fromMaybe = \default -> \Nothing -> default
+fromMaybe = \@t0 -> \default -> \(Just value) -> value
+fromMaybe = \@t0 -> \default -> \Nothing -> default

--- a/tests-integration/fixtures/semantic/1784643600_variable_value_declaration/Main.snap
+++ b/tests-integration/fixtures/semantic/1784643600_variable_value_declaration/Main.snap
@@ -4,4 +4,4 @@ assertion_line: 68
 expression: report
 ---
 identity :: forall t0. t0 -> t0
-identity = \a -> a
+identity = \@t0 -> \a -> a

--- a/tests-integration/fixtures/semantic/1784704260_automatic_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784704260_automatic_applications/Main.snap
@@ -14,9 +14,10 @@ interface Second :: Prim.Type -> Prim.Constraint
 interface Second a where
 
 useDefault :: forall a. Main.Default a => a
-useDefault = \{defaultDict} -> default @a {defaultDict}
+useDefault = \@a -> \{defaultDict} -> default @a {defaultDict}
 
 foreign import interleaved :: forall a. Main.First a => (forall b. Main.Second b => a -> b)
 
 useInterleaved :: forall a b. Main.First a => Main.Second b => a -> b
-useInterleaved = \{firstDict} -> \{secondDict} -> interleaved @a {firstDict} @b {secondDict}
+useInterleaved = \@a -> \@b -> \{firstDict} -> \{secondDict} ->
+  interleaved @a {firstDict} @b {secondDict}

--- a/tests-integration/fixtures/semantic/1784704260_constructor_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784704260_constructor_expressions/Main.snap
@@ -9,4 +9,4 @@ data Maybe @a
   | Nothing :: Main.Maybe a
 
 nothing :: forall a. Main.Maybe a
-nothing = Nothing @a
+nothing = \@a -> Nothing @a

--- a/tests-integration/fixtures/semantic/1784704260_guarded_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784704260_guarded_expressions/Main.snap
@@ -9,6 +9,6 @@ data Maybe @a
   | Nothing :: Main.Maybe a
 
 recover :: forall a. a -> Main.Maybe a -> a
-recover = \fallback -> \input ->
+recover = \@a -> \fallback -> \input ->
   | (Just value) <- input -> value
   | true -> fallback

--- a/tests-integration/fixtures/semantic/1784705640_array_binders/Main.snap
+++ b/tests-integration/fixtures/semantic/1784705640_array_binders/Main.snap
@@ -4,5 +4,5 @@ assertion_line: 68
 expression: report
 ---
 headOr :: forall a. a -> Prim.Array a -> a
-headOr = \fallback -> \[first, _] -> first
-headOr = \fallback -> \_ -> fallback
+headOr = \@a -> \fallback -> \[first, _] -> first
+headOr = \@a -> \fallback -> \_ -> fallback

--- a/tests-integration/fixtures/semantic/1784705640_literal_binders/Main.snap
+++ b/tests-integration/fixtures/semantic/1784705640_literal_binders/Main.snap
@@ -4,21 +4,21 @@ assertion_line: 68
 expression: report
 ---
 integer :: forall a. Prim.Int -> a -> a
-integer = \(-1) -> \value -> value
-integer = \_ -> \value -> value
+integer = \@a -> \(-1) -> \value -> value
+integer = \@a -> \_ -> \value -> value
 
 number :: forall a. Prim.Number -> a -> a
-number = \(-1.5) -> \value -> value
-number = \_ -> \value -> value
+number = \@a -> \(-1.5) -> \value -> value
+number = \@a -> \_ -> \value -> value
 
 string :: forall a. Prim.String -> a -> a
-string = \"life" -> \value -> value
-string = \_ -> \value -> value
+string = \@a -> \"life" -> \value -> value
+string = \@a -> \_ -> \value -> value
 
 character :: forall a. Prim.Char -> a -> a
-character = \'a' -> \value -> value
-character = \_ -> \value -> value
+character = \@a -> \'a' -> \value -> value
+character = \@a -> \_ -> \value -> value
 
 boolean :: forall a. Prim.Boolean -> a -> a
-boolean = \true -> \value -> value
-boolean = \false -> \value -> value
+boolean = \@a -> \true -> \value -> value
+boolean = \@a -> \false -> \value -> value

--- a/tests-integration/fixtures/semantic/1784705640_named_binders/Main.snap
+++ b/tests-integration/fixtures/semantic/1784705640_named_binders/Main.snap
@@ -9,5 +9,5 @@ data Maybe @a
   | Nothing :: Main.Maybe a
 
 fromMaybe :: forall a. a -> Main.Maybe a -> a
-fromMaybe = \fallback -> \whole@(Just value) -> value
-fromMaybe = \fallback -> \Nothing -> fallback
+fromMaybe = \@a -> \fallback -> \whole@(Just value) -> value
+fromMaybe = \@a -> \fallback -> \Nothing -> fallback

--- a/tests-integration/fixtures/semantic/1784705640_record_binders/Main.snap
+++ b/tests-integration/fixtures/semantic/1784705640_record_binders/Main.snap
@@ -4,4 +4,4 @@ assertion_line: 68
 expression: report
 ---
 project :: forall a b. { first :: a, second :: b } -> a
-project = \{ first, second: _ } -> first
+project = \@a -> \@b -> \{ first, second: _ } -> first

--- a/tests-integration/fixtures/semantic/1784705640_wildcard_binders/Main.snap
+++ b/tests-integration/fixtures/semantic/1784705640_wildcard_binders/Main.snap
@@ -4,4 +4,4 @@ assertion_line: 68
 expression: report
 ---
 ignore :: forall a b. a -> b -> b
-ignore = \_ -> \value -> value
+ignore = \@a -> \@b -> \_ -> \value -> value

--- a/tests-integration/fixtures/semantic/1784708400_explicit_term_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784708400_explicit_term_applications/Main.snap
@@ -4,7 +4,7 @@ assertion_line: 68
 expression: report
 ---
 identity :: forall a. a -> a
-identity = \value -> value
+identity = \@a -> \value -> value
 
 applyIdentity :: forall a. a -> a
-applyIdentity = \value -> identity @a (identity @a value)
+applyIdentity = \@a -> \value -> identity @a (identity @a value)

--- a/tests-integration/fixtures/semantic/1784708400_failed_visible_type_application/Main.snap
+++ b/tests-integration/fixtures/semantic/1784708400_failed_visible_type_application/Main.snap
@@ -4,7 +4,7 @@ assertion_line: 68
 expression: report
 ---
 identity :: forall @a. a -> a
-identity = \value -> value
+identity = \@a -> \value -> value
 
 test :: Prim.Int -> Prim.Int
 test = <error>

--- a/tests-integration/fixtures/semantic/1784708400_interleaved_explicit_applications/Main.purs
+++ b/tests-integration/fixtures/semantic/1784708400_interleaved_explicit_applications/Main.purs
@@ -10,3 +10,6 @@ foreign import interleaved :: forall a. First a => a -> (forall b. Second b => b
 
 applyInterleaved :: forall a b. First a => Second b => a -> b -> a
 applyInterleaved first second = interleaved first second
+
+layered :: forall a. First a => (forall b. Second b => a -> b -> a)
+layered first _ = first

--- a/tests-integration/fixtures/semantic/1784708400_interleaved_explicit_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784708400_interleaved_explicit_applications/Main.snap
@@ -12,5 +12,8 @@ interface Second a where
 foreign import interleaved :: forall a. Main.First a => a -> (forall b. Main.Second b => b -> a)
 
 applyInterleaved :: forall a b. Main.First a => Main.Second b => a -> b -> a
-applyInterleaved = \{firstDict} -> \{secondDict} -> \first -> \second ->
+applyInterleaved = \@a -> \@b -> \{firstDict} -> \{secondDict} -> \first -> \second ->
   interleaved @a {firstDict} first @b {secondDict} second
+
+layered :: forall a. Main.First a => (forall b. Main.Second b => a -> b -> a)
+layered = \@a -> \{firstDict} -> \@b -> \{secondDict} -> \first -> \_ -> first

--- a/tests-integration/fixtures/semantic/1784708400_visible_type_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784708400_visible_type_applications/Main.snap
@@ -4,13 +4,13 @@ assertion_line: 68
 expression: report
 ---
 identity :: forall @a. a -> a
-identity = \value -> value
+identity = \@a -> \value -> value
 
 const :: forall a @b. a -> b -> a
-const = \value -> \_ -> value
+const = \@a -> \@b -> \value -> \_ -> value
 
 testIdentity :: Prim.Int -> Prim.Int
 testIdentity = identity @Prim.Int
 
 testConst :: forall t0. t0 -> Prim.String -> t0
-testConst = const @t0 @Prim.String
+testConst = \@t0 -> const @t0 @Prim.String

--- a/tests-integration/fixtures/semantic/1784708580_interleaved_visible_type_application/Main.snap
+++ b/tests-integration/fixtures/semantic/1784708580_interleaved_visible_type_application/Main.snap
@@ -9,4 +9,4 @@ interface Default a where
 foreign import select :: forall a. Main.Default a => (forall @b. a -> b -> a)
 
 specialize :: forall a. Main.Default a => a -> Prim.String -> a
-specialize = \{defaultDict} -> select @a {defaultDict} @Prim.String
+specialize = \@a -> \{defaultDict} -> select @a {defaultDict} @Prim.String

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_constraints/Main.snap
@@ -14,7 +14,7 @@ interface Example a b where
   example :: a -> b -> Prim.Boolean
 
 implementation :: forall b a. Main.Second b => a -> b -> Prim.Boolean
-implementation = \{secondDict} -> \_ -> \_ -> boolean
+implementation = \@b -> \@a -> \{secondDict} -> \_ -> \_ -> boolean
 
 foreign import boolean :: Prim.Boolean
 

--- a/tests-integration/fixtures/semantic/1784741520_instance_dictionary_member_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741520_instance_dictionary_member_constraints/Main.snap
@@ -11,10 +11,10 @@ interface Example a where
   apply :: forall (b :: Prim.Type). Main.Required b => a -> b -> Prim.Boolean
 
 implementation :: forall a b. Main.Required b => a -> b -> Prim.Boolean
-implementation = \{requiredDict} -> \_ -> \_ -> boolean
+implementation = \@a -> \@b -> \{requiredDict} -> \_ -> \_ -> boolean
 
 foreign import boolean :: Prim.Boolean
 
 dictionary exampleInt :: Main.Example Prim.Int where
   apply :: forall (b :: Prim.Type). Main.Required b => Prim.Int -> b -> Prim.Boolean
-  apply = \{requiredDict} -> implementation @Prim.Int @b {requiredDict}
+  apply = \@b -> \{requiredDict} -> implementation @Prim.Int @b {requiredDict}

--- a/tests-integration/fixtures/semantic/1784779800_array_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784779800_array_expressions/Main.snap
@@ -4,7 +4,7 @@ assertion_line: 68
 expression: report
 ---
 identity :: forall t0. t0 -> t0
-identity = \value -> value
+identity = \@t0 -> \value -> value
 
 empty :: Prim.Array Prim.Int
 empty = []
@@ -16,7 +16,7 @@ nested :: Prim.Array (Prim.Array Prim.Int)
 nested = [[1], [2, 3]]
 
 inferredFunctions :: forall t0. Prim.Array (t0 -> t0)
-inferredFunctions = [identity]
+inferredFunctions = \@t0 -> [identity]
 
 checkedFunctions :: Prim.Array (Prim.Int -> Prim.Int)
 checkedFunctions = [identity @Prim.Int]

--- a/tests-integration/fixtures/semantic/1784779800_record_pun_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784779800_record_pun_applications/Main.snap
@@ -15,11 +15,11 @@ interface Capability m where
 foreign import interleaved :: forall a. Main.First a => (forall b. Main.Second b => a -> b)
 
 inferredPun :: forall t0 t1. Main.First t0 => Main.Second t1 => { interleaved :: t0 -> t1 }
-inferredPun = \{firstDict} -> \{secondDict} ->
+inferredPun = \@t0 -> \@t1 -> \{firstDict} -> \{secondDict} ->
   { interleaved: interleaved @t0 {firstDict} @t1 {secondDict} }
 
 inferredExplicit :: forall t0 t1. Main.First t0 => Main.Second t1 => { interleaved :: t0 -> t1 }
-inferredExplicit = \{firstDict} -> \{secondDict} ->
+inferredExplicit = \@t0 -> \@t1 -> \{firstDict} -> \{secondDict} ->
   { interleaved: interleaved @t0 {firstDict} @t1 {secondDict} }
 
 aliased :: Main.Alias

--- a/tests-integration/fixtures/semantic/1784789520_infix_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789520_infix_expressions/Main.snap
@@ -4,7 +4,7 @@ assertion_line: 68
 expression: report
 ---
 choose :: forall a b. a -> b -> a
-choose = \left -> \right -> left
+choose = \@a -> \@b -> \left -> \right -> left
 
 singleInfix :: Prim.Int
 singleInfix = choose @Prim.Int @Prim.String 1 "text"
@@ -13,7 +13,7 @@ multipleInfix :: Prim.Int
 multipleInfix = choose @Prim.Int @Prim.Boolean (choose @Prim.Int @Prim.String 1 "first") true
 
 identity :: forall a. a -> a
-identity = \value -> value
+identity = \@a -> \value -> value
 
 polymorphicHead :: forall t0. t0 -> t0
-polymorphicHead = choose @(t0 -> t0) @Prim.Int identity 1
+polymorphicHead = \@t0 -> choose @(t0 -> t0) @Prim.Int identity 1

--- a/tests-integration/fixtures/semantic/1784789520_operator_chains/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789520_operator_chains/Main.snap
@@ -30,5 +30,5 @@ rightAssociative = append 1 (append 2 3)
 foreign import interleaved :: forall a. Main.First a => a -> (forall b. Main.Second b => b -> a)
 
 implicitApplications :: forall a b. Main.First a => Main.Second b => a -> b -> a
-implicitApplications = \{firstDict} -> \{secondDict} -> \left -> \right ->
+implicitApplications = \@a -> \@b -> \{firstDict} -> \{secondDict} -> \left -> \right ->
   interleaved @a {firstDict} left @b {secondDict} right

--- a/tests-integration/fixtures/semantic/1784789520_operator_names/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789520_operator_names/Main.snap
@@ -13,10 +13,11 @@ data List @a
   | Nil :: Main.List a
 
 operatorName :: forall a. Main.Combine a => a -> a -> a
-operatorName = \{combineDict} -> combine @a {combineDict}
+operatorName = \@a -> \{combineDict} -> combine @a {combineDict}
 
 operatorApplication :: forall a. Main.Combine a => a -> a -> a
-operatorApplication = \{combineDict} -> \left -> \right -> combine @a {combineDict} left right
+operatorApplication = \@a -> \{combineDict} -> \left -> \right ->
+  combine @a {combineDict} left right
 
 constructorOperator :: forall t0. t0 -> Main.List t0 -> Main.List t0
-constructorOperator = Cons @t0
+constructorOperator = \@t0 -> Cons @t0

--- a/tests-integration/fixtures/semantic/1784789640_negate_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789640_negate_expressions/Main.snap
@@ -9,7 +9,7 @@ interface Negative a where
 foreign import negate :: forall a. Main.Negative a => a -> a
 
 negative :: forall a. Main.Negative a => a -> a
-negative = \{negativeDict} -> \value -> negate @a {negativeDict} value
+negative = \@a -> \{negativeDict} -> \value -> negate @a {negativeDict} value
 
 shadowedNegate :: (Prim.Int -> Prim.Int) -> Prim.Int -> Prim.Int
 shadowedNegate = \negate -> \value -> negate value

--- a/tests-integration/fixtures/semantic/1784814060_local_named_let_bindings/Main.purs
+++ b/tests-integration/fixtures/semantic/1784814060_local_named_let_bindings/Main.purs
@@ -15,6 +15,17 @@ whereBinding value = local
   local :: a
   local = value
 
+siblingPolymorphicBindings :: forall a. a -> { first :: a, second :: a }
+siblingPolymorphicBindings value =
+  let
+    first :: forall b. b -> b
+    first inner = inner
+
+    second :: forall b. b -> b
+    second inner = inner
+  in
+    { first: first value, second: second value }
+
 unIdentity :: forall a. Identity a -> a
 unIdentity value =
   let

--- a/tests-integration/fixtures/semantic/1784814060_local_named_let_bindings/Main.snap
+++ b/tests-integration/fixtures/semantic/1784814060_local_named_let_bindings/Main.snap
@@ -8,7 +8,7 @@ data Identity @a
   | Identity :: a -> Main.Identity a
 
 letBinding :: forall a. a -> a
-letBinding = \value ->
+letBinding = \@a -> \value ->
   let
     local :: a
     local = value
@@ -16,13 +16,23 @@ letBinding = \value ->
     local
 
 whereBinding :: forall a. a -> a
-whereBinding = \value -> local
+whereBinding = \@a -> \value -> local
   where
   local :: a
   local = value
 
+siblingPolymorphicBindings :: forall a. a -> { first :: a, second :: a }
+siblingPolymorphicBindings = \@a -> \value ->
+  let
+    first :: forall (b :: Prim.Type). b -> b
+    first = \@b -> \inner -> inner
+    second :: forall (b :: Prim.Type). b -> b
+    second = \@b -> \inner -> inner
+  in
+    { first: first @a value, second: second @a value }
+
 unIdentity :: forall a. Main.Identity a -> a
-unIdentity = \value ->
+unIdentity = \@a -> \value ->
   let
     (Identity inner) = value
   in

--- a/tests-integration/fixtures/semantic/1784821260_lambda_abstraction_wrapping/Main.snap
+++ b/tests-integration/fixtures/semantic/1784821260_lambda_abstraction_wrapping/Main.snap
@@ -4,8 +4,8 @@ assertion_line: 68
 expression: report
 ---
 identity :: forall a. a -> a
-identity = \value -> value
+identity = \@a -> \value -> value
 
 wrap :: forall a. a -> a -> a -> a -> a -> a -> a
-wrap = \firstArgument -> \secondArgument -> \thirdArgument -> \fourthArgument -> \fifthArgument ->
-  \sixthArgument -> firstArgument
+wrap = \@a -> \firstArgument -> \secondArgument -> \thirdArgument -> \fourthArgument ->
+  \fifthArgument -> \sixthArgument -> firstArgument

--- a/tests-integration/fixtures/semantic/1784824200_case_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784824200_case_expressions/Main.snap
@@ -32,6 +32,6 @@ multiple = \first -> \second ->
     _, _ -> 0
 
 partial :: forall t0. Prim.Partial => Main.Choice t0 -> t0
-partial = \{trivial} -> \choice ->
+partial = \@t0 -> \{trivial} -> \choice ->
   case choice of
     (One value) -> value

--- a/tests-integration/fixtures/semantic/1784825100_nested_case_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784825100_nested_case_expressions/Main.snap
@@ -10,7 +10,7 @@ data Choice @a
   | Pair :: a -> a -> Main.Choice a
 
 identity :: forall a. a -> a
-identity = \value -> value
+identity = \@a -> \value -> value
 
 nested :: Main.Choice (Main.Choice Prim.Int) -> Prim.Int
 nested = \choice ->

--- a/tests-integration/fixtures/semantic/1784825400_case_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784825400_case_expression_recovery/Main.snap
@@ -9,22 +9,22 @@ missingScrutinee =
     <error> -> true
 
 mismatchedBinders :: forall t0 t1. t0 -> t1 -> Prim.Boolean
-mismatchedBinders = \first -> \second ->
+mismatchedBinders = \@t0 -> \@t1 -> \first -> \second ->
   case first, second of
     _ -> true
 
 missingResult :: forall t0 t1. t0 -> t1
-missingResult = \value ->
+missingResult = \@t0 -> \@t1 -> \value ->
   case value of
     _ -> <error>
 
 missingGuardResult :: forall t0 t1. t0 -> t1
-missingGuardResult = \value ->
+missingGuardResult = \@t0 -> \@t1 -> \value ->
   case value of
     _
       | true -> <error>
 
 missingBranchBody :: forall t0 t1. t0 -> t1
-missingBranchBody = \value ->
+missingBranchBody = \@t0 -> \@t1 -> \value ->
   case value of
     _ -> <error>

--- a/tests-integration/fixtures/semantic/1784828280_lambda_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784828280_lambda_expression_recovery/Main.snap
@@ -7,7 +7,7 @@ missingBinder :: Prim.Boolean
 missingBinder = \<error> -> true
 
 missingBody :: forall t0 t1. t0 -> t1
-missingBody = \value -> <error>
+missingBody = \@t0 -> \@t1 -> \value -> <error>
 
 missingBinderAndBody :: forall t0. t0
-missingBinderAndBody = \<error> -> <error>
+missingBinderAndBody = \@t0 -> \<error> -> <error>

--- a/tests-integration/fixtures/semantic/1784828280_lambda_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784828280_lambda_expressions/Main.snap
@@ -4,10 +4,10 @@ assertion_line: 68
 expression: report
 ---
 checked :: forall a. a -> a
-checked = \value -> value
+checked = \@a -> \value -> value
 
 inferred :: forall t0. t0 -> t0
-inferred = \value -> value
+inferred = \@t0 -> \value -> value
 
 multiple :: forall t0 t1. t0 -> t1 -> t0
-multiple = \first second -> first
+multiple = \@t0 -> \@t1 -> \first second -> first

--- a/tests-integration/fixtures/semantic/1784828400_lambda_application_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784828400_lambda_application_expressions/Main.snap
@@ -4,10 +4,10 @@ assertion_line: 68
 expression: report
 ---
 apply :: forall a b. (a -> b) -> a -> b
-apply = \function -> \value -> function value
+apply = \@a -> \@b -> \function -> \value -> function value
 
 argument :: forall t0. t0 -> t0
-argument = apply @t0 @t0 \value -> value
+argument = \@t0 -> apply @t0 @t0 \value -> value
 
 functionPosition :: forall t0 t1. (t0 -> t1) -> t0 -> t1
-functionPosition = (\function -> function) (apply @t0 @t1)
+functionPosition = \@t0 -> \@t1 -> (\function -> function) (apply @t0 @t1)

--- a/tests-integration/fixtures/semantic/1784828400_nested_lambda_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784828400_nested_lambda_expressions/Main.snap
@@ -9,7 +9,7 @@ data Maybe @a
   | Just :: a -> Main.Maybe a
 
 nested :: forall t0 t1. t0 -> t1 -> t0
-nested = \first -> \second -> first
+nested = \@t0 -> \@t1 -> \first -> \second -> first
 
 caseBody :: Main.Maybe Prim.Int -> Prim.Int
 caseBody = \maybe ->

--- a/tests-integration/fixtures/semantic/1784828400_partial_lambda_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784828400_partial_lambda_expressions/Main.snap
@@ -12,4 +12,4 @@ checked :: Prim.Partial => Main.Maybe Prim.Int -> Prim.Int
 checked = \{partialDict} -> \(Just value) -> value
 
 inferred :: forall t0. Prim.Partial => Main.Maybe t0 -> t0
-inferred = \{trivial} -> \(Just value) -> value
+inferred = \@t0 -> \{trivial} -> \(Just value) -> value

--- a/tests-integration/fixtures/semantic/1784873220_do_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873220_do_expression_recovery/Main.snap
@@ -16,7 +16,7 @@ finalBind :: Main.Effect Prim.Int
 finalBind = pure @Prim.Int 1
 
 finalLet :: forall t0. t0
-finalLet =
+finalLet = \@t0 ->
   let
     value :: Prim.Int
     value = 1
@@ -24,4 +24,4 @@ finalLet =
     <error>
 
 missingDoAction :: forall t0. t0
-missingDoAction = <error> \value -> pure @?21 value
+missingDoAction = \@t0 -> <error> \value -> pure @?21 value

--- a/tests-integration/fixtures/semantic/1784873221_ado_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873221_ado_expression_recovery/Main.snap
@@ -13,7 +13,7 @@ emptyAdo :: ?[empty ado block]
 emptyAdo = <error>
 
 missingAdoAction :: forall t0 t1. t0 t1
-missingAdoAction = <error> <error>
+missingAdoAction = \@t0 -> \@t1 -> <error> <error>
 
 missingAdoResult :: forall t0. Main.Effect t0
-missingAdoResult = map @Prim.Int @t0 (\value -> <error>) (pure @Prim.Int 1)
+missingAdoResult = \@t0 -> map @Prim.Int @t0 (\value -> <error>) (pure @Prim.Int 1)

--- a/tests-integration/fixtures/semantic/1784873280_do_constrained_functions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873280_do_constrained_functions/Main.snap
@@ -12,13 +12,13 @@ interface Operations effect where
   effect value -> (value -> effect result) -> effect result
 
 usingBind :: forall effect. Main.Operations effect => effect Prim.Int
-usingBind = \{operationsDict} ->
+usingBind = \@effect -> \{operationsDict} ->
   bind @effect {operationsDict} @Prim.Int @Prim.Int
     (pure @effect {operationsDict} @Prim.Int 1) \value ->
     pure @effect {operationsDict} @Prim.Int value
 
 usingDiscard :: forall effect. Main.Operations effect => effect Prim.Int
-usingDiscard = \{operationsDict} ->
+usingDiscard = \@effect -> \{operationsDict} ->
   discard @effect {operationsDict} @Prim.String @Prim.Int
     (pure @effect {operationsDict} @Prim.String "ignored") \_ ->
     pure @effect {operationsDict} @Prim.Int 1

--- a/tests-integration/fixtures/semantic/1784873281_ado_constrained_functions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873281_ado_constrained_functions/Main.snap
@@ -16,7 +16,7 @@ interface Operations effect where
   effect (value -> result) -> effect value -> effect result
 
 usingMapApply :: forall effect. Main.Operations effect => effect (Main.Tuple Prim.Int Prim.String)
-usingMapApply = \{operationsDict} ->
+usingMapApply = \@effect -> \{operationsDict} ->
   apply @effect {operationsDict} @Prim.String @(Main.Tuple Prim.Int Prim.String)
     (map @effect {operationsDict} @Prim.Int @(Prim.String -> Main.Tuple Prim.Int Prim.String)
       (\first second -> Tuple @Prim.Int @Prim.String first second)
@@ -24,4 +24,4 @@ usingMapApply = \{operationsDict} ->
     (pure @effect {operationsDict} @Prim.String "two")
 
 usingPure :: forall effect. Main.Operations effect => effect Prim.Int
-usingPure = \{operationsDict} -> pure @effect {operationsDict} @Prim.Int 1
+usingPure = \@effect -> \{operationsDict} -> pure @effect {operationsDict} @Prim.Int 1

--- a/tests-integration/fixtures/semantic/1784873340_do_unresolved_functions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873340_do_unresolved_functions/Main.snap
@@ -4,7 +4,7 @@ assertion_line: 68
 expression: report
 ---
 unresolvedBind :: forall t0 t1. t0 t1
-unresolvedBind = <error> 1 \value -> value
+unresolvedBind = \@t0 -> \@t1 -> <error> 1 \value -> value
 
 unresolvedDiscard :: forall t0 t1. t0 t1
-unresolvedDiscard = <error> 1 \_ -> 2
+unresolvedDiscard = \@t0 -> \@t1 -> <error> 1 \_ -> 2

--- a/tests-integration/fixtures/semantic/1784873341_ado_unresolved_functions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873341_ado_unresolved_functions/Main.snap
@@ -4,10 +4,10 @@ assertion_line: 68
 expression: report
 ---
 unresolvedMap :: forall t0 t1. t0 t1
-unresolvedMap = <error> (\value -> value) 1
+unresolvedMap = \@t0 -> \@t1 -> <error> (\value -> value) 1
 
 unresolvedApply :: forall t0 t1. t0 t1
-unresolvedApply = <error> (<error> (\first second -> first) 1) 2
+unresolvedApply = \@t0 -> \@t1 -> <error> (<error> (\first second -> first) 1) 2
 
 unresolvedPure :: forall t0. t0 Prim.Int
-unresolvedPure = <error> 1
+unresolvedPure = \@t0 -> <error> 1

--- a/tests-integration/fixtures/semantic/1784875466_evidence_rendering/Main.snap
+++ b/tests-integration/fixtures/semantic/1784875466_evidence_rendering/Main.snap
@@ -23,4 +23,4 @@ instanceEvidence :: Prim.Int
 instanceEvidence = useChild @Prim.Int {childInt {parentInt}} 1
 
 superclassEvidence :: forall value. Main.Child value => value -> value
-superclassEvidence = \{childDict} -> useParent @value {childDict.parentDict}
+superclassEvidence = \@value -> \{childDict} -> useParent @value {childDict.parentDict}

--- a/tests-integration/fixtures/semantic/1784882000_if_then_else_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784882000_if_then_else_expressions/Main.snap
@@ -20,15 +20,15 @@ inferred = \condition ->
   if condition then "yes" else "no"
 
 constrained :: forall value. Main.Predicate value => value -> Prim.Int
-constrained = \{predicateDict} -> \value ->
+constrained = \@value -> \{predicateDict} -> \value ->
   if predicate @value {predicateDict} value then 1 else 2
 
 constrainedBranches :: forall value. Main.Default value => Prim.Boolean -> value
-constrainedBranches = \{defaultDict} -> \condition ->
+constrainedBranches = \@value -> \{defaultDict} -> \condition ->
   if condition then defaultValue @value {defaultDict} else defaultValue @value {defaultDict}
 
 higherRank :: Prim.Boolean -> (forall value. value -> value)
-higherRank = \condition ->
+higherRank = \@value -> \condition ->
   if condition then identity @value else identity @value
 
 nested :: Prim.Boolean -> Prim.Boolean -> Prim.Int
@@ -39,4 +39,4 @@ asArgument :: Prim.Boolean -> Prim.Int
 asArgument = \condition -> identity @Prim.Int if condition then 1 else 2
 
 identity :: forall value. value -> value
-identity = \value -> value
+identity = \@value -> \value -> value

--- a/tests-integration/fixtures/semantic/1784906340_record_access_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784906340_record_access_expressions/Main.snap
@@ -4,7 +4,7 @@ assertion_line: 68
 expression: report
 ---
 identity :: forall a. a -> a
-identity = \value -> value
+identity = \@a -> \value -> value
 
 record :: { function :: Prim.Int -> Prim.Int, nested :: { value :: Prim.Int } }
 record = { function: identity @Prim.Int, nested: { value: 42 } }

--- a/tests-integration/fixtures/semantic/1784906340_record_update_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784906340_record_update_expressions/Main.snap
@@ -4,7 +4,7 @@ assertion_line: 68
 expression: report
 ---
 identity :: forall a. a -> a
-identity = \value -> value
+identity = \@a -> \value -> value
 
 record :: { first :: Prim.Int, nested :: { value :: Prim.Int }, transform :: Prim.Int -> Prim.Int }
 record = { first: 1, nested: { value: 2 }, transform: identity @Prim.Int }
@@ -16,7 +16,7 @@ typeChanging :: { first :: Prim.String, nested :: { value :: Prim.Int }, transfo
 typeChanging = record { first = "two" }
 
 multiple :: forall t0. { first :: Prim.Int, nested :: { value :: Prim.Int }, transform :: t0 -> t0 }
-multiple = record { first = 2, transform = identity @t0 }
+multiple = \@t0 -> record { first = 2, transform = identity @t0 }
 
 nested :: { first :: Prim.Int, nested :: { value :: Prim.Int }, transform :: Prim.Int -> Prim.Int }
 nested = record { nested { value = 3 } }

--- a/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.snap
@@ -19,18 +19,19 @@ ordered :: Prim.Int -> Prim.String -> Prim.String
 ordered = \v64 v66 -> use v64 v66
 
 nested :: forall t0 t1. (((Prim.Int -> t0) -> t0) -> t1) -> t1
-nested = \v71 -> v71 \v75 -> v75 1
+nested = \@t0 -> \@t1 -> \v71 -> v71 \v75 -> v75 1
 
 access :: forall t0 t1. { value :: t0 | t1 } -> t0
-access = \v82 -> v82.value
+access = \@t0 -> \@t1 -> \v82 -> v82.value
 
 update :: forall t0 t1 t2 t3 t4.
   { first :: t0, second :: t1 | t2 } -> t3 -> t4 -> { first :: t3, second :: t4 | t2 }
-update = \v88 v91 v93 -> v88 { first = v91, second = v93 }
+update = \@t0 -> \@t1 -> \@t2 -> \@t3 -> \@t4 -> \v88 v91 v93 -> v88 { first = v91, second = v93 }
 
 conditional :: forall t0. Prim.Boolean -> t0 -> t0 -> t0
-conditional = \v99 v101 v103 ->
-  if v99 then v101 else v103
+conditional = \@t0 ->
+  \v99 v101 v103 ->
+    if v99 then v101 else v103
 
 caseScrutinee :: Prim.Boolean -> Prim.Int
 caseScrutinee = \v109 ->
@@ -45,7 +46,8 @@ caseScrutinees = \v128 v129 ->
     false, _ -> 0
 
 caseAlternatives :: forall t0 t1. Prim.Boolean -> { value :: t0 | t1 } -> t0
-caseAlternatives = \v150 ->
-  case v150 of
-    true -> \v158 -> v158.value
-    false -> \v166 -> v166.value
+caseAlternatives = \@t0 -> \@t1 ->
+  \v150 ->
+    case v150 of
+      true -> \v158 -> v158.value
+      false -> \v166 -> v166.value

--- a/tests-integration/fixtures/semantic/1784908740_section_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784908740_section_expression_recovery/Main.snap
@@ -4,19 +4,19 @@ assertion_line: 68
 expression: report
 ---
 identity :: forall a. a -> a
-identity = \value -> value
+identity = \@a -> \value -> value
 
 apply :: forall a b. (a -> b) -> a -> b
-apply = \function -> \argument -> function argument
+apply = \@a -> \@b -> \function -> \argument -> function argument
 
 orphan :: ?[missing expression]
 orphan = <error>
 
 orphanInLambda :: forall t0. t0 -> ?[missing expression]
-orphanInLambda = \value -> <error>
+orphanInLambda = \@t0 -> \value -> <error>
 
 failedBody :: forall t0. (?[missing expression] -> t0) -> t0
-failedBody = \v56 -> apply @?[missing expression] @t0 v56 <error>
+failedBody = \@t0 -> \v56 -> apply @?[missing expression] @t0 v56 <error>
 
 invalidExpected :: Prim.Int
 invalidExpected = \v67 -> identity @Prim.Int v67

--- a/tests-integration/fixtures/semantic/1784910000_record_access_sections/Main.snap
+++ b/tests-integration/fixtures/semantic/1784910000_record_access_sections/Main.snap
@@ -4,55 +4,58 @@ assertion_line: 68
 expression: report
 ---
 map :: forall a b. (a -> b) -> Prim.Array a -> Prim.Array b
-map = \f -> \x -> []
+map = \@a -> \@b -> \f -> \x -> []
 
 apply :: forall a b. (a -> b) -> a -> b
-apply = \f -> \x -> f x
+apply = \@a -> \@b -> \f -> \x -> f x
 
 f :: ({ foo :: Prim.Int } -> Prim.Int) -> Prim.Int
 f = \g -> g { foo: 1 }
 
 test1 :: forall t0 t1. { prop :: t0 | t1 } -> t0
-test1 = \v74 -> v74.prop
+test1 = \@t0 -> \@t1 -> \v74 -> v74.prop
 
 test2 :: forall t0 t1 t2 t3. { a :: { b :: { c :: t0 | t1 } | t2 } | t3 } -> t0
-test2 = \v80 -> v80.a.b.c
+test2 = \@t0 -> \@t1 -> \@t2 -> \@t3 -> \v80 -> v80.a.b.c
 
 test3 :: forall t0 t1. { poly :: t0 | t1 } -> t0
-test3 = \v88 -> v88.poly
+test3 = \@t0 -> \@t1 -> \v88 -> v88.poly
 
 test4 :: forall t0 t1. Prim.Array { prop :: t0 | t1 } -> Prim.Array t0
-test4 = map @{ prop :: t0 | t1 } @t0 \v97 -> v97.prop
+test4 = \@t0 -> \@t1 -> map @{ prop :: t0 | t1 } @t0 \v97 -> v97.prop
 
 test5 :: Prim.Int
 test5 = f \v106 -> v106.foo
 
 test6 :: forall t0 t1 t2 t3. t0 -> (({ bar :: t1 | t2 } -> t1) -> t3) -> t3
-test6 = \r -> \g -> g \v118 -> v118.bar
+test6 = \@t0 -> \@t1 -> \@t2 -> \@t3 -> \r -> \g -> g \v118 -> v118.bar
 
 test7 :: forall t0 t1. { nonexistent :: t0 | t1 } -> t0
-test7 = \r -> (\v128 -> v128.nonexistent) r
+test7 = \@t0 -> \@t1 -> \r -> (\v128 -> v128.nonexistent) r
 
 test8 :: forall t0 t1 t2. (({ foo :: t0 | t1 } -> t0) -> t2) -> t2
-test8 = \v137 -> v137 \v140 -> v140.foo
+test8 = \@t0 -> \@t1 -> \@t2 -> \v137 -> v137 \v140 -> v140.foo
 
 test9 :: forall t0 t1 t2. Prim.Array (({ prop :: t0 | t1 } -> t0) -> t2) -> Prim.Array t2
-test9 = map @(({ prop :: t0 | t1 } -> t0) -> t2) @t2 \v150 -> v150 \v153 -> v153.prop
+test9 = \@t0 -> \@t1 -> \@t2 ->
+  map @(({ prop :: t0 | t1 } -> t0) -> t2) @t2 \v150 -> v150 \v153 -> v153.prop
 
 test10 :: forall t0 t1 t2. { a :: { b :: t0 | t1 } | t2 } -> t0
-test10 = apply @{ a :: { b :: t0 | t1 } | t2 } @t0 \v163 -> v163.a.b
+test10 = \@t0 -> \@t1 -> \@t2 -> apply @{ a :: { b :: t0 | t1 } | t2 } @t0 \v163 -> v163.a.b
 
 test11 :: forall t0 t1 t2. t0 -> { a :: t0, b :: { foo :: t1 | t2 } -> t1 }
-test11 = \v171 -> { a: v171, b: \v174 -> v174.foo }
+test11 = \@t0 -> \@t1 -> \@t2 -> \v171 -> { a: v171, b: \v174 -> v174.foo }
 
 test12 :: forall t0 t1. ({ bar :: t0 | t1 } -> t0) -> Prim.Array ({ bar :: t0 | t1 } -> t0)
-test12 = \v180 -> [v180, \v182 -> v182.bar]
+test12 = \@t0 -> \@t1 -> \v180 -> [v180, \v182 -> v182.bar]
 
 test13 :: forall t0 t1 t2. t0 -> { prop :: t1 | t2 } -> t1
-test13 = \v189 ->
-  case v189 of
-    _ -> \v197 -> v197.prop
+test13 = \@t0 -> \@t1 -> \@t2 ->
+  \v189 ->
+    case v189 of
+      _ -> \v197 -> v197.prop
 
 test14 :: forall t0 t1. Prim.Boolean -> { a :: t0, b :: t0 | t1 } -> t0
-test14 = \v204 ->
-  if v204 then \v207 -> v207.a else \v211 -> v211.b
+test14 = \@t0 -> \@t1 ->
+  \v204 ->
+    if v204 then \v207 -> v207.a else \v211 -> v211.b

--- a/tests-integration/fixtures/semantic/1784910000_record_update_sections/Main.snap
+++ b/tests-integration/fixtures/semantic/1784910000_record_update_sections/Main.snap
@@ -4,45 +4,47 @@ assertion_line: 68
 expression: report
 ---
 singleFieldUpdate :: forall t0 t1. { a :: t0 | t1 } -> { a :: Prim.Int | t1 }
-singleFieldUpdate = \v9 -> v9 { a = 1 }
+singleFieldUpdate = \@t0 -> \@t1 -> \v9 -> v9 { a = 1 }
 
 multipleFieldUpdate :: forall t0 t1 t2 t3.
   { a :: t0, b :: t1, c :: t2 | t3 } -> { a :: Prim.Int, b :: Prim.Boolean, c :: Prim.String | t3 }
-multipleFieldUpdate = \v17 -> v17 { a = 2, b = true, c = "three" }
+multipleFieldUpdate = \@t0 -> \@t1 -> \@t2 -> \@t3 -> \v17 -> v17 { a = 2, b = true, c = "three" }
 
 nestedRecordUpdate :: forall t0 t1 t2 t3.
   { a :: { b :: { c :: t0 | t1 } | t2 } | t3 } -> { a :: { b :: { c :: Prim.Int | t1 } | t2 } | t3 }
-nestedRecordUpdate = \v29 -> v29 { a { b { c = 42 } } }
+nestedRecordUpdate = \@t0 -> \@t1 -> \@t2 -> \@t3 -> \v29 -> v29 { a { b { c = 42 } } }
 
 updateWithValueSection :: forall t0 t1. { a :: t0 | t1 } -> { a :: Prim.Int -> Prim.Int | t1 }
-updateWithValueSection = \v41 -> v41 { a = \v46 -> add v46 1 }
+updateWithValueSection = \@t0 -> \@t1 -> \v41 -> v41 { a = \v46 -> add v46 1 }
 
 updateWithSectionInteraction :: forall t0 t1 t2. { a :: t0 | t1 } -> t2 -> { a :: t2 | t1 }
-updateWithSectionInteraction = \v54 v57 -> v54 { a = v57 }
+updateWithSectionInteraction = \@t0 -> \@t1 -> \@t2 -> \v54 v57 -> v54 { a = v57 }
 
 polymorphicRecordUpdate :: forall t0 t1. { foo :: t0 | t1 } -> { foo :: Prim.Int | t1 }
-polymorphicRecordUpdate = \v62 -> v62 { foo = 0 }
+polymorphicRecordUpdate = \@t0 -> \@t1 -> \v62 -> v62 { foo = 0 }
 
 higherOrderContext :: forall t0 t1. Prim.Array { x :: t0 | t1 } -> Prim.Array { x :: Prim.Int | t1 }
-higherOrderContext = map @{ x :: t0 | t1 } @{ x :: Prim.Int | t1 } \v74 -> v74 { x = 10 }
+higherOrderContext = \@t0 -> \@t1 ->
+  map @{ x :: t0 | t1 } @{ x :: Prim.Int | t1 } \v74 -> v74 { x = 10 }
 
 multipleSectionsInteraction :: forall t0 t1 t2 t3 t4. { x :: t0, y :: t1 | t2 } -> t3 -> t4 -> { x :: t3, y :: t4 | t2 }
-multipleSectionsInteraction = \v82 v85 v87 -> v82 { x = v85, y = v87 }
+multipleSectionsInteraction = \@t0 -> \@t1 -> \@t2 -> \@t3 -> \@t4 ->
+  \v82 v85 v87 -> v82 { x = v85, y = v87 }
 
 nestedSectionInteraction :: forall t0 t1 t2 t3. { a :: { b :: t0 | t1 } | t2 } -> t3 -> { a :: { b :: t3 | t1 } | t2 }
-nestedSectionInteraction = \v92 v97 -> v92 { a { b = v97 } }
+nestedSectionInteraction = \@t0 -> \@t1 -> \@t2 -> \@t3 -> \v92 v97 -> v92 { a { b = v97 } }
 
 mixedSections :: forall t0 t1 t2. { a :: t0, b :: t1 | t2 } -> { a :: Prim.Int -> Prim.Int, b :: Prim.Int | t2 }
-mixedSections = \v102 -> v102 { a = \v106 -> add v106 1, b = 2 }
+mixedSections = \@t0 -> \@t1 -> \@t2 -> \v102 -> v102 { a = \v106 -> add v106 1, b = 2 }
 
 recordAccessSectionUpdate :: forall t0 t1 t2 t3. { a :: t0 | t1 } -> { a :: { b :: t2 | t3 } -> t2 | t1 }
-recordAccessSectionUpdate = \v116 -> v116 { a = \v120 -> v120.b }
+recordAccessSectionUpdate = \@t0 -> \@t1 -> \@t2 -> \@t3 -> \v116 -> v116 { a = \v120 -> v120.b }
 
 concreteRecordUpdateSection :: forall t0. t0 -> { a :: t0 }
-concreteRecordUpdateSection = \v132 -> { a: 1 } { a = v132 }
+concreteRecordUpdateSection = \@t0 -> \v132 -> { a: 1 } { a = v132 }
 
 map :: forall a b. (a -> b) -> Prim.Array a -> Prim.Array b
-map = \f -> \x -> []
+map = \@a -> \@b -> \f -> \x -> []
 
 add :: Prim.Int -> Prim.Int -> Prim.Int
 add = \x -> \y -> x

--- a/tests-integration/fixtures/semantic/1784913480_binder_operator_chains/Main.snap
+++ b/tests-integration/fixtures/semantic/1784913480_binder_operator_chains/Main.snap
@@ -14,13 +14,13 @@ data Snoc @a
   | Snoc :: Main.Snoc a -> a -> Main.Snoc a
 
 first :: forall a. Main.List a -> a
-first = \(Cons value _) -> value
+first = \@a -> \(Cons value _) -> value
 
 second :: forall a. Main.List a -> a
-second = \(Cons _ (Cons value _)) -> value
+second = \@a -> \(Cons _ (Cons value _)) -> value
 
 inferred :: forall t0. Prim.Partial => Main.List t0 -> t0
-inferred = \{trivial} -> \(Cons value _) -> value
+inferred = \@t0 -> \{trivial} -> \(Cons value _) -> value
 
 second' :: forall a. Main.Snoc a -> a
-second' = \(Snoc (Snoc _ value) _) -> value
+second' = \@a -> \(Snoc (Snoc _ value) _) -> value

--- a/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.snap
@@ -16,7 +16,7 @@ dictionary eqIdentity :: forall a. { eqDict :: Data.Eq.Eq a } => Data.Eq.Eq (Mai
 
 dictionary eq1Identity :: Data.Eq.Eq1 Main.Identity where
   eq1 :: forall (a :: Prim.Type). Data.Eq.Eq a => Main.Identity a -> Main.Identity a -> Prim.Boolean
-  eq1 = \{eqDict} -> eq @(Main.Identity a) {eqIdentity {eqDict}}
+  eq1 = \@a -> \{eqDict} -> eq @(Main.Identity a) {eqIdentity {eqDict}}
 
 dictionary ordIdentity :: forall a. { ordDict :: Data.Ord.Ord a } => Data.Ord.Ord (Main.Identity a)
   where
@@ -33,4 +33,4 @@ dictionary ord1Identity :: Data.Ord.Ord1 Main.Identity where
   superclass eq1Dict = eq1Identity
   compare1 :: forall (a :: Prim.Type).
   Data.Ord.Ord a => Main.Identity a -> Main.Identity a -> Data.Ordering.Ordering
-  compare1 = \{ordDict} -> compare @(Main.Identity a) {ordIdentity {ordDict}}
+  compare1 = \@a -> \{ordDict} -> compare @(Main.Identity a) {ordIdentity {ordDict}}

--- a/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
@@ -23,7 +23,7 @@ dictionary eq1Wrap :: forall f. { eq1Dict :: Data.Eq.Eq1 f } => Data.Eq.Eq1 (Mai
   where
   eq1 :: forall (a :: Prim.Type).
   Data.Eq.Eq a => Main.Wrap @Prim.Type f a -> Main.Wrap @Prim.Type f a -> Prim.Boolean
-  eq1 = \{eqDict} -> eq @(Main.Wrap @Prim.Type f a) {eqWrap {eq1Dict} {eqDict}}
+  eq1 = \@a -> \{eqDict} -> eq @(Main.Wrap @Prim.Type f a) {eqWrap {eq1Dict} {eqDict}}
 
 dictionary ordWrap ::
   forall f a.
@@ -48,4 +48,4 @@ dictionary ord1Wrap ::
   superclass eq1Dict = eq1Wrap {ord1Dict.eq1Dict}
   compare1 :: forall (a :: Prim.Type).
   Data.Ord.Ord a => Main.Wrap @Prim.Type f a -> Main.Wrap @Prim.Type f a -> Data.Ordering.Ordering
-  compare1 = \{ordDict} -> compare @(Main.Wrap @Prim.Type f a) {ordWrap {ord1Dict} {ordDict}}
+  compare1 = \@a -> \{ordDict} -> compare @(Main.Wrap @Prim.Type f a) {ordWrap {ord1Dict} {ordDict}}

--- a/tests-integration/fixtures/semantic/1785138420_derive_eq1_ord1_recursive_data/Main.snap
+++ b/tests-integration/fixtures/semantic/1785138420_derive_eq1_ord1_recursive_data/Main.snap
@@ -27,7 +27,7 @@ dictionary eqList :: forall a. { eqDict :: Data.Eq.Eq a } => Data.Eq.Eq (Main.Li
 
 dictionary eq1List :: Data.Eq.Eq1 Main.List where
   eq1 :: forall (a :: Prim.Type). Data.Eq.Eq a => Main.List a -> Main.List a -> Prim.Boolean
-  eq1 = \{eqDict} -> eq @(Main.List a) {eqList {eqDict}}
+  eq1 = \@a -> \{eqDict} -> eq @(Main.List a) {eqList {eqDict}}
 
 dictionary ordList :: forall a. { ordDict :: Data.Ord.Ord a } => Data.Ord.Ord (Main.List a) where
   superclass eqDict = eqList {ordDict.eqDict}
@@ -48,7 +48,7 @@ dictionary ordList :: forall a. { ordDict :: Data.Ord.Ord a } => Data.Ord.Ord (M
 dictionary ord1List :: Data.Ord.Ord1 Main.List where
   superclass eq1Dict = eq1List
   compare1 :: forall (a :: Prim.Type). Data.Ord.Ord a => Main.List a -> Main.List a -> Data.Ordering.Ordering
-  compare1 = \{ordDict} -> compare @(Main.List a) {ordList {ordDict}}
+  compare1 = \@a -> \{ordDict} -> compare @(Main.List a) {ordList {ordDict}}
 
 dictionary eqTree :: forall a. { eqDict :: Data.Eq.Eq a } => Data.Eq.Eq (Main.Tree a) where
   eq :: Main.Tree a -> Main.Tree a -> Prim.Boolean
@@ -65,7 +65,7 @@ dictionary eqTree :: forall a. { eqDict :: Data.Eq.Eq a } => Data.Eq.Eq (Main.Tr
 
 dictionary eq1Tree :: Data.Eq.Eq1 Main.Tree where
   eq1 :: forall (a :: Prim.Type). Data.Eq.Eq a => Main.Tree a -> Main.Tree a -> Prim.Boolean
-  eq1 = \{eqDict} -> eq @(Main.Tree a) {eqTree {eqDict}}
+  eq1 = \@a -> \{eqDict} -> eq @(Main.Tree a) {eqTree {eqDict}}
 
 dictionary ordTree :: forall a. { ordDict :: Data.Ord.Ord a } => Data.Ord.Ord (Main.Tree a) where
   superclass eqDict = eqTree {ordDict.eqDict}
@@ -89,4 +89,4 @@ dictionary ordTree :: forall a. { ordDict :: Data.Ord.Ord a } => Data.Ord.Ord (M
 dictionary ord1Tree :: Data.Ord.Ord1 Main.Tree where
   superclass eq1Dict = eq1Tree
   compare1 :: forall (a :: Prim.Type). Data.Ord.Ord a => Main.Tree a -> Main.Tree a -> Data.Ordering.Ordering
-  compare1 = \{ordDict} -> compare @(Main.Tree a) {ordTree {ordDict}}
+  compare1 = \@a -> \{ordDict} -> compare @(Main.Tree a) {ordTree {ordDict}}

--- a/tests-integration/fixtures/semantic/1785263040_derive_functor_generated_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785263040_derive_functor_generated_bodies/Main.snap
@@ -47,23 +47,26 @@ data OpenRecord @r @a
 
 dictionary functorIdentity :: Data.Functor.Functor Main.Identity where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Identity a -> Main.Identity b
-  map = \function value ->
-    case value of
-      (Identity field0) -> Identity @b (function field0)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Identity field0) -> Identity @b (function field0)
 
 dictionary functorConst :: forall e. Data.Functor.Functor (Main.Const @Prim.Type e) where
   map :: forall (a :: Prim.Type) (b :: Prim.Type).
   (a -> b) -> Main.Const @Prim.Type e a -> Main.Const @Prim.Type e b
-  map = \function value ->
-    case value of
-      (Const field0) -> Const @Prim.Type @e @b field0
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Const field0) -> Const @Prim.Type @e @b field0
 
 dictionary functorMaybe :: Data.Functor.Functor Main.Maybe where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Maybe a -> Main.Maybe b
-  map = \function value ->
-    case value of
-      Nothing -> Nothing @b
-      (Just field0) -> Just @b (function field0)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        Nothing -> Nothing @b
+        (Just field0) -> Just @b (function field0)
 
 dictionary functorWrap ::
   forall f.
@@ -72,10 +75,11 @@ dictionary functorWrap ::
   where
   map :: forall (a :: Prim.Type) (b :: Prim.Type).
   (a -> b) -> Main.Wrap @Prim.Type f a -> Main.Wrap @Prim.Type f b
-  map = \function value ->
-    case value of
-      (Wrap field0) -> Wrap @Prim.Type @f @b
-        (map @f {functorDict} @a @b (\element -> function element) field0)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Wrap field0) -> Wrap @Prim.Type @f @b
+          (map @f {functorDict} @a @b (\element -> function element) field0)
 
 dictionary functorCompose ::
   forall f g.
@@ -85,41 +89,47 @@ dictionary functorCompose ::
   where
   map :: forall (a :: Prim.Type) (b :: Prim.Type).
   (a -> b) -> Main.Compose @Prim.Type @Prim.Type f g a -> Main.Compose @Prim.Type @Prim.Type f g b
-  map = \function value ->
-    case value of
-      (Compose field0) -> Compose @Prim.Type @Prim.Type @f @g @b
-        (map @f {functorDict} @(g a) @(g b)
-          (\element -> map @g {functorDict1} @a @b (\element -> function element) element)
-          field0)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Compose field0) -> Compose @Prim.Type @Prim.Type @f @g @b
+          (map @f {functorDict} @(g a) @(g b)
+            (\element -> map @g {functorDict1} @a @b (\element -> function element) element)
+            field0)
 
 dictionary functorReader :: forall r. Data.Functor.Functor (Main.Reader r) where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Reader r a -> Main.Reader r b
-  map = \function value ->
-    case value of
-      (Reader field0) -> Reader @r @b \argument -> function (field0 argument)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Reader field0) -> Reader @r @b \argument -> function (field0 argument)
 
 dictionary functorNestedReader :: forall r s. Data.Functor.Functor (Main.NestedReader r s) where
   map :: forall (a :: Prim.Type) (b :: Prim.Type).
   (a -> b) -> Main.NestedReader r s a -> Main.NestedReader r s b
-  map = \function value ->
-    case value of
-      (NestedReader field0) -> NestedReader @r @s @b \argument ->
-        \argument1 -> function (field0 argument argument1)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (NestedReader field0) -> NestedReader @r @s @b \argument ->
+          \argument1 -> function (field0 argument argument1)
 
 dictionary functorCont :: forall r. Data.Functor.Functor (Main.Cont r) where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Cont r a -> Main.Cont r b
-  map = \function value ->
-    case value of
-      (Cont field0) -> Cont @r @b \argument -> field0 \argument1 -> argument (function argument1)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Cont field0) -> Cont @r @b \argument -> field0 \argument1 -> argument (function argument1)
 
 dictionary functorRecord :: Data.Functor.Functor Main.Record where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Record a -> Main.Record b
-  map = \function value ->
-    case value of
-      (Record field0) -> Record @b field0 { changed = function field0.changed }
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Record field0) -> Record @b field0 { changed = function field0.changed }
 
 dictionary functorOpenRecord :: forall r. Data.Functor.Functor (Main.OpenRecord r) where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.OpenRecord r a -> Main.OpenRecord r b
-  map = \function value ->
-    case value of
-      (OpenRecord field0) -> OpenRecord @r @b field0 { changed = function field0.changed }
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (OpenRecord field0) -> OpenRecord @r @b field0 { changed = function field0.changed }

--- a/tests-integration/fixtures/semantic/1785318540_derive_bifunctor_generated_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785318540_derive_bifunctor_generated_bodies/Main.snap
@@ -66,17 +66,19 @@ data RecordPair @a @b
 dictionary bifunctorEither :: Data.Bifunctor.Bifunctor Main.Either where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Either a c -> Main.Either b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (Left field0) -> Left @b @d (firstFunction field0)
-      (Right field0) -> Right @b @d (secondFunction field0)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Left field0) -> Left @b @d (firstFunction field0)
+        (Right field0) -> Right @b @d (secondFunction field0)
 
 dictionary bifunctorPair :: Data.Bifunctor.Bifunctor Main.Pair where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Pair a c -> Main.Pair b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (Pair field0 field1) -> Pair @b @d (firstFunction field0) (secondFunction field1)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Pair field0 field1) -> Pair @b @d (firstFunction field0) (secondFunction field1)
 
 dictionary bifunctorConst2 ::
   forall value.
@@ -87,9 +89,10 @@ dictionary bifunctorConst2 ::
   (c -> d) ->
   Main.Const2 @Prim.Type @Prim.Type value a c ->
   Main.Const2 @Prim.Type @Prim.Type value b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (Const2 field0) -> Const2 @Prim.Type @Prim.Type @value @b @d field0
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Const2 field0) -> Const2 @Prim.Type @Prim.Type @value @b @d field0
 
 dictionary bifunctorWrapBoth ::
   forall f g.
@@ -102,93 +105,103 @@ dictionary bifunctorWrapBoth ::
   (c -> d) ->
   Main.WrapBoth @Prim.Type @Prim.Type f g a c ->
   Main.WrapBoth @Prim.Type @Prim.Type f g b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (WrapBoth field0 field1) -> WrapBoth @Prim.Type @Prim.Type @f @g @b @d
-        (map @f {functorDict} @a @b (\element -> firstFunction element) field0)
-        (map @g {functorDict1} @c @d (\element -> secondFunction element) field1)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (WrapBoth field0 field1) -> WrapBoth @Prim.Type @Prim.Type @f @g @b @d
+          (map @f {functorDict} @a @b (\element -> firstFunction element) field0)
+          (map @g {functorDict1} @c @d (\element -> secondFunction element) field1)
 
 dictionary bifunctorTuple :: Data.Bifunctor.Bifunctor Main.Tuple where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Tuple a c -> Main.Tuple b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (Tuple field0 field1) -> Tuple @b @d (firstFunction field0) (secondFunction field1)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Tuple field0 field1) -> Tuple @b @d (firstFunction field0) (secondFunction field1)
 
 dictionary functorTuple :: forall a. Data.Functor.Functor (Main.Tuple a) where
   map :: forall (a1 :: Prim.Type) (b :: Prim.Type). (a1 -> b) -> Main.Tuple a a1 -> Main.Tuple a b
-  map = \function value ->
-    case value of
-      (Tuple field0 field1) -> Tuple @a @b field0 (function field1)
+  map = \@a1 -> \@b ->
+    \function value ->
+      case value of
+        (Tuple field0 field1) -> Tuple @a @b field0 (function field1)
 
 dictionary bifunctorBoth :: Data.Bifunctor.Bifunctor Main.Both where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Both a c -> Main.Both b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (Both field0) -> Both @b @d
-        (bimap @Main.Tuple {bifunctorTuple} @a @b @c @d (\element -> firstFunction element)
-          (\element -> secondFunction element)
-          field0)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Both field0) -> Both @b @d
+          (bimap @Main.Tuple {bifunctorTuple} @a @b @c @d (\element -> firstFunction element)
+            (\element -> secondFunction element)
+            field0)
 
 dictionary bifunctorOneSided :: Data.Bifunctor.Bifunctor Main.OneSided where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.OneSided a c -> Main.OneSided b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (OneSidedFirst field0) -> OneSidedFirst @b @d
-        (bimap @Main.Tuple {bifunctorTuple} @a @b @Prim.Int @Prim.Int
-          (\element -> firstFunction element)
-          (\unchanged -> unchanged)
-          field0)
-      (OneSidedSecond field0) -> OneSidedSecond @b @d
-        (map @(Main.Tuple Prim.Int) {functorTuple} @c @d (\element -> secondFunction element)
-          field0)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (OneSidedFirst field0) -> OneSidedFirst @b @d
+          (bimap @Main.Tuple {bifunctorTuple} @a @b @Prim.Int @Prim.Int
+            (\element -> firstFunction element)
+            (\unchanged -> unchanged)
+            field0)
+        (OneSidedSecond field0) -> OneSidedSecond @b @d
+          (map @(Main.Tuple Prim.Int) {functorTuple} @c @d (\element -> secondFunction element)
+            field0)
 
 dictionary functorBox :: Data.Functor.Functor Main.Box where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Box a -> Main.Box b
-  map = \function value ->
-    case value of
-      (Box field0) -> Box @b (function field0)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Box field0) -> Box @b (function field0)
 
 dictionary bifunctorNested :: Data.Bifunctor.Bifunctor Main.Nested where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Nested a c -> Main.Nested b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (Nested field0) -> Nested @b @d
-        (map @Main.Box {functorBox} @(Main.Tuple a c) @(Main.Tuple b d)
-          (\element ->
-            bimap @Main.Tuple {bifunctorTuple} @a @b @c @d (\element -> firstFunction element)
-              (\element -> secondFunction element)
-              element)
-          field0)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Nested field0) -> Nested @b @d
+          (map @Main.Box {functorBox} @(Main.Tuple a c) @(Main.Tuple b d)
+            (\element ->
+              bimap @Main.Tuple {bifunctorTuple} @a @b @c @d (\element -> firstFunction element)
+                (\element -> secondFunction element)
+                element)
+            field0)
 
 dictionary bifunctorTriple :: forall fixed. Data.Bifunctor.Bifunctor (Main.Triple fixed) where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Triple fixed a c -> Main.Triple fixed b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (Triple field0 field1 field2) -> Triple @fixed @b @d field0 (firstFunction field1)
-        (secondFunction field2)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Triple field0 field1 field2) -> Triple @fixed @b @d field0 (firstFunction field1)
+          (secondFunction field2)
 
 dictionary functorTriple :: forall fixed a. Data.Functor.Functor (Main.Triple fixed a) where
   map :: forall (a1 :: Prim.Type) (b :: Prim.Type).
   (a1 -> b) -> Main.Triple fixed a a1 -> Main.Triple fixed a b
-  map = \function value ->
-    case value of
-      (Triple field0 field1 field2) -> Triple @fixed @a @b field0 field1 (function field2)
+  map = \@a1 -> \@b ->
+    \function value ->
+      case value of
+        (Triple field0 field1 field2) -> Triple @fixed @a @b field0 field1 (function field2)
 
 dictionary bifunctorNestedTriple :: Data.Bifunctor.Bifunctor Main.NestedTriple where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.NestedTriple a c -> Main.NestedTriple b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (NestedTriple field0) -> NestedTriple @b @d
-        (bimap @(Main.Triple Prim.Int) {bifunctorTriple} @a @b @c @d
-          (\element -> firstFunction element)
-          (\element -> secondFunction element)
-          field0)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (NestedTriple field0) -> NestedTriple @b @d
+          (bimap @(Main.Triple Prim.Int) {bifunctorTriple} @a @b @c @d
+            (\element -> firstFunction element)
+            (\element -> secondFunction element)
+            field0)
 
 dictionary bifunctorNestedTripleLast :: Data.Bifunctor.Bifunctor (Main.NestedTripleLast @Prim.Type)
   where
@@ -197,27 +210,30 @@ dictionary bifunctorNestedTripleLast :: Data.Bifunctor.Bifunctor (Main.NestedTri
   (c -> d) ->
   Main.NestedTripleLast @Prim.Type a c ->
   Main.NestedTripleLast @Prim.Type b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (NestedTripleLast field0) -> NestedTripleLast @Prim.Type @b @d
-        (map @(Main.Triple Prim.Int Prim.String) {functorTriple} @c @d
-          (\element -> secondFunction element)
-          field0)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (NestedTripleLast field0) -> NestedTripleLast @Prim.Type @b @d
+          (map @(Main.Triple Prim.Int Prim.String) {functorTriple} @c @d
+            (\element -> secondFunction element)
+            field0)
 
 dictionary bifunctorReaderPair :: Data.Bifunctor.Bifunctor Main.ReaderPair where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.ReaderPair a c -> Main.ReaderPair b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (ReaderPair field0) -> ReaderPair @b @d \argument ->
-        bimap @Main.Tuple {bifunctorTuple} @a @b @c @d (\element -> firstFunction element)
-          (\element -> secondFunction element)
-          (field0 argument)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (ReaderPair field0) -> ReaderPair @b @d \argument ->
+          bimap @Main.Tuple {bifunctorTuple} @a @b @c @d (\element -> firstFunction element)
+            (\element -> secondFunction element)
+            (field0 argument)
 
 dictionary bifunctorRecordPair :: Data.Bifunctor.Bifunctor Main.RecordPair where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.RecordPair a c -> Main.RecordPair b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (RecordPair field0) -> RecordPair @b @d
-        field0 { first = firstFunction field0.first, second = secondFunction field0.second }
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (RecordPair field0) -> RecordPair @b @d
+          field0 { first = firstFunction field0.first, second = secondFunction field0.second }

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_either_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_either_body/Main.snap
@@ -11,27 +11,30 @@ data Either @a @b
 dictionary bifunctorEither :: Data.Bifunctor.Bifunctor Main.Either where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Either a c -> Main.Either b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (Left field0) -> Left @b @d (firstFunction field0)
-      (Right field0) -> Right @b @d (secondFunction field0)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Left field0) -> Left @b @d (firstFunction field0)
+        (Right field0) -> Right @b @d (secondFunction field0)
 
 dictionary bifoldableEither :: Data.Bifoldable.Bifoldable Main.Either where
   bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (a -> c -> c) -> (b -> c -> c) -> c -> Main.Either a b -> c
-  bifoldr = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Left field0) -> firstFunction field0 accumulator
-      (Right field0) -> secondFunction field0 accumulator
+  bifoldr = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Left field0) -> firstFunction field0 accumulator
+        (Right field0) -> secondFunction field0 accumulator
   bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (c -> a -> c) -> (c -> b -> c) -> c -> Main.Either a b -> c
-  bifoldl = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Left field0) -> firstFunction accumulator field0
-      (Right field0) -> secondFunction accumulator field0
+  bifoldl = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Left field0) -> firstFunction accumulator field0
+        (Right field0) -> secondFunction accumulator field0
   bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Either a b -> m
-  bifoldMap = \{monoidDict} ->
+  bifoldMap = \@m -> \@a -> \@b -> \{monoidDict} ->
     \firstFunction secondFunction value ->
       case value of
         (Left field0) -> firstFunction field0
@@ -44,7 +47,7 @@ dictionary bitraversableEither :: Data.Bitraversable.Bitraversable Main.Either w
   (d :: Prim.Type).
   Control.Applicative.Applicative f =>
   (a -> f c) -> (b -> f d) -> Main.Either a b -> f (Main.Either c d)
-  bitraverse = \{applicativeDict} ->
+  bitraverse = \@f -> \@a -> \@b -> \@c -> \@d -> \{applicativeDict} ->
     \firstFunction secondFunction value ->
       case value of
         (Left field0) -> map @f {applicativeDict.applyDict.functorDict} @c @(Main.Either c d)
@@ -55,7 +58,7 @@ dictionary bitraversableEither :: Data.Bitraversable.Bitraversable Main.Either w
           (secondFunction field0)
   bisequence :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Control.Applicative.Applicative f => Main.Either (f a) (f b) -> f (Main.Either a b)
-  bisequence = \{applicativeDict} ->
+  bisequence = \@f -> \@a -> \@b -> \{applicativeDict} ->
     \value ->
       bitraverse @Main.Either {bitraversableEither} @f @(f a) @(f b) @a @b {applicativeDict}
         (\effect0 -> effect0)

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_binary_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_binary_body/Main.snap
@@ -18,12 +18,13 @@ dictionary bifunctorNested ::
   (c -> d) ->
   Main.Nested @Prim.Type @Prim.Type p a c ->
   Main.Nested @Prim.Type @Prim.Type p b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (Nested field0) -> Nested @Prim.Type @Prim.Type @p @b @d
-        (bimap @p {bifunctorDict} @a @b @c @d (\element -> firstFunction element)
-          (\element -> secondFunction element)
-          field0)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Nested field0) -> Nested @Prim.Type @Prim.Type @p @b @d
+          (bimap @p {bifunctorDict} @a @b @c @d (\element -> firstFunction element)
+            (\element -> secondFunction element)
+            field0)
 
 dictionary bifoldableNested ::
   forall p.
@@ -32,25 +33,27 @@ dictionary bifoldableNested ::
   where
   bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (a -> c -> c) -> (b -> c -> c) -> c -> Main.Nested @Prim.Type @Prim.Type p a b -> c
-  bifoldr = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Nested field0) -> bifoldr @p {bifoldableDict} @a @b @c
-        (\element accumulator -> firstFunction element accumulator)
-        (\element accumulator -> secondFunction element accumulator)
-        accumulator
-        field0
+  bifoldr = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Nested field0) -> bifoldr @p {bifoldableDict} @a @b @c
+          (\element accumulator -> firstFunction element accumulator)
+          (\element accumulator -> secondFunction element accumulator)
+          accumulator
+          field0
   bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (c -> a -> c) -> (c -> b -> c) -> c -> Main.Nested @Prim.Type @Prim.Type p a b -> c
-  bifoldl = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Nested field0) -> bifoldl @p {bifoldableDict} @a @b @c
-        (\accumulator element -> firstFunction accumulator element)
-        (\accumulator element -> secondFunction accumulator element)
-        accumulator
-        field0
+  bifoldl = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Nested field0) -> bifoldl @p {bifoldableDict} @a @b @c
+          (\accumulator element -> firstFunction accumulator element)
+          (\accumulator element -> secondFunction accumulator element)
+          accumulator
+          field0
   bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Nested @Prim.Type @Prim.Type p a b -> m
-  bifoldMap = \{monoidDict} ->
+  bifoldMap = \@m -> \@a -> \@b -> \{monoidDict} ->
     \firstFunction secondFunction value ->
       case value of
         (Nested field0) -> bifoldMap @p {bifoldableDict} @m @a @b {monoidDict}
@@ -72,7 +75,7 @@ dictionary bitraversableNested ::
   (b -> f d) ->
   Main.Nested @Prim.Type @Prim.Type p a b ->
   f (Main.Nested @Prim.Type @Prim.Type p c d)
-  bitraverse = \{applicativeDict} ->
+  bitraverse = \@f -> \@a -> \@b -> \@c -> \@d -> \{applicativeDict} ->
     \firstFunction secondFunction value ->
       case value of
         (Nested field0) -> map @f {applicativeDict.applyDict.functorDict} @(p c d) @(Main.Nested @Prim.Type @Prim.Type p c d)
@@ -84,7 +87,7 @@ dictionary bitraversableNested ::
   bisequence :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Control.Applicative.Applicative f =>
   Main.Nested @Prim.Type @Prim.Type p (f a) (f b) -> f (Main.Nested @Prim.Type @Prim.Type p a b)
-  bisequence = \{applicativeDict} ->
+  bisequence = \@f -> \@a -> \@b -> \{applicativeDict} ->
     \value ->
       bitraverse @(Main.Nested @Prim.Type @Prim.Type p) {bitraversableNested {bitraversableDict}} @f @(f a) @(f b) @a @b {applicativeDict}
         (\effect0 -> effect0)

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_unary_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_unary_body/Main.snap
@@ -20,11 +20,12 @@ dictionary bifunctorWrap ::
   (c -> d) ->
   Main.Wrap @Prim.Type @Prim.Type f g a c ->
   Main.Wrap @Prim.Type @Prim.Type f g b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (Wrap field0 field1) -> Wrap @Prim.Type @Prim.Type @f @g @b @d
-        (map @f {functorDict} @a @b (\element -> firstFunction element) field0)
-        (map @g {functorDict1} @c @d (\element -> secondFunction element) field1)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Wrap field0 field1) -> Wrap @Prim.Type @Prim.Type @f @g @b @d
+          (map @f {functorDict} @a @b (\element -> firstFunction element) field0)
+          (map @g {functorDict1} @c @d (\element -> secondFunction element) field1)
 
 dictionary bifoldableWrap ::
   forall f g.
@@ -34,27 +35,30 @@ dictionary bifoldableWrap ::
   where
   bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (a -> c -> c) -> (b -> c -> c) -> c -> Main.Wrap @Prim.Type @Prim.Type f g a b -> c
-  bifoldr = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Wrap field0 field1) -> foldr @f {foldableDict} @a @c
-        (\element accumulator -> firstFunction element accumulator)
-        (foldr @g {foldableDict1} @b @c (\element accumulator -> secondFunction element accumulator)
-          accumulator
-          field1)
-        field0
+  bifoldr = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Wrap field0 field1) -> foldr @f {foldableDict} @a @c
+          (\element accumulator -> firstFunction element accumulator)
+          (foldr @g {foldableDict1} @b @c
+            (\element accumulator -> secondFunction element accumulator)
+            accumulator
+            field1)
+          field0
   bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (c -> a -> c) -> (c -> b -> c) -> c -> Main.Wrap @Prim.Type @Prim.Type f g a b -> c
-  bifoldl = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Wrap field0 field1) -> foldl @g {foldableDict1} @b @c
-        (\accumulator element -> secondFunction accumulator element)
-        (foldl @f {foldableDict} @a @c (\accumulator element -> firstFunction accumulator element)
-          accumulator
-          field0)
-        field1
+  bifoldl = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Wrap field0 field1) -> foldl @g {foldableDict1} @b @c
+          (\accumulator element -> secondFunction accumulator element)
+          (foldl @f {foldableDict} @a @c (\accumulator element -> firstFunction accumulator element)
+            accumulator
+            field0)
+          field1
   bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Wrap @Prim.Type @Prim.Type f g a b -> m
-  bifoldMap = \{monoidDict} ->
+  bifoldMap = \@m -> \@a -> \@b -> \{monoidDict} ->
     \firstFunction secondFunction value ->
       case value of
         (Wrap field0 field1) -> append @m {monoidDict.semigroupDict}
@@ -77,7 +81,7 @@ dictionary bitraversableWrap ::
   (b -> f1 d) ->
   Main.Wrap @Prim.Type @Prim.Type f g a b ->
   f1 (Main.Wrap @Prim.Type @Prim.Type f g c d)
-  bitraverse = \{applicativeDict} ->
+  bitraverse = \@f1 -> \@a -> \@b -> \@c -> \@d -> \{applicativeDict} ->
     \firstFunction secondFunction value ->
       case value of
         (Wrap field0 field1) -> apply @f1 {applicativeDict.applyDict} @(g d) @(Main.Wrap @Prim.Type @Prim.Type f g c d)
@@ -93,7 +97,7 @@ dictionary bitraversableWrap ::
   bisequence :: forall (f1 :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Control.Applicative.Applicative f1 =>
   Main.Wrap @Prim.Type @Prim.Type f g (f1 a) (f1 b) -> f1 (Main.Wrap @Prim.Type @Prim.Type f g a b)
-  bisequence = \{applicativeDict} ->
+  bisequence = \@f1 -> \@a -> \@b -> \{applicativeDict} ->
     \value ->
       bitraverse @(Main.Wrap @Prim.Type @Prim.Type f g) {bitraversableWrap {traversableDict} {traversableDict1}} @f1 @(f1 a) @(f1 b) @a @b {applicativeDict}
         (\effect0 -> effect0)

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_pair_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_pair_body/Main.snap
@@ -10,25 +10,28 @@ data Pair @a @b
 dictionary bifunctorPair :: Data.Bifunctor.Bifunctor Main.Pair where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Pair a c -> Main.Pair b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (Pair field0 field1 field2) -> Pair @b @d (firstFunction field0) field1
-        (secondFunction field2)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Pair field0 field1 field2) -> Pair @b @d (firstFunction field0) field1
+          (secondFunction field2)
 
 dictionary bifoldablePair :: Data.Bifoldable.Bifoldable Main.Pair where
   bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (a -> c -> c) -> (b -> c -> c) -> c -> Main.Pair a b -> c
-  bifoldr = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Pair field0 field1 field2) -> firstFunction field0 (secondFunction field2 accumulator)
+  bifoldr = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Pair field0 field1 field2) -> firstFunction field0 (secondFunction field2 accumulator)
   bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (c -> a -> c) -> (c -> b -> c) -> c -> Main.Pair a b -> c
-  bifoldl = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Pair field0 field1 field2) -> secondFunction (firstFunction accumulator field0) field2
+  bifoldl = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Pair field0 field1 field2) -> secondFunction (firstFunction accumulator field0) field2
   bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Pair a b -> m
-  bifoldMap = \{monoidDict} ->
+  bifoldMap = \@m -> \@a -> \@b -> \{monoidDict} ->
     \firstFunction secondFunction value ->
       case value of
         (Pair field0 field1 field2) -> append @m {monoidDict.semigroupDict} (firstFunction field0)
@@ -41,7 +44,7 @@ dictionary bitraversablePair :: Data.Bitraversable.Bitraversable Main.Pair where
   (d :: Prim.Type).
   Control.Applicative.Applicative f =>
   (a -> f c) -> (b -> f d) -> Main.Pair a b -> f (Main.Pair c d)
-  bitraverse = \{applicativeDict} ->
+  bitraverse = \@f -> \@a -> \@b -> \@c -> \@d -> \{applicativeDict} ->
     \firstFunction secondFunction value ->
       case value of
         (Pair field0 field1 field2) -> apply @f {applicativeDict.applyDict} @d @(Main.Pair c d)
@@ -51,7 +54,7 @@ dictionary bitraversablePair :: Data.Bitraversable.Bitraversable Main.Pair where
           (secondFunction field2)
   bisequence :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Control.Applicative.Applicative f => Main.Pair (f a) (f b) -> f (Main.Pair a b)
-  bisequence = \{applicativeDict} ->
+  bisequence = \@f -> \@a -> \@b -> \{applicativeDict} ->
     \value ->
       bitraverse @Main.Pair {bitraversablePair} @f @(f a) @(f b) @a @b {applicativeDict}
         (\effect0 -> effect0)

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_record_body/Main.snap
@@ -10,25 +10,28 @@ data RecordPair @a @b
 dictionary bifunctorRecordPair :: Data.Bifunctor.Bifunctor Main.RecordPair where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.RecordPair a c -> Main.RecordPair b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (RecordPair field0) -> RecordPair @b @d
-        field0 { alpha = firstFunction field0.alpha, zeta = secondFunction field0.zeta }
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (RecordPair field0) -> RecordPair @b @d
+          field0 { alpha = firstFunction field0.alpha, zeta = secondFunction field0.zeta }
 
 dictionary bifoldableRecordPair :: Data.Bifoldable.Bifoldable Main.RecordPair where
   bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (a -> c -> c) -> (b -> c -> c) -> c -> Main.RecordPair a b -> c
-  bifoldr = \firstFunction secondFunction accumulator value ->
-    case value of
-      (RecordPair field0) -> firstFunction field0.alpha (secondFunction field0.zeta accumulator)
+  bifoldr = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (RecordPair field0) -> firstFunction field0.alpha (secondFunction field0.zeta accumulator)
   bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (c -> a -> c) -> (c -> b -> c) -> c -> Main.RecordPair a b -> c
-  bifoldl = \firstFunction secondFunction accumulator value ->
-    case value of
-      (RecordPair field0) -> secondFunction (firstFunction accumulator field0.alpha) field0.zeta
+  bifoldl = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (RecordPair field0) -> secondFunction (firstFunction accumulator field0.alpha) field0.zeta
   bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.RecordPair a b -> m
-  bifoldMap = \{monoidDict} ->
+  bifoldMap = \@m -> \@a -> \@b -> \{monoidDict} ->
     \firstFunction secondFunction value ->
       case value of
         (RecordPair field0) -> append @m {monoidDict.semigroupDict} (firstFunction field0.alpha)
@@ -41,7 +44,7 @@ dictionary bitraversableRecordPair :: Data.Bitraversable.Bitraversable Main.Reco
   (d :: Prim.Type).
   Control.Applicative.Applicative f =>
   (a -> f c) -> (b -> f d) -> Main.RecordPair a b -> f (Main.RecordPair c d)
-  bitraverse = \{applicativeDict} ->
+  bitraverse = \@f -> \@a -> \@b -> \@c -> \@d -> \{applicativeDict} ->
     \firstFunction secondFunction value ->
       case value of
         (RecordPair field0) -> map @f {applicativeDict.applyDict.functorDict} @{ alpha :: c, fixed :: Prim.Int, zeta :: d } @(Main.RecordPair c d)
@@ -53,7 +56,7 @@ dictionary bitraversableRecordPair :: Data.Bitraversable.Bitraversable Main.Reco
             (secondFunction field0.zeta))
   bisequence :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Control.Applicative.Applicative f => Main.RecordPair (f a) (f b) -> f (Main.RecordPair a b)
-  bisequence = \{applicativeDict} ->
+  bisequence = \@f -> \@a -> \@b -> \{applicativeDict} ->
     \value ->
       bitraverse @Main.RecordPair {bitraversableRecordPair} @f @(f a) @(f b) @a @b {applicativeDict}
         (\effect0 -> effect0)

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_both_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_both_body/Main.snap
@@ -14,7 +14,7 @@ dictionary functorDuplicate ::
   where
   map :: forall (a :: Prim.Type) (b :: Prim.Type).
   (a -> b) -> Main.Duplicate @Prim.Type p a -> Main.Duplicate @Prim.Type p b
-  map = \function -> \(Duplicate value) ->
+  map = \@a -> \@b -> \function -> \(Duplicate value) ->
     Duplicate @Prim.Type @p @b (bimap @p {bifunctorDict} @a @b @a @b function function value)
 
 dictionary foldableDuplicate ::
@@ -23,14 +23,14 @@ dictionary foldableDuplicate ::
   Data.Foldable.Foldable (Main.Duplicate @Prim.Type p)
   where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Duplicate @Prim.Type p a -> b
-  foldr = \function -> \initial -> \(Duplicate value) ->
+  foldr = \@a -> \@b -> \function -> \initial -> \(Duplicate value) ->
     bifoldr @p {bifoldableDict} @a @a @b function function initial value
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Duplicate @Prim.Type p a -> b
-  foldl = \function -> \initial -> \(Duplicate value) ->
+  foldl = \@a -> \@b -> \function -> \initial -> \(Duplicate value) ->
     bifoldl @p {bifoldableDict} @a @a @b function function initial value
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> Main.Duplicate @Prim.Type p a -> m
-  foldMap = \{monoidDict} -> \function -> \(Duplicate value) ->
+  foldMap = \@a -> \@m -> \{monoidDict} -> \function -> \(Duplicate value) ->
     bifoldMap @p {bifoldableDict} @m @a @a {monoidDict} function function value
 
 dictionary traversableDuplicate ::
@@ -43,7 +43,7 @@ dictionary traversableDuplicate ::
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   (a -> m b) -> Main.Duplicate @Prim.Type p a -> m (Main.Duplicate @Prim.Type p b)
-  traverse = \{applicativeDict} ->
+  traverse = \@a -> \@b -> \@m -> \{applicativeDict} ->
     \function value ->
       case value of
         (Duplicate field0) -> map @m {applicativeDict.applyDict.functorDict} @(p b b) @(Main.Duplicate @Prim.Type p b)
@@ -55,7 +55,7 @@ dictionary traversableDuplicate ::
   sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   Main.Duplicate @Prim.Type p (m a) -> m (Main.Duplicate @Prim.Type p a)
-  sequence = \{applicativeDict} ->
+  sequence = \@a -> \@m -> \{applicativeDict} ->
     \value ->
       traverse @(Main.Duplicate @Prim.Type p) {traversableDuplicate {bitraversableDict}} @(m a) @a @m {applicativeDict}
         (\effect0 -> effect0)

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_left_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_left_body/Main.snap
@@ -14,7 +14,7 @@ dictionary functorLeftDuplicate ::
   where
   map :: forall (a :: Prim.Type) (b :: Prim.Type).
   (a -> b) -> Main.LeftDuplicate @Prim.Type p a -> Main.LeftDuplicate @Prim.Type p b
-  map = \function -> \(LeftDuplicate value) ->
+  map = \@a -> \@b -> \function -> \(LeftDuplicate value) ->
     LeftDuplicate @Prim.Type @p @b
       (bimap @p {bifunctorDict} @a @b @Prim.Int @Prim.Int function (\fixed -> fixed) value)
 
@@ -25,17 +25,17 @@ dictionary foldableLeftDuplicate ::
   where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type).
   (a -> b -> b) -> b -> Main.LeftDuplicate @Prim.Type p a -> b
-  foldr = \function -> \initial -> \(LeftDuplicate value) ->
+  foldr = \@a -> \@b -> \function -> \initial -> \(LeftDuplicate value) ->
     bifoldr @p {bifoldableDict} @a @Prim.Int @b function (\_ accumulated -> accumulated) initial
       value
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type).
   (b -> a -> b) -> b -> Main.LeftDuplicate @Prim.Type p a -> b
-  foldl = \function -> \initial -> \(LeftDuplicate value) ->
+  foldl = \@a -> \@b -> \function -> \initial -> \(LeftDuplicate value) ->
     bifoldl @p {bifoldableDict} @a @Prim.Int @b function (\accumulated _ -> accumulated) initial
       value
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> Main.LeftDuplicate @Prim.Type p a -> m
-  foldMap = \{monoidDict} -> \function -> \(LeftDuplicate value) ->
+  foldMap = \@a -> \@m -> \{monoidDict} -> \function -> \(LeftDuplicate value) ->
     bifoldMap @p {bifoldableDict} @m @a @Prim.Int {monoidDict} function
       (\_ -> mempty @m {monoidDict})
       value
@@ -50,7 +50,7 @@ dictionary traversableLeftDuplicate ::
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   (a -> m b) -> Main.LeftDuplicate @Prim.Type p a -> m (Main.LeftDuplicate @Prim.Type p b)
-  traverse = \{applicativeDict} ->
+  traverse = \@a -> \@b -> \@m -> \{applicativeDict} ->
     \function value ->
       case value of
         (LeftDuplicate field0) -> map @m {applicativeDict.applyDict.functorDict} @(p b Prim.Int) @(Main.LeftDuplicate @Prim.Type p b)
@@ -62,7 +62,7 @@ dictionary traversableLeftDuplicate ::
   sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   Main.LeftDuplicate @Prim.Type p (m a) -> m (Main.LeftDuplicate @Prim.Type p a)
-  sequence = \{applicativeDict} ->
+  sequence = \@a -> \@m -> \{applicativeDict} ->
     \value ->
       traverse @(Main.LeftDuplicate @Prim.Type p) {traversableLeftDuplicate {bitraversableDict}} @(m a) @a @m {applicativeDict}
         (\effect0 -> effect0)

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_const_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_const_body/Main.snap
@@ -10,22 +10,25 @@ data Const @e @a
 dictionary functorConst :: forall e. Data.Functor.Functor (Main.Const @Prim.Type e) where
   map :: forall (a :: Prim.Type) (b :: Prim.Type).
   (a -> b) -> Main.Const @Prim.Type e a -> Main.Const @Prim.Type e b
-  map = \function value ->
-    case value of
-      (Const field0) -> Const @Prim.Type @e @b field0
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Const field0) -> Const @Prim.Type @e @b field0
 
 dictionary foldableConst :: forall e. Data.Foldable.Foldable (Main.Const @Prim.Type e) where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Const @Prim.Type e a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (Const field0) -> accumulator
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Const field0) -> accumulator
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Const @Prim.Type e a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (Const field0) -> accumulator
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Const field0) -> accumulator
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> Main.Const @Prim.Type e a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (Const field0) -> mempty @m {monoidDict}
@@ -37,7 +40,7 @@ dictionary traversableConst :: forall e. Data.Traversable.Traversable (Main.Cons
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   (a -> m b) -> Main.Const @Prim.Type e a -> m (Main.Const @Prim.Type e b)
-  traverse = \{applicativeDict} ->
+  traverse = \@a -> \@b -> \@m -> \{applicativeDict} ->
     \function value ->
       case value of
         (Const field0) -> pure @m {applicativeDict} @(Main.Const @Prim.Type e b)
@@ -45,7 +48,7 @@ dictionary traversableConst :: forall e. Data.Traversable.Traversable (Main.Cons
   sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   Main.Const @Prim.Type e (m a) -> m (Main.Const @Prim.Type e a)
-  sequence = \{applicativeDict} ->
+  sequence = \@a -> \@m -> \{applicativeDict} ->
     \value ->
       traverse @(Main.Const @Prim.Type e) {traversableConst} @(m a) @a @m {applicativeDict}
         (\effect0 -> effect0)

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_identity_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_identity_body/Main.snap
@@ -9,21 +9,24 @@ data Identity @a
 
 dictionary functorIdentity :: Data.Functor.Functor Main.Identity where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Identity a -> Main.Identity b
-  map = \function value ->
-    case value of
-      (Identity field0) -> Identity @b (function field0)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Identity field0) -> Identity @b (function field0)
 
 dictionary foldableIdentity :: Data.Foldable.Foldable Main.Identity where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Identity a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (Identity field0) -> function field0 accumulator
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Identity field0) -> function field0 accumulator
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Identity a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (Identity field0) -> function accumulator field0
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Identity field0) -> function accumulator field0
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Identity a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (Identity field0) -> function field0
@@ -33,7 +36,7 @@ dictionary traversableIdentity :: Data.Traversable.Traversable Main.Identity whe
   superclass foldableDict = foldableIdentity
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m => (a -> m b) -> Main.Identity a -> m (Main.Identity b)
-  traverse = \{applicativeDict} ->
+  traverse = \@a -> \@b -> \@m -> \{applicativeDict} ->
     \function value ->
       case value of
         (Identity field0) -> map @m {applicativeDict.applyDict.functorDict} @b @(Main.Identity b)
@@ -41,7 +44,7 @@ dictionary traversableIdentity :: Data.Traversable.Traversable Main.Identity whe
           (function field0)
   sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m => Main.Identity (m a) -> m (Main.Identity a)
-  sequence = \{applicativeDict} ->
+  sequence = \@a -> \@m -> \{applicativeDict} ->
     \value ->
       traverse @Main.Identity {traversableIdentity} @(m a) @a @m {applicativeDict}
         (\effect0 -> effect0)

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_maybe_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_maybe_body/Main.snap
@@ -10,24 +10,27 @@ data Maybe @a
 
 dictionary functorMaybe :: Data.Functor.Functor Main.Maybe where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Maybe a -> Main.Maybe b
-  map = \function value ->
-    case value of
-      Nothing -> Nothing @b
-      (Just field0) -> Just @b (function field0)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        Nothing -> Nothing @b
+        (Just field0) -> Just @b (function field0)
 
 dictionary foldableMaybe :: Data.Foldable.Foldable Main.Maybe where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Maybe a -> b
-  foldr = \function accumulator value ->
-    case value of
-      Nothing -> accumulator
-      (Just field0) -> function field0 accumulator
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        Nothing -> accumulator
+        (Just field0) -> function field0 accumulator
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Maybe a -> b
-  foldl = \function accumulator value ->
-    case value of
-      Nothing -> accumulator
-      (Just field0) -> function accumulator field0
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        Nothing -> accumulator
+        (Just field0) -> function accumulator field0
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Maybe a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         Nothing -> mempty @m {monoidDict}
@@ -38,7 +41,7 @@ dictionary traversableMaybe :: Data.Traversable.Traversable Main.Maybe where
   superclass foldableDict = foldableMaybe
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m => (a -> m b) -> Main.Maybe a -> m (Main.Maybe b)
-  traverse = \{applicativeDict} ->
+  traverse = \@a -> \@b -> \@m -> \{applicativeDict} ->
     \function value ->
       case value of
         Nothing -> pure @m {applicativeDict} @(Main.Maybe b) (Nothing @b)
@@ -47,7 +50,7 @@ dictionary traversableMaybe :: Data.Traversable.Traversable Main.Maybe where
           (function field0)
   sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m => Main.Maybe (m a) -> m (Main.Maybe a)
-  sequence = \{applicativeDict} ->
+  sequence = \@a -> \@m -> \{applicativeDict} ->
     \value ->
       traverse @Main.Maybe {traversableMaybe} @(m a) @a @m {applicativeDict} (\effect0 -> effect0)
         value

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_nested_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_nested_body/Main.snap
@@ -16,12 +16,13 @@ dictionary functorCompose ::
   where
   map :: forall (a :: Prim.Type) (b :: Prim.Type).
   (a -> b) -> Main.Compose @Prim.Type @Prim.Type f g a -> Main.Compose @Prim.Type @Prim.Type f g b
-  map = \function value ->
-    case value of
-      (Compose field0) -> Compose @Prim.Type @Prim.Type @f @g @b
-        (map @f {functorDict} @(g a) @(g b)
-          (\element -> map @g {functorDict1} @a @b (\element -> function element) element)
-          field0)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Compose field0) -> Compose @Prim.Type @Prim.Type @f @g @b
+          (map @f {functorDict} @(g a) @(g b)
+            (\element -> map @g {functorDict1} @a @b (\element -> function element) element)
+            field0)
 
 dictionary foldableCompose ::
   forall f g.
@@ -31,29 +32,31 @@ dictionary foldableCompose ::
   where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type).
   (a -> b -> b) -> b -> Main.Compose @Prim.Type @Prim.Type f g a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (Compose field0) -> foldr @f {foldableDict} @(g a) @b
-        (\element accumulator ->
-          foldr @g {foldableDict1} @a @b (\element accumulator -> function element accumulator)
-            accumulator
-            element)
-        accumulator
-        field0
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Compose field0) -> foldr @f {foldableDict} @(g a) @b
+          (\element accumulator ->
+            foldr @g {foldableDict1} @a @b (\element accumulator -> function element accumulator)
+              accumulator
+              element)
+          accumulator
+          field0
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type).
   (b -> a -> b) -> b -> Main.Compose @Prim.Type @Prim.Type f g a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (Compose field0) -> foldl @f {foldableDict} @(g a) @b
-        (\accumulator element ->
-          foldl @g {foldableDict1} @a @b (\accumulator element -> function accumulator element)
-            accumulator
-            element)
-        accumulator
-        field0
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Compose field0) -> foldl @f {foldableDict} @(g a) @b
+          (\accumulator element ->
+            foldl @g {foldableDict1} @a @b (\accumulator element -> function accumulator element)
+              accumulator
+              element)
+          accumulator
+          field0
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> Main.Compose @Prim.Type @Prim.Type f g a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (Compose field0) -> foldMap @f {foldableDict} @(g a) @m {monoidDict}
@@ -74,7 +77,7 @@ dictionary traversableCompose ::
   (a -> m b) ->
   Main.Compose @Prim.Type @Prim.Type f g a ->
   m (Main.Compose @Prim.Type @Prim.Type f g b)
-  traverse = \{applicativeDict} ->
+  traverse = \@a -> \@b -> \@m -> \{applicativeDict} ->
     \function value ->
       case value of
         (Compose field0) -> map @m {applicativeDict.applyDict.functorDict} @(f (g b)) @(Main.Compose @Prim.Type @Prim.Type f g b)
@@ -88,7 +91,7 @@ dictionary traversableCompose ::
   sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   Main.Compose @Prim.Type @Prim.Type f g (m a) -> m (Main.Compose @Prim.Type @Prim.Type f g a)
-  sequence = \{applicativeDict} ->
+  sequence = \@a -> \@m -> \{applicativeDict} ->
     \value ->
       traverse @(Main.Compose @Prim.Type @Prim.Type f g) {traversableCompose {traversableDict} {traversableDict1}} @(m a) @a @m {applicativeDict}
         (\effect0 -> effect0)

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_product_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_product_body/Main.snap
@@ -9,21 +9,24 @@ data Product @a
 
 dictionary functorProduct :: Data.Functor.Functor Main.Product where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Product a -> Main.Product b
-  map = \function value ->
-    case value of
-      (Product field0 field1 field2) -> Product @b (function field0) field1 (function field2)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Product field0 field1 field2) -> Product @b (function field0) field1 (function field2)
 
 dictionary foldableProduct :: Data.Foldable.Foldable Main.Product where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Product a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (Product field0 field1 field2) -> function field0 (function field2 accumulator)
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Product field0 field1 field2) -> function field0 (function field2 accumulator)
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Product a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (Product field0 field1 field2) -> function (function accumulator field0) field2
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Product field0 field1 field2) -> function (function accumulator field0) field2
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Product a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (Product field0 field1 field2) -> append @m {monoidDict.semigroupDict} (function field0)
@@ -34,7 +37,7 @@ dictionary traversableProduct :: Data.Traversable.Traversable Main.Product where
   superclass foldableDict = foldableProduct
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m => (a -> m b) -> Main.Product a -> m (Main.Product b)
-  traverse = \{applicativeDict} ->
+  traverse = \@a -> \@b -> \@m -> \{applicativeDict} ->
     \function value ->
       case value of
         (Product field0 field1 field2) -> apply @m {applicativeDict.applyDict} @b @(Main.Product b)
@@ -44,7 +47,7 @@ dictionary traversableProduct :: Data.Traversable.Traversable Main.Product where
           (function field2)
   sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m => Main.Product (m a) -> m (Main.Product a)
-  sequence = \{applicativeDict} ->
+  sequence = \@a -> \@m -> \{applicativeDict} ->
     \value ->
       traverse @Main.Product {traversableProduct} @(m a) @a @m {applicativeDict}
         (\effect0 -> effect0)

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_record_body/Main.snap
@@ -9,22 +9,25 @@ data Record @a
 
 dictionary functorRecord :: Data.Functor.Functor Main.Record where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Record a -> Main.Record b
-  map = \function value ->
-    case value of
-      (Record field0) -> Record @b
-        field0 { alpha = function field0.alpha, zeta = function field0.zeta }
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Record field0) -> Record @b
+          field0 { alpha = function field0.alpha, zeta = function field0.zeta }
 
 dictionary foldableRecord :: Data.Foldable.Foldable Main.Record where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Record a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (Record field0) -> function field0.alpha (function field0.zeta accumulator)
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Record field0) -> function field0.alpha (function field0.zeta accumulator)
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Record a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (Record field0) -> function (function accumulator field0.alpha) field0.zeta
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Record field0) -> function (function accumulator field0.alpha) field0.zeta
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Record a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (Record field0) -> append @m {monoidDict.semigroupDict} (function field0.alpha)
@@ -35,7 +38,7 @@ dictionary traversableRecord :: Data.Traversable.Traversable Main.Record where
   superclass foldableDict = foldableRecord
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m => (a -> m b) -> Main.Record a -> m (Main.Record b)
-  traverse = \{applicativeDict} ->
+  traverse = \@a -> \@b -> \@m -> \{applicativeDict} ->
     \function value ->
       case value of
         (Record field0) -> map @m {applicativeDict.applyDict.functorDict} @{ alpha :: b, fixed :: Prim.Int, zeta :: b } @(Main.Record b)
@@ -47,7 +50,7 @@ dictionary traversableRecord :: Data.Traversable.Traversable Main.Record where
             (function field0.zeta))
   sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m => Main.Record (m a) -> m (Main.Record a)
-  sequence = \{applicativeDict} ->
+  sequence = \@a -> \@m -> \{applicativeDict} ->
     \value ->
       traverse @Main.Record {traversableRecord} @(m a) @a @m {applicativeDict} (\effect0 -> effect0)
         value

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_recursive_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_recursive_body/Main.snap
@@ -10,38 +10,41 @@ data Tree @a
 
 dictionary functorTree :: Data.Functor.Functor Main.Tree where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Tree a -> Main.Tree b
-  map = \function value ->
-    case value of
-      (Leaf field0) -> Leaf @b (function field0)
-      (Branch field0 field1) -> Branch @b
-        (map @Main.Tree {functorTree} @a @b (\element -> function element) field0)
-        (map @Main.Tree {functorTree} @a @b (\element -> function element) field1)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Leaf field0) -> Leaf @b (function field0)
+        (Branch field0 field1) -> Branch @b
+          (map @Main.Tree {functorTree} @a @b (\element -> function element) field0)
+          (map @Main.Tree {functorTree} @a @b (\element -> function element) field1)
 
 dictionary foldableTree :: Data.Foldable.Foldable Main.Tree where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Tree a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (Leaf field0) -> function field0 accumulator
-      (Branch field0 field1) -> foldr @Main.Tree {foldableTree} @a @b
-        (\element accumulator -> function element accumulator)
-        (foldr @Main.Tree {foldableTree} @a @b
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Leaf field0) -> function field0 accumulator
+        (Branch field0 field1) -> foldr @Main.Tree {foldableTree} @a @b
           (\element accumulator -> function element accumulator)
-          accumulator
-          field1)
-        field0
+          (foldr @Main.Tree {foldableTree} @a @b
+            (\element accumulator -> function element accumulator)
+            accumulator
+            field1)
+          field0
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Tree a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (Leaf field0) -> function accumulator field0
-      (Branch field0 field1) -> foldl @Main.Tree {foldableTree} @a @b
-        (\accumulator element -> function accumulator element)
-        (foldl @Main.Tree {foldableTree} @a @b
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Leaf field0) -> function accumulator field0
+        (Branch field0 field1) -> foldl @Main.Tree {foldableTree} @a @b
           (\accumulator element -> function accumulator element)
-          accumulator
-          field0)
-        field1
+          (foldl @Main.Tree {foldableTree} @a @b
+            (\accumulator element -> function accumulator element)
+            accumulator
+            field0)
+          field1
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Tree a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (Leaf field0) -> function field0
@@ -56,7 +59,7 @@ dictionary traversableTree :: Data.Traversable.Traversable Main.Tree where
   superclass foldableDict = foldableTree
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m => (a -> m b) -> Main.Tree a -> m (Main.Tree b)
-  traverse = \{applicativeDict} ->
+  traverse = \@a -> \@b -> \@m -> \{applicativeDict} ->
     \function value ->
       case value of
         (Leaf field0) -> map @m {applicativeDict.applyDict.functorDict} @b @(Main.Tree b)
@@ -73,7 +76,7 @@ dictionary traversableTree :: Data.Traversable.Traversable Main.Tree where
             field1)
   sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m => Main.Tree (m a) -> m (Main.Tree a)
-  sequence = \{applicativeDict} ->
+  sequence = \@a -> \@m -> \{applicativeDict} ->
     \value ->
       traverse @Main.Tree {traversableTree} @(m a) @a @m {applicativeDict} (\effect0 -> effect0)
         value

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_either_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_either_body/Main.snap
@@ -11,19 +11,21 @@ data Either @a @b
 dictionary bifoldableEither :: Data.Bifoldable.Bifoldable Main.Either where
   bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (a -> c -> c) -> (b -> c -> c) -> c -> Main.Either a b -> c
-  bifoldr = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Left field0) -> firstFunction field0 accumulator
-      (Right field0) -> secondFunction field0 accumulator
+  bifoldr = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Left field0) -> firstFunction field0 accumulator
+        (Right field0) -> secondFunction field0 accumulator
   bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (c -> a -> c) -> (c -> b -> c) -> c -> Main.Either a b -> c
-  bifoldl = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Left field0) -> firstFunction accumulator field0
-      (Right field0) -> secondFunction accumulator field0
+  bifoldl = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Left field0) -> firstFunction accumulator field0
+        (Right field0) -> secondFunction accumulator field0
   bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Either a b -> m
-  bifoldMap = \{monoidDict} ->
+  bifoldMap = \@m -> \@a -> \@b -> \{monoidDict} ->
     \firstFunction secondFunction value ->
       case value of
         (Left field0) -> firstFunction field0

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_binary_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_binary_body/Main.snap
@@ -15,25 +15,27 @@ dictionary bifoldableNested ::
   where
   bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (a -> c -> c) -> (b -> c -> c) -> c -> Main.Nested @Prim.Type @Prim.Type p a b -> c
-  bifoldr = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Nested field0) -> bifoldr @p {bifoldableDict} @a @b @c
-        (\element accumulator -> firstFunction element accumulator)
-        (\element accumulator -> secondFunction element accumulator)
-        accumulator
-        field0
+  bifoldr = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Nested field0) -> bifoldr @p {bifoldableDict} @a @b @c
+          (\element accumulator -> firstFunction element accumulator)
+          (\element accumulator -> secondFunction element accumulator)
+          accumulator
+          field0
   bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (c -> a -> c) -> (c -> b -> c) -> c -> Main.Nested @Prim.Type @Prim.Type p a b -> c
-  bifoldl = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Nested field0) -> bifoldl @p {bifoldableDict} @a @b @c
-        (\accumulator element -> firstFunction accumulator element)
-        (\accumulator element -> secondFunction accumulator element)
-        accumulator
-        field0
+  bifoldl = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Nested field0) -> bifoldl @p {bifoldableDict} @a @b @c
+          (\accumulator element -> firstFunction accumulator element)
+          (\accumulator element -> secondFunction accumulator element)
+          accumulator
+          field0
   bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Nested @Prim.Type @Prim.Type p a b -> m
-  bifoldMap = \{monoidDict} ->
+  bifoldMap = \@m -> \@a -> \@b -> \{monoidDict} ->
     \firstFunction secondFunction value ->
       case value of
         (Nested field0) -> bifoldMap @p {bifoldableDict} @m @a @b {monoidDict}

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_unary_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_unary_body/Main.snap
@@ -17,27 +17,30 @@ dictionary bifoldableWrap ::
   where
   bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (a -> c -> c) -> (b -> c -> c) -> c -> Main.Wrap @Prim.Type @Prim.Type f g a b -> c
-  bifoldr = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Wrap field0 field1) -> foldr @f {foldableDict} @a @c
-        (\element accumulator -> firstFunction element accumulator)
-        (foldr @g {foldableDict1} @b @c (\element accumulator -> secondFunction element accumulator)
-          accumulator
-          field1)
-        field0
+  bifoldr = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Wrap field0 field1) -> foldr @f {foldableDict} @a @c
+          (\element accumulator -> firstFunction element accumulator)
+          (foldr @g {foldableDict1} @b @c
+            (\element accumulator -> secondFunction element accumulator)
+            accumulator
+            field1)
+          field0
   bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (c -> a -> c) -> (c -> b -> c) -> c -> Main.Wrap @Prim.Type @Prim.Type f g a b -> c
-  bifoldl = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Wrap field0 field1) -> foldl @g {foldableDict1} @b @c
-        (\accumulator element -> secondFunction accumulator element)
-        (foldl @f {foldableDict} @a @c (\accumulator element -> firstFunction accumulator element)
-          accumulator
-          field0)
-        field1
+  bifoldl = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Wrap field0 field1) -> foldl @g {foldableDict1} @b @c
+          (\accumulator element -> secondFunction accumulator element)
+          (foldl @f {foldableDict} @a @c (\accumulator element -> firstFunction accumulator element)
+            accumulator
+            field0)
+          field1
   bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Wrap @Prim.Type @Prim.Type f g a b -> m
-  bifoldMap = \{monoidDict} ->
+  bifoldMap = \@m -> \@a -> \@b -> \{monoidDict} ->
     \firstFunction secondFunction value ->
       case value of
         (Wrap field0 field1) -> append @m {monoidDict.semigroupDict}

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_pair_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_pair_body/Main.snap
@@ -10,17 +10,19 @@ data Pair @a @b
 dictionary bifoldablePair :: Data.Bifoldable.Bifoldable Main.Pair where
   bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (a -> c -> c) -> (b -> c -> c) -> c -> Main.Pair a b -> c
-  bifoldr = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Pair field0 field1 field2) -> firstFunction field0 (secondFunction field2 accumulator)
+  bifoldr = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Pair field0 field1 field2) -> firstFunction field0 (secondFunction field2 accumulator)
   bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (c -> a -> c) -> (c -> b -> c) -> c -> Main.Pair a b -> c
-  bifoldl = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Pair field0 field1 field2) -> secondFunction (firstFunction accumulator field0) field2
+  bifoldl = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Pair field0 field1 field2) -> secondFunction (firstFunction accumulator field0) field2
   bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Pair a b -> m
-  bifoldMap = \{monoidDict} ->
+  bifoldMap = \@m -> \@a -> \@b -> \{monoidDict} ->
     \firstFunction secondFunction value ->
       case value of
         (Pair field0 field1 field2) -> append @m {monoidDict.semigroupDict} (firstFunction field0)

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_record_body/Main.snap
@@ -10,17 +10,19 @@ data RecordPair @a @b
 dictionary bifoldableRecordPair :: Data.Bifoldable.Bifoldable Main.RecordPair where
   bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (a -> c -> c) -> (b -> c -> c) -> c -> Main.RecordPair a b -> c
-  bifoldr = \firstFunction secondFunction accumulator value ->
-    case value of
-      (RecordPair field0) -> firstFunction field0.alpha (secondFunction field0.zeta accumulator)
+  bifoldr = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (RecordPair field0) -> firstFunction field0.alpha (secondFunction field0.zeta accumulator)
   bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (c -> a -> c) -> (c -> b -> c) -> c -> Main.RecordPair a b -> c
-  bifoldl = \firstFunction secondFunction accumulator value ->
-    case value of
-      (RecordPair field0) -> secondFunction (firstFunction accumulator field0.alpha) field0.zeta
+  bifoldl = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (RecordPair field0) -> secondFunction (firstFunction accumulator field0.alpha) field0.zeta
   bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.RecordPair a b -> m
-  bifoldMap = \{monoidDict} ->
+  bifoldMap = \@m -> \@a -> \@b -> \{monoidDict} ->
     \firstFunction secondFunction value ->
       case value of
         (RecordPair field0) -> append @m {monoidDict.semigroupDict} (firstFunction field0.alpha)

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_both_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_both_body/Main.snap
@@ -13,24 +13,26 @@ dictionary foldableDuplicate ::
   Data.Foldable.Foldable (Main.Duplicate @Prim.Type p)
   where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Duplicate @Prim.Type p a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (Duplicate field0) -> bifoldr @p {bifoldableDict} @a @a @b
-        (\element accumulator -> function element accumulator)
-        (\element accumulator -> function element accumulator)
-        accumulator
-        field0
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Duplicate field0) -> bifoldr @p {bifoldableDict} @a @a @b
+          (\element accumulator -> function element accumulator)
+          (\element accumulator -> function element accumulator)
+          accumulator
+          field0
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Duplicate @Prim.Type p a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (Duplicate field0) -> bifoldl @p {bifoldableDict} @a @a @b
-        (\accumulator element -> function accumulator element)
-        (\accumulator element -> function accumulator element)
-        accumulator
-        field0
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Duplicate field0) -> bifoldl @p {bifoldableDict} @a @a @b
+          (\accumulator element -> function accumulator element)
+          (\accumulator element -> function accumulator element)
+          accumulator
+          field0
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> Main.Duplicate @Prim.Type p a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (Duplicate field0) -> bifoldMap @p {bifoldableDict} @m @a @a {monoidDict}

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_left_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_left_body/Main.snap
@@ -14,25 +14,27 @@ dictionary foldableLeftDuplicate ::
   where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type).
   (a -> b -> b) -> b -> Main.LeftDuplicate @Prim.Type p a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (LeftDuplicate field0) -> bifoldr @p {bifoldableDict} @a @Prim.Int @b
-        (\element accumulator -> function element accumulator)
-        (\ignored accumulator -> accumulator)
-        accumulator
-        field0
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (LeftDuplicate field0) -> bifoldr @p {bifoldableDict} @a @Prim.Int @b
+          (\element accumulator -> function element accumulator)
+          (\ignored accumulator -> accumulator)
+          accumulator
+          field0
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type).
   (b -> a -> b) -> b -> Main.LeftDuplicate @Prim.Type p a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (LeftDuplicate field0) -> bifoldl @p {bifoldableDict} @a @Prim.Int @b
-        (\accumulator element -> function accumulator element)
-        (\accumulator ignored -> accumulator)
-        accumulator
-        field0
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (LeftDuplicate field0) -> bifoldl @p {bifoldableDict} @a @Prim.Int @b
+          (\accumulator element -> function accumulator element)
+          (\accumulator ignored -> accumulator)
+          accumulator
+          field0
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> Main.LeftDuplicate @Prim.Type p a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (LeftDuplicate field0) -> bifoldMap @p {bifoldableDict} @m @a @Prim.Int {monoidDict}

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_right_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_right_body/Main.snap
@@ -13,22 +13,24 @@ dictionary foldableRightNested ::
   Data.Foldable.Foldable (Main.RightNested @Prim.Type p)
   where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.RightNested @Prim.Type p a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (RightNested field0) -> foldr @(p Prim.Int) {foldableDict} @a @b
-        (\element accumulator -> function element accumulator)
-        accumulator
-        field0
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (RightNested field0) -> foldr @(p Prim.Int) {foldableDict} @a @b
+          (\element accumulator -> function element accumulator)
+          accumulator
+          field0
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.RightNested @Prim.Type p a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (RightNested field0) -> foldl @(p Prim.Int) {foldableDict} @a @b
-        (\accumulator element -> function accumulator element)
-        accumulator
-        field0
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (RightNested field0) -> foldl @(p Prim.Int) {foldableDict} @a @b
+          (\accumulator element -> function accumulator element)
+          accumulator
+          field0
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> Main.RightNested @Prim.Type p a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (RightNested field0) -> foldMap @(p Prim.Int) {foldableDict} @a @m {monoidDict}

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_identity_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_identity_body/Main.snap
@@ -9,15 +9,17 @@ data Identity @a
 
 dictionary foldableIdentity :: Data.Foldable.Foldable Main.Identity where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Identity a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (Identity field0) -> function field0 accumulator
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Identity field0) -> function field0 accumulator
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Identity a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (Identity field0) -> function accumulator field0
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Identity field0) -> function accumulator field0
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Identity a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (Identity field0) -> function field0

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_maybe_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_maybe_body/Main.snap
@@ -10,17 +10,19 @@ data Maybe @a
 
 dictionary foldableMaybe :: Data.Foldable.Foldable Main.Maybe where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Maybe a -> b
-  foldr = \function accumulator value ->
-    case value of
-      Nothing -> accumulator
-      (Just field0) -> function field0 accumulator
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        Nothing -> accumulator
+        (Just field0) -> function field0 accumulator
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Maybe a -> b
-  foldl = \function accumulator value ->
-    case value of
-      Nothing -> accumulator
-      (Just field0) -> function accumulator field0
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        Nothing -> accumulator
+        (Just field0) -> function accumulator field0
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Maybe a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         Nothing -> mempty @m {monoidDict}

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_nested_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_nested_body/Main.snap
@@ -16,29 +16,31 @@ dictionary foldableCompose ::
   where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type).
   (a -> b -> b) -> b -> Main.Compose @Prim.Type @Prim.Type f g a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (Compose field0) -> foldr @f {foldableDict} @(g a) @b
-        (\element accumulator ->
-          foldr @g {foldableDict1} @a @b (\element accumulator -> function element accumulator)
-            accumulator
-            element)
-        accumulator
-        field0
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Compose field0) -> foldr @f {foldableDict} @(g a) @b
+          (\element accumulator ->
+            foldr @g {foldableDict1} @a @b (\element accumulator -> function element accumulator)
+              accumulator
+              element)
+          accumulator
+          field0
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type).
   (b -> a -> b) -> b -> Main.Compose @Prim.Type @Prim.Type f g a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (Compose field0) -> foldl @f {foldableDict} @(g a) @b
-        (\accumulator element ->
-          foldl @g {foldableDict1} @a @b (\accumulator element -> function accumulator element)
-            accumulator
-            element)
-        accumulator
-        field0
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Compose field0) -> foldl @f {foldableDict} @(g a) @b
+          (\accumulator element ->
+            foldl @g {foldableDict1} @a @b (\accumulator element -> function accumulator element)
+              accumulator
+              element)
+          accumulator
+          field0
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> Main.Compose @Prim.Type @Prim.Type f g a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (Compose field0) -> foldMap @f {foldableDict} @(g a) @m {monoidDict}

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_product_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_product_body/Main.snap
@@ -9,18 +9,20 @@ data Product @a
 
 dictionary foldableProduct :: Data.Foldable.Foldable Main.Product where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Product a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (Product field0 field1 field2 field3) -> function field0
-        (function field2 (function field3 accumulator))
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Product field0 field1 field2 field3) -> function field0
+          (function field2 (function field3 accumulator))
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Product a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (Product field0 field1 field2 field3) -> function
-        (function (function accumulator field0) field2)
-        field3
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Product field0 field1 field2 field3) -> function
+          (function (function accumulator field0) field2)
+          field3
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Product a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (Product field0 field1 field2 field3) -> append @m {monoidDict.semigroupDict}

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_record_body/Main.snap
@@ -9,15 +9,17 @@ data Record @a
 
 dictionary foldableRecord :: Data.Foldable.Foldable Main.Record where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Record a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (Record field0) -> function field0.alpha (function field0.zeta accumulator)
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Record field0) -> function field0.alpha (function field0.zeta accumulator)
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Record a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (Record field0) -> function (function accumulator field0.alpha) field0.zeta
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Record field0) -> function (function accumulator field0.alpha) field0.zeta
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Record a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (Record field0) -> append @m {monoidDict.semigroupDict} (function field0.alpha)

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_recursive_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_recursive_body/Main.snap
@@ -10,29 +10,31 @@ data Tree @a
 
 dictionary foldableTree :: Data.Foldable.Foldable Main.Tree where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Tree a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (Leaf field0) -> function field0 accumulator
-      (Branch field0 field1) -> foldr @Main.Tree {foldableTree} @a @b
-        (\element accumulator -> function element accumulator)
-        (foldr @Main.Tree {foldableTree} @a @b
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Leaf field0) -> function field0 accumulator
+        (Branch field0 field1) -> foldr @Main.Tree {foldableTree} @a @b
           (\element accumulator -> function element accumulator)
-          accumulator
-          field1)
-        field0
+          (foldr @Main.Tree {foldableTree} @a @b
+            (\element accumulator -> function element accumulator)
+            accumulator
+            field1)
+          field0
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Tree a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (Leaf field0) -> function accumulator field0
-      (Branch field0 field1) -> foldl @Main.Tree {foldableTree} @a @b
-        (\accumulator element -> function accumulator element)
-        (foldl @Main.Tree {foldableTree} @a @b
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Leaf field0) -> function accumulator field0
+        (Branch field0 field1) -> foldl @Main.Tree {foldableTree} @a @b
           (\accumulator element -> function accumulator element)
-          accumulator
-          field0)
-        field1
+          (foldl @Main.Tree {foldableTree} @a @b
+            (\accumulator element -> function accumulator element)
+            accumulator
+            field0)
+          field1
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Tree a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (Leaf field0) -> function field0

--- a/tests-integration/fixtures/semantic/1785522600_derive_foldable_right_bifoldable_context/Main.snap
+++ b/tests-integration/fixtures/semantic/1785522600_derive_foldable_right_bifoldable_context/Main.snap
@@ -13,24 +13,26 @@ dictionary foldableRightNested ::
   Data.Foldable.Foldable (Main.RightNested @Prim.Type p)
   where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.RightNested @Prim.Type p a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (RightNested field0) -> bifoldr @p {bifoldableDict} @Prim.Int @a @b
-        (\ignored accumulator -> accumulator)
-        (\element accumulator -> function element accumulator)
-        accumulator
-        field0
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (RightNested field0) -> bifoldr @p {bifoldableDict} @Prim.Int @a @b
+          (\ignored accumulator -> accumulator)
+          (\element accumulator -> function element accumulator)
+          accumulator
+          field0
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.RightNested @Prim.Type p a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (RightNested field0) -> bifoldl @p {bifoldableDict} @Prim.Int @a @b
-        (\accumulator ignored -> accumulator)
-        (\accumulator element -> function accumulator element)
-        accumulator
-        field0
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (RightNested field0) -> bifoldl @p {bifoldableDict} @Prim.Int @a @b
+          (\accumulator ignored -> accumulator)
+          (\accumulator element -> function accumulator element)
+          accumulator
+          field0
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> Main.RightNested @Prim.Type p a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (RightNested field0) -> bifoldMap @p {bifoldableDict} @m @Prim.Int @a {monoidDict}

--- a/tests-integration/fixtures/semantic/1785522600_derive_traversable_right_bitraversable_context/Main.snap
+++ b/tests-integration/fixtures/semantic/1785522600_derive_traversable_right_bitraversable_context/Main.snap
@@ -14,7 +14,7 @@ dictionary functorRightNested ::
   where
   map :: forall (a :: Prim.Type) (b :: Prim.Type).
   (a -> b) -> Main.RightNested @Prim.Type p a -> Main.RightNested @Prim.Type p b
-  map = \function -> \(RightNested value) ->
+  map = \@a -> \@b -> \function -> \(RightNested value) ->
     RightNested @Prim.Type @p @b
       (bimap @p {bifunctorDict} @Prim.Int @Prim.Int @a @b (\fixed -> fixed) function value)
 
@@ -24,16 +24,16 @@ dictionary foldableRightNested ::
   Data.Foldable.Foldable (Main.RightNested @Prim.Type p)
   where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.RightNested @Prim.Type p a -> b
-  foldr = \function -> \initial -> \(RightNested value) ->
+  foldr = \@a -> \@b -> \function -> \initial -> \(RightNested value) ->
     bifoldr @p {bifoldableDict} @Prim.Int @a @b (\_ accumulated -> accumulated) function initial
       value
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.RightNested @Prim.Type p a -> b
-  foldl = \function -> \initial -> \(RightNested value) ->
+  foldl = \@a -> \@b -> \function -> \initial -> \(RightNested value) ->
     bifoldl @p {bifoldableDict} @Prim.Int @a @b (\accumulated _ -> accumulated) function initial
       value
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> Main.RightNested @Prim.Type p a -> m
-  foldMap = \{monoidDict} -> \function -> \(RightNested value) ->
+  foldMap = \@a -> \@m -> \{monoidDict} -> \function -> \(RightNested value) ->
     bifoldMap @p {bifoldableDict} @m @Prim.Int @a {monoidDict} (\_ -> mempty @m {monoidDict})
       function
       value
@@ -48,7 +48,7 @@ dictionary traversableRightNested ::
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   (a -> m b) -> Main.RightNested @Prim.Type p a -> m (Main.RightNested @Prim.Type p b)
-  traverse = \{applicativeDict} ->
+  traverse = \@a -> \@b -> \@m -> \{applicativeDict} ->
     \function value ->
       case value of
         (RightNested field0) -> map @m {applicativeDict.applyDict.functorDict} @(p Prim.Int b) @(Main.RightNested @Prim.Type p b)
@@ -60,7 +60,7 @@ dictionary traversableRightNested ::
   sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   Main.RightNested @Prim.Type p (m a) -> m (Main.RightNested @Prim.Type p a)
-  sequence = \{applicativeDict} ->
+  sequence = \@a -> \@m -> \{applicativeDict} ->
     \value ->
       traverse @(Main.RightNested @Prim.Type p) {traversableRightNested {bitraversableDict}} @(m a) @a @m {applicativeDict}
         (\effect0 -> effect0)

--- a/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_binary_superclass_context/Main.snap
+++ b/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_binary_superclass_context/Main.snap
@@ -13,24 +13,26 @@ dictionary foldableRightNested ::
   Data.Foldable.Foldable (Main.RightNested @Prim.Type p)
   where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.RightNested @Prim.Type p a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (RightNested field0) -> bifoldr @p {bitraversableDict.bifoldableDict} @Prim.Int @a @b
-        (\ignored accumulator -> accumulator)
-        (\element accumulator -> function element accumulator)
-        accumulator
-        field0
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (RightNested field0) -> bifoldr @p {bitraversableDict.bifoldableDict} @Prim.Int @a @b
+          (\ignored accumulator -> accumulator)
+          (\element accumulator -> function element accumulator)
+          accumulator
+          field0
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.RightNested @Prim.Type p a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (RightNested field0) -> bifoldl @p {bitraversableDict.bifoldableDict} @Prim.Int @a @b
-        (\accumulator ignored -> accumulator)
-        (\accumulator element -> function accumulator element)
-        accumulator
-        field0
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (RightNested field0) -> bifoldl @p {bitraversableDict.bifoldableDict} @Prim.Int @a @b
+          (\accumulator ignored -> accumulator)
+          (\accumulator element -> function accumulator element)
+          accumulator
+          field0
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> Main.RightNested @Prim.Type p a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (RightNested field0) -> bifoldMap @p {bitraversableDict.bifoldableDict} @m @Prim.Int @a {monoidDict}

--- a/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_concrete_instance_heads/Main.snap
+++ b/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_concrete_instance_heads/Main.snap
@@ -14,17 +14,19 @@ data RightNested @a
 dictionary bifoldableProduct :: Data.Bifoldable.Bifoldable Main.Product where
   bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (a -> c -> c) -> (b -> c -> c) -> c -> Main.Product a b -> c
-  bifoldr = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Product field0 field1) -> firstFunction field0 (secondFunction field1 accumulator)
+  bifoldr = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Product field0 field1) -> firstFunction field0 (secondFunction field1 accumulator)
   bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
   (c -> a -> c) -> (c -> b -> c) -> c -> Main.Product a b -> c
-  bifoldl = \firstFunction secondFunction accumulator value ->
-    case value of
-      (Product field0 field1) -> secondFunction (firstFunction accumulator field0) field1
+  bifoldl = \@a -> \@b -> \@c ->
+    \firstFunction secondFunction accumulator value ->
+      case value of
+        (Product field0 field1) -> secondFunction (firstFunction accumulator field0) field1
   bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Product a b -> m
-  bifoldMap = \{monoidDict} ->
+  bifoldMap = \@m -> \@a -> \@b -> \{monoidDict} ->
     \firstFunction secondFunction value ->
       case value of
         (Product field0 field1) -> append @m {monoidDict.semigroupDict} (firstFunction field0)
@@ -32,38 +34,42 @@ dictionary bifoldableProduct :: Data.Bifoldable.Bifoldable Main.Product where
 
 dictionary foldableProduct :: Data.Foldable.Foldable (Main.Product Prim.Int) where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Product Prim.Int a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (Product field0 field1) -> function field1 accumulator
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Product field0 field1) -> function field1 accumulator
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Product Prim.Int a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (Product field0 field1) -> function accumulator field1
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (Product field0 field1) -> function accumulator field1
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> Main.Product Prim.Int a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (Product field0 field1) -> function field1
 
 dictionary foldableRightNested :: Data.Foldable.Foldable Main.RightNested where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.RightNested a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (RightNested field0) -> foldr @(Main.Product Prim.Int) {foldableProduct} @a @b
-        (\element accumulator -> function element accumulator)
-        accumulator
-        field0
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (RightNested field0) -> foldr @(Main.Product Prim.Int) {foldableProduct} @a @b
+          (\element accumulator -> function element accumulator)
+          accumulator
+          field0
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.RightNested a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (RightNested field0) -> foldl @(Main.Product Prim.Int) {foldableProduct} @a @b
-        (\accumulator element -> function accumulator element)
-        accumulator
-        field0
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (RightNested field0) -> foldl @(Main.Product Prim.Int) {foldableProduct} @a @b
+          (\accumulator element -> function accumulator element)
+          accumulator
+          field0
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> Main.RightNested a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (RightNested field0) -> foldMap @(Main.Product Prim.Int) {foldableProduct} @a @m {monoidDict}

--- a/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_prefers_unary_context/Main.snap
+++ b/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_prefers_unary_context/Main.snap
@@ -14,22 +14,24 @@ dictionary foldableRightNested ::
   Data.Foldable.Foldable (Main.RightNested @Prim.Type p)
   where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.RightNested @Prim.Type p a -> b
-  foldr = \function accumulator value ->
-    case value of
-      (RightNested field0) -> foldr @(p Prim.Int) {foldableDict} @a @b
-        (\element accumulator -> function element accumulator)
-        accumulator
-        field0
+  foldr = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (RightNested field0) -> foldr @(p Prim.Int) {foldableDict} @a @b
+          (\element accumulator -> function element accumulator)
+          accumulator
+          field0
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.RightNested @Prim.Type p a -> b
-  foldl = \function accumulator value ->
-    case value of
-      (RightNested field0) -> foldl @(p Prim.Int) {foldableDict} @a @b
-        (\accumulator element -> function accumulator element)
-        accumulator
-        field0
+  foldl = \@a -> \@b ->
+    \function accumulator value ->
+      case value of
+        (RightNested field0) -> foldl @(p Prim.Int) {foldableDict} @a @b
+          (\accumulator element -> function accumulator element)
+          accumulator
+          field0
   foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
   Data.Monoid.Monoid m => (a -> m) -> Main.RightNested @Prim.Type p a -> m
-  foldMap = \{monoidDict} ->
+  foldMap = \@a -> \@m -> \{monoidDict} ->
     \function value ->
       case value of
         (RightNested field0) -> foldMap @(p Prim.Int) {foldableDict} @a @m {monoidDict}

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_empty_data_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_empty_data_body/Main.snap
@@ -10,6 +10,7 @@ dictionary contravariantEmpty :: Data.Functor.Contravariant.Contravariant (Main.
   where
   cmap :: forall (a :: Prim.Type) (b :: Prim.Type).
   (b -> a) -> Main.Empty @Prim.Type a -> Main.Empty @Prim.Type b
-  cmap = \function value ->
-    case value of
-      <error>
+  cmap = \@a -> \@b ->
+    \function value ->
+      case value of
+        <error>

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_function_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_function_body/Main.snap
@@ -9,6 +9,7 @@ data Predicate @a
 
 dictionary contravariantPredicate :: Data.Functor.Contravariant.Contravariant Main.Predicate where
   cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.Predicate a -> Main.Predicate b
-  cmap = \function value ->
-    case value of
-      (Predicate field0) -> Predicate @b \argument -> field0 (function argument)
+  cmap = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Predicate field0) -> Predicate @b \argument -> field0 (function argument)

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_functor_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_functor_application_body/Main.snap
@@ -13,17 +13,19 @@ data BoxedPredicate @a
 
 dictionary functorBox :: Data.Functor.Functor Main.Box where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Box a -> Main.Box b
-  map = \function value ->
-    case value of
-      (Box field0) -> Box @b (function field0)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Box field0) -> Box @b (function field0)
 
 dictionary contravariantBoxedPredicate ::
   Data.Functor.Contravariant.Contravariant Main.BoxedPredicate
   where
   cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.BoxedPredicate a -> Main.BoxedPredicate b
-  cmap = \function value ->
-    case value of
-      (BoxedPredicate field0) -> BoxedPredicate @b
-        (map @Main.Box {functorBox} @(a -> Prim.Boolean) @(b -> Prim.Boolean)
-          (\element -> \argument -> element (function argument))
-          field0)
+  cmap = \@a -> \@b ->
+    \function value ->
+      case value of
+        (BoxedPredicate field0) -> BoxedPredicate @b
+          (map @Main.Box {functorBox} @(a -> Prim.Boolean) @(b -> Prim.Boolean)
+            (\element -> \argument -> element (function argument))
+            field0)

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_mixed_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_mixed_application_body/Main.snap
@@ -17,21 +17,24 @@ data BoxedInput @a
 
 dictionary functorBox :: Data.Functor.Functor Main.Box where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Box a -> Main.Box b
-  map = \function value ->
-    case value of
-      (Box field0) -> Box @b (function field0)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Box field0) -> Box @b (function field0)
 
 dictionary contravariantPredicate :: Data.Functor.Contravariant.Contravariant Main.Predicate where
   cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.Predicate a -> Main.Predicate b
-  cmap = \function value ->
-    case value of
-      (Predicate field0) -> Predicate @b \argument -> field0 (function argument)
+  cmap = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Predicate field0) -> Predicate @b \argument -> field0 (function argument)
 
 dictionary contravariantBoxedInput :: Data.Functor.Contravariant.Contravariant Main.BoxedInput where
   cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.BoxedInput a -> Main.BoxedInput b
-  cmap = \function value ->
-    case value of
-      (BoxedInput field0) -> BoxedInput @b
-        (cmap @Main.Predicate {contravariantPredicate} @(Main.Box a) @(Main.Box b)
-          (\element -> map @Main.Box {functorBox} @b @a (\element -> function element) element)
-          field0)
+  cmap = \@a -> \@b ->
+    \function value ->
+      case value of
+        (BoxedInput field0) -> BoxedInput @b
+          (cmap @Main.Predicate {contravariantPredicate} @(Main.Box a) @(Main.Box b)
+            (\element -> map @Main.Box {functorBox} @b @a (\element -> function element) element)
+            field0)

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_record_body/Main.snap
@@ -12,7 +12,8 @@ dictionary contravariantPredicateRecord ::
   where
   cmap :: forall (a :: Prim.Type) (b :: Prim.Type).
   (b -> a) -> Main.PredicateRecord a -> Main.PredicateRecord b
-  cmap = \function value ->
-    case value of
-      (PredicateRecord field0) -> PredicateRecord @b
-        field0 { run = \argument -> field0.run (function argument) }
+  cmap = \@a -> \@b ->
+    \function value ->
+      case value of
+        (PredicateRecord field0) -> PredicateRecord @b
+          field0 { run = \argument -> field0.run (function argument) }

--- a/tests-integration/fixtures/semantic/1785598200_derive_profunctor_function_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_profunctor_function_body/Main.snap
@@ -10,7 +10,8 @@ data Function @a @b
 dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
   dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Function b c -> Main.Function a d
-  dimap = \firstFunction secondFunction value ->
-    case value of
-      (Function field0) -> Function @a @d \argument ->
-        secondFunction (field0 (firstFunction argument))
+  dimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Function field0) -> Function @a @d \argument ->
+          secondFunction (field0 (firstFunction argument))

--- a/tests-integration/fixtures/semantic/1785598200_derive_profunctor_nested_both_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_profunctor_nested_both_body/Main.snap
@@ -14,17 +14,19 @@ data Nested @a @b
 dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
   dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Function b c -> Main.Function a d
-  dimap = \firstFunction secondFunction value ->
-    case value of
-      (Function field0) -> Function @a @d \argument ->
-        secondFunction (field0 (firstFunction argument))
+  dimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Function field0) -> Function @a @d \argument ->
+          secondFunction (field0 (firstFunction argument))
 
 dictionary profunctorNested :: Data.Profunctor.Profunctor Main.Nested where
   dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Nested b c -> Main.Nested a d
-  dimap = \firstFunction secondFunction value ->
-    case value of
-      (Nested field0) -> Nested @a @d
-        (dimap @Main.Function {profunctorFunction} @a @b @c @d (\element -> firstFunction element)
-          (\element -> secondFunction element)
-          field0)
+  dimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Nested field0) -> Nested @a @d
+          (dimap @Main.Function {profunctorFunction} @a @b @c @d (\element -> firstFunction element)
+            (\element -> secondFunction element)
+            field0)

--- a/tests-integration/fixtures/semantic/1785598200_derive_profunctor_nested_left_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_profunctor_nested_left_body/Main.snap
@@ -14,18 +14,20 @@ data NestedLeft @a @b
 dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
   dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Function b c -> Main.Function a d
-  dimap = \firstFunction secondFunction value ->
-    case value of
-      (Function field0) -> Function @a @d \argument ->
-        secondFunction (field0 (firstFunction argument))
+  dimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Function field0) -> Function @a @d \argument ->
+          secondFunction (field0 (firstFunction argument))
 
 dictionary profunctorNestedLeft :: Data.Profunctor.Profunctor (Main.NestedLeft @Prim.Type) where
   dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.NestedLeft @Prim.Type b c -> Main.NestedLeft @Prim.Type a d
-  dimap = \firstFunction secondFunction value ->
-    case value of
-      (NestedLeft field0) -> NestedLeft @Prim.Type @a @d
-        (dimap @Main.Function {profunctorFunction} @a @b @Prim.Int @Prim.Int
-          (\element -> firstFunction element)
-          (\unchanged -> unchanged)
-          field0)
+  dimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (NestedLeft field0) -> NestedLeft @Prim.Type @a @d
+          (dimap @Main.Function {profunctorFunction} @a @b @Prim.Int @Prim.Int
+            (\element -> firstFunction element)
+            (\unchanged -> unchanged)
+            field0)

--- a/tests-integration/fixtures/semantic/1785598200_derive_profunctor_unary_preference_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_profunctor_unary_preference_body/Main.snap
@@ -14,22 +14,26 @@ data NestedRight @a @b
 dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
   dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Function b c -> Main.Function a d
-  dimap = \firstFunction secondFunction value ->
-    case value of
-      (Function field0) -> Function @a @d \argument ->
-        secondFunction (field0 (firstFunction argument))
+  dimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Function field0) -> Function @a @d \argument ->
+          secondFunction (field0 (firstFunction argument))
 
 dictionary functorFunction :: forall a. Data.Functor.Functor (Main.Function a) where
   map :: forall (a1 :: Prim.Type) (b :: Prim.Type). (a1 -> b) -> Main.Function a a1 -> Main.Function a b
-  map = \function value ->
-    case value of
-      (Function field0) -> Function @a @b \argument -> function (field0 argument)
+  map = \@a1 -> \@b ->
+    \function value ->
+      case value of
+        (Function field0) -> Function @a @b \argument -> function (field0 argument)
 
 dictionary profunctorNestedRight :: Data.Profunctor.Profunctor (Main.NestedRight @Prim.Type) where
   dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.NestedRight @Prim.Type b c -> Main.NestedRight @Prim.Type a d
-  dimap = \firstFunction secondFunction value ->
-    case value of
-      (NestedRight field0) -> NestedRight @Prim.Type @a @d
-        (map @(Main.Function Prim.Int) {functorFunction} @c @d (\element -> secondFunction element)
-          field0)
+  dimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (NestedRight field0) -> NestedRight @Prim.Type @a @d
+          (map @(Main.Function Prim.Int) {functorFunction} @c @d
+            (\element -> secondFunction element)
+            field0)

--- a/tests-integration/fixtures/semantic/1785598260_derive_profunctor_bifunctor_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598260_derive_profunctor_bifunctor_application_body/Main.snap
@@ -14,17 +14,19 @@ data Nested @a @b
 dictionary bifunctorPair :: Data.Bifunctor.Bifunctor Main.Pair where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Pair a c -> Main.Pair b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (Pair field0 field1) -> Pair @b @d (firstFunction field0) (secondFunction field1)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Pair field0 field1) -> Pair @b @d (firstFunction field0) (secondFunction field1)
 
 dictionary profunctorNested :: Data.Profunctor.Profunctor Main.Nested where
   dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Nested b c -> Main.Nested a d
-  dimap = \firstFunction secondFunction value ->
-    case value of
-      (Nested field0) -> Nested @a @d
-        (bimap @Main.Pair {bifunctorPair} @(b -> Prim.Int) @(a -> Prim.Int) @c @d
-          (\element -> \argument -> element (firstFunction argument))
-          (\element -> secondFunction element)
-          field0)
+  dimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Nested field0) -> Nested @a @d
+          (bimap @Main.Pair {bifunctorPair} @(b -> Prim.Int) @(a -> Prim.Int) @c @d
+            (\element -> \argument -> element (firstFunction argument))
+            (\element -> secondFunction element)
+            field0)

--- a/tests-integration/fixtures/semantic/1785598320_derive_contravariant_given_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598320_derive_contravariant_given_application_body/Main.snap
@@ -14,7 +14,8 @@ dictionary contravariantNested ::
   where
   cmap :: forall (a :: Prim.Type) (b :: Prim.Type).
   (b -> a) -> Main.Nested @Prim.Type f a -> Main.Nested @Prim.Type f b
-  cmap = \function value ->
-    case value of
-      (Nested field0) -> Nested @Prim.Type @f @b
-        (cmap @f {contravariantDict} @a @b (\element -> function element) field0)
+  cmap = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Nested field0) -> Nested @Prim.Type @f @b
+          (cmap @f {contravariantDict} @a @b (\element -> function element) field0)

--- a/tests-integration/fixtures/semantic/1785598320_derive_contravariant_triple_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598320_derive_contravariant_triple_application_body/Main.snap
@@ -13,22 +13,24 @@ data TripleNegative @a
 
 dictionary contravariantPredicate :: Data.Functor.Contravariant.Contravariant Main.Predicate where
   cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.Predicate a -> Main.Predicate b
-  cmap = \function value ->
-    case value of
-      (Predicate field0) -> Predicate @b \argument -> field0 (function argument)
+  cmap = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Predicate field0) -> Predicate @b \argument -> field0 (function argument)
 
 dictionary contravariantTripleNegative ::
   Data.Functor.Contravariant.Contravariant Main.TripleNegative
   where
   cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.TripleNegative a -> Main.TripleNegative b
-  cmap = \function value ->
-    case value of
-      (TripleNegative field0) -> TripleNegative @b
-        (cmap @Main.Predicate {contravariantPredicate} @(Main.Predicate (Main.Predicate a)) @(Main.Predicate (Main.Predicate b))
-          (\element ->
-            cmap @Main.Predicate {contravariantPredicate} @(Main.Predicate b) @(Main.Predicate a)
-              (\element ->
-                cmap @Main.Predicate {contravariantPredicate} @a @b (\element -> function element)
-                  element)
-              element)
-          field0)
+  cmap = \@a -> \@b ->
+    \function value ->
+      case value of
+        (TripleNegative field0) -> TripleNegative @b
+          (cmap @Main.Predicate {contravariantPredicate} @(Main.Predicate (Main.Predicate a)) @(Main.Predicate (Main.Predicate b))
+            (\element ->
+              cmap @Main.Predicate {contravariantPredicate} @(Main.Predicate b) @(Main.Predicate a)
+                (\element ->
+                  cmap @Main.Predicate {contravariantPredicate} @a @b (\element -> function element)
+                    element)
+                element)
+            field0)

--- a/tests-integration/fixtures/semantic/1785598320_derive_profunctor_given_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598320_derive_profunctor_given_application_body/Main.snap
@@ -18,9 +18,10 @@ dictionary profunctorNested ::
   (c -> d) ->
   Main.Nested @Prim.Type @Prim.Type p b c ->
   Main.Nested @Prim.Type @Prim.Type p a d
-  dimap = \firstFunction secondFunction value ->
-    case value of
-      (Nested field0) -> Nested @Prim.Type @Prim.Type @p @a @d
-        (dimap @p {profunctorDict} @a @b @c @d (\element -> firstFunction element)
-          (\element -> secondFunction element)
-          field0)
+  dimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Nested field0) -> Nested @Prim.Type @Prim.Type @p @a @d
+          (dimap @p {profunctorDict} @a @b @c @d (\element -> firstFunction element)
+            (\element -> secondFunction element)
+            field0)

--- a/tests-integration/fixtures/semantic/1785598320_derive_profunctor_nested_right_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598320_derive_profunctor_nested_right_body/Main.snap
@@ -14,18 +14,20 @@ data NestedRight @a @b
 dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
   dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Function b c -> Main.Function a d
-  dimap = \firstFunction secondFunction value ->
-    case value of
-      (Function field0) -> Function @a @d \argument ->
-        secondFunction (field0 (firstFunction argument))
+  dimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Function field0) -> Function @a @d \argument ->
+          secondFunction (field0 (firstFunction argument))
 
 dictionary profunctorNestedRight :: Data.Profunctor.Profunctor (Main.NestedRight @Prim.Type) where
   dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.NestedRight @Prim.Type b c -> Main.NestedRight @Prim.Type a d
-  dimap = \firstFunction secondFunction value ->
-    case value of
-      (NestedRight field0) -> NestedRight @Prim.Type @a @d
-        (dimap @Main.Function {profunctorFunction} @Prim.Int @Prim.Int @c @d
-          (\unchanged -> unchanged)
-          (\element -> secondFunction element)
-          field0)
+  dimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (NestedRight field0) -> NestedRight @Prim.Type @a @d
+          (dimap @Main.Function {profunctorFunction} @Prim.Int @Prim.Int @c @d
+            (\unchanged -> unchanged)
+            (\element -> secondFunction element)
+            field0)

--- a/tests-integration/fixtures/semantic/1785598440_derive_contravariant_nullary_constructor_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598440_derive_contravariant_nullary_constructor_body/Main.snap
@@ -13,7 +13,8 @@ dictionary contravariantOptionalPredicate ::
   where
   cmap :: forall (a :: Prim.Type) (b :: Prim.Type).
   (b -> a) -> Main.OptionalPredicate a -> Main.OptionalPredicate b
-  cmap = \function value ->
-    case value of
-      None -> None @b
-      (Some field0) -> Some @b \argument -> field0 (function argument)
+  cmap = \@a -> \@b ->
+    \function value ->
+      case value of
+        None -> None @b
+        (Some field0) -> Some @b \argument -> field0 (function argument)

--- a/tests-integration/fixtures/semantic/1785598440_derive_contravariant_open_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598440_derive_contravariant_open_record_body/Main.snap
@@ -13,7 +13,8 @@ dictionary contravariantOpenPredicate ::
   where
   cmap :: forall (a :: Prim.Type) (b :: Prim.Type).
   (b -> a) -> Main.OpenPredicate r a -> Main.OpenPredicate r b
-  cmap = \function value ->
-    case value of
-      (OpenPredicate field0) -> OpenPredicate @r @b
-        field0 { run = \argument -> field0.run (function argument) }
+  cmap = \@a -> \@b ->
+    \function value ->
+      case value of
+        (OpenPredicate field0) -> OpenPredicate @r @b
+          field0 { run = \argument -> field0.run (function argument) }

--- a/tests-integration/fixtures/semantic/1785598440_derive_contravariant_phantom_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598440_derive_contravariant_phantom_body/Main.snap
@@ -13,6 +13,7 @@ dictionary contravariantConstant ::
   where
   cmap :: forall (a :: Prim.Type) (b :: Prim.Type).
   (b -> a) -> Main.Constant @Prim.Type value a -> Main.Constant @Prim.Type value b
-  cmap = \function value ->
-    case value of
-      (Constant field0) -> Constant @Prim.Type @value @b field0
+  cmap = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Constant field0) -> Constant @Prim.Type @value @b field0

--- a/tests-integration/fixtures/semantic/1785598920_derive_contravariant_bifunctor_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598920_derive_contravariant_bifunctor_application_body/Main.snap
@@ -14,16 +14,18 @@ data Nested @a
 dictionary bifunctorPair :: Data.Bifunctor.Bifunctor Main.Pair where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Pair a c -> Main.Pair b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (Pair field0 field1) -> Pair @b @d (firstFunction field0) (secondFunction field1)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Pair field0 field1) -> Pair @b @d (firstFunction field0) (secondFunction field1)
 
 dictionary contravariantNested :: Data.Functor.Contravariant.Contravariant Main.Nested where
   cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.Nested a -> Main.Nested b
-  cmap = \function value ->
-    case value of
-      (Nested field0) -> Nested @b
-        (bimap @Main.Pair {bifunctorPair} @(a -> Prim.Int) @(b -> Prim.Int) @Prim.String @Prim.String
-          (\element -> \argument -> element (function argument))
-          (\unchanged -> unchanged)
-          field0)
+  cmap = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Nested field0) -> Nested @b
+          (bimap @Main.Pair {bifunctorPair} @(a -> Prim.Int) @(b -> Prim.Int) @Prim.String @Prim.String
+            (\element -> \argument -> element (function argument))
+            (\unchanged -> unchanged)
+            field0)

--- a/tests-integration/fixtures/semantic/1785598920_derive_profunctor_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598920_derive_profunctor_record_body/Main.snap
@@ -11,8 +11,9 @@ data RecordPro @a @b
 dictionary profunctorRecordPro :: Data.Profunctor.Profunctor Main.RecordPro where
   dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.RecordPro b c -> Main.RecordPro a d
-  dimap = \firstFunction secondFunction value ->
-    case value of
-      (RecordPro field0) -> RecordPro @a @d
-        field0 { consume = \argument ->
-          field0.consume (firstFunction argument), produce = secondFunction field0.produce }
+  dimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (RecordPro field0) -> RecordPro @a @d
+          field0 { consume = \argument ->
+            field0.consume (firstFunction argument), produce = secondFunction field0.produce }

--- a/tests-integration/fixtures/semantic/1785603960_derive_bifunctor_mixed_variance_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785603960_derive_bifunctor_mixed_variance_application_body/Main.snap
@@ -17,27 +17,31 @@ data Mixed @a @b
 
 dictionary contravariantPredicate :: Data.Functor.Contravariant.Contravariant Main.Predicate where
   cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.Predicate a -> Main.Predicate b
-  cmap = \function value ->
-    case value of
-      (Predicate field0) -> Predicate @b \argument -> field0 (function argument)
+  cmap = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Predicate field0) -> Predicate @b \argument -> field0 (function argument)
 
 dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
   dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Function b c -> Main.Function a d
-  dimap = \firstFunction secondFunction value ->
-    case value of
-      (Function field0) -> Function @a @d \argument ->
-        secondFunction (field0 (firstFunction argument))
+  dimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Function field0) -> Function @a @d \argument ->
+          secondFunction (field0 (firstFunction argument))
 
 dictionary bifunctorMixed :: Data.Bifunctor.Bifunctor Main.Mixed where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Mixed a c -> Main.Mixed b d
-  bimap = \firstFunction secondFunction value ->
-    case value of
-      (Mixed field0) -> Mixed @b @d
-        (dimap @Main.Function {profunctorFunction} @(Main.Predicate b) @(Main.Predicate a) @c @d
-          (\element ->
-            cmap @Main.Predicate {contravariantPredicate} @b @a (\element -> firstFunction element)
-              element)
-          (\element -> secondFunction element)
-          field0)
+  bimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Mixed field0) -> Mixed @b @d
+          (dimap @Main.Function {profunctorFunction} @(Main.Predicate b) @(Main.Predicate a) @c @d
+            (\element ->
+              cmap @Main.Predicate {contravariantPredicate} @b @a
+                (\element -> firstFunction element)
+                element)
+            (\element -> secondFunction element)
+            field0)

--- a/tests-integration/fixtures/semantic/1785603960_derive_functor_contravariant_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785603960_derive_functor_contravariant_application_body/Main.snap
@@ -13,17 +13,19 @@ data DoubleNegative @a
 
 dictionary contravariantPredicate :: Data.Functor.Contravariant.Contravariant Main.Predicate where
   cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.Predicate a -> Main.Predicate b
-  cmap = \function value ->
-    case value of
-      (Predicate field0) -> Predicate @b \argument -> field0 (function argument)
+  cmap = \@a -> \@b ->
+    \function value ->
+      case value of
+        (Predicate field0) -> Predicate @b \argument -> field0 (function argument)
 
 dictionary functorDoubleNegative :: Data.Functor.Functor Main.DoubleNegative where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.DoubleNegative a -> Main.DoubleNegative b
-  map = \function value ->
-    case value of
-      (DoubleNegative field0) -> DoubleNegative @b
-        (cmap @Main.Predicate {contravariantPredicate} @(Main.Predicate a) @(Main.Predicate b)
-          (\element ->
-            cmap @Main.Predicate {contravariantPredicate} @b @a (\element -> function element)
-              element)
-          field0)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (DoubleNegative field0) -> DoubleNegative @b
+          (cmap @Main.Predicate {contravariantPredicate} @(Main.Predicate a) @(Main.Predicate b)
+            (\element ->
+              cmap @Main.Predicate {contravariantPredicate} @b @a (\element -> function element)
+                element)
+            field0)

--- a/tests-integration/fixtures/semantic/1785603960_derive_functor_profunctor_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785603960_derive_functor_profunctor_application_body/Main.snap
@@ -14,21 +14,23 @@ data DoubleInput @a
 dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
   dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) -> (c -> d) -> Main.Function b c -> Main.Function a d
-  dimap = \firstFunction secondFunction value ->
-    case value of
-      (Function field0) -> Function @a @d \argument ->
-        secondFunction (field0 (firstFunction argument))
+  dimap = \@a -> \@b -> \@c -> \@d ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Function field0) -> Function @a @d \argument ->
+          secondFunction (field0 (firstFunction argument))
 
 dictionary functorDoubleInput :: Data.Functor.Functor Main.DoubleInput where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.DoubleInput a -> Main.DoubleInput b
-  map = \function value ->
-    case value of
-      (DoubleInput field0) -> DoubleInput @b
-        (dimap @Main.Function {profunctorFunction} @(Main.Function b Prim.Int) @(Main.Function a Prim.Int) @Prim.Int @Prim.Int
-          (\element ->
-            dimap @Main.Function {profunctorFunction} @a @b @Prim.Int @Prim.Int
-              (\element -> function element)
-              (\unchanged -> unchanged)
-              element)
-          (\unchanged -> unchanged)
-          field0)
+  map = \@a -> \@b ->
+    \function value ->
+      case value of
+        (DoubleInput field0) -> DoubleInput @b
+          (dimap @Main.Function {profunctorFunction} @(Main.Function b Prim.Int) @(Main.Function a Prim.Int) @Prim.Int @Prim.Int
+            (\element ->
+              dimap @Main.Function {profunctorFunction} @a @b @Prim.Int @Prim.Int
+                (\element -> function element)
+                (\unchanged -> unchanged)
+                element)
+            (\unchanged -> unchanged)
+            field0)

--- a/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.purs
+++ b/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.purs
@@ -1,0 +1,16 @@
+module Main where
+
+foreign import unsafeCoerce :: forall a b. a -> b
+
+class Convert :: (Type -> Type) -> (Type -> Type) -> Constraint
+class Convert f g where
+  convert :: forall a. f a -> g a
+
+data F :: Type -> Type
+data F a
+
+data G :: Type -> Type
+data G a
+
+instance Convert F G where
+  convert = (unsafeCoerce :: forall a. F a -> G a)

--- a/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.purs
+++ b/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.purs
@@ -5,6 +5,11 @@ foreign import unsafeCoerce :: forall a b. a -> b
 class Convert :: (Type -> Type) -> (Type -> Type) -> Constraint
 class Convert f g where
   convert :: forall a. f a -> g a
+  convertExplicit :: forall a. f a -> g a
+
+class Clash :: (Type -> Type) -> Constraint
+class Clash f where
+  clash :: forall a. f a -> f a
 
 data F :: Type -> Type
 data F a
@@ -14,3 +19,15 @@ data G a
 
 instance Convert F G where
   convert = (unsafeCoerce :: forall a. F a -> G a)
+
+  convertExplicit :: forall a. F a -> G a
+  convertExplicit = (unsafeCoerce :: forall a. F a -> G a)
+
+instance Clash f where
+  clash :: forall a. f a -> f a
+  clash (value :: f a) =
+    case value of
+      (matched :: f a) -> local matched
+    where
+    local :: f a -> f a
+    local = unsafeCoerce

--- a/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.snap
+++ b/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.snap
@@ -6,6 +6,11 @@ expression: report
 interface Convert :: (Prim.Type -> Prim.Type) -> (Prim.Type -> Prim.Type) -> Prim.Constraint
 interface Convert f g where
   convert :: forall (a :: Prim.Type). f a -> g a
+  convertExplicit :: forall (a :: Prim.Type). f a -> g a
+
+interface Clash :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+interface Clash f where
+  clash :: forall (a :: Prim.Type). f a -> f a
 
 data F :: Prim.Type -> Prim.Type
 data F @a
@@ -17,4 +22,15 @@ foreign import unsafeCoerce :: forall a b. a -> b
 
 dictionary convertG :: Main.Convert Main.F Main.G where
   convert :: forall (a :: Prim.Type). Main.F a -> Main.G a
-  convert = (\@a -> unsafeCoerce @(Main.F a) @(Main.G a)) @a1
+  convert = \@a -> (\@a1 -> unsafeCoerce @(Main.F a1) @(Main.G a1)) @a
+  convertExplicit :: forall (a :: Prim.Type). Main.F a -> Main.G a
+  convertExplicit = \@a -> (\@a1 -> unsafeCoerce @(Main.F a1) @(Main.G a1)) @a
+
+dictionary clash1 :: forall f. Main.Clash f where
+  clash :: forall (a :: Prim.Type). f a -> f a
+  clash = \@a -> \(value :: f a) ->
+    case value of
+      (matched :: f a) -> local matched
+    where
+    local :: f a -> f a
+    local = unsafeCoerce @(f a) @(f a)

--- a/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.snap
+++ b/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Convert :: (Prim.Type -> Prim.Type) -> (Prim.Type -> Prim.Type) -> Prim.Constraint
+interface Convert f g where
+  convert :: forall (a :: Prim.Type). f a -> g a
+
+data F :: Prim.Type -> Prim.Type
+data F @a
+
+data G :: Prim.Type -> Prim.Type
+data G @a
+
+foreign import unsafeCoerce :: forall a b. a -> b
+
+dictionary convertG :: Main.Convert Main.F Main.G where
+  convert :: forall (a :: Prim.Type). Main.F a -> Main.G a
+  convert = (\@a -> unsafeCoerce @(Main.F a) @(Main.G a)) @a1

--- a/tests-integration/fixtures/semantic/1786336800_typed_expression_available_constraint/Main.purs
+++ b/tests-integration/fixtures/semantic/1786336800_typed_expression_available_constraint/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+class Value :: Type -> Constraint
+class Value a where
+  value :: a
+
+test :: Value Int => Int
+test = (value :: Value Int => Int)

--- a/tests-integration/fixtures/semantic/1786336800_typed_expression_available_constraint/Main.snap
+++ b/tests-integration/fixtures/semantic/1786336800_typed_expression_available_constraint/Main.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Value :: Prim.Type -> Prim.Constraint
+interface Value a where
+  value :: a
+
+test :: Main.Value Prim.Int => Prim.Int
+test = \{valueDict} -> (\{valueDict1} -> value @Prim.Int {valueDict1}) {valueDict}

--- a/tests-integration/fixtures/semantic/1786336800_typed_expression_constraint_scope/Main.purs
+++ b/tests-integration/fixtures/semantic/1786336800_typed_expression_constraint_scope/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+class Value :: Type -> Constraint
+class Value a where
+  value :: a
+
+test :: Int
+test = (value :: Value Int => Int)

--- a/tests-integration/fixtures/semantic/1786336800_typed_expression_constraint_scope/Main.snap
+++ b/tests-integration/fixtures/semantic/1786336800_typed_expression_constraint_scope/Main.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Value :: Prim.Type -> Prim.Constraint
+interface Value a where
+  value :: a
+
+test :: Prim.Int
+test = (\{valueDict} -> value @Prim.Int {valueDict}) {error}

--- a/tests-integration/fixtures/semantic/1786336800_typed_expression_nested_constraint/Main.purs
+++ b/tests-integration/fixtures/semantic/1786336800_typed_expression_nested_constraint/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+class Value :: Type -> Constraint
+class Value a
+
+constrainedIdentity :: forall a. Value a => a -> a
+constrainedIdentity value = value
+
+test :: forall a. Value a => a -> a
+test = (constrainedIdentity :: forall b. Value b => b -> b)

--- a/tests-integration/fixtures/semantic/1786336800_typed_expression_nested_constraint/Main.snap
+++ b/tests-integration/fixtures/semantic/1786336800_typed_expression_nested_constraint/Main.snap
@@ -7,7 +7,8 @@ interface Value :: Prim.Type -> Prim.Constraint
 interface Value a where
 
 constrainedIdentity :: forall a. Main.Value a => a -> a
-constrainedIdentity = \{valueDict} -> \value -> value
+constrainedIdentity = \@a -> \{valueDict} -> \value -> value
 
 test :: forall a. Main.Value a => a -> a
-test = \{valueDict} -> (\@b -> \{valueDict1} -> constrainedIdentity @b {valueDict1}) @a {valueDict}
+test = \@a -> \{valueDict} ->
+  (\@b -> \{valueDict1} -> constrainedIdentity @b {valueDict1}) @a {valueDict}

--- a/tests-integration/fixtures/semantic/1786336800_typed_expression_nested_constraint/Main.snap
+++ b/tests-integration/fixtures/semantic/1786336800_typed_expression_nested_constraint/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Value :: Prim.Type -> Prim.Constraint
+interface Value a where
+
+constrainedIdentity :: forall a. Main.Value a => a -> a
+constrainedIdentity = \{valueDict} -> \value -> value
+
+test :: forall a. Main.Value a => a -> a
+test = \{valueDict} -> (\@b -> \{valueDict1} -> constrainedIdentity @b {valueDict1}) @a {valueDict}


### PR DESCRIPTION
## Summary

Retain declaration-level abstractions on checked values, local declarations, and instance members. Each retained `forall` layer records both its source binder and the exact rigid used while checking the equations; constrained layers retain their evidence in the same ordered sequence. Generated derived members use the same representation.

Pretty-printing now scopes these abstractions over the complete equation body, and final zonking updates both retained binder kinds and rigid types without losing their identity. Semantic fixtures cover explicit and inferred values, local declarations, constrained signatures, nested abstractions, and polymorphic instance members.

## Motivation

PR #277 exposed a free member-signature rigid in the checked semantic tree:

```text
convert :: forall (a :: Prim.Type). Main.F a -> Main.G a
convert = (\@a -> unsafeCoerce @(Main.F a) @(Main.G a)) @a1
```

The checker created a fresh declaration/member rigid and used it throughout equation checking, but discarded the mapping from the signature's `ForallBinderId` afterward. Because Alexandrite retains explicit type abstractions and applications, the resulting checked tree had a rigid use with no retained owner.

The corrected representation preserves the mapping and scopes it over term binder types, guards, where bindings, local declarations, and RHS expressions. The example now renders as:

```text
convert :: forall (a :: Prim.Type). Main.F a -> Main.G a
convert = \@a -> (\@a1 -> unsafeCoerce @(Main.F a1) @(Main.G a1)) @a
```

## Verification

- `cargo check -p checking --tests`
- `cargo check -p tests-compatibility --tests`
- `cargo nextest run -p checking`
- `just t checking`
- `just t semantic`
- `just t lowering`
- `git diff --check origin/main..HEAD`

All affected integration categories passed with no pending snapshots.
