### PR TITLE
[checking] Reject lambda binders after non-function types

### DIFF
--- a/compiler-core/checking/src/source/terms/forms.rs
+++ b/compiler-core/checking/src/source/terms/forms.rs
@@ -169,7 +169,13 @@ where
             remaining = result;
             argument
         } else {
-            state.fresh_unification(context.queries, context.prim.t)
+            let argument = state.fresh_unification(context.queries, context.prim.t);
+            let result = state.fresh_unification(context.queries, context.prim.t);
+            let function = context.intern_function(argument, result);
+
+            unification::subtype(state, context, function, remaining)?;
+            remaining = result;
+            argument
         };
         let checked_binder = binder::check_binder(state, context, binder_id, argument)?;
         arguments.push(argument);

--- a/tests-integration/fixtures/checking/1786461240_lambda_against_non_function_expected_type/Main.purs
+++ b/tests-integration/fixtures/checking/1786461240_lambda_against_non_function_expected_type/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+data Unit = Unit
+
+foreign import consume :: Int -> Unit
+
+test :: Unit
+test = consume (\value -> 0)

--- a/tests-integration/fixtures/checking/1786461240_lambda_against_non_function_expected_type/Main.snap
+++ b/tests-integration/fixtures/checking/1786461240_lambda_against_non_function_expected_type/Main.snap
@@ -13,3 +13,10 @@ Unit :: Prim.Type
 
 Roles
 Unit = []
+
+Diagnostics
+error[CannotUnify]: Cannot unify '?0 -> Int' with 'Int'
+  --> 8:17..8:28
+  |
+8 | test = consume (\value -> 0)
+  |                 ^~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786461240_lambda_against_non_function_expected_type/Main.snap
+++ b/tests-integration/fixtures/checking/1786461240_lambda_against_non_function_expected_type/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Unit :: Main.Unit
+consume :: Prim.Int -> Main.Unit
+test :: Main.Unit
+
+Types
+Unit :: Prim.Type
+
+Roles
+Unit = []

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_constraint/Main.purs
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_constraint/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+data Unit = Unit
+
+class Marker :: Type -> Constraint
+class Marker value
+
+foreign import consume :: (Unit -> Marker Int => Int) -> Unit
+
+test :: Unit
+test = consume \_ extra -> 0

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_constraint/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Unit :: Main.Unit
+consume :: (Main.Unit -> (Main.Marker Prim.Int => Prim.Int)) -> Main.Unit
+test :: Main.Unit
+
+Types
+Unit :: Prim.Type
+Marker :: Prim.Type -> Prim.Constraint
+
+Classes
+class forall (value :: Prim.Type). Main.Marker (value :: Prim.Type)
+
+Roles
+Unit = []

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_constraint/Main.snap
@@ -17,3 +17,10 @@ class forall (value :: Prim.Type). Main.Marker (value :: Prim.Type)
 
 Roles
 Unit = []
+
+Diagnostics
+error[CannotUnify]: Cannot unify '?0 -> Int' with 'Int'
+  --> 11:16..11:29
+   |
+11 | test = consume \_ extra -> 0
+   |                ^~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_forall/Main.purs
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_forall/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+data Unit = Unit
+
+data Proxy :: Type -> Type
+data Proxy value = Proxy
+
+foreign import consume :: (Unit -> forall value. Proxy value) -> Unit
+
+test :: Unit
+test = consume \_ extra -> Proxy

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_forall/Main.snap
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_forall/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Unit :: Main.Unit
+Proxy :: forall (@value :: Prim.Type). Main.Proxy (value :: Prim.Type)
+consume ::
+  (Main.Unit -> (forall (value :: Prim.Type). Main.Proxy (value :: Prim.Type))) -> Main.Unit
+test :: Main.Unit
+
+Types
+Unit :: Prim.Type
+Proxy :: Prim.Type -> Prim.Type
+
+Roles
+Unit = []
+Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_forall/Main.snap
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_forall/Main.snap
@@ -17,3 +17,20 @@ Proxy :: Prim.Type -> Prim.Type
 Roles
 Unit = []
 Proxy = [Phantom]
+
+Diagnostics
+error[CannotUnify]: Cannot unify 'Function ?1' with 'Proxy'
+  --> 11:16..11:33
+   |
+11 | test = consume \_ extra -> Proxy
+   |                ^~~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify 'Function ?1 (Proxy ?3)' with 'Proxy (value :: Type)'
+  --> 11:16..11:33
+   |
+11 | test = consume \_ extra -> Proxy
+   |                ^~~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify '?1 -> Proxy ?3' with 'Proxy (value :: Type)'
+  --> 11:16..11:33
+   |
+11 | test = consume \_ extra -> Proxy
+   |                ^~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_function/Main.purs
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_function/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+data Unit = Unit
+
+foreign import consume :: (Int -> Int) -> Unit
+
+test :: Unit
+test = consume \value extra -> value

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_function/Main.snap
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_function/Main.snap
@@ -13,3 +13,10 @@ Unit :: Prim.Type
 
 Roles
 Unit = []
+
+Diagnostics
+error[CannotUnify]: Cannot unify '?0 -> Int' with 'Int'
+  --> 8:16..8:37
+  |
+8 | test = consume \value extra -> value
+  |                ^~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_function/Main.snap
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_function/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Unit :: Main.Unit
+consume :: (Prim.Int -> Prim.Int) -> Main.Unit
+test :: Main.Unit
+
+Types
+Unit :: Prim.Type
+
+Roles
+Unit = []

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_interleaved_forall_constraint/Main.purs
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_interleaved_forall_constraint/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+data Unit = Unit
+
+data Proxy :: Type -> Type
+data Proxy value = Proxy
+
+class Marker :: Type -> Constraint
+class Marker value
+
+foreign import consume ::
+  (Unit -> forall value. Marker value => Proxy value) -> Unit
+
+test :: Unit
+test = consume \_ extra -> Proxy

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_interleaved_forall_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_interleaved_forall_constraint/Main.snap
@@ -24,3 +24,20 @@ class forall (value :: Prim.Type). Main.Marker (value :: Prim.Type)
 Roles
 Unit = []
 Proxy = [Phantom]
+
+Diagnostics
+error[CannotUnify]: Cannot unify 'Function ?1' with 'Proxy'
+  --> 15:16..15:33
+   |
+15 | test = consume \_ extra -> Proxy
+   |                ^~~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify 'Function ?1 (Proxy ?3)' with 'Proxy (value :: Type)'
+  --> 15:16..15:33
+   |
+15 | test = consume \_ extra -> Proxy
+   |                ^~~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify '?1 -> Proxy ?3' with 'Proxy (value :: Type)'
+  --> 15:16..15:33
+   |
+15 | test = consume \_ extra -> Proxy
+   |                ^~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_interleaved_forall_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_interleaved_forall_constraint/Main.snap
@@ -1,0 +1,26 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Unit :: Main.Unit
+Proxy :: forall (@value :: Prim.Type). Main.Proxy (value :: Prim.Type)
+consume ::
+  (Main.Unit ->
+  (forall (value :: Prim.Type).
+    Main.Marker (value :: Prim.Type) => Main.Proxy (value :: Prim.Type))) ->
+  Main.Unit
+test :: Main.Unit
+
+Types
+Unit :: Prim.Type
+Proxy :: Prim.Type -> Prim.Type
+Marker :: Prim.Type -> Prim.Constraint
+
+Classes
+class forall (value :: Prim.Type). Main.Marker (value :: Prim.Type)
+
+Roles
+Unit = []
+Proxy = [Phantom]


### PR DESCRIPTION
## Summary

- report function-type mismatches when expression lambdas have source binders after the residual expected type stops being a function
- constrain failed lambda decomposition with a fresh function shape and continue recovery through its fresh result
- cover direct, ordinary-arrow, `forall`, constraint, and interleaved `forall`/constraint cases with separate checking fixtures

## Stack

This pull request is based on and depends on #287 so the post-`forall` and post-constraint fixtures exercise recursive abstraction checking. It preserves that pull request’s abstraction ordering and per-segment exhaustiveness scoping.

Fixes #288.

## Verification

- `just t checking 1786461240_lambda`
- `cargo check -p checking --tests`
- `just t checking`
- `just t semantic 1786380720_higher_rank_grouped_lambda_binders`