### PR TITLE
[checking] Preserve evidence for constrained operator subtrees

### DIFF
--- a/compiler-core/checking/src/source/operator.rs
+++ b/compiler-core/checking/src/source/operator.rs
@@ -90,6 +90,30 @@ where
     Q: ExternalQueries,
     E: IsOperator<Q>,
 {
+    if let OperatorKindMode::Check { expected_type } = mode {
+        return E::check_expected_subtree(state, context, expected_type, |state, expected_type| {
+            traverse_operator_tree_core(
+                state,
+                context,
+                operator_tree,
+                OperatorKindMode::Check { expected_type },
+            )
+        });
+    }
+
+    traverse_operator_tree_core(state, context, operator_tree, mode)
+}
+
+fn traverse_operator_tree_core<Q, E>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    operator_tree: &OperatorTree<E>,
+    mode: OperatorKindMode,
+) -> QueryResult<(E::Elaborated, TypeId)>
+where
+    Q: ExternalQueries,
+    E: IsOperator<Q>,
+{
     let unknown_elaborated = E::unknown_elaborated(context);
 
     match operator_tree {
@@ -263,6 +287,18 @@ pub trait IsOperator<Q: ExternalQueries>: IsElement {
         expected: TypeId,
     ) -> QueryResult<(Self::Elaborated, TypeId)>;
 
+    fn check_expected_subtree<F>(
+        state: &mut CheckState,
+        _context: &CheckContext<Q>,
+        expected: TypeId,
+        check: F,
+    ) -> QueryResult<(Self::Elaborated, TypeId)>
+    where
+        F: FnOnce(&mut CheckState, TypeId) -> QueryResult<(Self::Elaborated, TypeId)>,
+    {
+        check(state, expected)
+    }
+
     fn should_defer_expansion(
         _state: &CheckState,
         _context: &CheckContext<Q>,
@@ -334,6 +370,36 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
         let checked = terms::check_expression(state, context, id, expected)?;
         Ok((Some(checked), checked.type_id))
+    }
+
+    fn check_expected_subtree<F>(
+        state: &mut CheckState,
+        context: &CheckContext<Q>,
+        expected: TypeId,
+        check: F,
+    ) -> QueryResult<(Self::Elaborated, TypeId)>
+    where
+        F: FnOnce(&mut CheckState, TypeId) -> QueryResult<(Self::Elaborated, TypeId)>,
+    {
+        let expected = normalise::expand(state, context, expected)?;
+        let Type::Constrained(constraint, constrained) = context.lookup_type(expected) else {
+            return check(state, expected);
+        };
+
+        state.with_implication(|state| {
+            let binder = state.push_given(constraint);
+            let (checked, _) = Self::check_expected_subtree(state, context, constrained, check)?;
+
+            let checked = checked.map(|checked| {
+                let kind = tree::ExpressionKind::EvidenceAbstraction {
+                    binder,
+                    expression: checked.expression,
+                };
+                terms::allocate_expression(state, expected, kind)
+            });
+
+            Ok((checked, expected))
+        })
     }
 
     fn build(

--- a/tests-integration/fixtures/checking/1786550220_expression_operator_constraint_scope_isolation/Main.purs
+++ b/tests-integration/fixtures/checking/1786550220_expression_operator_constraint_scope_isolation/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+class First a
+
+foreign import combine
+  :: forall result
+   . (First Int => Int)
+  -> result
+  -> result
+
+infixr 0 combine as <+>
+
+foreign import constrainedValue :: First Int => Int
+foreign import needsFirst :: First Int => Int
+
+test :: Int
+test = constrainedValue <+> needsFirst

--- a/tests-integration/fixtures/checking/1786550220_expression_operator_constraint_scope_isolation/Main.snap
+++ b/tests-integration/fixtures/checking/1786550220_expression_operator_constraint_scope_isolation/Main.snap
@@ -1,0 +1,21 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+combine ::
+  forall (result :: Prim.Type).
+    (Main.First @Prim.Type Prim.Int => Prim.Int) -> (result :: Prim.Type) -> (result :: Prim.Type)
+<+> ::
+  forall (result :: Prim.Type).
+    (Main.First @Prim.Type Prim.Int => Prim.Int) -> (result :: Prim.Type) -> (result :: Prim.Type)
+constrainedValue :: Main.First @Prim.Type Prim.Int => Prim.Int
+needsFirst :: Main.First @Prim.Type Prim.Int => Prim.Int
+test :: Prim.Int
+
+Types
+First :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> Prim.Constraint
+
+Classes
+class forall (t0 :: Prim.Type) (a :: (t0 :: Prim.Type)). Main.First @(t0 :: Prim.Type) (a :: (t0 :: Prim.Type))

--- a/tests-integration/fixtures/checking/1786550220_expression_operator_constraint_scope_isolation/Main.snap
+++ b/tests-integration/fixtures/checking/1786550220_expression_operator_constraint_scope_isolation/Main.snap
@@ -19,3 +19,10 @@ First :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> Prim.Constraint
 
 Classes
 class forall (t0 :: Prim.Type) (a :: (t0 :: Prim.Type)). Main.First @(t0 :: Prim.Type) (a :: (t0 :: Prim.Type))
+
+Diagnostics
+error[NoInstanceFound]: No instance found for: First @Type Int
+  --> 16:1..16:12
+   |
+16 | test :: Int
+   | ^~~~~~~~~~~

--- a/tests-integration/fixtures/semantic/1786550220_constrained_expression_operator_evidence/Main.purs
+++ b/tests-integration/fixtures/semantic/1786550220_constrained_expression_operator_evidence/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+class First a
+
+foreign import apply
+  :: forall argument result
+   . (argument -> result)
+  -> argument
+  -> result
+
+infixr 0 apply as $
+
+foreign import constrainedValue :: First Int => Int
+foreign import consumeConstrained :: (First Int => Int) -> Int
+
+constrainedLeaf :: Int
+constrainedLeaf = consumeConstrained $ constrainedValue

--- a/tests-integration/fixtures/semantic/1786550220_constrained_expression_operator_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1786550220_constrained_expression_operator_evidence/Main.snap
@@ -1,0 +1,16 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface First :: forall (k0 :: Prim.Type). k0 -> Prim.Constraint
+interface First a where
+
+foreign import apply :: forall argument result. (argument -> result) -> argument -> result
+
+foreign import constrainedValue :: Main.First @Prim.Type Prim.Int => Prim.Int
+
+foreign import consumeConstrained :: (Main.First @Prim.Type Prim.Int => Prim.Int) -> Prim.Int
+
+constrainedLeaf :: Prim.Int
+constrainedLeaf = apply consumeConstrained (constrainedValue {firstDict})

--- a/tests-integration/fixtures/semantic/1786550220_constrained_expression_operator_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1786550220_constrained_expression_operator_evidence/Main.snap
@@ -13,4 +13,4 @@ foreign import constrainedValue :: Main.First @Prim.Type Prim.Int => Prim.Int
 foreign import consumeConstrained :: (Main.First @Prim.Type Prim.Int => Prim.Int) -> Prim.Int
 
 constrainedLeaf :: Prim.Int
-constrainedLeaf = apply consumeConstrained (constrainedValue {firstDict})
+constrainedLeaf = apply consumeConstrained \{firstDict} -> constrainedValue {firstDict}

--- a/tests-integration/fixtures/semantic/1786551180_constrained_expression_operator_multiple_layers/Main.purs
+++ b/tests-integration/fixtures/semantic/1786551180_constrained_expression_operator_multiple_layers/Main.purs
@@ -1,0 +1,18 @@
+module Main where
+
+class First a
+class Second a
+
+foreign import apply
+  :: forall argument result
+   . (argument -> result)
+  -> argument
+  -> result
+
+infixr 0 apply as $
+
+foreign import multiplyConstrained :: First Int => Second Int => Int
+foreign import consumeMultiplyConstrained :: (First Int => Second Int => Int) -> Int
+
+multipleConstraintLayers :: Int
+multipleConstraintLayers = consumeMultiplyConstrained $ multiplyConstrained

--- a/tests-integration/fixtures/semantic/1786551180_constrained_expression_operator_multiple_layers/Main.snap
+++ b/tests-integration/fixtures/semantic/1786551180_constrained_expression_operator_multiple_layers/Main.snap
@@ -17,4 +17,5 @@ foreign import consumeMultiplyConstrained :: (Main.First @Prim.Type Prim.Int => 
 
 multipleConstraintLayers :: Prim.Int
 multipleConstraintLayers =
-  apply consumeMultiplyConstrained (multiplyConstrained {firstDict} {secondDict})
+  apply consumeMultiplyConstrained \{firstDict} ->
+    \{secondDict} -> multiplyConstrained {firstDict} {secondDict}

--- a/tests-integration/fixtures/semantic/1786551180_constrained_expression_operator_multiple_layers/Main.snap
+++ b/tests-integration/fixtures/semantic/1786551180_constrained_expression_operator_multiple_layers/Main.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface First :: forall (k0 :: Prim.Type). k0 -> Prim.Constraint
+interface First a where
+
+interface Second :: forall (k0 :: Prim.Type). k0 -> Prim.Constraint
+interface Second a where
+
+foreign import apply :: forall argument result. (argument -> result) -> argument -> result
+
+foreign import multiplyConstrained :: Main.First @Prim.Type Prim.Int => Main.Second @Prim.Type Prim.Int => Prim.Int
+
+foreign import consumeMultiplyConstrained :: (Main.First @Prim.Type Prim.Int => Main.Second @Prim.Type Prim.Int => Prim.Int) -> Prim.Int
+
+multipleConstraintLayers :: Prim.Int
+multipleConstraintLayers =
+  apply consumeMultiplyConstrained (multiplyConstrained {firstDict} {secondDict})

--- a/tests-integration/fixtures/semantic/1786551180_constrained_expression_operator_nested_subtree/Main.purs
+++ b/tests-integration/fixtures/semantic/1786551180_constrained_expression_operator_nested_subtree/Main.purs
@@ -1,0 +1,18 @@
+module Main where
+
+class First a
+
+foreign import apply
+  :: forall argument result
+   . (argument -> result)
+  -> argument
+  -> result
+
+infixr 0 apply as $
+
+foreign import identity :: forall a. a -> a
+foreign import constrainedValue :: First Int => Int
+foreign import consumeConstrained :: (First Int => Int) -> Int
+
+constrainedSubtree :: Int
+constrainedSubtree = consumeConstrained $ identity $ constrainedValue

--- a/tests-integration/fixtures/semantic/1786551180_constrained_expression_operator_nested_subtree/Main.snap
+++ b/tests-integration/fixtures/semantic/1786551180_constrained_expression_operator_nested_subtree/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface First :: forall (k0 :: Prim.Type). k0 -> Prim.Constraint
+interface First a where
+
+foreign import apply :: forall argument result. (argument -> result) -> argument -> result
+
+foreign import identity :: forall a. a -> a
+
+foreign import constrainedValue :: Main.First @Prim.Type Prim.Int => Prim.Int
+
+foreign import consumeConstrained :: (Main.First @Prim.Type Prim.Int => Prim.Int) -> Prim.Int
+
+constrainedSubtree :: Prim.Int
+constrainedSubtree = apply consumeConstrained (apply identity (constrainedValue {firstDict}))

--- a/tests-integration/fixtures/semantic/1786551180_constrained_expression_operator_nested_subtree/Main.snap
+++ b/tests-integration/fixtures/semantic/1786551180_constrained_expression_operator_nested_subtree/Main.snap
@@ -15,4 +15,5 @@ foreign import constrainedValue :: Main.First @Prim.Type Prim.Int => Prim.Int
 foreign import consumeConstrained :: (Main.First @Prim.Type Prim.Int => Prim.Int) -> Prim.Int
 
 constrainedSubtree :: Prim.Int
-constrainedSubtree = apply consumeConstrained (apply identity (constrainedValue {firstDict}))
+constrainedSubtree =
+  apply consumeConstrained \{firstDict} -> apply identity (constrainedValue {firstDict})

--- a/tests-integration/fixtures/semantic/1786551240_ordinary_constrained_expression_operator/Main.purs
+++ b/tests-integration/fixtures/semantic/1786551240_ordinary_constrained_expression_operator/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+class Equal a where
+  equal :: a -> a -> Boolean
+
+instance equalInt :: Equal Int where
+  equal left right = true
+
+infix 4 equal as ==
+
+ordinaryConstrainedOperator :: Boolean
+ordinaryConstrainedOperator = 1 == 2

--- a/tests-integration/fixtures/semantic/1786551240_ordinary_constrained_expression_operator/Main.snap
+++ b/tests-integration/fixtures/semantic/1786551240_ordinary_constrained_expression_operator/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Equal :: Prim.Type -> Prim.Constraint
+interface Equal a where
+  equal :: a -> a -> Prim.Boolean
+
+dictionary equalInt :: Main.Equal Prim.Int where
+  equal :: Prim.Int -> Prim.Int -> Prim.Boolean
+  equal = \left -> \right -> true
+
+ordinaryConstrainedOperator :: Prim.Boolean
+ordinaryConstrainedOperator = equal {equalInt} 1 2

--- a/tests-integration/fixtures/semantic/1786551840_ordinary_constrained_expression_operator_chain/Main.purs
+++ b/tests-integration/fixtures/semantic/1786551840_ordinary_constrained_expression_operator_chain/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+class Semigroup a where
+  append :: a -> a -> a
+
+instance semigroupString :: Semigroup String where
+  append left right = left
+
+infixr 5 append as <>
+
+ordinaryConstrainedOperatorChain :: String
+ordinaryConstrainedOperatorChain = "first" <> "second" <> "third"

--- a/tests-integration/fixtures/semantic/1786551840_ordinary_constrained_expression_operator_chain/Main.snap
+++ b/tests-integration/fixtures/semantic/1786551840_ordinary_constrained_expression_operator_chain/Main.snap
@@ -1,0 +1,16 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Semigroup :: Prim.Type -> Prim.Constraint
+interface Semigroup a where
+  append :: a -> a -> a
+
+dictionary semigroupString :: Main.Semigroup Prim.String where
+  append :: Prim.String -> Prim.String -> Prim.String
+  append = \left -> \right -> left
+
+ordinaryConstrainedOperatorChain :: Prim.String
+ordinaryConstrainedOperatorChain =
+  append {semigroupString} "first" (append {semigroupString} "second" "third")


### PR DESCRIPTION
Closes #300.

## Summary

Expression operator trees elaborate into ordinary function applications, so constrained expected types on their subtrees need lexical runtime evidence ownership. Previously, operator checking peeled those constraints with `collect_givens`, discarded their evidence binder IDs, and introduced the givens into the ambient implication. This could leave evidence applications without enclosing abstractions and allow a subtree given to solve sibling wanted constraints.

This change routes every checked operator subtree through an expected-type boundary. For expression operators, each constraint layer now:

- opens a fresh implication scope;
- retains the given's `EvidenceBinderId`;
- checks the complete subtree under that given;
- wraps the checked subtree in an `EvidenceAbstraction`; and
- retains the constrained expected type on the resulting expression.

The generic boundary is a no-op for type and binder operators, preserving their existing non-runtime behavior.

## Regression coverage

The first commit records the previous behavior, and the fix commit updates the same snapshots to cover:

- constrained operator leaves;
- complete nested operator subtrees;
- multiple nested constraint layers;
- isolation from sibling wanted constraints;
- ordinary constrained `==` behavior; and
- repeated constrained `<>` operator chains.

## Verification

- `cargo check -p checking --tests`
- `cargo nextest run -p checking` — 30 passed
- `just t checking` — passed, no pending snapshots
- `just t semantic` — passed, no pending snapshots
- core + acme compatibility — 630 packages, 7,344 files, 0 compiler errors, 0 packages with errors, 33 existing warnings