### PR TITLE
[checking] Check abstractions between grouped lambda binders

### DIFF
--- a/compiler-core/checking/src/source/terms/forms.rs
+++ b/compiler-core/checking/src/source/terms/forms.rs
@@ -1,7 +1,7 @@
 use building_types::QueryResult;
 
 use crate::context::CheckContext;
-use crate::core::{TypeId, exhaustive, toolkit, unification};
+use crate::core::{Type, TypeId, exhaustive, normalise, toolkit, unification};
 use crate::source::binder;
 use crate::source::terms::{ElaboratedExpression, application, guarded};
 use crate::state::CheckState;
@@ -148,6 +148,17 @@ where
     let mut remaining = expected;
 
     for &binder_id in binders.iter() {
+        if !arguments.is_empty() {
+            let expanded = normalise::expand(state, context, remaining)?;
+            let requires_abstraction = matches!(
+                context.lookup_type(expanded),
+                Type::Forall(_, _) | Type::Constrained(_, _)
+            );
+            if requires_abstraction {
+                break;
+            }
+        }
+
         let decomposed = toolkit::decompose_function(state, context, remaining)?;
         let argument = if let Some((argument, result)) = decomposed {
             let argument = if binder::requires_instantiation(context, binder_id) {
@@ -165,7 +176,12 @@ where
         checked_binders.push(checked_binder.binder);
     }
 
-    let body = if let Some(body) = expression {
+    let (current_binders, remaining_binders) = binders.split_at(arguments.len());
+    let body = if !remaining_binders.is_empty() {
+        super::check_expected_expression(state, context, remaining, |state, expected| {
+            check_lambda(state, context, remaining_binders, expression, expected)
+        })?
+    } else if let Some(body) = expression {
         super::check_expression(state, context, body, remaining)?
     } else {
         let type_id = state.fresh_unification(context.queries, context.prim.t);
@@ -175,7 +191,8 @@ where
 
     let function_type = context.intern_function_list(&arguments, body.type_id);
 
-    let exhaustiveness = exhaustive::check_lambda_patterns(state, context, &arguments, binders)?;
+    let exhaustiveness =
+        exhaustive::check_lambda_patterns(state, context, &arguments, current_binders)?;
 
     let has_missing = exhaustiveness.missing.is_some();
     state.report_exhaustiveness(exhaustiveness);

--- a/tests-integration/fixtures/checking/1786380060_higher_rank_lambda_passed_to_hoist_spec/Main.purs
+++ b/tests-integration/fixtures/checking/1786380060_higher_rank_lambda_passed_to_hoist_spec/Main.purs
@@ -1,0 +1,58 @@
+module Main where
+
+infixl 1 apply as #
+
+data Unit = Unit
+
+data First :: Type -> Type
+data First a = First
+
+data Second :: Type -> Type
+data Second a = Second
+
+data Third :: Type -> Type
+data Third a = Third
+
+data SpecT :: (Type -> Type) -> (Type -> Type) -> Type
+data SpecT effect monad = SpecT
+
+type NaturalTransformation f g = forall a. f a -> g a
+
+identity :: forall a. a -> a
+identity x = x
+
+apply :: forall a b. a -> (a -> b) -> b
+apply x function = function x
+
+describe :: forall effect monad. String -> SpecT effect monad -> SpecT effect monad
+describe _ specification = specification
+
+it :: forall effect monad. String -> effect Unit -> SpecT effect monad
+it _ _ = SpecT
+
+hoistSpec
+  :: forall first second monad monad'
+   . NaturalTransformation monad monad'
+  -> (Unit -> NaturalTransformation first second)
+  -> SpecT first monad
+  -> SpecT second monad'
+hoistSpec _ _ _ = SpecT
+
+catchFirst :: NaturalTransformation First Second
+catchFirst _ = Second
+
+catchSecond :: NaturalTransformation Second Third
+catchSecond _ = Third
+
+runExample :: First Unit
+runExample = First
+
+spec :: SpecT Third First
+spec =
+  describe "outer" do
+    it "inner" runExample
+    # hoistSpec identity
+        ( \_ value -> value
+            # catchFirst
+            # catchSecond
+        )

--- a/tests-integration/fixtures/checking/1786380060_higher_rank_lambda_passed_to_hoist_spec/Main.snap
+++ b/tests-integration/fixtures/checking/1786380060_higher_rank_lambda_passed_to_hoist_spec/Main.snap
@@ -66,20 +66,3 @@ First = [Phantom]
 Second = [Phantom]
 Third = [Phantom]
 SpecT = [Phantom, Phantom]
-
-Diagnostics
-error[CannotUnify]: Cannot unify 'Third' with 'Function (First (a :: Type))'
-  --> 55:23..57:26
-   |
-55 |         ( \_ value -> value
-   |                       ^~~~~
-error[CannotUnify]: Cannot unify 'Third ?53' with 'Function (First (a :: Type)) (Third (a :: Type))'
-  --> 55:23..57:26
-   |
-55 |         ( \_ value -> value
-   |                       ^~~~~
-error[CannotUnify]: Cannot unify 'Third ?53' with 'First (a :: Type) -> Third (a :: Type)'
-  --> 55:23..57:26
-   |
-55 |         ( \_ value -> value
-   |                       ^~~~~

--- a/tests-integration/fixtures/checking/1786380060_higher_rank_lambda_passed_to_hoist_spec/Main.snap
+++ b/tests-integration/fixtures/checking/1786380060_higher_rank_lambda_passed_to_hoist_spec/Main.snap
@@ -1,0 +1,85 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+# ::
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    (a :: Prim.Type) -> ((a :: Prim.Type) -> (b :: Prim.Type)) -> (b :: Prim.Type)
+Unit :: Main.Unit
+First :: forall (@a :: Prim.Type). Main.First (a :: Prim.Type)
+Second :: forall (@a :: Prim.Type). Main.Second (a :: Prim.Type)
+Third :: forall (@a :: Prim.Type). Main.Third (a :: Prim.Type)
+SpecT ::
+  forall (@effect :: Prim.Type -> Prim.Type) (@monad :: Prim.Type -> Prim.Type).
+    Main.SpecT (effect :: Prim.Type -> Prim.Type) (monad :: Prim.Type -> Prim.Type)
+identity :: forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)
+apply ::
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    (a :: Prim.Type) -> ((a :: Prim.Type) -> (b :: Prim.Type)) -> (b :: Prim.Type)
+describe ::
+  forall (effect :: Prim.Type -> Prim.Type) (monad :: Prim.Type -> Prim.Type).
+    Prim.String ->
+    Main.SpecT (effect :: Prim.Type -> Prim.Type) (monad :: Prim.Type -> Prim.Type) ->
+    Main.SpecT (effect :: Prim.Type -> Prim.Type) (monad :: Prim.Type -> Prim.Type)
+it ::
+  forall (effect :: Prim.Type -> Prim.Type) (monad :: Prim.Type -> Prim.Type).
+    Prim.String ->
+    (effect :: Prim.Type -> Prim.Type) Main.Unit ->
+    Main.SpecT (effect :: Prim.Type -> Prim.Type) (monad :: Prim.Type -> Prim.Type)
+hoistSpec ::
+  forall (first :: Prim.Type -> Prim.Type) (second :: Prim.Type -> Prim.Type)
+    (monad :: Prim.Type -> Prim.Type) (monad' :: Prim.Type -> Prim.Type).
+    Main.NaturalTransformation @Prim.Type
+      (monad :: Prim.Type -> Prim.Type)
+      (monad' :: Prim.Type -> Prim.Type) ->
+    (Main.Unit ->
+    Main.NaturalTransformation @Prim.Type
+      (first :: Prim.Type -> Prim.Type)
+      (second :: Prim.Type -> Prim.Type)) ->
+    Main.SpecT (first :: Prim.Type -> Prim.Type) (monad :: Prim.Type -> Prim.Type) ->
+    Main.SpecT (second :: Prim.Type -> Prim.Type) (monad' :: Prim.Type -> Prim.Type)
+catchFirst :: Main.NaturalTransformation @Prim.Type Main.First Main.Second
+catchSecond :: Main.NaturalTransformation @Prim.Type Main.Second Main.Third
+runExample :: Main.First Main.Unit
+spec :: Main.SpecT Main.Third Main.First
+
+Types
+Unit :: Prim.Type
+First :: Prim.Type -> Prim.Type
+Second :: Prim.Type -> Prim.Type
+Third :: Prim.Type -> Prim.Type
+SpecT :: (Prim.Type -> Prim.Type) -> (Prim.Type -> Prim.Type) -> Prim.Type
+NaturalTransformation ::
+  forall (t0 :: Prim.Type).
+    ((t0 :: Prim.Type) -> Prim.Type) -> ((t0 :: Prim.Type) -> Prim.Type) -> Prim.Type
+
+Synonyms
+type NaturalTransformation f g = forall (a :: (t0 :: Prim.Type)).
+  (f :: (t0 :: Prim.Type) -> Prim.Type) (a :: (t0 :: Prim.Type)) ->
+  (g :: (t0 :: Prim.Type) -> Prim.Type) (a :: (t0 :: Prim.Type))
+
+Roles
+Unit = []
+First = [Phantom]
+Second = [Phantom]
+Third = [Phantom]
+SpecT = [Phantom, Phantom]
+
+Diagnostics
+error[CannotUnify]: Cannot unify 'Third' with 'Function (First (a :: Type))'
+  --> 55:23..57:26
+   |
+55 |         ( \_ value -> value
+   |                       ^~~~~
+error[CannotUnify]: Cannot unify 'Third ?53' with 'Function (First (a :: Type)) (Third (a :: Type))'
+  --> 55:23..57:26
+   |
+55 |         ( \_ value -> value
+   |                       ^~~~~
+error[CannotUnify]: Cannot unify 'Third ?53' with 'First (a :: Type) -> Third (a :: Type)'
+  --> 55:23..57:26
+   |
+55 |         ( \_ value -> value
+   |                       ^~~~~

--- a/tests-integration/fixtures/semantic/1786380720_higher_rank_grouped_lambda_binders/Main.purs
+++ b/tests-integration/fixtures/semantic/1786380720_higher_rank_grouped_lambda_binders/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+data Unit = Unit
+
+class Identity value
+
+foreign import consume :: (Unit -> forall value. Identity value => value -> value) -> Unit
+
+test :: Unit
+test = consume \_ value -> value

--- a/tests-integration/fixtures/semantic/1786380720_higher_rank_grouped_lambda_binders/Main.snap
+++ b/tests-integration/fixtures/semantic/1786380720_higher_rank_grouped_lambda_binders/Main.snap
@@ -13,4 +13,4 @@ interface Identity value where
 foreign import consume :: (Main.Unit -> (forall value. Main.Identity @Prim.Type value => value -> value)) -> Main.Unit
 
 test :: Main.Unit
-test = consume \_ value -> \@value -> \{identityDict} -> value
+test = consume \_ -> \@value -> \{identityDict} -> \value -> value

--- a/tests-integration/fixtures/semantic/1786380720_higher_rank_grouped_lambda_binders/Main.snap
+++ b/tests-integration/fixtures/semantic/1786380720_higher_rank_grouped_lambda_binders/Main.snap
@@ -1,0 +1,16 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Unit :: Prim.Type
+data Unit
+  | Unit :: Main.Unit
+
+interface Identity :: forall (k0 :: Prim.Type). k0 -> Prim.Constraint
+interface Identity value where
+
+foreign import consume :: (Main.Unit -> (forall value. Main.Identity @Prim.Type value => value -> value)) -> Main.Unit
+
+test :: Main.Unit
+test = consume \_ value -> \@value -> \{identityDict} -> value


### PR DESCRIPTION
## Summary

When a grouped lambda is checked against a type such as `Unit -> forall a. First a -> Third a`, the checker previously consumed every term binder before introducing the nested type abstraction. The binder after the `forall` therefore received an unrelated unification type and produced false `CannotUnify` diagnostics.

Split grouped lambda checking when a nested `forall` or constrained type is encountered, then check the remaining binders beneath the corresponding type or evidence abstraction. Each resulting lambda segment now runs exhaustiveness checking against only its own source binders.

The commit stack first records the incorrect checking diagnostics and semantic elaboration, then applies the fix and updates both snapshots.

Fixes #286.

## Verification

- `just t checking`
- `just t semantic`
- `cargo nextest run -p checking`
- `cargo check -p checking --tests`