### PR TITLE
[agents] Address compatibility workflow review

### DIFF
--- a/.agents/skills/running-compatibility-checks/SKILL.md
+++ b/.agents/skills/running-compatibility-checks/SKILL.md
@@ -28,7 +28,7 @@ Pass another commit, branch, or tag when requested:
 just compatibility <base-ref>
 ```
 
-Do not require a clean worktree. The candidate is the current checkout, including uncommitted source changes. The base runs in a temporary detached worktree, so the command does not switch or modify the active checkout.
+Do not require a clean worktree. The candidate is the current checkout, including uncommitted source changes. The base runs in a temporary detached worktree, so the command does not switch or modify the active checkout. The candidate build and prepared corpus are written under `target/`.
 
 ## Interpret the result
 

--- a/.agents/skills/running-compatibility-checks/scripts/run.sh
+++ b/.agents/skills/running-compatibility-checks/scripts/run.sh
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+setup_failure() {
+  printf 'compatibility: %s failed\n' "$1" >&2
+  exit 2
+}
+
 usage() {
   cat <<'EOF'
 Usage: run.sh [base-ref]
@@ -22,7 +27,7 @@ if [[ $# -gt 1 ]]; then
 fi
 
 base_ref="${1:-origin/main}"
-workspace=$(git rev-parse --show-toplevel)
+workspace=$(git rev-parse --show-toplevel) || setup_failure "locating the workspace"
 base_commit=$(git -C "$workspace" rev-parse --verify "${base_ref}^{commit}") || {
   printf 'compatibility: base revision not found: %s\n' "$base_ref" >&2
   exit 2
@@ -30,7 +35,8 @@ base_commit=$(git -C "$workspace" rev-parse --verify "${base_ref}^{commit}") || 
 
 timestamp=$(date -u +%Y%m%dT%H%M%SZ)
 report_dir=${COMPATIBILITY_REPORT_DIR:-"$workspace/target/compatibility-reports/$timestamp-$$"}
-temporary_dir=$(mktemp -d "${TMPDIR:-/tmp}/alexandrite-compatibility.XXXXXX")
+temporary_dir=$(mktemp -d "${TMPDIR:-/tmp}/alexandrite-compatibility.XXXXXX") || \
+  setup_failure "creating the temporary directory"
 base_workspace="$temporary_dir/base"
 
 cleanup() {
@@ -41,33 +47,43 @@ cleanup() {
 trap cleanup EXIT
 trap 'exit 130' INT TERM
 
-mkdir -p "$report_dir"
+if ! mkdir -p "$report_dir"; then
+  setup_failure "creating the report directory"
+fi
 
 printf 'Compatibility base: %s (%s)\n' "$base_ref" "$base_commit"
 printf 'Building candidate verifier in release mode...\n'
-cargo build --manifest-path "$workspace/Cargo.toml" \
+if ! cargo build --manifest-path "$workspace/Cargo.toml" \
   --target-dir "$workspace/target" \
   --release \
-  -p tests-compatibility
+  -p tests-compatibility; then
+  setup_failure "building the candidate verifier"
+fi
 
 printf 'Creating temporary base worktree...\n'
-git -C "$workspace" worktree add --detach "$base_workspace" "$base_commit" >/dev/null
+if ! git -C "$workspace" worktree add --detach "$base_workspace" "$base_commit" >/dev/null; then
+  setup_failure "creating the base worktree"
+fi
 
 printf 'Building base verifier in release mode...\n'
-cargo build --manifest-path "$base_workspace/Cargo.toml" \
+if ! cargo build --manifest-path "$base_workspace/Cargo.toml" \
   --target-dir "$base_workspace/target" \
   --release \
-  -p tests-compatibility
+  -p tests-compatibility; then
+  setup_failure "building the base verifier"
+fi
 
 candidate_verifier="$workspace/target/release/tests-compatibility"
 base_verifier="$base_workspace/target/release/tests-compatibility"
 corpus_dir="$workspace/target/compatibility"
 
 printf 'Preparing core and Acme corpus...\n'
-(
+if ! (
   cd "$workspace"
   "$candidate_verifier" prepare --preset core --preset acme
-)
+); then
+  setup_failure "preparing the compatibility corpus"
+fi
 
 printf 'Collecting base and candidate reports...\n'
 set +e

--- a/justfile
+++ b/justfile
@@ -34,7 +34,7 @@ coverage-html:
 
 [doc("Compare package compatibility with a base revision using release builds")]
 @compatibility base="origin/main":
-  bash .agents/skills/running-compatibility-checks/scripts/run.sh "{{base}}"
+  bash .agents/skills/running-compatibility-checks/scripts/run.sh {{quote(base)}}
 
 [doc("Apply clippy fixes and format")]
 fix:


### PR DESCRIPTION
## Summary

- shell-quote the compatibility base revision through `just` before invoking the runner
- normalize setup failures to the documented status 2 with operation-specific diagnostics
- document the candidate build and corpus written under `target/`

## Context

This follows up on the three actionable CodeRabbit comments from #302. Codecov did not leave actionable review feedback; its report said all changed coverable lines were covered.

## Validation

- `bash -n .agents/skills/running-compatibility-checks/scripts/run.sh`
- `just --dry-run compatibility 'branch\"; printf INJECTED; #'` preserves the base as one quoted argument
- an actual malicious-looking base argument exits 2 during revision validation without executing its shell payload
- forced report-directory and Cargo failures both exit 2 with operation-specific messages
- `just compatibility origin/main`
  - release-built base and candidate verifiers
  - 630 packages prepared
  - no introduced compiler or verifier errors
  - no warning changes