### PR TITLE
[checking] Use annotation types for typed expressions

### DIFF
--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -365,7 +365,8 @@ where
             };
 
             let (t, _) = types::infer_kind(state, context, *t)?;
-            check_expression(state, context, *e, t)
+            let ElaboratedExpression { expression, .. } = check_expression(state, context, *e, t)?;
+            Ok(ElaboratedExpression { type_id: t, expression })
         }
 
         lowering::ExpressionKind::OperatorChain { .. } => {

--- a/tests-integration/fixtures/checking/1786466700_coercible_annotated_polymorphic_result/Main.purs
+++ b/tests-integration/fixtures/checking/1786466700_coercible_annotated_polymorphic_result/Main.purs
@@ -1,0 +1,18 @@
+module Main where
+
+import Data.Unit (Unit)
+import Safe.Coerce (coerce)
+
+data Map :: Type -> Type -> Type
+data Map key value = Map
+
+newtype Set :: Type -> Type
+newtype Set value = Set (Map value Unit)
+
+foreign import filterKeys
+  :: forall key
+   . (key -> Boolean)
+  -> (forall value. Map key value -> Map key value)
+
+filter :: forall value. (value -> Boolean) -> Set value -> Set value
+filter = coerce (filterKeys :: _ -> Map value Unit -> _)

--- a/tests-integration/fixtures/checking/1786466700_coercible_annotated_polymorphic_result/Main.snap
+++ b/tests-integration/fixtures/checking/1786466700_coercible_annotated_polymorphic_result/Main.snap
@@ -1,0 +1,40 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Map ::
+  forall (@key :: Prim.Type) (@value :: Prim.Type). Main.Map (key :: Prim.Type) (value :: Prim.Type)
+Set ::
+  forall (@value :: Prim.Type).
+    Main.Map (value :: Prim.Type) Data.Unit.Unit -> Main.Set (value :: Prim.Type)
+filterKeys ::
+  forall (key :: Prim.Type).
+    ((key :: Prim.Type) -> Prim.Boolean) ->
+    (forall (value :: Prim.Type).
+      Main.Map (key :: Prim.Type) (value :: Prim.Type) ->
+      Main.Map (key :: Prim.Type) (value :: Prim.Type))
+filter ::
+  forall (value :: Prim.Type).
+    ((value :: Prim.Type) -> Prim.Boolean) ->
+    Main.Set (value :: Prim.Type) ->
+    Main.Set (value :: Prim.Type)
+
+Types
+Map :: Prim.Type -> Prim.Type -> Prim.Type
+Set :: Prim.Type -> Prim.Type
+
+Roles
+Map = [Phantom, Phantom]
+Set = [Representational]
+
+Diagnostics
+error[NoInstanceFound]: No instance found for: Coercible @Type
+  (forall (value :: Type).
+    Map (value1 :: Type) (value :: Type) -> Map (value1 :: Type) (value :: Type))
+  (Set (value1 :: Type) -> Set (value1 :: Type))
+  --> 17:1..17:69
+   |
+17 | filter :: forall value. (value -> Boolean) -> Set value -> Set value
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786466700_coercible_annotated_polymorphic_result/Main.snap
+++ b/tests-integration/fixtures/checking/1786466700_coercible_annotated_polymorphic_result/Main.snap
@@ -28,13 +28,3 @@ Set :: Prim.Type -> Prim.Type
 Roles
 Map = [Phantom, Phantom]
 Set = [Representational]
-
-Diagnostics
-error[NoInstanceFound]: No instance found for: Coercible @Type
-  (forall (value :: Type).
-    Map (value1 :: Type) (value :: Type) -> Map (value1 :: Type) (value :: Type))
-  (Set (value1 :: Type) -> Set (value1 :: Type))
-  --> 17:1..17:69
-   |
-17 | filter :: forall value. (value -> Boolean) -> Set value -> Set value
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

- make typed expressions expose their elaborated annotation type after checking
- preserve the checked elaborated expression while preventing its pre-annotation polymorphic type from leaking outward
- add an ordered-collections regression fixture for a partially annotated polymorphic result used with `Coercible`

## Motivation

The `Typed` inference rule elaborated an annotation and checked the underlying expression against it, but then returned the checked expression's original inferred type. For annotations containing wildcards, checking correctly constrained those wildcards, yet an underlying nested `forall` could still be exposed to the enclosing expression.

This caused the valid shape used by `Data.Set.filter` in `ordered-collections` to produce a `NoInstanceFound` diagnostic: the coercion solver saw the original polymorphic `Map` transformation instead of the annotation-constrained `Map a Unit -> Map a Unit` type.

The rule now keeps the checked expression node and returns the elaborated annotation as the typed expression's type. The regression snapshot changes only by removing the erroneous coercion diagnostic.

## Validation

- `just t checking 1786466700`
- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (30 passed)
- `just t checking`
- `just t semantic`
- `just format`
- `cargo fmt --all --check`
- `git diff --check`
