### PR TITLE
[checking] Reuse delegated newtype superclass dictionaries

### DIFF
--- a/compiler-core/checking/src/source/derive/generate.rs
+++ b/compiler-core/checking/src/source/derive/generate.rs
@@ -84,14 +84,6 @@ where
             evidences.push(tree::InstanceEvidence { constraint: signature_constraint, evidence });
         }
 
-        let superclasses = emit_instance_superclass_constraints(
-            state,
-            context,
-            result.class_file,
-            result.class_id,
-            &freshened.arguments,
-        )?;
-
         let delegate_constraint =
             freshened.renaming.substitute(state, context, delegate_constraint)?;
         let evidence = state.push_wanted(delegate_constraint);
@@ -100,7 +92,7 @@ where
             class: (result.class_file, result.class_id),
             rigid_parameters: Arc::from(freshened.rigids),
             evidences: Arc::from(evidences),
-            superclasses: Arc::from(superclasses),
+            superclasses: Arc::from([]),
             implementation: tree::InstanceImplementation::Delegate {
                 constraint: delegate_constraint,
                 evidence,

--- a/tests-integration/fixtures/checking/1786504980_derive_newtype_delegated_superclass/Main.purs
+++ b/tests-integration/fixtures/checking/1786504980_derive_newtype_delegated_superclass/Main.purs
@@ -1,0 +1,22 @@
+module Main where
+
+class Parent :: (Type -> Type) -> Constraint
+class Parent constructor
+
+class Parent constructor <= Child constructor
+
+class Gate :: (Type -> Type) -> Constraint
+class Gate constructor
+
+data Representation :: (Type -> Type) -> Type -> Type
+data Representation parameter value = Representation
+
+instance Parent (Representation parameter)
+instance Child (Representation parameter)
+
+newtype Wrapper :: (Type -> Type) -> Type -> Type
+newtype Wrapper parameter value = Wrapper (Representation parameter value)
+
+instance Gate parameter => Parent (Wrapper parameter)
+
+derive newtype instance Child (Wrapper parameter)

--- a/tests-integration/fixtures/checking/1786504980_derive_newtype_delegated_superclass/Main.snap
+++ b/tests-integration/fixtures/checking/1786504980_derive_newtype_delegated_superclass/Main.snap
@@ -40,10 +40,3 @@ derive forall (parameter :: Prim.Type -> Prim.Type).
 Roles
 Representation = [Phantom, Phantom]
 Wrapper = [Representational, Representational]
-
-Diagnostics
-error[NoInstanceFound]: No instance found for: Gate (parameter :: Type -> Type)
-  --> 22:1..22:50
-   |
-22 | derive newtype instance Child (Wrapper parameter)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786504980_derive_newtype_delegated_superclass/Main.snap
+++ b/tests-integration/fixtures/checking/1786504980_derive_newtype_delegated_superclass/Main.snap
@@ -1,0 +1,49 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Representation ::
+  forall (@parameter :: Prim.Type -> Prim.Type) (@value :: Prim.Type).
+    Main.Representation (parameter :: Prim.Type -> Prim.Type) (value :: Prim.Type)
+Wrapper ::
+  forall (@parameter :: Prim.Type -> Prim.Type) (@value :: Prim.Type).
+    Main.Representation (parameter :: Prim.Type -> Prim.Type) (value :: Prim.Type) ->
+    Main.Wrapper (parameter :: Prim.Type -> Prim.Type) (value :: Prim.Type)
+
+Types
+Parent :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+Child :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+Gate :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+Representation :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type
+Wrapper :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type
+
+Classes
+class forall (constructor :: Prim.Type -> Prim.Type). Main.Parent (constructor :: Prim.Type -> Prim.Type)
+class forall (constructor :: Prim.Type -> Prim.Type). Main.Parent (constructor :: Prim.Type -> Prim.Type) <= Main.Child (constructor :: Prim.Type -> Prim.Type)
+class forall (constructor :: Prim.Type -> Prim.Type). Main.Gate (constructor :: Prim.Type -> Prim.Type)
+
+Instances
+instance forall (parameter :: Prim.Type -> Prim.Type).
+  Main.Parent (Main.Representation (parameter :: Prim.Type -> Prim.Type))
+instance forall (parameter :: Prim.Type -> Prim.Type).
+  Main.Child (Main.Representation (parameter :: Prim.Type -> Prim.Type))
+instance forall (parameter :: Prim.Type -> Prim.Type).
+  Main.Gate (parameter :: Prim.Type -> Prim.Type) =>
+  Main.Parent (Main.Wrapper (parameter :: Prim.Type -> Prim.Type))
+
+Derived
+derive forall (parameter :: Prim.Type -> Prim.Type).
+  Main.Child (Main.Wrapper (parameter :: Prim.Type -> Prim.Type))
+
+Roles
+Representation = [Phantom, Phantom]
+Wrapper = [Representational, Representational]
+
+Diagnostics
+error[NoInstanceFound]: No instance found for: Gate (parameter :: Type -> Type)
+  --> 22:1..22:50
+   |
+22 | derive newtype instance Child (Wrapper parameter)
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786504980_derive_newtype_missing_delegated_subclass/Main.purs
+++ b/tests-integration/fixtures/checking/1786504980_derive_newtype_missing_delegated_subclass/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+class Parent value
+
+class Parent value <= Child value
+
+data Representation = Representation
+
+instance Parent Representation
+
+newtype Wrapper = Wrapper Representation
+
+instance Parent Wrapper
+
+derive newtype instance Child Wrapper

--- a/tests-integration/fixtures/checking/1786504980_derive_newtype_missing_delegated_subclass/Main.snap
+++ b/tests-integration/fixtures/checking/1786504980_derive_newtype_missing_delegated_subclass/Main.snap
@@ -1,0 +1,36 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Representation :: Main.Representation
+Wrapper :: Main.Representation -> Main.Wrapper
+
+Types
+Parent :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> Prim.Constraint
+Child :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> Prim.Constraint
+Representation :: Prim.Type
+Wrapper :: Prim.Type
+
+Classes
+class forall (t0 :: Prim.Type) (value :: (t0 :: Prim.Type)). Main.Parent @(t0 :: Prim.Type) (value :: (t0 :: Prim.Type))
+class forall (t0 :: Prim.Type) (value :: (t0 :: Prim.Type)). Main.Parent @(t0 :: Prim.Type) (value :: (t0 :: Prim.Type)) <= Main.Child @(t0 :: Prim.Type) (value :: (t0 :: Prim.Type))
+
+Instances
+instance Main.Parent @Prim.Type Main.Representation
+instance Main.Parent @Prim.Type Main.Wrapper
+
+Derived
+derive Main.Child @Prim.Type Main.Wrapper
+
+Roles
+Representation = []
+Wrapper = []
+
+Diagnostics
+error[NoInstanceFound]: No instance found for: Child @Type Representation
+  --> 15:1..15:38
+   |
+15 | derive newtype instance Child Wrapper
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/semantic/1786504980_derive_newtype_context_delegate_evidence/Main.purs
+++ b/tests-integration/fixtures/semantic/1786504980_derive_newtype_context_delegate_evidence/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+class Parent :: Type -> Constraint
+class Parent value
+
+class Relation :: Type -> Type -> Constraint
+class Parent value <= Relation label value | value -> label
+
+newtype Wrapper value = Wrapper value
+
+derive newtype instance Relation label value => Relation label (Wrapper value)

--- a/tests-integration/fixtures/semantic/1786504980_derive_newtype_context_delegate_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1786504980_derive_newtype_context_delegate_evidence/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Parent :: Prim.Type -> Prim.Constraint
+interface Parent value where
+
+interface Relation :: Prim.Type -> Prim.Type -> Prim.Constraint
+interface Relation label value where
+  superclass parentDict :: Main.Parent value
+
+newtype Wrapper :: Prim.Type -> Prim.Type
+newtype Wrapper @value
+  | Wrapper :: value -> Main.Wrapper value

--- a/tests-integration/fixtures/semantic/1786504980_derive_newtype_context_delegate_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1786504980_derive_newtype_context_delegate_evidence/Main.snap
@@ -13,3 +13,8 @@ interface Relation label value where
 newtype Wrapper :: Prim.Type -> Prim.Type
 newtype Wrapper @value
   | Wrapper :: value -> Main.Wrapper value
+
+dictionary relationWrapper ::
+  forall label value.
+  { relationDict :: Main.Relation label value } =>
+  Main.Relation label (Main.Wrapper value) = relationDict

--- a/tests-integration/fixtures/semantic/1786504980_derive_newtype_delegated_superclass_evidence/Main.purs
+++ b/tests-integration/fixtures/semantic/1786504980_derive_newtype_delegated_superclass_evidence/Main.purs
@@ -1,0 +1,30 @@
+module Main where
+
+class Parent value where
+  parent :: value -> value
+
+class Parent value <= Child value where
+  child :: value -> value
+
+class Gate
+
+data Representation = Representation
+
+instance Parent Representation where
+  parent value = value
+
+instance Child Representation where
+  child value = value
+
+newtype Wrapper = Wrapper Representation
+
+instance Gate => Parent Wrapper where
+  parent value = value
+
+derive newtype instance Child Wrapper
+
+parentFromChild :: forall value. Child value => value -> value
+parentFromChild = parent
+
+useDelegateSuperclass :: Wrapper -> Wrapper
+useDelegateSuperclass = parentFromChild

--- a/tests-integration/fixtures/semantic/1786504980_derive_newtype_delegated_superclass_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1786504980_derive_newtype_delegated_superclass_evidence/Main.snap
@@ -1,0 +1,43 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Parent :: Prim.Type -> Prim.Constraint
+interface Parent value where
+  parent :: value -> value
+
+interface Child :: Prim.Type -> Prim.Constraint
+interface Child value where
+  superclass parentDict :: Main.Parent value
+  child :: value -> value
+
+interface Gate :: Prim.Constraint
+interface Gate where
+
+data Representation :: Prim.Type
+data Representation
+  | Representation :: Main.Representation
+
+newtype Wrapper :: Prim.Type
+newtype Wrapper
+  | Wrapper :: Main.Representation -> Main.Wrapper
+
+dictionary parentRepresentation :: Main.Parent Main.Representation where
+  parent :: Main.Representation -> Main.Representation
+  parent = \value -> value
+
+dictionary childRepresentation :: Main.Child Main.Representation where
+  superclass parentDict = parentRepresentation
+  child :: Main.Representation -> Main.Representation
+  child = \value -> value
+
+dictionary parentWrapper :: { gateDict :: Main.Gate } => Main.Parent Main.Wrapper where
+  parent :: Main.Wrapper -> Main.Wrapper
+  parent = \value -> value
+
+parentFromChild :: forall value. Main.Child value => value -> value
+parentFromChild = \@value -> \{childDict} -> parent @value {childDict.parentDict}
+
+useDelegateSuperclass :: Main.Wrapper -> Main.Wrapper
+useDelegateSuperclass = parentFromChild @Main.Wrapper {<instance>}

--- a/tests-integration/fixtures/semantic/1786504980_derive_newtype_delegated_superclass_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1786504980_derive_newtype_delegated_superclass_evidence/Main.snap
@@ -36,8 +36,10 @@ dictionary parentWrapper :: { gateDict :: Main.Gate } => Main.Parent Main.Wrappe
   parent :: Main.Wrapper -> Main.Wrapper
   parent = \value -> value
 
+dictionary childWrapper :: Main.Child Main.Wrapper = childRepresentation
+
 parentFromChild :: forall value. Main.Child value => value -> value
 parentFromChild = \@value -> \{childDict} -> parent @value {childDict.parentDict}
 
 useDelegateSuperclass :: Main.Wrapper -> Main.Wrapper
-useDelegateSuperclass = parentFromChild @Main.Wrapper {<instance>}
+useDelegateSuperclass = parentFromChild @Main.Wrapper {childWrapper}


### PR DESCRIPTION
## Summary

- stop generating wrapper-level superclass wanteds for delegated newtype dictionaries
- retain represented-dictionary validation and evidence generation
- cover overconstrained wrapper superclasses, context-selected multi-parameter evidence, superclass projection, and missing represented evidence

Delegated instances return the complete represented dictionary directly. Unlike member-built dictionaries, they do not construct independent superclass fields; solving those fields at the wrapper type rejected valid programs and could select evidence unrelated to the delegated dictionary.

Fixes #295.

## Verification

- `cargo check -p checking --tests`
- `cargo nextest run -p checking` — 30 passed
- `just t checking 1786504980 --verbose` — 2 passed, no pending snapshots
- `just t semantic 1786504980 --verbose` — 2 passed, no pending snapshots
- `just t checking --verbose` — 361 passed, no pending snapshots
- `just t semantic --verbose` — 151 passed, no pending snapshots
- `just format --check`

Release compatibility against package set 80.3.1 (`purs` 0.15.15) checked 67 packages and 466 files:

```sh
cargo run -q -p tests-compatibility --release -- verify \
  --registry-dir /tmp/alex-registry \
  --index-dir /tmp/alex-registry-index \
  --package jelly --package trivial-unfold \
  --cache-dir /tmp/alex-compat-cache \
  --json-output /tmp/alex-fix-report.json
```

Neither `jelly` nor `trivial-unfold` reports an error. The verifier still exits 1 for two unrelated existing `Eq1 Lazy` / `Ord1 Lazy` derive errors.

As an upstream behavioral check, `purs --version` reported `0.15.15`, and this compiled all 466 package-set files, including both affected modules:

```sh
/tmp/purs-oracle/node_modules/.bin/purs compile \
  '/tmp/alex-compat-cache/sources/*/*/src/**/*.purs' \
  --output /tmp/purs-out-packages-clean --codegen corefn
```