### PR TITLE
[checking] Preserve scoped rigid depths in source types

### DIFF
--- a/compiler-core/checking/src/core/substitute.rs
+++ b/compiler-core/checking/src/core/substitute.rs
@@ -7,7 +7,7 @@ use building_types::QueryResult;
 use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::fold::{FoldAction, TypeFold, fold_type};
-use crate::core::{Name, Type, TypeId};
+use crate::core::{Depth, Name, Type, TypeId};
 use crate::state::CheckState;
 
 pub type NameToType = FxHashMap<Name, TypeId>;
@@ -15,6 +15,7 @@ pub type NameToType = FxHashMap<Name, TypeId>;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct RigidReplacement {
     name: Name,
+    depth: Depth,
     type_id: TypeId,
 }
 
@@ -32,10 +33,10 @@ impl RigidRenaming {
     where
         Q: ExternalQueries,
     {
-        let Type::Rigid(name, _, _) = context.lookup_type(replacement) else {
+        let Type::Rigid(name, depth, _) = context.lookup_type(replacement) else {
             unreachable!("invariant violated: expected a rigid variable");
         };
-        let replacement = RigidReplacement { name, type_id: replacement };
+        let replacement = RigidReplacement { name, depth, type_id: replacement };
         self.replacements.insert(original, replacement);
     }
 
@@ -51,8 +52,8 @@ impl RigidRenaming {
         fold_type(state, context, in_type, &mut SubstituteRigidName { renaming: self })
     }
 
-    pub(crate) fn replacement_name(&self, original: Name) -> Option<Name> {
-        self.replacements.get(&original).map(|replacement| replacement.name)
+    pub(crate) fn replacement(&self, original: Name) -> Option<(Name, Depth)> {
+        self.replacements.get(&original).map(|replacement| (replacement.name, replacement.depth))
     }
 }
 

--- a/compiler-core/checking/src/source/type_items.rs
+++ b/compiler-core/checking/src/source/type_items.rs
@@ -388,7 +388,7 @@ where
 
         let name = state.names.fresh();
         state.checked.node_types.forall_bindings.insert(equation_binding.id, kind);
-        state.bindings.bind_forall(equation_binding.id, name, kind);
+        state.bindings.bind_forall(equation_binding.id, name, state.depth, kind);
 
         let text = if let Some(name) = &equation_binding.name {
             SmolStr::clone(name)

--- a/compiler-core/checking/src/source/types.rs
+++ b/compiler-core/checking/src/source/types.rs
@@ -261,7 +261,7 @@ where
                     .lookup_source_type_variable(context, SourceTypeVariableKey::Forall(*forall))?
                     .expect("invariant violated: KindScope::bind_forall");
 
-                let t = context.intern_rigid(variable.name, state.depth, variable.kind);
+                let t = context.intern_rigid(variable.name, variable.depth, variable.kind);
 
                 Ok((t, variable.kind))
             }
@@ -278,7 +278,7 @@ where
                         state.checked.names.insert(n, text);
                     }
 
-                    state.bindings.bind_implicit(implicit.node, implicit.id, n, k);
+                    state.bindings.bind_implicit(implicit.node, implicit.id, n, state.depth, k);
                     state
                         .checked
                         .node_types
@@ -293,7 +293,7 @@ where
                         .lookup_source_type_variable(context, key)?
                         .expect("invariant violated: KindScope::bind_implicit");
 
-                    let t = context.intern_rigid(variable.name, state.depth, variable.kind);
+                    let t = context.intern_rigid(variable.name, variable.depth, variable.kind);
 
                     Ok((t, variable.kind))
                 }
@@ -493,7 +493,7 @@ where
 
     state.checked.names.insert(name, text);
     state.checked.node_types.forall_bindings.insert(binding.id, kind);
-    state.bindings.bind_forall(binding.id, name, kind);
+    state.bindings.bind_forall(binding.id, name, state.depth, kind);
     Ok(ForallBinder { visible, name, kind })
 }
 

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -116,21 +116,23 @@ pub(crate) enum SourceTypeVariableKey {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SourceTypeVariable {
     pub(crate) name: Name,
+    pub(crate) depth: Depth,
     pub(crate) kind: TypeId,
 }
 
 impl Bindings {
-    fn bind(&mut self, key: SourceTypeVariableKey, name: Name, kind: TypeId) {
-        self.variables.insert(key, SourceTypeVariable { name, kind });
+    fn bind(&mut self, key: SourceTypeVariableKey, name: Name, depth: Depth, kind: TypeId) {
+        self.variables.insert(key, SourceTypeVariable { name, depth, kind });
     }
 
     pub(crate) fn bind_forall(
         &mut self,
         id: lowering::TypeVariableBindingId,
         name: Name,
+        depth: Depth,
         kind: TypeId,
     ) {
-        self.bind(SourceTypeVariableKey::Forall(id), name, kind);
+        self.bind(SourceTypeVariableKey::Forall(id), name, depth, kind);
     }
 
     pub(crate) fn bind_implicit(
@@ -138,9 +140,10 @@ impl Bindings {
         node: lowering::GraphNodeId,
         id: lowering::ImplicitBindingId,
         name: Name,
+        depth: Depth,
         kind: TypeId,
     ) {
-        self.bind(SourceTypeVariableKey::Implicit { node, id }, name, kind);
+        self.bind(SourceTypeVariableKey::Implicit { node, id }, name, depth, kind);
     }
 
     pub(crate) fn lookup(&self, key: SourceTypeVariableKey) -> Option<SourceTypeVariable> {
@@ -378,8 +381,9 @@ impl CheckState {
 
         for renaming in Vec::clone(&self.bindings.renamings) {
             variable.kind = renaming.substitute(self, context, variable.kind)?;
-            if let Some(name) = renaming.replacement_name(variable.name) {
+            if let Some((name, depth)) = renaming.replacement(variable.name) {
                 variable.name = name;
+                variable.depth = depth;
             }
         }
 

--- a/tests-integration/fixtures/checking/1786465440_higher_rank_lambda_preserves_outer_scoped_variable/Main.purs
+++ b/tests-integration/fixtures/checking/1786465440_higher_rank_lambda_preserves_outer_scoped_variable/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+foreign import value :: forall a. a
+
+newtype Packed = Packed (forall r. (forall z. z -> r) -> r)
+
+recover :: forall a. Packed -> a
+recover (Packed run) = run (\_ -> value :: a)

--- a/tests-integration/fixtures/checking/1786465440_higher_rank_lambda_preserves_outer_scoped_variable/Main.snap
+++ b/tests-integration/fixtures/checking/1786465440_higher_rank_lambda_preserves_outer_scoped_variable/Main.snap
@@ -16,10 +16,3 @@ Packed :: Prim.Type
 
 Roles
 Packed = []
-
-Diagnostics
-error[CannotUnify]: Cannot unify '(a :: Type)' with '(a :: Type)'
-  --> 8:35..8:45
-  |
-8 | recover (Packed run) = run (\_ -> value :: a)
-  |                                   ^~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786465440_higher_rank_lambda_preserves_outer_scoped_variable/Main.snap
+++ b/tests-integration/fixtures/checking/1786465440_higher_rank_lambda_preserves_outer_scoped_variable/Main.snap
@@ -1,0 +1,25 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+value :: forall (a :: Prim.Type). (a :: Prim.Type)
+Packed ::
+  (forall (r :: Prim.Type).
+    (forall (z :: Prim.Type). (z :: Prim.Type) -> (r :: Prim.Type)) -> (r :: Prim.Type)) ->
+  Main.Packed
+recover :: forall (a :: Prim.Type). Main.Packed -> (a :: Prim.Type)
+
+Types
+Packed :: Prim.Type
+
+Roles
+Packed = []
+
+Diagnostics
+error[CannotUnify]: Cannot unify '(a :: Type)' with '(a :: Type)'
+  --> 8:35..8:45
+  |
+8 | recover (Packed run) = run (\_ -> value :: a)
+  |                                   ^~~~~~~~~~


### PR DESCRIPTION
## Summary

- retain the binding depth of source type variables alongside their rigid name and kind
- carry replacement rigid depths through active source-variable renamings
- reconstruct explicit and implicit source type variables at their binding depth instead of the current nested checking depth
- add a regression fixture for an outer scoped variable referenced inside a rank-N lambda

## Motivation

Source type variables previously retained only a rigid name and kind. During checking, active rigid renamings replaced the name, but source occurrences reconstructed the rigid at the current checker depth. An occurrence beneath a higher-rank `forall` could therefore give an outer rigid variable an incorrectly deeper scope, triggering the skolem-escape guard and producing a contradictory diagnostic such as `Cannot unify '(a :: Type)' with '(a :: Type)'`.

This change preserves the rigid's original or replacement depth. The unification and skolem-escape rules remain unchanged, so genuinely escaping higher-rank variables are still rejected.

## Verification

- `just t checking 1786465440 1785433380 1785435780 1778816760 1786380060 1786297500 1784872200`
- `cargo check -p checking --tests`
- `cargo nextest run -p checking`
- `just t checking`
- `just t semantic`

### Package set 80.3.1

The release-mode acme corpus was checked at the exact PR head:

```text
cargo run -p tests-compatibility --release -- verify --package-set 80.3.1 --preset acme --json-output target/compatibility/scoped-rigid-acme-80.3.1.json
```

The verifier covered 630 packages and 7,344 source files. The scoped-rigid `CannotUnify` diagnostics were eliminated from `dissect`, `open-pairing`, and `webb-aff-list`. Eight diagnostics each remain in `foreign-object` and `js-maps`; those occur at `mutate` call sites whose expected rank-2 type is supplied by a typed declaration and require the separate `Typed` expression checking-rule fix, which is intentionally outside this PR.

The command exited 1 with 26 checking errors across seven packages, including those 16 typed-expression diagnostics and unrelated instance/deriving failures. It also reported three missing-package verifier entries (`elmish-hooks`, `elmish-time-machine`, and `morello`).