### PR TITLE
[checking] Allow lifted deriving for local foreign data

### DIFF
--- a/compiler-core/checking/src/source/derive/eq1_ord1.rs
+++ b/compiler-core/checking/src/source/derive/eq1_ord1.rs
@@ -66,7 +66,7 @@ where
         return Ok(None);
     };
 
-    if tools::extract_local_algebraic_data(state, context, *derived_type)?.is_none() {
+    if tools::extract_local_type_constructor(state, context, *derived_type)?.is_none() {
         state.insert_error(ErrorKind::CannotDeriveForType { type_id: *derived_type });
         return Ok(None);
     }

--- a/compiler-core/checking/src/source/derive/tools.rs
+++ b/compiler-core/checking/src/source/derive/tools.rs
@@ -74,6 +74,32 @@ where
     }
 }
 
+pub fn extract_local_type_constructor<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    derived_type: TypeId,
+) -> QueryResult<Option<(FileId, TypeItemId)>>
+where
+    Q: ExternalQueries,
+{
+    let Some((type_file, type_id)) =
+        toolkit::extract_type_constructor(state, context, derived_type)?
+    else {
+        return Ok(None);
+    };
+    if type_file != context.id {
+        return Ok(None);
+    }
+
+    let kind = &context.indexed.items[type_id].kind;
+    match kind {
+        IndexedTypeItemKind::Data { .. }
+        | IndexedTypeItemKind::Newtype { .. }
+        | IndexedTypeItemKind::Foreign { .. } => Ok(Some((type_file, type_id))),
+        _ => Ok(None),
+    }
+}
+
 pub fn extract_local_algebraic_data<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
@@ -82,14 +108,10 @@ pub fn extract_local_algebraic_data<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some((data_file, data_id)) =
-        toolkit::extract_type_constructor(state, context, derived_type)?
+    let Some((data_file, data_id)) = extract_local_type_constructor(state, context, derived_type)?
     else {
         return Ok(None);
     };
-    if data_file != context.id {
-        return Ok(None);
-    }
 
     let kind = &context.indexed.items[data_id].kind;
     match kind {

--- a/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Library.purs
+++ b/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Library.purs
@@ -1,3 +1,20 @@
 module Library where
 
-data Imported a = Imported a
+import Data.Eq (class Eq)
+import Data.Ord (class Ord)
+import Data.Ordering (Ordering(..))
+
+data ImportedStructural a = ImportedStructural a
+
+data ImportedLifted a = ImportedLifted a
+
+derive instance Eq a => Eq (ImportedLifted a)
+derive instance Ord a => Ord (ImportedLifted a)
+
+foreign import data ImportedOpaque :: Type -> Type
+
+instance Eq a => Eq (ImportedOpaque a) where
+  eq _ _ = true
+
+instance Ord a => Ord (ImportedOpaque a) where
+  compare _ _ = EQ

--- a/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.purs
+++ b/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.purs
@@ -2,14 +2,13 @@ module Main where
 
 import Data.Eq (class Eq, class Eq1)
 import Data.Ord (class Ord, class Ord1)
-import Library (Imported)
+import Library (ImportedLifted, ImportedOpaque, ImportedStructural)
 
-foreign import data Opaque1 :: Type -> Type
+derive instance Eq a => Eq (ImportedStructural a)
+derive instance Ord a => Ord (ImportedStructural a)
 
-derive instance Eq1 Opaque1
-derive instance Ord1 Opaque1
+derive instance Eq1 ImportedLifted
+derive instance Ord1 ImportedLifted
 
-derive instance Eq a => Eq (Imported a)
-derive instance Eq1 Imported
-derive instance Ord a => Ord (Imported a)
-derive instance Ord1 Imported
+derive instance Eq1 ImportedOpaque
+derive instance Ord1 ImportedOpaque

--- a/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.snap
+++ b/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.snap
@@ -6,49 +6,45 @@ expression: report
 Terms
 
 Types
-Opaque1 :: Prim.Type -> Prim.Type
 
 Derived
-derive Data.Eq.Eq1 Main.Opaque1
-derive Data.Ord.Ord1 Main.Opaque1
 derive forall (a :: Prim.Type).
-  Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Library.Imported (a :: Prim.Type))
-derive Data.Eq.Eq1 Library.Imported
+  Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Library.ImportedStructural (a :: Prim.Type))
 derive forall (a :: Prim.Type).
-  Data.Ord.Ord (a :: Prim.Type) => Data.Ord.Ord (Library.Imported (a :: Prim.Type))
-derive Data.Ord.Ord1 Library.Imported
-
-Roles
-Opaque1 = [Nominal]
+  Data.Ord.Ord (a :: Prim.Type) => Data.Ord.Ord (Library.ImportedStructural (a :: Prim.Type))
+derive Data.Eq.Eq1 Library.ImportedLifted
+derive Data.Ord.Ord1 Library.ImportedLifted
+derive Data.Eq.Eq1 Library.ImportedOpaque
+derive Data.Ord.Ord1 Library.ImportedOpaque
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: Opaque1
-  --> 9:1..9:28
+error[CannotDeriveForType]: Cannot derive for type: ImportedStructural (a :: Type)
+  --> 7:1..7:50
   |
-9 | derive instance Eq1 Opaque1
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: Opaque1
-  --> 10:1..10:29
+7 | derive instance Eq a => Eq (ImportedStructural a)
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotDeriveForType]: Cannot derive for type: ImportedStructural (a1 :: Type)
+  --> 8:1..8:52
+  |
+8 | derive instance Ord a => Ord (ImportedStructural a)
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotDeriveForType]: Cannot derive for type: ImportedLifted
+  --> 10:1..10:35
    |
-10 | derive instance Ord1 Opaque1
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: Imported (a :: Type)
-  --> 12:1..12:40
+10 | derive instance Eq1 ImportedLifted
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotDeriveForType]: Cannot derive for type: ImportedLifted
+  --> 11:1..11:36
    |
-12 | derive instance Eq a => Eq (Imported a)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: Imported
-  --> 13:1..13:29
+11 | derive instance Ord1 ImportedLifted
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotDeriveForType]: Cannot derive for type: ImportedOpaque
+  --> 13:1..13:35
    |
-13 | derive instance Eq1 Imported
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: Imported (a1 :: Type)
-  --> 14:1..14:42
+13 | derive instance Eq1 ImportedOpaque
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotDeriveForType]: Cannot derive for type: ImportedOpaque
+  --> 14:1..14:36
    |
-14 | derive instance Ord a => Ord (Imported a)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: Imported
-  --> 15:1..15:30
-   |
-15 | derive instance Ord1 Imported
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+14 | derive instance Ord1 ImportedOpaque
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786505040_derive_eq1_ord1_local_foreign_data/Main.purs
+++ b/tests-integration/fixtures/checking/1786505040_derive_eq1_ord1_local_foreign_data/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+import Data.Eq (class Eq, class Eq1)
+import Data.Ord (class Ord, class Ord1)
+import Data.Ordering (Ordering(..))
+
+foreign import data Opaque :: Type -> Type
+
+instance Eq a => Eq (Opaque a) where
+  eq _ _ = true
+
+derive instance Eq1 Opaque
+
+instance Ord a => Ord (Opaque a) where
+  compare _ _ = EQ
+
+derive instance Ord1 Opaque

--- a/tests-integration/fixtures/checking/1786505040_derive_eq1_ord1_local_foreign_data/Main.snap
+++ b/tests-integration/fixtures/checking/1786505040_derive_eq1_ord1_local_foreign_data/Main.snap
@@ -1,0 +1,33 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+
+Types
+Opaque :: Prim.Type -> Prim.Type
+
+Instances
+instance forall (a :: Prim.Type). Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Main.Opaque (a :: Prim.Type))
+instance forall (a :: Prim.Type).
+  Data.Ord.Ord (a :: Prim.Type) => Data.Ord.Ord (Main.Opaque (a :: Prim.Type))
+
+Derived
+derive Data.Eq.Eq1 Main.Opaque
+derive Data.Ord.Ord1 Main.Opaque
+
+Roles
+Opaque = [Nominal]
+
+Diagnostics
+error[CannotDeriveForType]: Cannot derive for type: Opaque
+  --> 12:1..12:27
+   |
+12 | derive instance Eq1 Opaque
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotDeriveForType]: Cannot derive for type: Opaque
+  --> 17:1..17:28
+   |
+17 | derive instance Ord1 Opaque
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786505040_derive_eq1_ord1_local_foreign_data/Main.snap
+++ b/tests-integration/fixtures/checking/1786505040_derive_eq1_ord1_local_foreign_data/Main.snap
@@ -19,15 +19,3 @@ derive Data.Ord.Ord1 Main.Opaque
 
 Roles
 Opaque = [Nominal]
-
-Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: Opaque
-  --> 12:1..12:27
-   |
-12 | derive instance Eq1 Opaque
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: Opaque
-  --> 17:1..17:28
-   |
-17 | derive instance Ord1 Opaque
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786505040_derive_lifted_foreign_ownership_boundaries/Library.purs
+++ b/tests-integration/fixtures/checking/1786505040_derive_lifted_foreign_ownership_boundaries/Library.purs
@@ -1,0 +1,8 @@
+module Library where
+
+import Data.Eq (class Eq)
+
+foreign import data ImportedOpaque :: Type -> Type
+
+instance Eq a => Eq (ImportedOpaque a) where
+  eq _ _ = true

--- a/tests-integration/fixtures/checking/1786505040_derive_lifted_foreign_ownership_boundaries/Main.purs
+++ b/tests-integration/fixtures/checking/1786505040_derive_lifted_foreign_ownership_boundaries/Main.purs
@@ -1,0 +1,27 @@
+module Main where
+
+import Data.Eq (class Eq, class Eq1)
+import Library (ImportedOpaque)
+
+foreign import data LocalOpaque :: Type -> Type
+
+instance Eq a => Eq (LocalOpaque a) where
+  eq _ _ = true
+
+type LocalAlias = LocalOpaque
+
+derive instance Eq1 LocalAlias
+
+type ImportedAlias = ImportedOpaque
+
+derive instance Eq1 ImportedAlias
+
+foreign import data NoBase :: Type -> Type
+
+derive instance Eq1 NoBase
+
+data Product a b = Product a b
+
+type ProductInt a = Product Int a
+
+derive instance Eq1 ProductInt

--- a/tests-integration/fixtures/checking/1786505040_derive_lifted_foreign_ownership_boundaries/Main.snap
+++ b/tests-integration/fixtures/checking/1786505040_derive_lifted_foreign_ownership_boundaries/Main.snap
@@ -37,21 +37,11 @@ NoBase = [Nominal]
 Product = [Representational, Representational]
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: LocalAlias
-  --> 13:1..13:31
-   |
-13 | derive instance Eq1 LocalAlias
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 error[CannotDeriveForType]: Cannot derive for type: ImportedAlias
   --> 17:1..17:34
    |
 17 | derive instance Eq1 ImportedAlias
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: NoBase
-  --> 21:1..21:27
-   |
-21 | derive instance Eq1 NoBase
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~
 error[PartialSynonymApplication]: Partial type synonym application
   --> 27:21..27:31
    |
@@ -67,3 +57,9 @@ error[CannotDeriveForType]: Cannot derive for type: ?[partial synonym applicatio
    |
 27 | derive instance Eq1 ProductInt
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[NoInstanceFound]: No instance found for: Eq (NoBase (t0 :: Type))
+  --> 21:1..21:27
+   |
+21 | derive instance Eq1 NoBase
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: Eq (t0 :: Type) is in scope

--- a/tests-integration/fixtures/checking/1786505040_derive_lifted_foreign_ownership_boundaries/Main.snap
+++ b/tests-integration/fixtures/checking/1786505040_derive_lifted_foreign_ownership_boundaries/Main.snap
@@ -1,0 +1,69 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Product ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Product (a :: Prim.Type) (b :: Prim.Type)
+
+Types
+LocalOpaque :: Prim.Type -> Prim.Type
+LocalAlias :: Prim.Type -> Prim.Type
+ImportedAlias :: Prim.Type -> Prim.Type
+NoBase :: Prim.Type -> Prim.Type
+Product :: Prim.Type -> Prim.Type -> Prim.Type
+ProductInt :: Prim.Type -> Prim.Type
+
+Synonyms
+type LocalAlias = Main.LocalOpaque
+type ImportedAlias = Library.ImportedOpaque
+type ProductInt a = Main.Product Prim.Int (a :: Prim.Type)
+
+Instances
+instance forall (a :: Prim.Type).
+  Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Main.LocalOpaque (a :: Prim.Type))
+
+Derived
+derive Data.Eq.Eq1 Main.LocalAlias
+derive Data.Eq.Eq1 Main.ImportedAlias
+derive Data.Eq.Eq1 Main.NoBase
+derive Data.Eq.Eq1 ?[partial synonym application]
+
+Roles
+LocalOpaque = [Nominal]
+NoBase = [Nominal]
+Product = [Representational, Representational]
+
+Diagnostics
+error[CannotDeriveForType]: Cannot derive for type: LocalAlias
+  --> 13:1..13:31
+   |
+13 | derive instance Eq1 LocalAlias
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotDeriveForType]: Cannot derive for type: ImportedAlias
+  --> 17:1..17:34
+   |
+17 | derive instance Eq1 ImportedAlias
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotDeriveForType]: Cannot derive for type: NoBase
+  --> 21:1..21:27
+   |
+21 | derive instance Eq1 NoBase
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~
+error[PartialSynonymApplication]: Partial type synonym application
+  --> 27:21..27:31
+   |
+27 | derive instance Eq1 ProductInt
+   |                     ^~~~~~~~~~
+error[CannotUnify]: Cannot unify '?[partial synonym application]' with 'Type -> Type'
+  --> 27:21..27:31
+   |
+27 | derive instance Eq1 ProductInt
+   |                     ^~~~~~~~~~
+error[CannotDeriveForType]: Cannot derive for type: ?[partial synonym application]
+  --> 27:1..27:31
+   |
+27 | derive instance Eq1 ProductInt
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/semantic/1786505040_derive_eq1_ord1_local_foreign_data/Main.purs
+++ b/tests-integration/fixtures/semantic/1786505040_derive_eq1_ord1_local_foreign_data/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+import Data.Eq (class Eq, class Eq1)
+import Data.Ord (class Ord, class Ord1)
+import Data.Ordering (Ordering(..))
+
+foreign import data Opaque :: Type -> Type
+
+instance Eq a => Eq (Opaque a) where
+  eq _ _ = true
+
+derive instance Eq1 Opaque
+
+instance Ord a => Ord (Opaque a) where
+  compare _ _ = EQ
+
+derive instance Ord1 Opaque

--- a/tests-integration/fixtures/semantic/1786505040_derive_eq1_ord1_local_foreign_data/Main.snap
+++ b/tests-integration/fixtures/semantic/1786505040_derive_eq1_ord1_local_foreign_data/Main.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+dictionary eqOpaque :: forall a. { eqDict :: Data.Eq.Eq a } => Data.Eq.Eq (Main.Opaque a) where
+  eq :: Main.Opaque a -> Main.Opaque a -> Prim.Boolean
+  eq = \_ -> \_ -> true
+
+dictionary ordOpaque :: forall a. { ordDict :: Data.Ord.Ord a } => Data.Ord.Ord (Main.Opaque a)
+  where
+  superclass eqDict = eqOpaque {ordDict.eqDict}
+  compare :: Main.Opaque a -> Main.Opaque a -> Data.Ordering.Ordering
+  compare = \_ -> \_ -> EQ

--- a/tests-integration/fixtures/semantic/1786505040_derive_eq1_ord1_local_foreign_data/Main.snap
+++ b/tests-integration/fixtures/semantic/1786505040_derive_eq1_ord1_local_foreign_data/Main.snap
@@ -7,8 +7,17 @@ dictionary eqOpaque :: forall a. { eqDict :: Data.Eq.Eq a } => Data.Eq.Eq (Main.
   eq :: Main.Opaque a -> Main.Opaque a -> Prim.Boolean
   eq = \_ -> \_ -> true
 
+dictionary eq1Opaque :: Data.Eq.Eq1 Main.Opaque where
+  eq1 :: forall (a :: Prim.Type). Data.Eq.Eq a => Main.Opaque a -> Main.Opaque a -> Prim.Boolean
+  eq1 = \@a -> \{eqDict} -> eq @(Main.Opaque a) {eqOpaque {eqDict}}
+
 dictionary ordOpaque :: forall a. { ordDict :: Data.Ord.Ord a } => Data.Ord.Ord (Main.Opaque a)
   where
   superclass eqDict = eqOpaque {ordDict.eqDict}
   compare :: Main.Opaque a -> Main.Opaque a -> Data.Ordering.Ordering
   compare = \_ -> \_ -> EQ
+
+dictionary ord1Opaque :: Data.Ord.Ord1 Main.Opaque where
+  superclass eq1Dict = eq1Opaque
+  compare1 :: forall (a :: Prim.Type). Data.Ord.Ord a => Main.Opaque a -> Main.Opaque a -> Data.Ordering.Ordering
+  compare1 = \@a -> \{ordDict} -> compare @(Main.Opaque a) {ordOpaque {ordDict}}


### PR DESCRIPTION
## Summary

- split known-derive eligibility by generation strategy while preserving normalized-head ownership
- keep structural `Eq`/`Ord` deriving restricted to local `data` and `newtype`
- allow delegated `Eq1`/`Ord1` deriving for local `foreign data` when their ordinary base constraints solve
- retain imported-head rejection through direct references and local type synonyms
- cover successful delegated bodies, default nominal roles, missing base dictionaries, imported algebraic/foreign heads, and synonym saturation

## Commit narrative

1. `Add failing test case for lifted foreign data derives` introduces all checking and semantic fixture sources, supporting modules, and accepted pre-fix snapshots. The snapshot harness passes while recording local-foreign rejection, alias and missing-dictionary boundaries, imported-head rejection, and the absence of lifted semantic dictionaries.
2. `Allow lifted deriving for local foreign data` changes only the two production deriving files and three snapshots already introduced by the parent. The focused checking snapshot removes the two diagnostics, the boundary snapshot accepts the local alias and moves the missing dictionary to constraint solving, and the semantic snapshot adds the delegated dictionaries.

## Why

`Eq` and `Ord` synthesize structural comparisons from constructor metadata, so they require a local algebraic declaration. `Eq1` and `Ord1` instead generate members equivalent to `eq1 = eq` and `compare1 = compare`; their correctness is established by solving `Eq (f a)` or `Ord (f a)` under the corresponding constraint for a rigid `a`, followed by generated-member type checking.

Requiring constructor metadata for the delegated strategies regressed `lazy@6.0.0`, whose locally owned `foreign data Lazy` has ordinary `Eq (Lazy a)` and `Ord (Lazy a)` instances. The new helper still normalizes aliases and requires the resulting head to belong to the current module, which keeps imported heads unavailable for stock deriving.

Closes #293.

## Validation

Passed:

```text
cargo check -p checking --tests
cargo nextest run -p checking                         # 30 passed
just t checking 1785144540 1785133080 1786505040     # no pending snapshots
just t semantic 1786505040                            # no pending snapshots
just t checking                                       # full category, no pending snapshots
just t semantic                                       # full category, no pending snapshots
cargo run -p tests-compatibility --release -- verify --package lazy
                                                     # 21 packages, 124 files, 0 errors
```

The Core preset is not green on the base branch because `foreign-object@4.1.0` currently produces eight unrelated ST unification errors. Candidate/base comparison on package set `80.3.1` shows this change introduces no compatibility errors and fixes the two `Lazy` errors:

```text
cargo run -p tests-compatibility --release -- verify --preset core
# candidate: 8 errors in foreign-object, 0 errors in lazy
# base:     8 errors in foreign-object, 2 errors in lazy

cargo run -p tests-compatibility --release -- compare ...
# introduced compiler errors: 0
# fixed compiler errors: 2
```