### PR TITLE
[agents] Add release compatibility check workflow

### DIFF
--- a/.agents/skills/running-compatibility-checks/SKILL.md
+++ b/.agents/skills/running-compatibility-checks/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: running-compatibility-checks
+description: "Runs Alexandrite package-set compatibility comparisons with release-built verifiers. Use when checking the current checkout against a base revision, investigating compatibility regressions, or reviewing compatibility reports."
+---
+
+# Running Compatibility Checks
+
+Use the repository's compatibility runner to compare the current checkout with a base revision. The runner mirrors the CI package selection (`core` and `acme`), builds both verifiers in release mode, and preserves the generated reports.
+
+## Run the comparison
+
+From the repository root:
+
+```bash
+just compatibility
+```
+
+The default base is the local `origin/main` ref. When the comparison must use the latest remote `main`, fetch it first:
+
+```bash
+git fetch origin main
+just compatibility
+```
+
+Pass another commit, branch, or tag when requested:
+
+```bash
+just compatibility <base-ref>
+```
+
+Do not require a clean worktree. The candidate is the current checkout, including uncommitted source changes. The base runs in a temporary detached worktree, so the command does not switch or modify the active checkout.
+
+## Interpret the result
+
+The runner prints the Markdown summary and the report directory. Inspect at least:
+
+- `summary.md` for introduced and fixed diagnostics
+- `comparison.json` for the structured comparison
+- `base.log` and `candidate.log` when either verifier fails
+- `comparison.log` when report comparison fails
+
+Exit statuses have stable meanings:
+
+- `0`: no compatibility regressions
+- `1`: the candidate introduces compatibility errors; the reports are valid and must be reviewed
+- `2`: preparation, verification, or comparison could not execute correctly
+
+Do not describe status 1 as a broken checker. Report the introduced errors from `summary.md`. For status 2, diagnose the relevant log and distinguish network/package-corpus failures from compiler failures.
+
+## Run one revision without comparison
+
+Only use a direct verification when the user explicitly wants one revision rather than a base/candidate regression check:
+
+```bash
+cargo run --release -p tests-compatibility -- prepare --preset core --preset acme
+cargo run --release -p tests-compatibility -- verify --preset core --preset acme
+```
+
+The direct verifier also uses status 1 for a valid report containing errors and status 2 for an execution failure.

--- a/.agents/skills/running-compatibility-checks/scripts/run.sh
+++ b/.agents/skills/running-compatibility-checks/scripts/run.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: run.sh [base-ref]
+
+Compare the current checkout with base-ref using release-built compatibility
+verifiers. base-ref defaults to origin/main.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -gt 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+base_ref="${1:-origin/main}"
+workspace=$(git rev-parse --show-toplevel)
+base_commit=$(git -C "$workspace" rev-parse --verify "${base_ref}^{commit}") || {
+  printf 'compatibility: base revision not found: %s\n' "$base_ref" >&2
+  exit 2
+}
+
+timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+report_dir=${COMPATIBILITY_REPORT_DIR:-"$workspace/target/compatibility-reports/$timestamp-$$"}
+temporary_dir=$(mktemp -d "${TMPDIR:-/tmp}/alexandrite-compatibility.XXXXXX")
+base_workspace="$temporary_dir/base"
+
+cleanup() {
+  git -C "$workspace" worktree remove --force "$base_workspace" >/dev/null 2>&1 || true
+  rm -rf "$temporary_dir"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+mkdir -p "$report_dir"
+
+printf 'Compatibility base: %s (%s)\n' "$base_ref" "$base_commit"
+printf 'Building candidate verifier in release mode...\n'
+cargo build --manifest-path "$workspace/Cargo.toml" \
+  --target-dir "$workspace/target" \
+  --release \
+  -p tests-compatibility
+
+printf 'Creating temporary base worktree...\n'
+git -C "$workspace" worktree add --detach "$base_workspace" "$base_commit" >/dev/null
+
+printf 'Building base verifier in release mode...\n'
+cargo build --manifest-path "$base_workspace/Cargo.toml" \
+  --target-dir "$base_workspace/target" \
+  --release \
+  -p tests-compatibility
+
+candidate_verifier="$workspace/target/release/tests-compatibility"
+base_verifier="$base_workspace/target/release/tests-compatibility"
+corpus_dir="$workspace/target/compatibility"
+
+printf 'Preparing core and Acme corpus...\n'
+(
+  cd "$workspace"
+  "$candidate_verifier" prepare --preset core --preset acme
+)
+
+printf 'Collecting base and candidate reports...\n'
+set +e
+(
+  cd "$base_workspace"
+  "$base_verifier" verify \
+    --preset core \
+    --preset acme \
+    --registry-dir "$corpus_dir/registry" \
+    --index-dir "$corpus_dir/registry-index" \
+    --cache-dir "$corpus_dir" \
+    --json-output "$report_dir/base.json"
+) >"$report_dir/base.log" 2>&1
+base_status=$?
+
+(
+  cd "$workspace"
+  "$candidate_verifier" verify \
+    --preset core \
+    --preset acme \
+    --registry-dir "$corpus_dir/registry" \
+    --index-dir "$corpus_dir/registry-index" \
+    --cache-dir "$corpus_dir" \
+    --json-output "$report_dir/candidate.json"
+) >"$report_dir/candidate.log" 2>&1
+candidate_status=$?
+set -e
+
+if [[ "$base_status" != 0 && "$base_status" != 1 ]]; then
+  printf 'compatibility: base verifier failed with status %s; inspect %s/base.log\n' \
+    "$base_status" "$report_dir" >&2
+  exit 2
+fi
+
+if [[ "$candidate_status" != 0 && "$candidate_status" != 1 ]]; then
+  printf 'compatibility: candidate verifier failed with status %s; inspect %s/candidate.log\n' \
+    "$candidate_status" "$report_dir" >&2
+  exit 2
+fi
+
+printf 'Comparing reports...\n'
+set +e
+(
+  cd "$workspace"
+  "$candidate_verifier" compare \
+    --base-report "$report_dir/base.json" \
+    --candidate-report "$report_dir/candidate.json" \
+    --json-output "$report_dir/comparison.json" \
+    --summary-output "$report_dir/summary.md"
+) >"$report_dir/comparison.log" 2>&1
+comparison_status=$?
+set -e
+
+if [[ "$comparison_status" != 0 && "$comparison_status" != 1 ]]; then
+  printf 'compatibility: comparison failed with status %s; inspect %s/comparison.log\n' \
+    "$comparison_status" "$report_dir" >&2
+  exit 2
+fi
+
+printf '\n'
+cat "$report_dir/summary.md"
+printf '\nCompatibility reports: %s\n' "$report_dir"
+exit "$comparison_status"

--- a/justfile
+++ b/justfile
@@ -32,6 +32,10 @@ coverage-html:
 @bench *args="":
   cargo criterion -p tests-compatibility "$@"
 
+[doc("Compare package compatibility with a base revision using release builds")]
+@compatibility base="origin/main":
+  bash .agents/skills/running-compatibility-checks/scripts/run.sh "{{base}}"
+
 [doc("Apply clippy fixes and format")]
 fix:
   cargo clippy --workspace --fix && cargo fmt


### PR DESCRIPTION
## Summary

- add a repository skill for running and interpreting package-set compatibility checks
- add a reusable runner that compares the current checkout with a configurable base revision
- build both compatibility verifiers in release mode while isolating the base in a temporary worktree
- expose the workflow as `just compatibility [base-ref]` and retain structured reports under `target/compatibility-reports`

## Motivation

The compatibility comparison currently lives primarily in CI, making it cumbersome to run on demand while developing compiler changes. This gives contributors one local command that mirrors the CI core and Acme corpus, includes uncommitted candidate changes, and clearly distinguishes regressions from verifier execution failures.

## Validation

- `bash -n .agents/skills/running-compatibility-checks/scripts/run.sh`
- `just --dry-run compatibility`
- `just compatibility`
  - release-built base and candidate verifiers
  - 630 packages prepared
  - 0 introduced compiler errors
  - 0 introduced verifier errors
  - 0 warning changes