### PR TITLE
[tests] Report package compatibility regressions in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -48,6 +48,124 @@ jobs:
       - name: Run integration tests
         run: cargo nextest run -p tests-integration
 
+  compatibility:
+    name: Package compatibility
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout candidate revision
+        uses: actions/checkout@v7
+        with:
+          path: candidate
+
+      - name: Checkout base revision
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Install Rust toolchain
+        run: rustup update stable && rustup default stable
+
+      - name: Build compatibility verifiers
+        run: |
+          cargo build --manifest-path base/Cargo.toml -p tests-compatibility
+          cargo build --manifest-path candidate/Cargo.toml -p tests-compatibility
+
+      - name: Prepare core and Acme corpus
+        working-directory: candidate
+        run: target/debug/tests-compatibility prepare --preset core --preset acme
+
+      - name: Collect base and candidate reports
+        id: reports
+        env:
+          CORPUS_DIR: ${{ github.workspace }}/candidate/target/compatibility
+          REPORT_DIR: ${{ github.workspace }}/compatibility-artifacts
+        run: |
+          mkdir -p "$REPORT_DIR"
+
+          # Status 1 is a valid verifier report containing diagnostics; status 2 is an execution failure.
+          set +e
+          (
+            cd base
+            target/debug/tests-compatibility verify \
+              --preset core \
+              --preset acme \
+              --registry-dir "$CORPUS_DIR/registry" \
+              --index-dir "$CORPUS_DIR/registry-index" \
+              --cache-dir "$CORPUS_DIR" \
+              --json-output "$REPORT_DIR/base.json"
+          ) > "$REPORT_DIR/base.log" 2>&1
+          base_status=$?
+
+          (
+            cd candidate
+            target/debug/tests-compatibility verify \
+              --preset core \
+              --preset acme \
+              --registry-dir "$CORPUS_DIR/registry" \
+              --index-dir "$CORPUS_DIR/registry-index" \
+              --cache-dir "$CORPUS_DIR" \
+              --json-output "$REPORT_DIR/candidate.json"
+          ) > "$REPORT_DIR/candidate.log" 2>&1
+          candidate_status=$?
+          set -e
+
+          echo "base_status=$base_status" >> "$GITHUB_OUTPUT"
+          echo "candidate_status=$candidate_status" >> "$GITHUB_OUTPUT"
+
+      - name: Compare compatibility reports
+        id: comparison
+        env:
+          REPORT_DIR: ${{ github.workspace }}/compatibility-artifacts
+        run: |
+          set +e
+          candidate/target/debug/tests-compatibility compare \
+            --base-report "$REPORT_DIR/base.json" \
+            --candidate-report "$REPORT_DIR/candidate.json" \
+            --json-output "$REPORT_DIR/comparison.json" \
+            --summary-output "$GITHUB_STEP_SUMMARY" \
+            --github-annotations \
+            2>&1 | tee "$REPORT_DIR/comparison.log"
+          comparison_status=${PIPESTATUS[0]}
+          set -e
+
+          echo "status=$comparison_status" >> "$GITHUB_OUTPUT"
+
+      - name: Upload compatibility reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: compatibility-reports
+          path: compatibility-artifacts
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Enforce compatibility result
+        if: always()
+        env:
+          BASE_STATUS: ${{ steps.reports.outputs.base_status }}
+          CANDIDATE_STATUS: ${{ steps.reports.outputs.candidate_status }}
+          COMPARISON_STATUS: ${{ steps.comparison.outputs.status }}
+        run: |
+          # Preserve verifier status 1 for comparison, then fail only for execution failures or regressions.
+          if [[ "$BASE_STATUS" != "0" && "$BASE_STATUS" != "1" ]]; then
+            echo "::error::Base compatibility verifier failed with status ${BASE_STATUS:-missing}"
+            exit 1
+          fi
+          if [[ "$CANDIDATE_STATUS" != "0" && "$CANDIDATE_STATUS" != "1" ]]; then
+            echo "::error::Candidate compatibility verifier failed with status ${CANDIDATE_STATUS:-missing}"
+            exit 1
+          fi
+          if [[ "$COMPARISON_STATUS" != "0" && "$COMPARISON_STATUS" != "1" ]]; then
+            echo "::error::Compatibility report comparison failed with status ${COMPARISON_STATUS:-missing}"
+            exit 1
+          fi
+          exit "$COMPARISON_STATUS"
+
   wasm:
     name: Compilation (docs-lib)
     runs-on: ubuntu-latest

--- a/tests-compatibility/src/main.rs
+++ b/tests-compatibility/src/main.rs
@@ -13,8 +13,10 @@ use tests_compatibility::registry::{FsRegistry, RegistryLayout, RegistryReader};
 use tests_compatibility::{PackageCache, Preset, default_cache_dir};
 
 use crate::verifier::cli::{Cli, Command, DEFAULT_INDEX_DIR, DEFAULT_REGISTRY_DIR};
+use crate::verifier::comparison::compare_reports;
 use crate::verifier::compile::compile_sources;
 use crate::verifier::report::{PackageSetReport, Report, SelectionReport};
+use crate::verifier::reporting::{append_markdown, github_annotations, render_markdown};
 use crate::verifier::selection::{SelectedPackage, package_map, resolve_selection};
 use crate::verifier::sources::discover_sources;
 
@@ -107,22 +109,18 @@ fn run() -> Result<bool> {
             let cache = PackageCache::new(cache_dir);
             prepare_packages(&cache, &selection.packages, "Preparing selected packages")?;
 
-            let source_files = selection
-                .packages
-                .par_iter()
-                .map(|package| {
-                    let extracted = cache.source_path(&package.name, &package.version);
-                    discover_sources(&package.name, &package.version, &extracted).with_context(
-                        || {
-                            format!(
-                                "failed to discover source files for {}@{}",
-                                package.name, package.version
-                            )
-                        },
+            let source_files = selection.packages.par_iter().map(|package| {
+                let extracted = cache.source_path(&package.name, &package.version);
+                discover_sources(&package.name, &package.version, &extracted).with_context(|| {
+                    format!(
+                        "failed to discover source files for {}@{}",
+                        package.name, package.version
                     )
                 })
-                .collect::<Result<Vec<_>>>()?;
-            let mut source_files = source_files.into_iter().flatten().collect::<Vec<_>>();
+            });
+            let source_files = source_files.collect::<Result<Vec<_>>>()?;
+            let source_files = source_files.into_iter().flatten();
+            let mut source_files = source_files.collect::<Vec<_>>();
             source_files.sort_by(|a, b| {
                 (&a.package, &a.version, &a.relative_path).cmp(&(
                     &b.package,
@@ -155,12 +153,45 @@ fn run() -> Result<bool> {
             report.print_human();
 
             if let Some(path) = args.json_output {
-                report.write_json(path.clone()).with_context(|| {
+                report.write_json(&path).with_context(|| {
                     format!("failed to write JSON report to {}", path.display())
                 })?;
             }
 
             Ok(report.has_errors())
+        }
+        Command::Compare(args) => {
+            let base = Report::read_json(&args.base_report).with_context(|| {
+                format!("failed to read base report from {}", args.base_report.display())
+            })?;
+            let candidate = Report::read_json(&args.candidate_report).with_context(|| {
+                format!("failed to read candidate report from {}", args.candidate_report.display())
+            })?;
+            let comparison = compare_reports(&base, &candidate)?;
+            comparison.write_json(&args.json_output).with_context(|| {
+                format!("failed to write comparison report to {}", args.json_output.display())
+            })?;
+
+            let markdown = render_markdown(&comparison, &candidate, args.detail_limit);
+            if let Some(path) = args.summary_output {
+                append_markdown(&path, &markdown).with_context(|| {
+                    format!("failed to append comparison summary to {}", path.display())
+                })?;
+            } else {
+                println!("{markdown}");
+            }
+            if args.github_annotations {
+                print!(
+                    "{}",
+                    github_annotations(
+                        &comparison,
+                        args.error_annotation_limit,
+                        args.warning_annotation_limit,
+                    )
+                );
+            }
+
+            Ok(comparison.has_regressions())
         }
     }
 }
@@ -172,8 +203,8 @@ fn prepare_packages(
 ) -> Result<()> {
     let pending = packages
         .iter()
-        .filter(|package| !cache.is_package_prepared(&package.name, &package.version))
-        .collect::<Vec<_>>();
+        .filter(|package| !cache.is_package_prepared(&package.name, &package.version));
+    let pending = pending.collect::<Vec<_>>();
 
     if pending.is_empty() {
         return Ok(());

--- a/tests-compatibility/src/verifier.rs
+++ b/tests-compatibility/src/verifier.rs
@@ -1,6 +1,8 @@
 pub mod cli;
+pub mod comparison;
 pub mod compile;
 pub mod error;
 pub mod report;
+pub mod reporting;
 pub mod selection;
 pub mod sources;

--- a/tests-compatibility/src/verifier/cli.rs
+++ b/tests-compatibility/src/verifier/cli.rs
@@ -17,6 +17,7 @@ pub struct Cli {
 pub enum Command {
     Prepare(PrepareArgs),
     Verify(VerifyArgs),
+    Compare(CompareArgs),
 }
 
 #[derive(Debug, Args)]
@@ -49,6 +50,26 @@ pub struct VerifyArgs {
     pub json_output: Option<PathBuf>,
     #[arg(long)]
     pub cache_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+pub struct CompareArgs {
+    #[arg(long)]
+    pub base_report: PathBuf,
+    #[arg(long)]
+    pub candidate_report: PathBuf,
+    #[arg(long)]
+    pub json_output: PathBuf,
+    #[arg(long)]
+    pub summary_output: Option<PathBuf>,
+    #[arg(long)]
+    pub github_annotations: bool,
+    #[arg(long, default_value_t = 100)]
+    pub detail_limit: usize,
+    #[arg(long, default_value_t = 10)]
+    pub error_annotation_limit: usize,
+    #[arg(long, default_value_t = 10)]
+    pub warning_annotation_limit: usize,
 }
 
 fn parse_package_name(value: &str) -> Result<String, String> {

--- a/tests-compatibility/src/verifier/comparison.rs
+++ b/tests-compatibility/src/verifier/comparison.rs
@@ -1,0 +1,492 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
+
+use serde::Serialize;
+
+use super::error::VerifierError;
+use super::report::{
+    CompilationStage, CompilerDiagnostic, DiagnosticSeverity, IssueLocation, PackageSetReport,
+    Report, Summary, VerifierIssue, VerifierIssueKind,
+};
+
+#[derive(Clone, Copy)]
+enum VerifierIssueIdentity {
+    LegacySchema,
+    StructuredSchema,
+}
+
+#[derive(Clone, Copy)]
+enum ReportPathFormat {
+    LegacySchema,
+    PackageRelative,
+}
+
+impl ReportPathFormat {
+    fn from_schema_version(schema_version: u32) -> ReportPathFormat {
+        if schema_version == 0 {
+            ReportPathFormat::LegacySchema
+        } else {
+            ReportPathFormat::PackageRelative
+        }
+    }
+}
+
+const COMPARISON_REPORT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticKey {
+    pub(super) package: String,
+    pub(super) version: String,
+    pub(super) file: String,
+    pub(super) stage: CompilationStage,
+    pub(super) severity: DiagnosticSeverity,
+    pub(super) code: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifierKey {
+    pub(super) kind: VerifierIssueKind,
+    pub(super) package: Option<String>,
+    pub(super) version: Option<String>,
+    pub(super) dependency: Option<String>,
+    pub(super) locations: Vec<IssueLocation>,
+    pub(super) stage: Option<CompilationStage>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticChange {
+    pub(super) key: DiagnosticKey,
+    pub(super) base_diagnostics: Vec<CompilerDiagnostic>,
+    pub(super) candidate_diagnostics: Vec<CompilerDiagnostic>,
+}
+
+impl DiagnosticChange {
+    pub(super) fn introduced_count(&self) -> usize {
+        self.candidate_diagnostics.len().saturating_sub(self.base_diagnostics.len())
+    }
+
+    pub(super) fn fixed_count(&self) -> usize {
+        self.base_diagnostics.len().saturating_sub(self.candidate_diagnostics.len())
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifierChange {
+    pub(super) key: VerifierKey,
+    pub(super) base_issues: Vec<VerifierIssue>,
+    pub(super) candidate_issues: Vec<VerifierIssue>,
+}
+
+impl VerifierChange {
+    pub(super) fn introduced_count(&self) -> usize {
+        self.candidate_issues.len().saturating_sub(self.base_issues.len())
+    }
+
+    pub(super) fn fixed_count(&self) -> usize {
+        self.base_issues.len().saturating_sub(self.candidate_issues.len())
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComparisonSummary {
+    pub(super) introduced_compiler_errors: usize,
+    pub(super) fixed_compiler_errors: usize,
+    pub(super) introduced_compiler_warnings: usize,
+    pub(super) fixed_compiler_warnings: usize,
+    pub(super) introduced_verifier_errors: usize,
+    pub(super) fixed_verifier_errors: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComparisonReport {
+    schema_version: u32,
+    pub(super) package_set: PackageSetReport,
+    pub(super) base_summary: Summary,
+    pub(super) candidate_summary: Summary,
+    pub(super) summary: ComparisonSummary,
+    pub(super) diagnostic_changes: Vec<DiagnosticChange>,
+    pub(super) verifier_changes: Vec<VerifierChange>,
+}
+
+impl ComparisonReport {
+    pub fn has_regressions(&self) -> bool {
+        self.summary.introduced_compiler_errors > 0 || self.summary.introduced_verifier_errors > 0
+    }
+
+    pub fn write_json(&self, path: &Path) -> Result<(), VerifierError> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let content = serde_json::to_string_pretty(self)?;
+        fs::write(path, content).map_err(VerifierError::from)
+    }
+}
+
+pub fn compare_reports(
+    base: &Report,
+    candidate: &Report,
+) -> Result<ComparisonReport, VerifierError> {
+    validate_comparable(base, candidate)?;
+
+    let mut base = base.clone();
+    let mut candidate = candidate.clone();
+    normalize_report_paths(&mut base);
+    normalize_report_paths(&mut candidate);
+    base.recompute_summary();
+    candidate.recompute_summary();
+
+    let diagnostic_changes = compare_diagnostics(&base.diagnostics, &candidate.diagnostics);
+    let verifier_issue_identity = if base.schema_version == 0 || candidate.schema_version == 0 {
+        VerifierIssueIdentity::LegacySchema
+    } else {
+        VerifierIssueIdentity::StructuredSchema
+    };
+    let verifier_changes = compare_verifier_issues(
+        &base.verifier_errors,
+        &candidate.verifier_errors,
+        verifier_issue_identity,
+    );
+    let summary = comparison_summary(&diagnostic_changes, &verifier_changes);
+
+    Ok(ComparisonReport {
+        schema_version: COMPARISON_REPORT_SCHEMA_VERSION,
+        package_set: candidate.package_set,
+        base_summary: base.summary,
+        candidate_summary: candidate.summary,
+        summary,
+        diagnostic_changes,
+        verifier_changes,
+    })
+}
+
+fn validate_comparable(base: &Report, candidate: &Report) -> Result<(), VerifierError> {
+    if base.package_set != candidate.package_set {
+        return Err(VerifierError::IncompatibleReports(format!(
+            "package sets differ (base {}, candidate {})",
+            base.package_set.version, candidate.package_set.version
+        )));
+    }
+    if base.selection.resolved_packages != candidate.selection.resolved_packages {
+        return Err(VerifierError::IncompatibleReports(
+            "resolved package selections differ".to_string(),
+        ));
+    }
+    if base.summary.source_files != candidate.summary.source_files {
+        return Err(VerifierError::IncompatibleReports(format!(
+            "source file counts differ (base {}, candidate {})",
+            base.summary.source_files, candidate.summary.source_files
+        )));
+    }
+    Ok(())
+}
+
+fn normalize_report_paths(report: &mut Report) {
+    let path_format = ReportPathFormat::from_schema_version(report.schema_version);
+    for diagnostic in &mut report.diagnostics {
+        normalize_diagnostic_path(diagnostic, path_format);
+    }
+    for issue in &mut report.verifier_errors {
+        for location in &mut issue.locations {
+            location.file =
+                normalize_file(&location.file, &location.package, &location.version, path_format);
+        }
+        issue.locations.sort();
+    }
+}
+
+fn normalize_diagnostic_path(diagnostic: &mut CompilerDiagnostic, path_format: ReportPathFormat) {
+    diagnostic.file =
+        normalize_file(&diagnostic.file, &diagnostic.package, &diagnostic.version, path_format);
+}
+
+fn normalize_file(
+    file: &str,
+    package: &str,
+    version: &str,
+    path_format: ReportPathFormat,
+) -> String {
+    let file = file.replace('\\', "/");
+    match path_format {
+        ReportPathFormat::PackageRelative => file,
+        ReportPathFormat::LegacySchema => {
+            let cache_marker = format!("/sources/{package}/{version}/");
+            file.rsplit_once(&cache_marker)
+                .map_or(file.clone(), |(_, relative)| relative.to_string())
+        }
+    }
+}
+
+pub(super) fn diagnostic_groups(
+    report: &Report,
+) -> BTreeMap<DiagnosticKey, Vec<CompilerDiagnostic>> {
+    let mut diagnostics = report.diagnostics.clone();
+    let path_format = ReportPathFormat::from_schema_version(report.schema_version);
+    for diagnostic in &mut diagnostics {
+        normalize_diagnostic_path(diagnostic, path_format);
+    }
+    group_diagnostics(&diagnostics)
+}
+
+fn compare_diagnostics(
+    base: &[CompilerDiagnostic],
+    candidate: &[CompilerDiagnostic],
+) -> Vec<DiagnosticChange> {
+    let base = group_diagnostics(base);
+    let candidate = group_diagnostics(candidate);
+    let keys = base.keys().chain(candidate.keys()).cloned();
+    let keys = keys.collect::<BTreeSet<_>>();
+    let changes = keys.into_iter().filter_map(|key| {
+        let base_diagnostics = base.get(&key).cloned().unwrap_or_default();
+        let candidate_diagnostics = candidate.get(&key).cloned().unwrap_or_default();
+        let base_count = base_diagnostics.len();
+        let candidate_count = candidate_diagnostics.len();
+        (base_count != candidate_count).then_some(DiagnosticChange {
+            key,
+            base_diagnostics,
+            candidate_diagnostics,
+        })
+    });
+    changes.collect()
+}
+
+fn group_diagnostics(
+    diagnostics: &[CompilerDiagnostic],
+) -> BTreeMap<DiagnosticKey, Vec<CompilerDiagnostic>> {
+    let mut groups: BTreeMap<DiagnosticKey, Vec<CompilerDiagnostic>> = BTreeMap::new();
+    for diagnostic in diagnostics {
+        let key = DiagnosticKey {
+            package: diagnostic.package.clone(),
+            version: diagnostic.version.clone(),
+            file: diagnostic.file.clone(),
+            stage: diagnostic.stage,
+            severity: diagnostic.severity,
+            code: diagnostic.code.clone(),
+        };
+        groups.entry(key).or_default().push(diagnostic.clone());
+    }
+    for diagnostics in groups.values_mut() {
+        diagnostics.sort_by(|left, right| {
+            (left.span.start, left.span.end, &left.message).cmp(&(
+                right.span.start,
+                right.span.end,
+                &right.message,
+            ))
+        });
+    }
+    groups
+}
+
+fn compare_verifier_issues(
+    base: &[VerifierIssue],
+    candidate: &[VerifierIssue],
+    identity: VerifierIssueIdentity,
+) -> Vec<VerifierChange> {
+    let base = group_verifier_issues(base, identity);
+    let candidate = group_verifier_issues(candidate, identity);
+    let keys = base.keys().chain(candidate.keys()).cloned();
+    let keys = keys.collect::<BTreeSet<_>>();
+    let changes = keys.into_iter().filter_map(|key| {
+        let base_issues = base.get(&key).cloned().unwrap_or_default();
+        let candidate_issues = candidate.get(&key).cloned().unwrap_or_default();
+        let base_count = base_issues.len();
+        let candidate_count = candidate_issues.len();
+        (base_count != candidate_count).then_some(VerifierChange {
+            key,
+            base_issues,
+            candidate_issues,
+        })
+    });
+    changes.collect()
+}
+
+fn group_verifier_issues(
+    issues: &[VerifierIssue],
+    identity: VerifierIssueIdentity,
+) -> BTreeMap<VerifierKey, Vec<VerifierIssue>> {
+    let mut groups: BTreeMap<VerifierKey, Vec<VerifierIssue>> = BTreeMap::new();
+    for issue in issues {
+        let key = VerifierKey {
+            kind: issue.kind,
+            package: issue.package.clone(),
+            version: match identity {
+                VerifierIssueIdentity::LegacySchema => None,
+                VerifierIssueIdentity::StructuredSchema => issue.version.clone(),
+            },
+            dependency: issue.dependency.clone(),
+            locations: match identity {
+                VerifierIssueIdentity::LegacySchema => Vec::new(),
+                VerifierIssueIdentity::StructuredSchema => issue.locations.clone(),
+            },
+            stage: match identity {
+                VerifierIssueIdentity::LegacySchema => None,
+                VerifierIssueIdentity::StructuredSchema => issue.stage,
+            },
+        };
+        groups.entry(key).or_default().push(issue.clone());
+    }
+    for issues in groups.values_mut() {
+        issues.sort_by(|left, right| left.message.cmp(&right.message));
+    }
+    groups
+}
+
+fn comparison_summary(
+    diagnostic_changes: &[DiagnosticChange],
+    verifier_changes: &[VerifierChange],
+) -> ComparisonSummary {
+    let mut summary = ComparisonSummary::default();
+    for change in diagnostic_changes {
+        match change.key.severity {
+            DiagnosticSeverity::Error => {
+                summary.introduced_compiler_errors += change.introduced_count();
+                summary.fixed_compiler_errors += change.fixed_count();
+            }
+            DiagnosticSeverity::Warning => {
+                summary.introduced_compiler_warnings += change.introduced_count();
+                summary.fixed_compiler_warnings += change.fixed_count();
+            }
+        }
+    }
+    for change in verifier_changes {
+        summary.introduced_verifier_errors += change.introduced_count();
+        summary.fixed_verifier_errors += change.fixed_count();
+    }
+    summary
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::report::{
+        CompilationStage, CompilerDiagnostic, DiagnosticSeverity, PackageSetReport, Report,
+        SelectionReport, SourcePosition, SpanReport, VerifierIssue,
+    };
+    use super::super::selection::{SelectedPackage, SelectionMode};
+
+    use super::compare_reports;
+
+    #[test]
+    fn ignores_diagnostic_message_span_and_legacy_path_changes() {
+        let mut base = report();
+        base.schema_version = 0;
+        base.diagnostics.push(diagnostic(
+            DiagnosticSeverity::Error,
+            "CannotUnify",
+            "base message",
+            "/tmp/target/compatibility/sources/prelude/6.0.2/src/Prelude.purs",
+            1,
+        ));
+        base.recompute_summary();
+        let mut candidate = report();
+        candidate.diagnostics.push(diagnostic(
+            DiagnosticSeverity::Error,
+            "CannotUnify",
+            "candidate message",
+            "src/Prelude.purs",
+            9,
+        ));
+        candidate.recompute_summary();
+
+        let comparison = compare_reports(&base, &candidate).unwrap();
+
+        assert!(comparison.diagnostic_changes.is_empty());
+        assert!(!comparison.has_regressions());
+    }
+
+    #[test]
+    fn distinguishes_introduced_errors_warnings_and_fixes() {
+        let mut base = report();
+        base.diagnostics.push(diagnostic(
+            DiagnosticSeverity::Error,
+            "FixedError",
+            "fixed",
+            "src/Prelude.purs",
+            1,
+        ));
+        base.recompute_summary();
+        let mut candidate = report();
+        candidate.diagnostics.extend([
+            diagnostic(DiagnosticSeverity::Error, "NewError", "new", "src/Prelude.purs", 1),
+            diagnostic(DiagnosticSeverity::Warning, "NewWarning", "warning", "src/Prelude.purs", 1),
+        ]);
+        candidate.verifier_errors.push(VerifierIssue::query_error(
+            "prelude",
+            "6.0.2",
+            "src/Prelude.purs",
+            CompilationStage::Checking,
+            "query failed".to_string(),
+        ));
+        candidate.recompute_summary();
+
+        let comparison = compare_reports(&base, &candidate).unwrap();
+
+        assert_eq!(comparison.summary.introduced_compiler_errors, 1);
+        assert_eq!(comparison.summary.fixed_compiler_errors, 1);
+        assert_eq!(comparison.summary.introduced_compiler_warnings, 1);
+        assert_eq!(comparison.summary.fixed_compiler_warnings, 0);
+        assert_eq!(comparison.summary.introduced_verifier_errors, 1);
+        assert!(comparison.has_regressions());
+    }
+
+    #[test]
+    fn rejects_different_corpora() {
+        let base = report();
+        let mut candidate = report();
+        candidate.summary.source_files += 1;
+
+        let error = compare_reports(&base, &candidate).unwrap_err();
+
+        assert!(error.to_string().contains("source file counts differ"));
+    }
+
+    fn report() -> Report {
+        let mut report = Report::new(
+            PackageSetReport {
+                version: "80.3.1".to_string(),
+                compiler: "0.15.15".to_string(),
+                published: "2026-08-07".to_string(),
+            },
+            SelectionReport {
+                mode: SelectionMode::Combined,
+                requested_packages: Vec::new(),
+                resolved_packages: vec![SelectedPackage {
+                    name: "prelude".to_string(),
+                    version: "6.0.2".to_string(),
+                }],
+            },
+        );
+        report.summary.source_files = 1;
+        report
+    }
+
+    fn diagnostic(
+        severity: DiagnosticSeverity,
+        code: &str,
+        message: &str,
+        file: &str,
+        start: u32,
+    ) -> CompilerDiagnostic {
+        CompilerDiagnostic {
+            package: "prelude".to_string(),
+            version: "6.0.2".to_string(),
+            file: file.to_string(),
+            stage: CompilationStage::Checking,
+            severity,
+            code: code.to_string(),
+            message: message.to_string(),
+            span: SpanReport {
+                start,
+                end: start + 1,
+                start_position: Some(SourcePosition { line: 1, column: start + 1 }),
+                end_position: Some(SourcePosition { line: 1, column: start + 2 }),
+            },
+            human: String::new(),
+        }
+    }
+}

--- a/tests-compatibility/src/verifier/compile.rs
+++ b/tests-compatibility/src/verifier/compile.rs
@@ -6,10 +6,14 @@ use diagnostics::{
     Diagnostic, DiagnosticsContext, Severity, Span, ToDiagnostics, format_rustc_with_path,
 };
 use files::{FileId, Files};
+use rayon::prelude::*;
 use url::Url;
 
 use super::error::VerifierError;
-use super::report::{CompilerDiagnostic, SpanReport, VerifierIssue};
+use super::report::{
+    CompilationStage, CompilerDiagnostic, DiagnosticSeverity, IssueLocation, SourcePosition,
+    SpanReport, VerifierIssue,
+};
 use super::sources::SourceFile;
 
 #[derive(Debug, Default)]
@@ -19,10 +23,10 @@ pub struct CompileReport {
 }
 
 #[derive(Debug, Clone)]
-struct FileMeta {
+struct FileMetadata {
     package: String,
     version: String,
-    path: String,
+    relative_path: String,
     content: String,
 }
 
@@ -33,7 +37,7 @@ pub fn compile_sources(source_files: &[SourceFile]) -> Result<CompileReport, Ver
 
     let mut report = CompileReport::default();
     let mut file_ids = Vec::new();
-    let mut meta = HashMap::new();
+    let mut file_metadata = HashMap::new();
 
     for source in source_files {
         let content = fs::read_to_string(&source.path)?;
@@ -44,26 +48,35 @@ pub fn compile_sources(source_files: &[SourceFile]) -> Result<CompileReport, Ver
         let file_id = files.insert(uri, content.clone());
         engine.set_content(file_id, content.clone());
         file_ids.push(file_id);
-        meta.insert(
+        file_metadata.insert(
             file_id,
-            FileMeta {
+            FileMetadata {
                 package: source.package.clone(),
                 version: source.version.clone(),
-                path: source.path.to_string_lossy().into_owned(),
+                relative_path: source.relative_path.to_string_lossy().replace('\\', "/"),
                 content,
             },
         );
     }
 
-    register_modules(&engine, &file_ids, &meta, &mut report);
+    register_modules(&engine, &file_ids, &file_metadata, &mut report);
 
-    for &file_id in &file_ids {
+    let file_reports = file_ids.par_iter().map(|&file_id| {
+        let engine = engine.snapshot();
+        let mut file_report = CompileReport::default();
         collect_file(
             &engine,
             file_id,
-            meta.get(&file_id).expect("file metadata exists"),
-            &mut report,
+            file_metadata.get(&file_id).expect("file metadata exists"),
+            &mut file_report,
         );
+        file_report
+    });
+    let file_reports = file_reports.collect::<Vec<_>>();
+
+    for file_report in file_reports {
+        report.diagnostics.extend(file_report.diagnostics);
+        report.verifier_errors.extend(file_report.verifier_errors);
     }
 
     Ok(report)
@@ -72,25 +85,33 @@ pub fn compile_sources(source_files: &[SourceFile]) -> Result<CompileReport, Ver
 fn register_modules(
     engine: &QueryEngine,
     file_ids: &[FileId],
-    meta: &HashMap<FileId, FileMeta>,
+    file_metadata: &HashMap<FileId, FileMetadata>,
     report: &mut CompileReport,
 ) {
     let mut modules: HashMap<String, FileId> = HashMap::new();
 
     for &file_id in file_ids {
-        let file_meta = meta.get(&file_id).expect("file metadata exists");
+        let metadata = file_metadata.get(&file_id).expect("file metadata exists");
         match engine.parsed(file_id) {
             Ok((parsed, errors)) => {
-                report.diagnostics.extend(parse_diagnostics(file_meta, &errors));
+                report.diagnostics.extend(parse_diagnostics(metadata, &errors));
 
-                if let Some(module_name) = parsed.module_name(&file_meta.content) {
+                if let Some(module_name) = parsed.module_name(&metadata.content) {
                     let module_name = module_name.to_string();
                     if let Some(existing) = modules.get(&module_name) {
-                        let first = meta.get(existing).expect("file metadata exists");
+                        let first = file_metadata.get(existing).expect("file metadata exists");
                         report.verifier_errors.push(VerifierIssue::duplicate_module(
                             &module_name,
-                            &first.path,
-                            &file_meta.path,
+                            IssueLocation {
+                                package: first.package.clone(),
+                                version: first.version.clone(),
+                                file: first.relative_path.clone(),
+                            },
+                            IssueLocation {
+                                package: metadata.package.clone(),
+                                version: metadata.version.clone(),
+                                file: metadata.relative_path.clone(),
+                            },
                         ));
                     } else {
                         engine.set_module_file(&module_name, file_id);
@@ -98,7 +119,9 @@ fn register_modules(
                     }
                 }
             }
-            Err(error) => push_query_error(report, file_meta, "parse", error),
+            Err(error) => {
+                push_query_error(report, metadata, CompilationStage::Parse, error);
+            }
         }
     }
 }
@@ -106,7 +129,7 @@ fn register_modules(
 fn collect_file(
     engine: &QueryEngine,
     file_id: FileId,
-    meta: &FileMeta,
+    metadata: &FileMetadata,
     report: &mut CompileReport,
 ) {
     let Ok((parsed, _)) = engine.parsed(file_id) else {
@@ -115,94 +138,106 @@ fn collect_file(
     let root = parsed.syntax_node();
 
     if let Err(error) = engine.stabilized(file_id) {
-        push_query_error(report, meta, "stabilizing", error);
+        push_query_error(report, metadata, CompilationStage::Stabilizing, error);
         return;
     }
 
     match engine.indexed(file_id) {
         Ok(indexed) => {
-            with_diagnostics_context(engine, file_id, &root, meta, |ctx| {
+            with_diagnostics_context(engine, file_id, &root, metadata, |ctx| {
                 for error in &indexed.errors {
                     let diagnostics = error.to_diagnostics(&ctx);
                     if diagnostics.is_empty() {
                         report.diagnostics.push(debug_diagnostic(
-                            meta,
-                            "indexing",
+                            metadata,
+                            CompilationStage::Indexing,
                             "IndexingError",
                             error,
                         ));
                     } else {
-                        report.diagnostics.extend(convert_diagnostics(meta, diagnostics));
+                        report.diagnostics.extend(convert_diagnostics(
+                            metadata,
+                            CompilationStage::Indexing,
+                            diagnostics,
+                        ));
                     }
                 }
             });
         }
         Err(error) => {
-            push_query_error(report, meta, "indexing", error);
+            push_query_error(report, metadata, CompilationStage::Indexing, error);
             return;
         }
     }
 
     match engine.resolved(file_id) {
         Ok(resolved) => {
-            with_diagnostics_context(engine, file_id, &root, meta, |ctx| {
+            with_diagnostics_context(engine, file_id, &root, metadata, |ctx| {
                 for error in &resolved.errors {
-                    report
-                        .diagnostics
-                        .extend(convert_diagnostics(meta, error.to_diagnostics(&ctx)));
+                    report.diagnostics.extend(convert_diagnostics(
+                        metadata,
+                        CompilationStage::Resolving,
+                        error.to_diagnostics(&ctx),
+                    ));
                 }
             });
         }
         Err(error) => {
-            push_query_error(report, meta, "resolving", error);
+            push_query_error(report, metadata, CompilationStage::Resolving, error);
         }
     }
 
     match engine.lowered(file_id) {
         Ok(lowered) => {
-            with_diagnostics_context(engine, file_id, &root, meta, |ctx| {
+            with_diagnostics_context(engine, file_id, &root, metadata, |ctx| {
                 for error in &lowered.errors {
-                    report
-                        .diagnostics
-                        .extend(convert_diagnostics(meta, error.to_diagnostics(&ctx)));
+                    report.diagnostics.extend(convert_diagnostics(
+                        metadata,
+                        CompilationStage::Lowering,
+                        error.to_diagnostics(&ctx),
+                    ));
                 }
             });
         }
-        Err(error) => push_query_error(report, meta, "lowering", error),
+        Err(error) => push_query_error(report, metadata, CompilationStage::Lowering, error),
     }
 
     match engine.grouped(file_id) {
         Ok(grouped) => {
-            with_diagnostics_context(engine, file_id, &root, meta, |ctx| {
+            with_diagnostics_context(engine, file_id, &root, metadata, |ctx| {
                 for error in &grouped.cycle_errors {
-                    report
-                        .diagnostics
-                        .extend(convert_diagnostics(meta, error.to_diagnostics(&ctx)));
+                    report.diagnostics.extend(convert_diagnostics(
+                        metadata,
+                        CompilationStage::Lowering,
+                        error.to_diagnostics(&ctx),
+                    ));
                 }
             });
         }
-        Err(error) => push_query_error(report, meta, "grouping", error),
+        Err(error) => push_query_error(report, metadata, CompilationStage::Grouping, error),
     }
 
     if let Err(error) = engine.bracketed(file_id) {
-        push_query_error(report, meta, "bracketing", error);
+        push_query_error(report, metadata, CompilationStage::Bracketing, error);
     }
 
     if let Err(error) = engine.sectioned(file_id) {
-        push_query_error(report, meta, "sectioning", error);
+        push_query_error(report, metadata, CompilationStage::Sectioning, error);
     }
 
     match engine.checked(file_id) {
         Ok(checked) => {
-            with_diagnostics_context(engine, file_id, &root, meta, |ctx| {
+            with_diagnostics_context(engine, file_id, &root, metadata, |ctx| {
                 for error in &checked.errors {
-                    report
-                        .diagnostics
-                        .extend(convert_diagnostics(meta, error.to_diagnostics(&ctx)));
+                    report.diagnostics.extend(convert_diagnostics(
+                        metadata,
+                        CompilationStage::Checking,
+                        error.to_diagnostics(&ctx),
+                    ));
                 }
             });
         }
-        Err(error) => push_query_error(report, meta, "checking", error),
+        Err(error) => push_query_error(report, metadata, CompilationStage::Checking, error),
     }
 }
 
@@ -210,7 +245,7 @@ fn with_diagnostics_context(
     engine: &QueryEngine,
     file_id: FileId,
     root: &syntax::SyntaxNode,
-    meta: &FileMeta,
+    metadata: &FileMetadata,
     f: impl FnOnce(DiagnosticsContext<'_, QueryEngine>),
 ) {
     let Ok(stabilized) = engine.stabilized(file_id) else {
@@ -227,7 +262,7 @@ fn with_diagnostics_context(
     };
     f(DiagnosticsContext::new(
         engine,
-        &meta.content,
+        &metadata.content,
         root,
         &stabilized,
         &indexed,
@@ -236,73 +271,107 @@ fn with_diagnostics_context(
     ));
 }
 
-fn parse_diagnostics(meta: &FileMeta, errors: &[parsing::ParseError]) -> Vec<CompilerDiagnostic> {
-    errors
-        .iter()
-        .map(|error| {
-            let start = error.offset as u32;
-            let end = start.saturating_add(1);
-            let diagnostic = Diagnostic::error(
-                "ParseError",
-                error.message.to_string(),
-                Span::new(start, end),
-                "parse",
-            );
-            compiler_diagnostic(meta, "parse", diagnostic)
-        })
-        .collect()
+fn parse_diagnostics(
+    metadata: &FileMetadata,
+    errors: &[parsing::ParseError],
+) -> Vec<CompilerDiagnostic> {
+    let diagnostics = errors.iter().map(|error| {
+        let start = error.offset as u32;
+        let content_end = metadata.content.len() as u32;
+        let end = start.saturating_add(1).min(content_end);
+        let diagnostic = Diagnostic::error(
+            "ParseError",
+            error.message.to_string(),
+            Span::new(start, end),
+            "parse",
+        );
+        compiler_diagnostic(metadata, CompilationStage::Parse, diagnostic)
+    });
+    diagnostics.collect()
 }
 
 fn debug_diagnostic(
-    meta: &FileMeta,
-    stage: &'static str,
+    metadata: &FileMetadata,
+    stage: CompilationStage,
     code: &'static str,
     error: &impl std::fmt::Debug,
 ) -> CompilerDiagnostic {
     let diagnostic = Diagnostic::error(
         code,
         format!("{error:?}"),
-        Span::new(0, meta.content.len() as u32),
-        stage,
+        Span::new(0, metadata.content.len() as u32),
+        stage.as_str(),
     );
-    compiler_diagnostic(meta, stage, diagnostic)
+    compiler_diagnostic(metadata, stage, diagnostic)
 }
 
-fn convert_diagnostics(meta: &FileMeta, diagnostics: Vec<Diagnostic>) -> Vec<CompilerDiagnostic> {
-    diagnostics
-        .into_iter()
-        .map(|diagnostic| compiler_diagnostic(meta, diagnostic.source, diagnostic))
-        .collect()
+fn convert_diagnostics(
+    metadata: &FileMetadata,
+    stage: CompilationStage,
+    diagnostics: Vec<Diagnostic>,
+) -> Vec<CompilerDiagnostic> {
+    let diagnostics =
+        diagnostics.into_iter().map(|diagnostic| compiler_diagnostic(metadata, stage, diagnostic));
+    diagnostics.collect()
 }
 
-fn compiler_diagnostic(meta: &FileMeta, stage: &str, diagnostic: Diagnostic) -> CompilerDiagnostic {
+fn compiler_diagnostic(
+    metadata: &FileMetadata,
+    stage: CompilationStage,
+    diagnostic: Diagnostic,
+) -> CompilerDiagnostic {
     let severity = match diagnostic.severity {
-        Severity::Error => "error",
-        Severity::Warning => "warning",
+        Severity::Error => DiagnosticSeverity::Error,
+        Severity::Warning => DiagnosticSeverity::Warning,
     };
-    let human =
-        format_rustc_with_path(std::slice::from_ref(&diagnostic), &meta.content, &meta.path);
+    let human = format_rustc_with_path(
+        std::slice::from_ref(&diagnostic),
+        &metadata.content,
+        &metadata.relative_path,
+    );
 
     CompilerDiagnostic {
-        package: meta.package.clone(),
-        version: meta.version.clone(),
-        file: meta.path.clone(),
-        stage: stage.to_string(),
-        severity: severity.to_string(),
+        package: metadata.package.clone(),
+        version: metadata.version.clone(),
+        file: metadata.relative_path.clone(),
+        stage,
+        severity,
         code: diagnostic.code.to_string(),
         message: diagnostic.message,
-        span: SpanReport { start: diagnostic.span.start, end: diagnostic.span.end },
+        span: SpanReport {
+            start: diagnostic.span.start,
+            end: diagnostic.span.end,
+            start_position: Some(source_position(&metadata.content, diagnostic.span.start)),
+            end_position: Some(source_position(&metadata.content, diagnostic.span.end)),
+        },
         human,
     }
 }
 
-fn push_query_error(report: &mut CompileReport, meta: &FileMeta, stage: &str, error: QueryError) {
+fn push_query_error(
+    report: &mut CompileReport,
+    metadata: &FileMetadata,
+    stage: CompilationStage,
+    error: QueryError,
+) {
     report.verifier_errors.push(VerifierIssue::query_error(
-        &meta.package,
-        &meta.path,
+        &metadata.package,
+        &metadata.version,
+        &metadata.relative_path,
         stage,
         format!("{error:?}"),
     ));
+}
+
+fn source_position(content: &str, offset: u32) -> SourcePosition {
+    let offset = offset as usize;
+    let prefix = content.get(..offset).expect("diagnostic span is a source text boundary");
+    let preceding_lines = prefix.bytes().filter(|byte| *byte == b'\n');
+    let line = preceding_lines.count() as u32 + 1;
+    let current_line = prefix.rsplit_once('\n').map_or(prefix, |(_, current_line)| current_line);
+    let characters = current_line.chars();
+    let column = characters.count() as u32 + 1;
+    SourcePosition { line, column }
 }
 
 #[cfg(test)]
@@ -311,6 +380,7 @@ mod tests {
 
     use tempfile::tempdir;
 
+    use super::super::report::{CompilationStage, IssueLocation, VerifierIssueKind};
     use super::super::sources::SourceFile;
 
     use super::compile_sources;
@@ -341,10 +411,53 @@ mod tests {
         fs::write(&b, "module Main where\n").unwrap();
 
         let report =
-            compile_sources(&[source("fixture", "1.0.0", &a), source("fixture", "1.0.0", &b)])
+            compile_sources(&[source("fixture-a", "1.0.0", &a), source("fixture-b", "2.0.0", &b)])
                 .unwrap();
 
-        assert!(report.verifier_errors.iter().any(|issue| issue.kind == "DuplicateModule"));
+        let duplicate = report
+            .verifier_errors
+            .iter()
+            .find(|issue| issue.kind == VerifierIssueKind::DuplicateModule)
+            .expect("duplicate module issue");
+        assert_eq!(
+            duplicate.locations,
+            [
+                IssueLocation {
+                    package: "fixture-a".to_string(),
+                    version: "1.0.0".to_string(),
+                    file: "src/A.purs".to_string(),
+                },
+                IssueLocation {
+                    package: "fixture-b".to_string(),
+                    version: "2.0.0".to_string(),
+                    file: "src/B.purs".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn reports_parse_errors_at_end_of_file() {
+        let dir = tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("src")).unwrap();
+        let path = dir.path().join("src/Broken.purs");
+        let content = "module Broken where\n\nimport Prelude (";
+        fs::write(&path, content).unwrap();
+
+        let report = compile_sources(&[source("fixture", "1.0.0", &path)]).unwrap();
+        let diagnostic = report
+            .diagnostics
+            .iter()
+            .find(|diagnostic| {
+                diagnostic.stage == CompilationStage::Parse
+                    && diagnostic.span.start == content.len() as u32
+            })
+            .expect("parse diagnostic at end of file");
+
+        assert_eq!(diagnostic.file, "src/Broken.purs");
+        assert_eq!(diagnostic.span.end, content.len() as u32);
+        assert_eq!(diagnostic.span.end_position.as_ref().unwrap().line, 3);
+        assert_eq!(diagnostic.span.end_position.as_ref().unwrap().column, 17);
     }
 
     fn source(package: &str, version: &str, path: &std::path::Path) -> SourceFile {
@@ -352,7 +465,7 @@ mod tests {
             package: package.to_string(),
             version: version.to_string(),
             path: path.to_path_buf(),
-            relative_path: path.file_name().unwrap().into(),
+            relative_path: std::path::Path::new("src").join(path.file_name().unwrap()),
         }
     }
 }

--- a/tests-compatibility/src/verifier/error.rs
+++ b/tests-compatibility/src/verifier/error.rs
@@ -17,4 +17,10 @@ pub enum VerifierError {
     Url(#[from] url::ParseError),
     #[error("failed to convert path to file URL: {0}")]
     FileUrl(PathBuf),
+    #[error(
+        "unsupported report schema version {found}; latest supported version is {latest_supported}"
+    )]
+    UnsupportedReportSchemaVersion { found: u32, latest_supported: u32 },
+    #[error("cannot compare compatibility reports: {0}")]
+    IncompatibleReports(String),
 }

--- a/tests-compatibility/src/verifier/report.rs
+++ b/tests-compatibility/src/verifier/report.rs
@@ -1,13 +1,15 @@
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::PathBuf;
+use std::path::Path;
+use std::{fmt, fs};
 
 use serde::{Deserialize, Serialize};
 
 use super::error::VerifierError;
 use super::selection::{SelectedPackage, SelectionMode};
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+pub const REPORT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PackageSetReport {
     pub version: String,
@@ -15,7 +17,7 @@ pub struct PackageSetReport {
     pub published: String,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SelectionReport {
     pub mode: SelectionMode,
@@ -23,7 +25,7 @@ pub struct SelectionReport {
     pub resolved_packages: Vec<SelectedPackage>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Summary {
     pub packages: usize,
@@ -34,19 +36,73 @@ pub struct Summary {
     pub packages_with_errors: usize,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SourcePosition {
+    pub line: u32,
+    pub column: u32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct SpanReport {
     pub start: u32,
     pub end: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_position: Option<SourcePosition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_position: Option<SourcePosition>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "lowercase")]
+pub enum DiagnosticSeverity {
+    Error,
+    Warning,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "lowercase")]
+pub enum CompilationStage {
+    Parse,
+    Stabilizing,
+    Indexing,
+    Resolving,
+    Lowering,
+    Grouping,
+    Bracketing,
+    Sectioning,
+    Checking,
+}
+
+impl CompilationStage {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CompilationStage::Parse => "parse",
+            CompilationStage::Stabilizing => "stabilizing",
+            CompilationStage::Indexing => "indexing",
+            CompilationStage::Resolving => "resolving",
+            CompilationStage::Lowering => "lowering",
+            CompilationStage::Grouping => "grouping",
+            CompilationStage::Bracketing => "bracketing",
+            CompilationStage::Sectioning => "sectioning",
+            CompilationStage::Checking => "checking",
+        }
+    }
+}
+
+impl fmt::Display for CompilationStage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct CompilerDiagnostic {
     pub package: String,
     pub version: String,
     pub file: String,
-    pub stage: String,
-    pub severity: String,
+    pub stage: CompilationStage,
+    pub severity: DiagnosticSeverity,
     pub code: String,
     pub message: String,
     pub span: SpanReport,
@@ -54,62 +110,142 @@ pub struct CompilerDiagnostic {
     pub human: String,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct IssueLocation {
+    pub package: String,
+    pub version: String,
+    pub file: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "PascalCase")]
+pub enum VerifierIssueKind {
+    MissingPackageSetPackage,
+    MissingManifest,
+    MissingPackageSetDependency,
+    DuplicateModule,
+    QueryError,
+}
+
+impl VerifierIssueKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            VerifierIssueKind::MissingPackageSetPackage => "MissingPackageSetPackage",
+            VerifierIssueKind::MissingManifest => "MissingManifest",
+            VerifierIssueKind::MissingPackageSetDependency => "MissingPackageSetDependency",
+            VerifierIssueKind::DuplicateModule => "DuplicateModule",
+            VerifierIssueKind::QueryError => "QueryError",
+        }
+    }
+}
+
+impl fmt::Display for VerifierIssueKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct VerifierIssue {
-    pub kind: String,
+    pub kind: VerifierIssueKind,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub package: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dependency: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub locations: Vec<IssueLocation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stage: Option<CompilationStage>,
     pub message: String,
 }
 
 impl VerifierIssue {
     pub fn missing_package(package: &str) -> VerifierIssue {
         VerifierIssue {
-            kind: "MissingPackageSetPackage".to_string(),
+            kind: VerifierIssueKind::MissingPackageSetPackage,
             package: Some(package.to_string()),
+            version: None,
             dependency: None,
+            locations: Vec::new(),
+            stage: None,
             message: format!("package '{package}' is not present in the selected package set"),
         }
     }
 
     pub fn missing_manifest(package: &str, version: &str) -> VerifierIssue {
         VerifierIssue {
-            kind: "MissingManifest".to_string(),
+            kind: VerifierIssueKind::MissingManifest,
             package: Some(package.to_string()),
+            version: Some(version.to_string()),
             dependency: None,
+            locations: Vec::new(),
+            stage: None,
             message: format!(
                 "package '{package}' has package-set version '{version}' but no matching registry-index manifest"
             ),
         }
     }
 
-    pub fn missing_dependency(package: &str, dependency: &str) -> VerifierIssue {
+    pub fn missing_dependency(package: &str, version: &str, dependency: &str) -> VerifierIssue {
         VerifierIssue {
-            kind: "MissingPackageSetDependency".to_string(),
+            kind: VerifierIssueKind::MissingPackageSetDependency,
             package: Some(package.to_string()),
+            version: Some(version.to_string()),
             dependency: Some(dependency.to_string()),
+            locations: Vec::new(),
+            stage: None,
             message: format!(
                 "package '{package}' depends on '{dependency}', which is absent from the selected package set"
             ),
         }
     }
 
-    pub fn duplicate_module(module: &str, first: &str, second: &str) -> VerifierIssue {
+    pub fn duplicate_module(
+        module: &str,
+        first: IssueLocation,
+        second: IssueLocation,
+    ) -> VerifierIssue {
+        let mut locations = vec![first, second];
+        locations.sort();
+        let [first, second] = locations.as_slice() else {
+            unreachable!("duplicate modules have two locations");
+        };
+        let first_display = format!("{}@{}/{}", first.package, first.version, first.file);
+        let second_display = format!("{}@{}/{}", second.package, second.version, second.file);
+
         VerifierIssue {
-            kind: "DuplicateModule".to_string(),
+            kind: VerifierIssueKind::DuplicateModule,
             package: None,
+            version: None,
             dependency: None,
-            message: format!("module '{module}' is provided by both '{first}' and '{second}'"),
+            locations,
+            stage: Some(CompilationStage::Parse),
+            message: format!(
+                "module '{module}' is provided by both '{first_display}' and '{second_display}'"
+            ),
         }
     }
 
-    pub fn query_error(package: &str, file: &str, stage: &str, message: String) -> VerifierIssue {
+    pub fn query_error(
+        package: &str,
+        version: &str,
+        file: &str,
+        stage: CompilationStage,
+        message: String,
+    ) -> VerifierIssue {
         VerifierIssue {
-            kind: "QueryError".to_string(),
+            kind: VerifierIssueKind::QueryError,
             package: Some(package.to_string()),
+            version: Some(version.to_string()),
             dependency: None,
+            locations: vec![IssueLocation {
+                package: package.to_string(),
+                version: version.to_string(),
+                file: file.to_string(),
+            }],
+            stage: Some(stage),
             message: format!("{stage} failed for {file}: {message}"),
         }
     }
@@ -118,6 +254,8 @@ impl VerifierIssue {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Report {
+    #[serde(default)]
+    pub schema_version: u32,
     pub package_set: PackageSetReport,
     pub selection: SelectionReport,
     pub summary: Summary,
@@ -125,10 +263,18 @@ pub struct Report {
     pub verifier_errors: Vec<VerifierIssue>,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReportSchema {
+    #[serde(default)]
+    schema_version: u32,
+}
+
 impl Report {
     pub fn new(package_set: PackageSetReport, selection: SelectionReport) -> Report {
         let packages = selection.resolved_packages.len();
         Report {
+            schema_version: REPORT_SCHEMA_VERSION,
             package_set,
             selection,
             summary: Summary { packages, ..Summary::default() },
@@ -140,17 +286,23 @@ impl Report {
     pub fn recompute_summary(&mut self) {
         self.summary.packages = self.selection.resolved_packages.len();
         self.summary.verifier_errors = self.verifier_errors.len();
-        self.summary.compiler_errors =
-            self.diagnostics.iter().filter(|diag| diag.severity == "error").count();
-        self.summary.compiler_warnings =
-            self.diagnostics.iter().filter(|diag| diag.severity == "warning").count();
-        self.summary.packages_with_errors = self
+        let compiler_errors = self
             .diagnostics
             .iter()
-            .filter(|diag| diag.severity == "error")
-            .map(|diag| diag.package.as_str())
-            .collect::<BTreeSet<_>>()
-            .len();
+            .filter(|diagnostic| diagnostic.severity == DiagnosticSeverity::Error);
+        self.summary.compiler_errors = compiler_errors.count();
+        let compiler_warnings = self
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.severity == DiagnosticSeverity::Warning);
+        self.summary.compiler_warnings = compiler_warnings.count();
+        let packages_with_errors = self
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.severity == DiagnosticSeverity::Error)
+            .map(|diagnostic| diagnostic.package.as_str());
+        let packages_with_errors = packages_with_errors.collect::<BTreeSet<_>>();
+        self.summary.packages_with_errors = packages_with_errors.len();
     }
 
     pub fn has_errors(&self) -> bool {
@@ -180,29 +332,94 @@ impl Report {
 
         println!("Summary:");
         println!("  verifier errors: {}", self.summary.verifier_errors);
-        println!("  parse errors: {}", self.stage_error_count("parse"));
-        println!("  indexing errors: {}", self.stage_error_count("indexing"));
-        println!("  resolving errors: {}", self.stage_error_count("resolving"));
-        println!("  lowering errors: {}", self.stage_error_count("lowering"));
-        println!("  checking errors: {}", self.stage_error_count("checking"));
+        println!("  parse errors: {}", self.stage_error_count(CompilationStage::Parse));
+        println!("  indexing errors: {}", self.stage_error_count(CompilationStage::Indexing));
+        println!("  resolving errors: {}", self.stage_error_count(CompilationStage::Resolving));
+        println!("  lowering errors: {}", self.stage_error_count(CompilationStage::Lowering));
+        println!("  checking errors: {}", self.stage_error_count(CompilationStage::Checking));
         println!("  compiler errors: {}", self.summary.compiler_errors);
         println!("  compiler warnings: {}", self.summary.compiler_warnings);
         println!("  packages with errors: {}", self.summary.packages_with_errors);
     }
 
-    pub fn write_json(&self, path: PathBuf) -> Result<(), VerifierError> {
+    pub fn write_json(&self, path: &Path) -> Result<(), VerifierError> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let content = serde_json::to_string_pretty(self)?;
+        let mut report = self.clone();
+        report.sort_details();
+        let content = serde_json::to_string_pretty(&report)?;
         fs::write(path, content).map_err(VerifierError::from)
     }
 
-    fn stage_error_count(&self, stage: &str) -> usize {
-        self.diagnostics
-            .iter()
-            .filter(|diagnostic| diagnostic.severity == "error" && diagnostic.stage == stage)
-            .count()
+    pub fn read_json(path: &Path) -> Result<Report, VerifierError> {
+        let content = fs::read_to_string(path)?;
+        let schema: ReportSchema = serde_json::from_str(&content)?;
+        if !matches!(schema.schema_version, 0 | REPORT_SCHEMA_VERSION) {
+            return Err(VerifierError::UnsupportedReportSchemaVersion {
+                found: schema.schema_version,
+                latest_supported: REPORT_SCHEMA_VERSION,
+            });
+        }
+        let report: Report = serde_json::from_str(&content)?;
+        Ok(report)
+    }
+
+    fn sort_details(&mut self) {
+        self.diagnostics.sort_by(|left, right| {
+            (
+                &left.package,
+                &left.version,
+                &left.file,
+                &left.stage,
+                &left.severity,
+                &left.code,
+                left.span.start,
+                left.span.end,
+                &left.message,
+            )
+                .cmp(&(
+                    &right.package,
+                    &right.version,
+                    &right.file,
+                    &right.stage,
+                    &right.severity,
+                    &right.code,
+                    right.span.start,
+                    right.span.end,
+                    &right.message,
+                ))
+        });
+        for issue in &mut self.verifier_errors {
+            issue.locations.sort();
+        }
+        self.verifier_errors.sort_by(|left, right| {
+            (
+                &left.kind,
+                &left.package,
+                &left.version,
+                &left.dependency,
+                &left.locations,
+                &left.stage,
+                &left.message,
+            )
+                .cmp(&(
+                    &right.kind,
+                    &right.package,
+                    &right.version,
+                    &right.dependency,
+                    &right.locations,
+                    &right.stage,
+                    &right.message,
+                ))
+        });
+    }
+
+    fn stage_error_count(&self, stage: CompilationStage) -> usize {
+        let errors = self.diagnostics.iter().filter(|diagnostic| {
+            diagnostic.severity == DiagnosticSeverity::Error && diagnostic.stage == stage
+        });
+        errors.count()
     }
 }
 
@@ -213,11 +430,12 @@ mod tests {
     use super::super::selection::{SelectedPackage, SelectionMode};
 
     use super::{
-        CompilerDiagnostic, PackageSetReport, Report, SelectionReport, SpanReport, VerifierIssue,
+        CompilationStage, CompilerDiagnostic, DiagnosticSeverity, PackageSetReport,
+        REPORT_SCHEMA_VERSION, Report, SelectionReport, SourcePosition, SpanReport, VerifierIssue,
     };
 
     #[test]
-    fn json_serialization_includes_core_sections() {
+    fn json_round_trip_preserves_report_details() {
         let mut report = Report::new(
             PackageSetReport {
                 version: "64.7.1".to_string(),
@@ -238,27 +456,76 @@ mod tests {
             package: "effect".to_string(),
             version: "4.0.0".to_string(),
             file: "src/Effect.purs".to_string(),
-            stage: "checking".to_string(),
-            severity: "error".to_string(),
+            stage: CompilationStage::Checking,
+            severity: DiagnosticSeverity::Error,
             code: "UnknownType".to_string(),
             message: "unknown type".to_string(),
-            span: SpanReport { start: 0, end: 10 },
+            span: SpanReport {
+                start: 0,
+                end: 10,
+                start_position: Some(SourcePosition { line: 1, column: 1 }),
+                end_position: Some(SourcePosition { line: 1, column: 11 }),
+            },
             human: "hidden from JSON".to_string(),
         });
-        report.verifier_errors.push(VerifierIssue::missing_dependency("effect", "prelude"));
+        report
+            .verifier_errors
+            .push(VerifierIssue::missing_dependency("effect", "4.0.0", "prelude"));
         report.recompute_summary();
 
         let dir = tempdir().unwrap();
         let path = dir.path().join("report.json");
-        report.write_json(path.clone()).unwrap();
-        let json = std::fs::read_to_string(path).unwrap();
+        report.write_json(&path).unwrap();
+        let json = std::fs::read_to_string(&path).unwrap();
 
-        assert!(json.contains("\"packageSet\""));
-        assert!(json.contains("\"selection\""));
-        assert!(json.contains("\"summary\""));
-        assert!(json.contains("\"diagnostics\""));
-        assert!(json.contains("\"verifierErrors\""));
+        let deserialized = Report::read_json(&path).unwrap();
+        let mut expected = report.clone();
+        expected.sort_details();
+        for diagnostic in &mut expected.diagnostics {
+            diagnostic.human.clear();
+        }
+
+        assert_eq!(deserialized.schema_version, REPORT_SCHEMA_VERSION);
+        assert_eq!(deserialized.package_set, expected.package_set);
+        assert_eq!(deserialized.selection, expected.selection);
+        assert_eq!(deserialized.summary, expected.summary);
+        assert_eq!(deserialized.diagnostics, expected.diagnostics);
+        assert_eq!(deserialized.verifier_errors, expected.verifier_errors);
         assert!(!json.contains("hidden from JSON"));
-        assert!(report.has_errors());
+    }
+
+    #[test]
+    fn reads_legacy_reports() {
+        let dir = tempdir().unwrap();
+        let legacy_path = dir.path().join("legacy.json");
+        let report = Report::new(
+            PackageSetReport {
+                version: "64.7.1".to_string(),
+                compiler: "0.15.15".to_string(),
+                published: "2025-05-06".to_string(),
+            },
+            SelectionReport {
+                mode: SelectionMode::Core,
+                requested_packages: Vec::new(),
+                resolved_packages: Vec::new(),
+            },
+        );
+        let mut legacy = serde_json::to_value(&report).unwrap();
+        legacy.as_object_mut().unwrap().remove("schemaVersion");
+        std::fs::write(&legacy_path, serde_json::to_vec(&legacy).unwrap()).unwrap();
+
+        let legacy = Report::read_json(&legacy_path).unwrap();
+        assert_eq!(legacy.schema_version, 0);
+    }
+
+    #[test]
+    fn rejects_future_schema_before_deserializing_report_fields() {
+        let dir = tempdir().unwrap();
+        let future_path = dir.path().join("future.json");
+        let future = serde_json::json!({ "schemaVersion": REPORT_SCHEMA_VERSION + 1 });
+        std::fs::write(&future_path, serde_json::to_vec(&future).unwrap()).unwrap();
+
+        let error = Report::read_json(&future_path).unwrap_err();
+        assert!(error.to_string().contains("unsupported report schema version"));
     }
 }

--- a/tests-compatibility/src/verifier/reporting.rs
+++ b/tests-compatibility/src/verifier/reporting.rs
@@ -1,0 +1,507 @@
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+
+use super::comparison::{
+    ComparisonReport, DiagnosticChange, DiagnosticKey, VerifierChange, diagnostic_groups,
+};
+use super::error::VerifierError;
+use super::report::{CompilerDiagnostic, DiagnosticSeverity, Report, VerifierIssue};
+
+#[derive(Clone, Copy)]
+enum ChangeKind {
+    Introduced,
+    Fixed,
+}
+
+#[derive(Clone, Copy)]
+enum AnnotationLevel {
+    Error,
+    Warning,
+}
+
+impl AnnotationLevel {
+    fn as_str(self) -> &'static str {
+        match self {
+            AnnotationLevel::Error => "error",
+            AnnotationLevel::Warning => "warning",
+        }
+    }
+}
+
+pub fn render_markdown(
+    comparison: &ComparisonReport,
+    candidate: &Report,
+    detail_limit: usize,
+) -> String {
+    let mut output = String::new();
+    output.push_str("# Compatibility regression report\n\n");
+    output.push_str(&format!(
+        "Package set {} for PureScript {}.\n\n",
+        html_code(&comparison.package_set.version),
+        html_code(&comparison.package_set.compiler)
+    ));
+    if comparison.has_regressions() {
+        output.push_str("❌ The candidate introduces compatibility errors.\n\n");
+    } else {
+        output.push_str("✅ The candidate introduces no compatibility errors.\n\n");
+    }
+    render_summary_table(&mut output, comparison);
+    render_introduced_errors(&mut output, comparison, detail_limit);
+    render_fixed_errors(&mut output, comparison, detail_limit);
+    render_warning_changes(&mut output, comparison, detail_limit);
+    let candidate_groups = diagnostic_groups(candidate);
+    render_candidate_diagnostics(
+        &mut output,
+        &candidate_groups,
+        DiagnosticSeverity::Error,
+        "Candidate errors",
+        detail_limit,
+    );
+    render_candidate_diagnostics(
+        &mut output,
+        &candidate_groups,
+        DiagnosticSeverity::Warning,
+        "Candidate warnings",
+        detail_limit,
+    );
+    output
+}
+
+pub fn append_markdown(path: &Path, markdown: &str) -> Result<(), VerifierError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    file.write_all(markdown.as_bytes())?;
+    Ok(())
+}
+
+pub fn github_annotations(
+    comparison: &ComparisonReport,
+    error_limit: usize,
+    warning_limit: usize,
+) -> String {
+    let mut annotations = String::new();
+    let introduced_errors = comparison.diagnostic_changes.iter().filter(|change| {
+        change.key.severity == DiagnosticSeverity::Error && change.introduced_count() > 0
+    });
+    let introduced_errors = introduced_errors.take(error_limit);
+    let mut emitted_errors = 0;
+    for change in introduced_errors {
+        let diagnostic = change
+            .candidate_diagnostics
+            .first()
+            .expect("introduced diagnostic has candidate evidence");
+        annotations.push_str(&github_command(
+            AnnotationLevel::Error,
+            &diagnostic_title(&change.key),
+            &annotation_diagnostic_message(diagnostic, change.introduced_count()),
+        ));
+        emitted_errors += 1;
+    }
+
+    let verifier_limit = error_limit.saturating_sub(emitted_errors);
+    let introduced_verifier_errors = comparison
+        .verifier_changes
+        .iter()
+        .filter(|change| change.introduced_count() > 0)
+        .take(verifier_limit);
+    for change in introduced_verifier_errors {
+        let issue = change
+            .candidate_issues
+            .first()
+            .expect("introduced verifier issue has candidate evidence");
+        annotations.push_str(&github_command(
+            AnnotationLevel::Error,
+            &format!("Compatibility verifier {}", change.key.kind),
+            &annotation_verifier_message(issue, change.introduced_count()),
+        ));
+    }
+
+    let introduced_warnings = comparison
+        .diagnostic_changes
+        .iter()
+        .filter(|change| {
+            change.key.severity == DiagnosticSeverity::Warning && change.introduced_count() > 0
+        })
+        .take(warning_limit);
+    for change in introduced_warnings {
+        let diagnostic = change
+            .candidate_diagnostics
+            .first()
+            .expect("introduced diagnostic has candidate evidence");
+        annotations.push_str(&github_command(
+            AnnotationLevel::Warning,
+            &diagnostic_title(&change.key),
+            &annotation_diagnostic_message(diagnostic, change.introduced_count()),
+        ));
+    }
+    annotations
+}
+
+fn render_summary_table(output: &mut String, comparison: &ComparisonReport) {
+    output.push_str("| Diagnostic class | Base | Candidate | Introduced | Fixed |\n");
+    output.push_str("| --- | ---: | ---: | ---: | ---: |\n");
+    output.push_str(&format!(
+        "| Compiler errors | {} | {} | {} | {} |\n",
+        comparison.base_summary.compiler_errors,
+        comparison.candidate_summary.compiler_errors,
+        comparison.summary.introduced_compiler_errors,
+        comparison.summary.fixed_compiler_errors
+    ));
+    output.push_str(&format!(
+        "| Compiler warnings | {} | {} | {} | {} |\n",
+        comparison.base_summary.compiler_warnings,
+        comparison.candidate_summary.compiler_warnings,
+        comparison.summary.introduced_compiler_warnings,
+        comparison.summary.fixed_compiler_warnings
+    ));
+    output.push_str(&format!(
+        "| Verifier errors | {} | {} | {} | {} |\n\n",
+        comparison.base_summary.verifier_errors,
+        comparison.candidate_summary.verifier_errors,
+        comparison.summary.introduced_verifier_errors,
+        comparison.summary.fixed_verifier_errors
+    ));
+}
+
+fn render_introduced_errors(
+    output: &mut String,
+    comparison: &ComparisonReport,
+    detail_limit: usize,
+) {
+    let diagnostics =
+        diagnostic_changes(comparison, DiagnosticSeverity::Error, ChangeKind::Introduced);
+    let verifier = verifier_changes(comparison, ChangeKind::Introduced);
+    output.push_str("## Introduced errors\n\n");
+    if diagnostics.is_empty() && verifier.is_empty() {
+        output.push_str("None.\n\n");
+        return;
+    }
+    if !diagnostics.is_empty() {
+        render_diagnostic_changes(output, &diagnostics, ChangeKind::Introduced, detail_limit);
+    }
+    if !verifier.is_empty() {
+        render_verifier_changes(output, &verifier, ChangeKind::Introduced, detail_limit);
+    }
+}
+
+fn render_fixed_errors(output: &mut String, comparison: &ComparisonReport, detail_limit: usize) {
+    let diagnostics = diagnostic_changes(comparison, DiagnosticSeverity::Error, ChangeKind::Fixed);
+    let verifier = verifier_changes(comparison, ChangeKind::Fixed);
+    let total = comparison.summary.fixed_compiler_errors + comparison.summary.fixed_verifier_errors;
+    output.push_str(&format!("<details>\n<summary>Fixed errors ({total})</summary>\n\n"));
+    if diagnostics.is_empty() && verifier.is_empty() {
+        output.push_str("None.\n\n");
+    } else {
+        if !diagnostics.is_empty() {
+            render_diagnostic_changes(output, &diagnostics, ChangeKind::Fixed, detail_limit);
+        }
+        if !verifier.is_empty() {
+            render_verifier_changes(output, &verifier, ChangeKind::Fixed, detail_limit);
+        }
+    }
+    output.push_str("</details>\n\n");
+}
+
+fn render_warning_changes(output: &mut String, comparison: &ComparisonReport, detail_limit: usize) {
+    let introduced =
+        diagnostic_changes(comparison, DiagnosticSeverity::Warning, ChangeKind::Introduced);
+    let fixed = diagnostic_changes(comparison, DiagnosticSeverity::Warning, ChangeKind::Fixed);
+    output.push_str(&format!(
+        "<details>\n<summary>Warning changes ({} introduced, {} fixed)</summary>\n\n",
+        comparison.summary.introduced_compiler_warnings, comparison.summary.fixed_compiler_warnings
+    ));
+    output.push_str("**Introduced**\n\n");
+    render_diagnostic_changes(output, &introduced, ChangeKind::Introduced, detail_limit);
+    output.push_str("**Fixed**\n\n");
+    render_diagnostic_changes(output, &fixed, ChangeKind::Fixed, detail_limit);
+    output.push_str("</details>\n\n");
+}
+
+fn diagnostic_changes(
+    comparison: &ComparisonReport,
+    severity: DiagnosticSeverity,
+    change_kind: ChangeKind,
+) -> Vec<&DiagnosticChange> {
+    let changes = comparison.diagnostic_changes.iter().filter(|change| {
+        change.key.severity == severity && diagnostic_change_count(change, change_kind) > 0
+    });
+    changes.collect()
+}
+
+fn verifier_changes(
+    comparison: &ComparisonReport,
+    change_kind: ChangeKind,
+) -> Vec<&VerifierChange> {
+    let changes = comparison
+        .verifier_changes
+        .iter()
+        .filter(|change| verifier_change_count(change, change_kind) > 0);
+    changes.collect()
+}
+
+fn render_diagnostic_changes(
+    output: &mut String,
+    changes: &[&DiagnosticChange],
+    change_kind: ChangeKind,
+    detail_limit: usize,
+) {
+    if changes.is_empty() {
+        output.push_str("None.\n\n");
+        return;
+    }
+    for change in changes.iter().take(detail_limit) {
+        let count = diagnostic_change_count(change, change_kind);
+        let evidence = diagnostic_evidence(change, change_kind);
+        output.push_str(&format_diagnostic_item(&change.key, evidence, count));
+    }
+    render_omitted(output, changes.len(), detail_limit);
+    output.push('\n');
+}
+
+fn render_verifier_changes(
+    output: &mut String,
+    changes: &[&VerifierChange],
+    change_kind: ChangeKind,
+    detail_limit: usize,
+) {
+    for change in changes.iter().take(detail_limit) {
+        let count = verifier_change_count(change, change_kind);
+        let evidence = verifier_evidence(change, change_kind);
+        output.push_str(&format!(
+            "- <strong>Verifier {}</strong>{}: {}\n",
+            html_code(change.key.kind.as_str()),
+            count_suffix(count),
+            escape_markdown_text(&evidence.message)
+        ));
+    }
+    render_omitted(output, changes.len(), detail_limit);
+    if !changes.is_empty() {
+        output.push('\n');
+    }
+}
+
+fn render_candidate_diagnostics(
+    output: &mut String,
+    groups: &BTreeMap<DiagnosticKey, Vec<CompilerDiagnostic>>,
+    severity: DiagnosticSeverity,
+    title: &str,
+    detail_limit: usize,
+) {
+    let matching_groups = groups.iter().filter(|(key, _)| key.severity == severity);
+    let matching_groups = matching_groups.collect::<Vec<_>>();
+    let diagnostic_counts = matching_groups.iter().map(|(_, diagnostics)| diagnostics.len());
+    let total = diagnostic_counts.sum::<usize>();
+    output.push_str(&format!("<details>\n<summary>{title} ({total})</summary>\n\n"));
+    for (key, diagnostics) in matching_groups.iter().take(detail_limit) {
+        let evidence = diagnostics.first().expect("diagnostic group is non-empty");
+        output.push_str(&format_diagnostic_item(key, evidence, diagnostics.len()));
+    }
+    if matching_groups.is_empty() {
+        output.push_str("None.\n");
+    }
+    render_omitted(output, matching_groups.len(), detail_limit);
+    output.push_str("\n</details>\n\n");
+}
+
+fn diagnostic_change_count(change: &DiagnosticChange, change_kind: ChangeKind) -> usize {
+    match change_kind {
+        ChangeKind::Introduced => change.introduced_count(),
+        ChangeKind::Fixed => change.fixed_count(),
+    }
+}
+
+fn verifier_change_count(change: &VerifierChange, change_kind: ChangeKind) -> usize {
+    match change_kind {
+        ChangeKind::Introduced => change.introduced_count(),
+        ChangeKind::Fixed => change.fixed_count(),
+    }
+}
+
+fn diagnostic_evidence(change: &DiagnosticChange, change_kind: ChangeKind) -> &CompilerDiagnostic {
+    let evidence = match change_kind {
+        ChangeKind::Introduced => change.candidate_diagnostics.first(),
+        ChangeKind::Fixed => change.base_diagnostics.first(),
+    };
+    evidence.expect("changed diagnostic has evidence")
+}
+
+fn verifier_evidence(change: &VerifierChange, change_kind: ChangeKind) -> &VerifierIssue {
+    let evidence = match change_kind {
+        ChangeKind::Introduced => change.candidate_issues.first(),
+        ChangeKind::Fixed => change.base_issues.first(),
+    };
+    evidence.expect("changed verifier issue has evidence")
+}
+
+fn format_diagnostic_item(
+    key: &DiagnosticKey,
+    diagnostic: &CompilerDiagnostic,
+    count: usize,
+) -> String {
+    let location = diagnostic
+        .span
+        .start_position
+        .as_ref()
+        .map(|position| format!(":{}:{}", position.line, position.column))
+        .unwrap_or_default();
+    let path = format!("{}@{}/{}{}", key.package, key.version, key.file, location);
+    format!(
+        "- {} — <strong>{}</strong> ({}){}: {}\n",
+        html_code(&path),
+        escape_html(&key.code),
+        html_code(key.stage.as_str()),
+        count_suffix(count),
+        escape_markdown_text(&diagnostic.message)
+    )
+}
+
+fn render_omitted(output: &mut String, count: usize, limit: usize) {
+    if count > limit {
+        output.push_str(&format!(
+            "- … {} additional groups are available in the JSON artifact.\n",
+            count - limit
+        ));
+    }
+}
+
+fn count_suffix(count: usize) -> String {
+    if count == 1 { String::new() } else { format!(" × {count}") }
+}
+
+fn diagnostic_title(key: &DiagnosticKey) -> String {
+    format!("{}@{}/{} [{}:{}]", key.package, key.version, key.file, key.stage, key.code)
+}
+
+fn annotation_diagnostic_message(diagnostic: &CompilerDiagnostic, count: usize) -> String {
+    let location = diagnostic
+        .span
+        .start_position
+        .as_ref()
+        .map(|position| format!("{}:{}:{}: ", diagnostic.file, position.line, position.column))
+        .unwrap_or_else(|| format!("{}: ", diagnostic.file));
+    format!("{location}{}{}", diagnostic.message, count_suffix(count))
+}
+
+fn annotation_verifier_message(issue: &VerifierIssue, count: usize) -> String {
+    format!("{}{}", issue.message, count_suffix(count))
+}
+
+fn github_command(level: AnnotationLevel, title: &str, message: &str) -> String {
+    let level = level.as_str();
+    format!("::{level} title={}::{}\n", github_property(title), github_data(message))
+}
+
+fn github_property(value: &str) -> String {
+    github_data(value).replace(':', "%3A").replace(',', "%2C")
+}
+
+fn github_data(value: &str) -> String {
+    value.replace('%', "%25").replace('\r', "%0D").replace('\n', "%0A")
+}
+
+fn html_code(value: &str) -> String {
+    format!("<code>{}</code>", escape_html(value))
+}
+
+fn escape_html(value: &str) -> String {
+    value.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
+}
+
+fn escape_markdown_text(value: &str) -> String {
+    let value = value.replace('\r', "");
+    let lines = value.split('\n').map(|line| {
+        let mut escaped = String::new();
+        for character in line.chars() {
+            match character {
+                '&' => escaped.push_str("&amp;"),
+                '<' => escaped.push_str("&lt;"),
+                '>' => escaped.push_str("&gt;"),
+                '\\' | '`' | '*' | '_' | '{' | '}' | '[' | ']' | '(' | ')' | '#' | '+' | '-'
+                | '.' | '!' | '|' => {
+                    escaped.push('\\');
+                    escaped.push(character);
+                }
+                _ => escaped.push(character),
+            }
+        }
+        escaped
+    });
+    let lines = lines.collect::<Vec<_>>();
+    lines.join("<br>")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::comparison::compare_reports;
+    use super::super::report::{
+        CompilationStage, CompilerDiagnostic, DiagnosticSeverity, PackageSetReport, Report,
+        SelectionReport, SourcePosition, SpanReport,
+    };
+    use super::super::selection::{SelectedPackage, SelectionMode};
+
+    use super::{github_annotations, render_markdown};
+
+    #[test]
+    fn renders_warnings_safely_in_markdown_and_annotations() {
+        let base = report();
+        let mut candidate = report();
+        candidate.diagnostics.push(warning("first line%\r\nsecond *line* _[x]_ `tick` \\ <tag> &"));
+        candidate.recompute_summary();
+        let comparison = compare_reports(&base, &candidate).unwrap();
+
+        let markdown = render_markdown(&comparison, &candidate, 20);
+        let annotations = github_annotations(&comparison, 10, 10);
+
+        assert!(markdown.contains("<summary>Warning changes (1 introduced, 0 fixed)</summary>"));
+        assert!(
+            markdown.contains(
+                r"first line%<br>second \*line\* \_\[x\]\_ \`tick\` \\ &lt;tag&gt; &amp;"
+            )
+        );
+        assert!(annotations.starts_with("::warning title="));
+        assert!(annotations.contains("first line%25%0D%0Asecond *line*"));
+    }
+
+    fn report() -> Report {
+        let mut report = Report::new(
+            PackageSetReport {
+                version: "80.3.1".to_string(),
+                compiler: "0.15.15".to_string(),
+                published: "2026-08-07".to_string(),
+            },
+            SelectionReport {
+                mode: SelectionMode::Combined,
+                requested_packages: Vec::new(),
+                resolved_packages: vec![SelectedPackage {
+                    name: "prelude".to_string(),
+                    version: "6.0.2".to_string(),
+                }],
+            },
+        );
+        report.summary.source_files = 1;
+        report
+    }
+
+    fn warning(message: &str) -> CompilerDiagnostic {
+        CompilerDiagnostic {
+            package: "prelude".to_string(),
+            version: "6.0.2".to_string(),
+            file: "src/Prelude.purs".to_string(),
+            stage: CompilationStage::Checking,
+            severity: DiagnosticSeverity::Warning,
+            code: "Warning".to_string(),
+            message: message.to_string(),
+            span: SpanReport {
+                start: 1,
+                end: 2,
+                start_position: Some(SourcePosition { line: 1, column: 2 }),
+                end_position: Some(SourcePosition { line: 1, column: 3 }),
+            },
+            human: String::new(),
+        }
+    }
+}

--- a/tests-compatibility/src/verifier/selection.rs
+++ b/tests-compatibility/src/verifier/selection.rs
@@ -56,7 +56,10 @@ pub fn resolve_selection(
         _ => SelectionMode::Combined,
     };
 
-    roots.extend(preset_package_names(&presets));
+    let preset_packages = preset_package_names(&presets);
+    let available_preset_packages =
+        preset_packages.into_iter().filter(|package| package_versions.contains_key(package));
+    roots.extend(available_preset_packages);
 
     let mut manifests: HashMap<String, Manifest> = HashMap::new();
     let mut selection = resolve_closure_with(roots, package_versions, |name| {
@@ -116,7 +119,7 @@ where
             if package_versions.contains_key(dependency) {
                 queue.push_back(dependency.clone());
             } else {
-                errors.push(VerifierIssue::missing_dependency(&package, dependency));
+                errors.push(VerifierIssue::missing_dependency(&package, version, dependency));
             }
         }
     }
@@ -138,6 +141,7 @@ mod tests {
 
     use tests_compatibility::registry::{Location, Manifest};
 
+    use super::super::report::VerifierIssueKind;
     use super::{normalize_core_package, resolve_closure_with};
 
     fn manifest(name: &str, version: &str, deps: &[&str]) -> Manifest {
@@ -190,7 +194,7 @@ mod tests {
             })
             .unwrap();
 
-        assert_eq!(resolved.errors[0].kind, "MissingPackageSetDependency");
+        assert_eq!(resolved.errors[0].kind, VerifierIssueKind::MissingPackageSetDependency);
     }
 
     #[test]
@@ -201,6 +205,6 @@ mod tests {
             resolve_closure_with(BTreeSet::from(["effect".to_string()]), &versions, |_| Ok(None))
                 .unwrap();
 
-        assert_eq!(resolved.errors[0].kind, "MissingManifest");
+        assert_eq!(resolved.errors[0].kind, VerifierIssueKind::MissingManifest);
     }
 }


### PR DESCRIPTION
## Intent

Package compatibility runs currently show whether the selected corpus compiles, but they do not distinguish existing incompatibilities from regressions introduced by a pull request. Make core and Acme compatibility a pull-request regression check that reports actionable package, file, and diagnostic details without treating the package set's existing warnings as failures.

## What changed

- Build the base and candidate compatibility verifiers in a dedicated pull-request job.
- Prepare core and Acme once, then run both revisions against the same package set, registry snapshot, cache, and extracted sources.
- Collect each file's compiler queries in parallel through query-engine snapshots after sequential module registration.
- Persist versioned JSON reports with package-relative paths, structured verifier locations, typed stages and severities, and one-based source positions.
- Compare diagnostics as multisets keyed by package, version, file, stage, severity, and code. Diagnostic messages and spans remain informative evidence rather than identity.
- Retain schema-v0 report compatibility so the candidate comparator can read reports produced by the base revision.

## Regression behavior

- Fail for introduced compiler errors or verifier errors.
- Report introduced and fixed warnings without failing.
- Treat message-only and span-only changes as non-regressions.
- Reject comparisons if the package set, resolved package selection, or source-file count differs.

## GitHub output

- Emit capped error and warning workflow annotations.
- Append a Markdown summary with introduced errors expanded and warning/existing-diagnostic sections collapsed.
- Upload uncapped base, candidate, and comparison JSON reports together with command logs.
- Preserve reports and summaries before propagating a regression or execution failure.

## Validation

- `cargo check -p tests-compatibility --tests`
- `cargo nextest run -p tests-compatibility` (23 passed)
- `just format`
- Prettier validation for `.github/workflows/checks.yml`
- Current core+Acme corpus: 630 packages and 7,344 files in 28.20 seconds; 50 existing errors, 33 existing warnings, and no verifier errors
- Legacy-base comparison: no introduced compiler errors, warnings, or verifier errors
- Synthetic introduced error: comparator exited 1, emitted an error annotation, and marked the job summary failed