### PR TITLE
[checking] Reject expected forall skolem escapes

### DIFF
--- a/compiler-core/checking/src/core.rs
+++ b/compiler-core/checking/src/core.rs
@@ -8,6 +8,7 @@ pub mod generalise;
 pub mod normalise;
 pub mod pretty;
 pub mod signature;
+pub mod skolem;
 pub mod substitute;
 pub mod toolkit;
 pub mod unification;
@@ -25,6 +26,7 @@ use smol_str::{SmolStr, SmolStrBuilder};
 pub struct Name {
     pub file: FileId,
     pub unique: u32,
+    pub scope: Option<SkolemScope>,
 }
 
 impl Name {
@@ -47,6 +49,13 @@ impl Depth {
     }
 }
 
+/// A globally unique lexical scope introduced while checking an expected forall.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SkolemScope {
+    pub file: FileId,
+    pub unique: u32,
+}
+
 /// Carries information about a type variable under a forall.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ForallBinder {
@@ -56,6 +65,8 @@ pub struct ForallBinder {
     pub name: Name,
     /// The kind of the type variable.
     pub kind: TypeId,
+    /// The lexical scope owned by an expected forall during expression checking.
+    pub scope: Option<SkolemScope>,
 }
 
 /// Represents a row type.

--- a/compiler-core/checking/src/core/generalise.rs
+++ b/compiler-core/checking/src/core/generalise.rs
@@ -245,7 +245,7 @@ where
             }
         };
 
-        let binder = ForallBinder { visible: false, name, kind };
+        let binder = ForallBinder { visible: false, name, kind, scope: None };
         let binder = context.intern_forall_binder(binder);
         quantified = context.intern_forall(binder, quantified);
         parameters.push(GeneralisedParameter { binder, rigid });
@@ -624,13 +624,13 @@ where
     for implicit_unification in implicits_unifications {
         match implicit_unification {
             ImplicitOrUnification::Implicit(name, kind) => {
-                binders.push(ForallBinder { visible: false, name, kind })
+                binders.push(ForallBinder { visible: false, name, kind, scope: None })
             }
             ImplicitOrUnification::Unification(id, kind) => {
                 let name = state.names.fresh();
                 let rigid = context.intern_rigid(name, depth, kind);
                 state.unifications.solve(id, rigid);
-                binders.push(ForallBinder { visible: false, name, kind })
+                binders.push(ForallBinder { visible: false, name, kind, scope: None })
             }
         }
     }

--- a/compiler-core/checking/src/core/skolem.rs
+++ b/compiler-core/checking/src/core/skolem.rs
@@ -1,0 +1,664 @@
+//! Checks that each skolem introduced by an expected forall appears only in
+//! judgments structurally dominated by that forall's typed expression.
+
+use std::sync::Arc;
+
+use building_types::QueryResult;
+use itertools::Itertools;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::context::CheckContext;
+use crate::core::{SkolemScope, Type, TypeId};
+use crate::error::{CheckingError, ErrorCrumb, ErrorKind};
+use crate::state::CheckState;
+use crate::tree::{
+    BinderId, BinderKind, CaseAlternative, DeclarationAbstraction, Equation, ExpressionId,
+    ExpressionKind, GuardedExpression, InstanceDeclaration, InstanceImplementation, InstanceMember,
+    LetBindingChunk, LetBindings, LocalDeclarationId, PatternGuard, RecordBinderField,
+    RecordExpressionField, RecordExpressionUpdate, TermDeclaration, TermDeclarationKind,
+    WhereExpression,
+};
+use crate::{CheckedModule, ExternalQueries};
+
+enum Task<'c> {
+    Term(&'c TermDeclaration, ErrorCrumb),
+    Member(&'c InstanceMember, ErrorCrumb),
+    Local(LocalDeclarationId),
+    Equation(&'c Equation, ErrorCrumb),
+    Guarded(&'c GuardedExpression, ErrorCrumb),
+    Where(&'c WhereExpression, ErrorCrumb),
+    Bindings(&'c LetBindings, ErrorCrumb),
+    Alternative(&'c CaseAlternative, ErrorCrumb),
+    Updates(&'c [RecordExpressionUpdate], ErrorCrumb),
+    Binder(BinderId, ErrorCrumb),
+    Expression(ExpressionId, ErrorCrumb),
+    ExitScope(SkolemScope),
+    EnterLocalEvidence(LocalDeclarationId),
+    ExitEvidence,
+}
+
+enum Pass {
+    Discover,
+    Audit(FxHashSet<SkolemScope>),
+}
+
+struct SkolemChecker<'c, 'context, 'queries, Q>
+where
+    Q: ExternalQueries,
+{
+    checked: &'c CheckedModule,
+    context: &'context CheckContext<'queries, Q>,
+    local: Option<LocalDeclarationId>,
+    discovering: bool,
+    expected_skolems: FxHashSet<SkolemScope>,
+    tasks: Vec<Task<'c>>,
+    active: FxHashMap<SkolemScope, u32>,
+    reported: FxHashSet<SkolemScope>,
+    errors: Vec<CheckingError>,
+    evidence_depth: u32,
+}
+
+pub fn check<Q>(state: &mut CheckState, context: &CheckContext<Q>)
+where
+    Q: ExternalQueries,
+{
+    let mut expected_skolems = FxHashSet::default();
+    for (_, expression) in state.checked.tree.arena.expressions.iter() {
+        let scopes = leading_scopes(context, expression.type_id);
+        expected_skolems.extend(scopes);
+    }
+
+    let (errors, _) = collect_errors(&state.checked, context, None, Pass::Audit(expected_skolems));
+    state.checked.errors.extend(errors);
+}
+
+pub fn check_local<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    declaration: LocalDeclarationId,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    let type_id = state.checked.tree[declaration].type_id;
+    let type_id = super::zonk::zonk(state, context, type_id)?;
+    state.checked.tree.set_let_type(declaration, type_id);
+
+    let (_, expected_skolems) =
+        collect_errors(&state.checked, context, Some(declaration), Pass::Discover);
+    let (errors, _) =
+        collect_errors(&state.checked, context, Some(declaration), Pass::Audit(expected_skolems));
+    state.checked.errors.extend(errors);
+    Ok(())
+}
+
+fn new_checker<'c, 'context, 'queries, Q>(
+    checked: &'c CheckedModule,
+    context: &'context CheckContext<'queries, Q>,
+    local: Option<LocalDeclarationId>,
+    pass: Pass,
+) -> SkolemChecker<'c, 'context, 'queries, Q>
+where
+    Q: ExternalQueries,
+{
+    let (discovering, expected_skolems) = match pass {
+        Pass::Discover => (true, FxHashSet::default()),
+        Pass::Audit(expected_skolems) => (false, expected_skolems),
+    };
+
+    let mut tasks = if let Some(declaration) = local {
+        vec![Task::Local(declaration)]
+    } else {
+        let terms = checked.tree.iter_terms();
+        let terms = terms.collect_vec();
+        let tasks = terms.iter().map(|&(source, declaration)| {
+            let crumb = ErrorCrumb::TermDeclaration(source);
+            Task::Term(&checked.tree[declaration], crumb)
+        });
+        tasks.collect_vec()
+    };
+    tasks.reverse();
+
+    let reported = checked.errors.iter().filter_map(|error| {
+        let ErrorKind::EscapedSkolem { skolem, .. } = error.kind else { return None };
+        let Type::Rigid(name, _, _) = context.lookup_type(skolem) else { return None };
+        name.scope
+    });
+    let reported = reported.collect();
+
+    SkolemChecker {
+        checked,
+        context,
+        local,
+        discovering,
+        expected_skolems,
+        tasks,
+        active: FxHashMap::default(),
+        reported,
+        errors: vec![],
+        evidence_depth: 0,
+    }
+}
+
+fn check_term<'c, Q>(
+    checker: &mut SkolemChecker<'c, '_, '_, Q>,
+    declaration: &'c TermDeclaration,
+    crumb: ErrorCrumb,
+) where
+    Q: ExternalQueries,
+{
+    inspect_type(checker, declaration.type_id, crumb);
+
+    match &declaration.kind {
+        TermDeclarationKind::Value(value) => {
+            inspect_abstractions(checker, &value.abstractions, crumb);
+            let equations = value.equations.iter().map(|equation| Task::Equation(equation, crumb));
+            checker.tasks.extend(equations);
+        }
+        TermDeclarationKind::Foreign => {}
+        TermDeclarationKind::Constructor(constructor) => {
+            for &argument in constructor.arguments.iter() {
+                inspect_type(checker, argument, crumb);
+            }
+        }
+        TermDeclarationKind::Instance(instance) => check_instance(checker, instance, crumb),
+    }
+}
+
+fn check_instance<'c, Q>(
+    checker: &mut SkolemChecker<'c, '_, '_, Q>,
+    instance: &'c InstanceDeclaration,
+    crumb: ErrorCrumb,
+) where
+    Q: ExternalQueries,
+{
+    for &parameter in instance.rigid_parameters.iter() {
+        inspect_rigid_kind(checker, parameter, crumb);
+    }
+    for evidence in instance.evidences.iter() {
+        inspect_type(checker, evidence.constraint, crumb);
+    }
+    for superclass in instance.superclasses.iter() {
+        inspect_type(checker, superclass.constraint, crumb);
+    }
+
+    match &instance.implementation {
+        InstanceImplementation::Members(members) => {
+            let members = members.iter().map(|member| Task::Member(member, crumb));
+            checker.tasks.extend(members);
+        }
+        InstanceImplementation::Delegate { constraint, .. } => {
+            inspect_type(checker, *constraint, crumb);
+        }
+    }
+}
+
+fn check_member<'c, Q>(
+    checker: &mut SkolemChecker<'c, '_, '_, Q>,
+    member: &'c InstanceMember,
+    crumb: ErrorCrumb,
+) where
+    Q: ExternalQueries,
+{
+    inspect_type(checker, member.implementation_type, crumb);
+    inspect_abstractions(checker, &member.abstractions, crumb);
+    let equations = member.equations.iter().map(|equation| Task::Equation(equation, crumb));
+    checker.tasks.extend(equations);
+}
+
+fn check_local_declaration<Q>(
+    checker: &mut SkolemChecker<'_, '_, '_, Q>,
+    declaration_id: LocalDeclarationId,
+) where
+    Q: ExternalQueries,
+{
+    let checked = checker.checked;
+    let declaration = &checked.tree[declaration_id];
+    let crumb = ErrorCrumb::CheckingLetName(declaration.source);
+    if checker.evidence_depth == 0 {
+        inspect_type(checker, declaration.type_id, crumb);
+        inspect_abstractions(checker, &declaration.value.abstractions, crumb);
+    } else {
+        inspect_evidence_abstractions(checker, &declaration.value.abstractions, crumb);
+    }
+    let equations =
+        declaration.value.equations.iter().map(|equation| Task::Equation(equation, crumb));
+    checker.tasks.extend(equations);
+}
+
+fn check_equation<'c, Q>(
+    checker: &mut SkolemChecker<'c, '_, '_, Q>,
+    equation: &'c Equation,
+    crumb: ErrorCrumb,
+) where
+    Q: ExternalQueries,
+{
+    checker.tasks.push(Task::Guarded(&equation.guarded_expression, crumb));
+    let binders = equation.binders.iter().map(|&binder| Task::Binder(binder, crumb));
+    checker.tasks.extend(binders);
+}
+
+fn check_guarded<'c, Q>(
+    checker: &mut SkolemChecker<'c, '_, '_, Q>,
+    guarded: &'c GuardedExpression,
+    crumb: ErrorCrumb,
+) where
+    Q: ExternalQueries,
+{
+    for alternative in guarded.alternatives.iter() {
+        checker.tasks.push(Task::Where(&alternative.where_expression, crumb));
+        for guard in alternative.pattern_guards.iter() {
+            match guard {
+                PatternGuard::Boolean { expression } => {
+                    checker.tasks.push(Task::Expression(*expression, crumb));
+                }
+                PatternGuard::Pattern { binder, expression } => {
+                    checker.tasks.push(Task::Binder(*binder, crumb));
+                    checker.tasks.push(Task::Expression(*expression, crumb));
+                }
+            }
+        }
+    }
+}
+
+fn check_where<'c, Q>(
+    checker: &mut SkolemChecker<'c, '_, '_, Q>,
+    where_expression: &'c WhereExpression,
+    crumb: ErrorCrumb,
+) where
+    Q: ExternalQueries,
+{
+    checker.tasks.push(Task::Bindings(&where_expression.bindings, crumb));
+    checker.tasks.push(Task::Expression(where_expression.expression, crumb));
+}
+
+fn check_bindings<'c, Q>(
+    checker: &mut SkolemChecker<'c, '_, '_, Q>,
+    bindings: &'c LetBindings,
+    crumb: ErrorCrumb,
+) where
+    Q: ExternalQueries,
+{
+    for chunk in bindings.chunks.iter() {
+        match chunk {
+            LetBindingChunk::Pattern { binder, where_expression, .. } => {
+                checker.tasks.push(Task::Binder(*binder, crumb));
+                checker.tasks.push(Task::Where(where_expression, crumb));
+            }
+            LetBindingChunk::PatternError { where_expression, .. } => {
+                if let Some(where_expression) = where_expression {
+                    checker.tasks.push(Task::Where(where_expression, crumb));
+                }
+            }
+            LetBindingChunk::Names { declarations, .. } => {
+                if checker.evidence_depth > 0 || checker.local.is_none() {
+                    let declarations = declarations
+                        .iter()
+                        .map(|&declaration| Task::EnterLocalEvidence(declaration));
+                    checker.tasks.extend(declarations);
+                }
+            }
+        }
+    }
+}
+
+fn check_alternative<'c, Q>(
+    checker: &mut SkolemChecker<'c, '_, '_, Q>,
+    alternative: &'c CaseAlternative,
+    crumb: ErrorCrumb,
+) where
+    Q: ExternalQueries,
+{
+    checker.tasks.push(Task::Guarded(&alternative.guarded_expression, crumb));
+    let binders = alternative.binders.iter().map(|&binder| Task::Binder(binder, crumb));
+    checker.tasks.extend(binders);
+}
+
+fn check_updates<'c, Q>(
+    checker: &mut SkolemChecker<'c, '_, '_, Q>,
+    updates: &'c [RecordExpressionUpdate],
+    crumb: ErrorCrumb,
+) where
+    Q: ExternalQueries,
+{
+    for update in updates {
+        match update {
+            RecordExpressionUpdate::Error => {}
+            RecordExpressionUpdate::Leaf { expression, .. } => {
+                checker.tasks.push(Task::Expression(*expression, crumb));
+            }
+            RecordExpressionUpdate::Branch { updates, .. } => {
+                checker.tasks.push(Task::Updates(updates, crumb));
+            }
+        }
+    }
+}
+
+fn check_binder<Q>(
+    checker: &mut SkolemChecker<'_, '_, '_, Q>,
+    binder_id: BinderId,
+    crumb: ErrorCrumb,
+) where
+    Q: ExternalQueries,
+{
+    if checker.evidence_depth > 0 {
+        return;
+    }
+
+    let checked = checker.checked;
+    let binder = &checked.tree[binder_id];
+    inspect_type(checker, binder.type_id, crumb);
+    match &binder.kind {
+        BinderKind::Error
+        | BinderKind::Integer { .. }
+        | BinderKind::Number { .. }
+        | BinderKind::Variable
+        | BinderKind::Wildcard
+        | BinderKind::String { .. }
+        | BinderKind::Char { .. }
+        | BinderKind::Boolean { .. } => {}
+        BinderKind::Typed { binder, annotation } => {
+            inspect_type(checker, *annotation, crumb);
+            checker.tasks.push(Task::Binder(*binder, crumb));
+        }
+        BinderKind::Named { binder, .. } => {
+            checker.tasks.push(Task::Binder(*binder, crumb));
+        }
+        BinderKind::Array { elements } => {
+            let elements = elements.iter().map(|&element| Task::Binder(element, crumb));
+            checker.tasks.extend(elements);
+        }
+        BinderKind::Record { fields } => {
+            for field in fields.iter() {
+                if let RecordBinderField::Field { binder, .. } = field {
+                    checker.tasks.push(Task::Binder(*binder, crumb));
+                }
+            }
+        }
+        BinderKind::Constructor { arguments, .. } => {
+            let arguments = arguments.iter().map(|&argument| Task::Binder(argument, crumb));
+            checker.tasks.extend(arguments);
+        }
+    }
+}
+
+fn check_expression<Q>(
+    checker: &mut SkolemChecker<'_, '_, '_, Q>,
+    expression_id: ExpressionId,
+    crumb: ErrorCrumb,
+) where
+    Q: ExternalQueries,
+{
+    let checked = checker.checked;
+    let expression = &checked.tree[expression_id];
+
+    for scope in leading_scopes(checker.context, expression.type_id) {
+        if checker.discovering {
+            checker.expected_skolems.insert(scope);
+            checker.reported.insert(scope);
+        }
+        *checker.active.entry(scope).or_default() += 1;
+        checker.tasks.push(Task::ExitScope(scope));
+    }
+
+    if checker.evidence_depth == 0 && expression.retained_judgment {
+        inspect_type(checker, expression.type_id, crumb);
+    }
+
+    match &expression.kind {
+        ExpressionKind::Error
+        | ExpressionKind::String { .. }
+        | ExpressionKind::Char { .. }
+        | ExpressionKind::Boolean { .. }
+        | ExpressionKind::Integer { .. }
+        | ExpressionKind::Number { .. }
+        | ExpressionKind::Constructor { .. }
+        | ExpressionKind::Variable { .. }
+        | ExpressionKind::RecordPun { .. } => {}
+        ExpressionKind::Section { binder } => {
+            checker.tasks.push(Task::Binder(*binder, crumb));
+        }
+        ExpressionKind::Array { elements } => {
+            let elements = elements.iter().map(|&element| Task::Expression(element, crumb));
+            checker.tasks.extend(elements);
+        }
+        ExpressionKind::Record { fields } => {
+            for field in fields.iter() {
+                let expression = match field {
+                    RecordExpressionField::Field { expression, .. }
+                    | RecordExpressionField::Pun { expression, .. } => *expression,
+                };
+                checker.tasks.push(Task::Expression(expression, crumb));
+            }
+        }
+        ExpressionKind::RecordAccess { record, .. } => {
+            checker.tasks.push(Task::Expression(*record, crumb));
+        }
+        ExpressionKind::RecordUpdate { record, updates } => {
+            checker.tasks.push(Task::Expression(*record, crumb));
+            checker.tasks.push(Task::Updates(updates, crumb));
+        }
+        ExpressionKind::TermApplication { function, argument } => {
+            checker.tasks.push(Task::Expression(*function, crumb));
+            checker.tasks.push(Task::Expression(*argument, crumb));
+        }
+        ExpressionKind::EvidenceApplication { function, constraint, .. } => {
+            inspect_type(checker, *constraint, crumb);
+            checker.tasks.push(Task::Expression(*function, crumb));
+        }
+        ExpressionKind::EvidenceAbstraction { binder, expression } => {
+            inspect_type(checker, checked.evidence[*binder].constraint, crumb);
+            checker.tasks.push(Task::Expression(*expression, crumb));
+        }
+        ExpressionKind::Lambda { binders, expression } => {
+            checker.tasks.push(Task::Expression(*expression, crumb));
+            let binders = binders.iter().map(|&binder| Task::Binder(binder, crumb));
+            checker.tasks.extend(binders);
+        }
+        ExpressionKind::IfThenElse { condition, then, else_ } => {
+            checker.tasks.push(Task::Expression(*condition, crumb));
+            checker.tasks.push(Task::Expression(*then, crumb));
+            checker.tasks.push(Task::Expression(*else_, crumb));
+        }
+        ExpressionKind::Case { scrutinees, alternatives } => {
+            let scrutinees = scrutinees.iter().map(|&scrutinee| Task::Expression(scrutinee, crumb));
+            checker.tasks.extend(scrutinees);
+            let alternatives =
+                alternatives.iter().map(|alternative| Task::Alternative(alternative, crumb));
+            checker.tasks.extend(alternatives);
+        }
+        ExpressionKind::Let { bindings, expression } => {
+            checker.tasks.push(Task::Bindings(bindings, crumb));
+            checker.tasks.push(Task::Expression(*expression, crumb));
+        }
+    }
+}
+
+fn exit_scope<Q>(checker: &mut SkolemChecker<'_, '_, '_, Q>, scope: SkolemScope)
+where
+    Q: ExternalQueries,
+{
+    let count =
+        checker.active.get_mut(&scope).expect("invariant violated: exited inactive skolem scope");
+    *count -= 1;
+    if *count == 0 {
+        checker.active.remove(&scope);
+    }
+}
+
+fn enter_local_evidence<Q>(
+    checker: &mut SkolemChecker<'_, '_, '_, Q>,
+    declaration: LocalDeclarationId,
+) where
+    Q: ExternalQueries,
+{
+    checker.evidence_depth += 1;
+    checker.tasks.push(Task::ExitEvidence);
+    checker.tasks.push(Task::Local(declaration));
+}
+
+fn exit_evidence<Q>(checker: &mut SkolemChecker<'_, '_, '_, Q>)
+where
+    Q: ExternalQueries,
+{
+    checker.evidence_depth -= 1;
+}
+
+fn inspect_abstractions<Q>(
+    checker: &mut SkolemChecker<'_, '_, '_, Q>,
+    abstractions: &[DeclarationAbstraction],
+    crumb: ErrorCrumb,
+) where
+    Q: ExternalQueries,
+{
+    for abstraction in abstractions {
+        match abstraction {
+            DeclarationAbstraction::Type { binder, rigid } => {
+                let binder = checker.context.lookup_forall_binder(*binder);
+                inspect_type(checker, binder.kind, crumb);
+                inspect_rigid_kind(checker, *rigid, crumb);
+            }
+            DeclarationAbstraction::Evidence { constraint, .. } => {
+                inspect_type(checker, *constraint, crumb);
+            }
+        }
+    }
+}
+
+fn inspect_evidence_abstractions<Q>(
+    checker: &mut SkolemChecker<'_, '_, '_, Q>,
+    abstractions: &[DeclarationAbstraction],
+    crumb: ErrorCrumb,
+) where
+    Q: ExternalQueries,
+{
+    for abstraction in abstractions {
+        if let DeclarationAbstraction::Evidence { constraint, .. } = abstraction {
+            inspect_type(checker, *constraint, crumb);
+        }
+    }
+}
+
+fn inspect_rigid_kind<Q>(
+    checker: &mut SkolemChecker<'_, '_, '_, Q>,
+    rigid: TypeId,
+    crumb: ErrorCrumb,
+) where
+    Q: ExternalQueries,
+{
+    if let Type::Rigid(_, _, kind) = checker.context.lookup_type(rigid) {
+        inspect_type(checker, kind, crumb);
+    }
+}
+
+fn inspect_type<Q>(
+    checker: &mut SkolemChecker<'_, '_, '_, Q>,
+    annotation: TypeId,
+    crumb: ErrorCrumb,
+) where
+    Q: ExternalQueries,
+{
+    let mut pending = vec![annotation];
+    let mut visited = FxHashSet::default();
+
+    while let Some(type_id) = pending.pop() {
+        if !visited.insert(type_id) {
+            continue;
+        }
+
+        match checker.context.lookup_type(type_id) {
+            Type::Application(function, argument)
+            | Type::KindApplication(function, argument)
+            | Type::Constrained(function, argument)
+            | Type::Function(function, argument)
+            | Type::Kinded(function, argument) => {
+                pending.push(function);
+                pending.push(argument);
+            }
+            Type::Forall(binder, inner) => {
+                let binder = checker.context.lookup_forall_binder(binder);
+                pending.push(binder.kind);
+                pending.push(inner);
+            }
+            Type::Row(row) => {
+                let row = checker.context.lookup_row_type(row);
+                let fields = row.fields.iter().map(|field| field.id);
+                pending.extend(fields);
+                pending.extend(row.tail);
+            }
+            Type::Rigid(name, _, kind) => {
+                if let Some(scope) = name.scope
+                    && checker.expected_skolems.contains(&scope)
+                    && !checker.active.contains_key(&scope)
+                    && checker.reported.insert(scope)
+                {
+                    let skolem = type_id;
+                    let kind = ErrorKind::EscapedSkolem { skolem, type_id: annotation };
+                    checker.errors.push(CheckingError { kind, crumbs: Arc::from([crumb]) });
+                }
+                pending.push(kind);
+            }
+            Type::Constructor(_, _)
+            | Type::Integer(_)
+            | Type::String(_, _)
+            | Type::Unification(_)
+            | Type::Free(_)
+            | Type::Unknown(_) => {}
+        }
+    }
+}
+
+fn collect_errors<Q>(
+    checked: &CheckedModule,
+    context: &CheckContext<Q>,
+    local: Option<LocalDeclarationId>,
+    pass: Pass,
+) -> (Vec<CheckingError>, FxHashSet<SkolemScope>)
+where
+    Q: ExternalQueries,
+{
+    let mut checker = new_checker(checked, context, local, pass);
+
+    while let Some(task) = checker.tasks.pop() {
+        match task {
+            Task::Term(declaration, crumb) => check_term(&mut checker, declaration, crumb),
+            Task::Member(member, crumb) => check_member(&mut checker, member, crumb),
+            Task::Local(declaration) => check_local_declaration(&mut checker, declaration),
+            Task::Equation(equation, crumb) => check_equation(&mut checker, equation, crumb),
+            Task::Guarded(guarded, crumb) => check_guarded(&mut checker, guarded, crumb),
+            Task::Where(where_expression, crumb) => {
+                check_where(&mut checker, where_expression, crumb);
+            }
+            Task::Bindings(bindings, crumb) => check_bindings(&mut checker, bindings, crumb),
+            Task::Alternative(alternative, crumb) => {
+                check_alternative(&mut checker, alternative, crumb);
+            }
+            Task::Updates(updates, crumb) => check_updates(&mut checker, updates, crumb),
+            Task::Binder(binder, crumb) => check_binder(&mut checker, binder, crumb),
+            Task::Expression(expression, crumb) => {
+                check_expression(&mut checker, expression, crumb);
+            }
+            Task::ExitScope(scope) => exit_scope(&mut checker, scope),
+            Task::EnterLocalEvidence(declaration) => {
+                enter_local_evidence(&mut checker, declaration);
+            }
+            Task::ExitEvidence => exit_evidence(&mut checker),
+        }
+    }
+
+    (checker.errors, checker.expected_skolems)
+}
+
+fn leading_scopes<Q>(context: &CheckContext<Q>, mut type_id: TypeId) -> Vec<SkolemScope>
+where
+    Q: ExternalQueries,
+{
+    let mut scopes = vec![];
+    while let Type::Forall(binder, inner) = context.lookup_type(type_id) {
+        let binder = context.lookup_forall_binder(binder);
+        let Some(scope) = binder.scope else { break };
+        scopes.push(scope);
+        type_id = inner;
+    }
+    scopes
+}

--- a/compiler-core/checking/src/core/skolem.rs
+++ b/compiler-core/checking/src/core/skolem.rs
@@ -48,6 +48,7 @@ where
 {
     checked: &'c CheckedModule,
     context: &'context CheckContext<'queries, Q>,
+    judgments: &'c FxHashSet<ExpressionId>,
     local: Option<LocalDeclarationId>,
     discovering: bool,
     expected_skolems: FxHashSet<SkolemScope>,
@@ -68,7 +69,13 @@ where
         expected_skolems.extend(scopes);
     }
 
-    let (errors, _) = collect_errors(&state.checked, context, None, Pass::Audit(expected_skolems));
+    let (errors, _) = collect_errors(
+        &state.checked,
+        &state.judgments,
+        context,
+        None,
+        Pass::Audit(expected_skolems),
+    );
     state.checked.errors.extend(errors);
 }
 
@@ -84,16 +91,27 @@ where
     let type_id = super::zonk::zonk(state, context, type_id)?;
     state.checked.tree.set_let_type(declaration, type_id);
 
-    let (_, expected_skolems) =
-        collect_errors(&state.checked, context, Some(declaration), Pass::Discover);
-    let (errors, _) =
-        collect_errors(&state.checked, context, Some(declaration), Pass::Audit(expected_skolems));
+    let (_, expected_skolems) = collect_errors(
+        &state.checked,
+        &state.judgments,
+        context,
+        Some(declaration),
+        Pass::Discover,
+    );
+    let (errors, _) = collect_errors(
+        &state.checked,
+        &state.judgments,
+        context,
+        Some(declaration),
+        Pass::Audit(expected_skolems),
+    );
     state.checked.errors.extend(errors);
     Ok(())
 }
 
 fn new_checker<'c, 'context, 'queries, Q>(
     checked: &'c CheckedModule,
+    judgments: &'c FxHashSet<ExpressionId>,
     context: &'context CheckContext<'queries, Q>,
     local: Option<LocalDeclarationId>,
     pass: Pass,
@@ -129,6 +147,7 @@ where
     SkolemChecker {
         checked,
         context,
+        judgments,
         local,
         discovering,
         expected_skolems,
@@ -401,7 +420,7 @@ fn check_expression<Q>(
         checker.tasks.push(Task::ExitScope(scope));
     }
 
-    if checker.evidence_depth == 0 && expression.retained_judgment {
+    if checker.evidence_depth == 0 && checker.judgments.contains(&expression_id) {
         inspect_type(checker, expression.type_id, crumb);
     }
 
@@ -608,8 +627,9 @@ fn inspect_type<Q>(
     }
 }
 
-fn collect_errors<Q>(
-    checked: &CheckedModule,
+fn collect_errors<'c, Q>(
+    checked: &'c CheckedModule,
+    judgments: &'c FxHashSet<ExpressionId>,
     context: &CheckContext<Q>,
     local: Option<LocalDeclarationId>,
     pass: Pass,
@@ -617,7 +637,7 @@ fn collect_errors<Q>(
 where
     Q: ExternalQueries,
 {
-    let mut checker = new_checker(checked, context, local, pass);
+    let mut checker = new_checker(checked, judgments, context, local, pass);
 
     while let Some(task) = checker.tasks.pop() {
         match task {

--- a/compiler-core/checking/src/core/toolkit.rs
+++ b/compiler-core/checking/src/core/toolkit.rs
@@ -425,7 +425,7 @@ where
         }
 
         substitution.insert(binder.name, rigid);
-        freshened.push(ForallBinder { visible: binder.visible, name, kind });
+        freshened.push(ForallBinder { visible: binder.visible, name, kind, scope: None });
     }
 
     let quantified = SubstituteName::many(state, context, &substitution, quantified)?;

--- a/compiler-core/checking/src/core/unification.rs
+++ b/compiler-core/checking/src/core/unification.rs
@@ -31,7 +31,7 @@ impl CanUnify {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SubtypeApplication {
     Type { result: TypeId },
-    Evidence { evidence: EvidenceVarId, result: TypeId },
+    Evidence { evidence: EvidenceVarId, constraint: TypeId, result: TypeId },
 }
 
 /// Strategy for handling constrained types during [`subtype_with`].
@@ -156,7 +156,7 @@ where
         }
         (Type::Constrained(constraint, result), _) => {
             let evidence = state.push_wanted(constraint);
-            applications.push(SubtypeApplication::Evidence { evidence, result });
+            applications.push(SubtypeApplication::Evidence { evidence, constraint, result });
             subtype_with_applications_core(state, context, result, t2, applications)
         }
         (_, _) => subtype(state, context, t1, t2),

--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -125,6 +125,11 @@ where
     let mut expressions = mem::take(&mut state.checked.tree.arena.expressions);
     for (_, expression) in expressions.iter_mut() {
         expression.type_id = zonk(state, context, expression.type_id)?;
+        if let crate::tree::ExpressionKind::EvidenceApplication { constraint, .. } =
+            &mut expression.kind
+        {
+            *constraint = zonk(state, context, *constraint)?;
+        }
     }
     state.checked.tree.arena.expressions = expressions;
 
@@ -294,6 +299,11 @@ where
             let t1 = zonk(state, context, t1)?;
             let t2 = zonk(state, context, t2)?;
             ErrorKind::CannotUnify { t1, t2 }
+        }
+        ErrorKind::EscapedSkolem { skolem, type_id } => {
+            let skolem = zonk(state, context, skolem)?;
+            let type_id = zonk(state, context, type_id)?;
+            ErrorKind::EscapedSkolem { skolem, type_id }
         }
         ErrorKind::InstanceHeadLabeledRow { class_file, class_item, position, type_id } => {
             let type_id = zonk(state, context, type_id)?;

--- a/compiler-core/checking/src/error.rs
+++ b/compiler-core/checking/src/error.rs
@@ -70,6 +70,10 @@ pub enum ErrorKind {
     DeriveMissingFunctor,
     EmptyAdoBlock,
     EmptyDoBlock,
+    EscapedSkolem {
+        skolem: TypeId,
+        type_id: TypeId,
+    },
     TermHole {
         source_term: lowering::ExpressionId,
     },

--- a/compiler-core/checking/src/lib.rs
+++ b/compiler-core/checking/src/lib.rs
@@ -226,6 +226,7 @@ fn check_source(queries: &impl ExternalQueries, file_id: FileId) -> QueryResult<
         core::zonk::zonk_tree(state, &context)?;
         core::zonk::zonk_evidence(state, &context)?;
         core::zonk::zonk_holes(state, &context)?;
+        core::skolem::check(state, &context);
         core::zonk::zonk_errors(state, &context)
     })?;
     state.checked.evidence.assert_finished();

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -46,6 +46,17 @@ fn allocate_error_expression(state: &mut CheckState, type_id: TypeId) -> Elabora
     ElaboratedExpression { type_id, expression }
 }
 
+fn retain_expression_judgment(
+    state: &mut CheckState,
+    expression: ElaboratedExpression,
+) -> ElaboratedExpression {
+    // Only source expression roots correspond to PureScript's `TypedValue`
+    // judgments. Generated elaboration nodes can cache transient unification
+    // solutions and must not become independent judgments.
+    state.checked.tree.retain_expression_judgment(expression.expression);
+    expression
+}
+
 pub(super) fn allocate_term_reference<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
@@ -87,6 +98,7 @@ where
 {
     state.with_error_crumb(ErrorCrumb::CheckingExpression(expression), |state| {
         let checked = check_expression_quiet(state, context, expression, expected)?;
+        let checked = retain_expression_judgment(state, checked);
         state.checked.node_types.expressions.insert(expression, checked.type_id);
         Ok(checked)
     })
@@ -121,9 +133,10 @@ where
     Q: ExternalQueries,
 {
     let expected = normalise::normalise(state, context, expected)?;
-    check_expected_expression(state, context, expected, |state, expected| {
+    let checked = check_expected_expression(state, context, expected, |state, expected| {
         check_elaborated_expression_quiet(state, context, inferred, expected)
-    })
+    })?;
+    Ok(retain_expression_judgment(state, checked))
 }
 
 fn check_expected_expression<Q, F>(
@@ -143,11 +156,16 @@ where
 
             let kind = normalise::normalise(state, context, binder.kind)?;
             let text = state.checked.lookup_name(binder.name);
-            let rigid = state.fresh_rigid_named(context.queries, kind, text);
+            let (rigid, name, scope) = state.fresh_scoped_rigid_named(context.queries, kind, text);
 
             let inner = SubstituteName::one(state, context, binder.name, rigid, inner)?;
             let checked = check_expected_expression(state, context, inner, check)?;
-            Ok(checked)
+            let binder = crate::core::ForallBinder { name, scope: Some(scope), ..binder };
+            let binder = context.intern_forall_binder(binder);
+            let inner = state.checked.tree[checked.expression].type_id;
+            let scoped = context.intern_forall(binder, inner);
+            state.checked.tree.set_expression_type(checked.expression, scoped);
+            Ok(ElaboratedExpression { type_id: expected, expression: checked.expression })
         }
         Type::Constrained(constraint, constrained) => state.with_implication(|state| {
             let binder = state.push_given(constraint);
@@ -289,6 +307,7 @@ where
 {
     state.with_error_crumb(ErrorCrumb::InferringExpression(expression), |state| {
         let inferred = infer_expression_quiet(state, context, expression)?;
+        let inferred = retain_expression_judgment(state, inferred);
         state.checked.node_types.expressions.insert(expression, inferred.type_id);
         Ok(inferred)
     })

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -53,7 +53,7 @@ fn retain_expression_judgment(
     // Only source expression roots correspond to PureScript's `TypedValue`
     // judgments. Generated elaboration nodes can cache transient unification
     // solutions and must not become independent judgments.
-    state.checked.tree.retain_expression_judgment(expression.expression);
+    state.retain_expression_judgment(expression.expression);
     expression
 }
 

--- a/compiler-core/checking/src/source/terms/application.rs
+++ b/compiler-core/checking/src/source/terms/application.rs
@@ -19,7 +19,7 @@ pub struct UnanchoredApplication {
 
 pub enum ImplicitApplication {
     Type { result: TypeId },
-    Evidence { evidence: EvidenceVarId, result: TypeId },
+    Evidence { evidence: EvidenceVarId, constraint: TypeId, result: TypeId },
 }
 
 enum PendingImplicitApplication {
@@ -139,6 +139,7 @@ where
                 let kind = tree::ExpressionKind::EvidenceApplication {
                     function: expression.expression,
                     evidence,
+                    constraint,
                 };
                 expression = super::allocate_expression(state, result, kind);
             }
@@ -166,6 +167,7 @@ where
         let kind = tree::ExpressionKind::EvidenceApplication {
             function: expression.expression,
             evidence,
+            constraint,
         };
         expression = super::allocate_expression(state, result, kind);
     }
@@ -199,7 +201,7 @@ where
                     }
                     PendingImplicitApplication::Constraint { constraint, result } => {
                         let evidence = state.push_wanted(constraint);
-                        ImplicitApplication::Evidence { evidence, result }
+                        ImplicitApplication::Evidence { evidence, constraint, result }
                     }
                 });
                 let implicit = implicit.collect();
@@ -225,8 +227,8 @@ where
         unification::subtype_with_applications(state, context, expression.type_id, expected)?;
     let applications = applications.into_iter().map(|application| match application {
         unification::SubtypeApplication::Type { result } => ImplicitApplication::Type { result },
-        unification::SubtypeApplication::Evidence { evidence, result } => {
-            ImplicitApplication::Evidence { evidence, result }
+        unification::SubtypeApplication::Evidence { evidence, constraint, result } => {
+            ImplicitApplication::Evidence { evidence, constraint, result }
         }
     });
     Ok(materialize_implicit_applications(state, expression, applications))
@@ -242,10 +244,11 @@ fn materialize_implicit_applications(
             ImplicitApplication::Type { result } => {
                 expression.type_id = result;
             }
-            ImplicitApplication::Evidence { evidence, result } => {
+            ImplicitApplication::Evidence { evidence, constraint, result } => {
                 let kind = tree::ExpressionKind::EvidenceApplication {
                     function: expression.expression,
                     evidence,
+                    constraint,
                 };
                 expression = super::allocate_expression(state, result, kind);
             }
@@ -327,6 +330,7 @@ where
                 let kind = tree::ExpressionKind::EvidenceApplication {
                     function: function.expression,
                     evidence,
+                    constraint,
                 };
                 function = super::allocate_expression(state, result, kind);
             }
@@ -381,6 +385,7 @@ where
                 let kind = tree::ExpressionKind::EvidenceApplication {
                     function: function.expression,
                     evidence,
+                    constraint,
                 };
                 function = super::allocate_expression(state, result, kind);
             }

--- a/compiler-core/checking/src/source/terms/form_let.rs
+++ b/compiler-core/checking/src/source/terms/form_let.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use building_types::QueryResult;
 
 use crate::context::CheckContext;
-use crate::core::{Type, TypeId, exhaustive, normalise, unification};
+use crate::core::{Type, TypeId, exhaustive, normalise, skolem, unification};
 use crate::error::ErrorCrumb;
 use crate::source::terms::{ElaboratedExpression, application, equations, guarded};
 use crate::source::{binder, types};
@@ -169,12 +169,14 @@ where
         match item {
             lowering::Scc::Base(id) | lowering::Scc::Recursive(id) => {
                 let declaration = check_let_name_binding(state, context, *id)?;
-                state.checked.tree.insert_let(declaration);
+                let declaration = state.checked.tree.insert_let(declaration);
+                skolem::check_local(state, context, declaration)?;
             }
             lowering::Scc::Mutual(mutual) => {
                 for &id in mutual {
                     let declaration = check_let_name_binding(state, context, id)?;
-                    state.checked.tree.insert_let(declaration);
+                    let declaration = state.checked.tree.insert_let(declaration);
+                    skolem::check_local(state, context, declaration)?;
                 }
             }
         }

--- a/compiler-core/checking/src/source/type_items.rs
+++ b/compiler-core/checking/src/source/type_items.rs
@@ -400,7 +400,7 @@ where
         state.checked.names.insert(name, text);
         let visible = equation_binding.visible;
 
-        binders.push(ForallBinder { visible, name, kind });
+        binders.push(ForallBinder { visible, name, kind, scope: None });
     }
 
     Ok(binders)

--- a/compiler-core/checking/src/source/types.rs
+++ b/compiler-core/checking/src/source/types.rs
@@ -494,7 +494,7 @@ where
     state.checked.names.insert(name, text);
     state.checked.node_types.forall_bindings.insert(binding.id, kind);
     state.bindings.bind_forall(binding.id, name, state.depth, kind);
-    Ok(ForallBinder { visible, name, kind })
+    Ok(ForallBinder { visible, name, kind, scope: None })
 }
 
 pub fn infer_application_kind<Q>(

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -13,7 +13,7 @@ use crate::core::exhaustive::{
     ExhaustivenessReport, Pattern, PatternConstructor, PatternId, PatternInterner, PatternKind,
 };
 use crate::core::substitute::RigidRenaming;
-use crate::core::{Depth, Name, SmolStrId, Type, TypeId, constraint};
+use crate::core::{Depth, Name, SkolemScope, SmolStrId, Type, TypeId, constraint};
 use crate::error::{CheckingError, ErrorCrumb, ErrorKind};
 use crate::evidence::{EvidenceBinderId, EvidenceVarId};
 use crate::implication::{GivenConstraint, Implications, Patterns, WantedConstraint};
@@ -33,7 +33,14 @@ impl Names {
     pub fn fresh(&mut self) -> Name {
         let unique = self.unique;
         self.unique += 1;
-        Name { file: self.file, unique }
+        Name { file: self.file, unique, scope: None }
+    }
+
+    pub fn fresh_scoped(&mut self) -> (Name, SkolemScope) {
+        let name = self.fresh();
+        let scope = SkolemScope { file: name.file, unique: name.unique };
+        let name = Name { scope: Some(scope), ..name };
+        (name, scope)
     }
 }
 
@@ -264,6 +271,20 @@ impl CheckState {
         queries.intern_type(Type::Rigid(name, self.depth, kind))
     }
 
+    pub fn fresh_scoped_rigid_named(
+        &mut self,
+        queries: &impl ExternalQueries,
+        kind: TypeId,
+        text: Option<SmolStrId>,
+    ) -> (TypeId, Name, SkolemScope) {
+        let (name, scope) = self.names.fresh_scoped();
+        if let Some(text) = text {
+            self.checked.names.insert(name, text);
+        }
+        let rigid = queries.intern_type(Type::Rigid(name, self.depth, kind));
+        (rigid, name, scope)
+    }
+
     pub fn insert_error(&mut self, kind: ErrorKind) {
         let crumbs = self.crumbs.iter().copied().collect();
         self.checked.errors.push(CheckingError { kind, crumbs });
@@ -286,7 +307,7 @@ impl CheckState {
         type_id: TypeId,
         kind: tree::ExpressionKind,
     ) -> tree::ExpressionId {
-        let expression = tree::Expression { type_id, kind };
+        let expression = tree::Expression { type_id, retained_judgment: false, kind };
         self.checked.tree.allocate_expression(expression)
     }
 

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use building_types::QueryResult;
 use files::FileId;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::context::CheckContext;
 use crate::core::constraint::{CanonicalConstraintId, Canonicals, ConstraintInScope};
@@ -167,6 +167,7 @@ pub struct CheckState {
     pub patterns: PatternInterner,
 
     zonk_cache: Option<FxHashMap<TypeId, TypeId>>,
+    pub(crate) judgments: FxHashSet<tree::ExpressionId>,
 
     pub unifications: Unifications,
     pub implications: Implications,
@@ -187,6 +188,7 @@ impl CheckState {
             bindings: Default::default(),
             patterns: Default::default(),
             zonk_cache: None,
+            judgments: Default::default(),
             unifications: Default::default(),
             implications: Default::default(),
             canonicals: Default::default(),
@@ -307,8 +309,12 @@ impl CheckState {
         type_id: TypeId,
         kind: tree::ExpressionKind,
     ) -> tree::ExpressionId {
-        let expression = tree::Expression { type_id, retained_judgment: false, kind };
+        let expression = tree::Expression { type_id, kind };
         self.checked.tree.allocate_expression(expression)
+    }
+
+    pub(crate) fn retain_expression_judgment(&mut self, expression: tree::ExpressionId) {
+        self.judgments.insert(expression);
     }
 
     pub fn allocate_error_expression(&mut self, type_id: TypeId) -> tree::ExpressionId {

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -330,6 +330,7 @@ pub enum RecordBinderField {
 #[derive(Debug, PartialEq, Eq)]
 pub struct Expression {
     pub type_id: TypeId,
+    pub(crate) retained_judgment: bool,
     pub kind: ExpressionKind,
 }
 
@@ -356,7 +357,7 @@ pub enum ExpressionKind {
     RecordPun { source: lowering::RecordPunId, resolution: VariableResolution },
     Section { binder: BinderId },
     TermApplication { function: ExpressionId, argument: ExpressionId },
-    EvidenceApplication { function: ExpressionId, evidence: EvidenceVarId },
+    EvidenceApplication { function: ExpressionId, evidence: EvidenceVarId, constraint: TypeId },
     EvidenceAbstraction { binder: EvidenceBinderId, expression: ExpressionId },
     Lambda { binders: Arc<[BinderId]>, expression: ExpressionId },
     IfThenElse { condition: ExpressionId, then: ExpressionId, else_: ExpressionId },
@@ -380,6 +381,14 @@ pub enum RecordExpressionUpdate {
 impl CheckedTree {
     pub fn allocate_expression(&mut self, expression: Expression) -> ExpressionId {
         self.arena.expressions.alloc(expression)
+    }
+
+    pub(crate) fn set_expression_type(&mut self, expression: ExpressionId, type_id: TypeId) {
+        self.arena.expressions[expression].type_id = type_id;
+    }
+
+    pub(crate) fn retain_expression_judgment(&mut self, expression: ExpressionId) {
+        self.arena.expressions[expression].retained_judgment = true;
     }
 
     pub fn allocate_binder(&mut self, binder: Binder) -> BinderId {
@@ -413,6 +422,10 @@ impl CheckedTree {
         self.terms.get(source).copied()
     }
 
+    pub(crate) fn iter_terms(&self) -> impl Iterator<Item = (TermItemId, TermDeclarationId)> + '_ {
+        self.terms.iter().map(|(source, declaration)| (source, *declaration))
+    }
+
     pub fn insert_let(&mut self, declaration: LocalDeclaration) -> LocalDeclarationId {
         let source = declaration.source;
         let declaration = self.arena.lets.alloc(declaration);
@@ -423,6 +436,10 @@ impl CheckedTree {
 
     pub fn lookup_let(&self, source: LetBindingNameGroupId) -> Option<LocalDeclarationId> {
         self.lets.get(source).copied()
+    }
+
+    pub(crate) fn set_let_type(&mut self, declaration: LocalDeclarationId, type_id: TypeId) {
+        self.arena.lets[declaration].type_id = type_id;
     }
 
     pub fn insert_type_declaration(

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -330,7 +330,6 @@ pub enum RecordBinderField {
 #[derive(Debug, PartialEq, Eq)]
 pub struct Expression {
     pub type_id: TypeId,
-    pub(crate) retained_judgment: bool,
     pub kind: ExpressionKind,
 }
 
@@ -385,10 +384,6 @@ impl CheckedTree {
 
     pub(crate) fn set_expression_type(&mut self, expression: ExpressionId, type_id: TypeId) {
         self.arena.expressions[expression].type_id = type_id;
-    }
-
-    pub(crate) fn retain_expression_judgment(&mut self, expression: ExpressionId) {
-        self.arena.expressions[expression].retained_judgment = true;
     }
 
     pub fn allocate_binder(&mut self, binder: Binder) -> BinderId {

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -1547,7 +1547,7 @@ where
                     Ok(breakable_continuation(self.arena, function, argument))
                 }
             }
-            ExpressionKind::EvidenceApplication { function, evidence } => {
+            ExpressionKind::EvidenceApplication { function, evidence, .. } => {
                 let function = self.expression_at(
                     *function,
                     ExpressionPrecedence::Application,

--- a/compiler-core/diagnostics/src/convert.rs
+++ b/compiler-core/diagnostics/src/convert.rs
@@ -291,6 +291,17 @@ impl ToDiagnostics for CheckingError {
             ErrorKind::EmptyDoBlock => {
                 (Severity::Error, "EmptyDoBlock", "Empty do block".to_string())
             }
+            ErrorKind::EscapedSkolem { skolem, type_id } => {
+                let skolem = render_type(*skolem);
+                let type_id = render_type(*type_id);
+                (
+                    Severity::Error,
+                    "EscapedSkolem",
+                    format!(
+                        "Type variable '{skolem}' has escaped its scope, appearing in type '{type_id}'"
+                    ),
+                )
+            }
             ErrorKind::TermHole { source_term } => {
                 let name = context.text_of(span).trim();
                 if let Some(hole) = context.checked.lookup_term_hole(*source_term) {

--- a/tests-integration/fixtures/checking/1786297500_nested_abstraction_scoping/Main.snap
+++ b/tests-integration/fixtures/checking/1786297500_nested_abstraction_scoping/Main.snap
@@ -29,3 +29,8 @@ error[NoInstanceFound]: No instance found for: Eq (a :: Type)
   |
 7 | evidenceDoesNotEscape
   | ^~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(a1 :: Type)' has escaped its scope, appearing in type '(a1 :: Type)'
+  --> 19:1..19:55
+   |
+19 | typeDoesNotEscape = consume { value: \value -> value }
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786636800_expected_forall_skolem_escape/Main.purs
+++ b/tests-integration/fixtures/checking/1786636800_expected_forall_skolem_escape/Main.purs
@@ -1,0 +1,110 @@
+module Main where
+
+data Unit = Unit
+
+data Token scope = Token
+
+data Effect value = Effect value
+
+data Proxy value = Proxy
+
+data Map key value = Map
+
+class Witness scope
+
+class EscapingEvidence scope result | result -> scope
+
+identity :: forall value. value -> value
+identity value = value
+
+modify :: forall scope. Token scope -> Token scope
+modify token = token
+
+foreign import consumeIdentity :: (forall value. value -> value) -> Unit
+
+foreign import discardValue :: forall value. value -> Unit
+
+foreign import leak
+  :: forall result
+   . (forall scope. Token scope -> result)
+  -> result
+
+foreign import mutate
+  :: forall discarded
+   . (forall scope. Token scope -> Effect discarded)
+  -> Unit
+
+foreign import mutateConstrained
+  :: (forall scope. Witness scope => Token scope -> Effect Unit)
+  -> Unit
+
+foreign import poke :: forall scope. Token scope -> Effect Unit
+
+foreign import pokeReturningToken
+  :: forall scope
+   . Token scope
+  -> Effect (Token scope)
+
+foreign import pokeConstrained
+  :: forall scope
+   . Witness scope
+  => Token scope
+  -> Effect Unit
+
+foreign import pokeWithoutWitness
+  :: forall scope result
+   . EscapingEvidence scope result
+  => Token scope
+  -> Proxy result
+
+foreign import mutateMap
+  :: forall key value discarded
+   . Witness key
+  => (forall scope. Token scope -> Effect discarded)
+  -> Map key value
+  -> Map key value
+
+foreign import pokeMap
+  :: forall key value scope
+   . Witness key
+  => key
+  -> value
+  -> Token scope
+  -> Effect (Token scope)
+
+validRankTwoCallback :: (forall value. value -> value) -> Unit
+validRankTwoCallback callback = consumeIdentity callback
+
+validDirectPolymorphicExpression :: Unit
+validDirectPolymorphicExpression = consumeIdentity identity
+
+validDiscardedHigherRankResult :: Unit
+validDiscardedHigherRankResult = mutate poke
+
+validDiscardedScopedHigherRankResult :: Unit
+validDiscardedScopedHigherRankResult = mutate pokeReturningToken
+
+validDiscardedConstrainedHigherRankResult :: Unit
+validDiscardedConstrainedHigherRankResult = mutateConstrained pokeConstrained
+
+validConstrainedTypeErasingCallback
+  :: forall key value
+   . Witness key
+  => key
+  -> value
+  -> Map key value
+  -> Map key value
+validConstrainedTypeErasingCallback key value = mutateMap (pokeMap key value)
+
+escapedResult = leak modify
+
+escapedBinder = \callback -> consumeIdentity callback
+
+escapedNestedUse = identity (leak modify)
+
+escapedDiscardedOuterArgument _ = leak modify
+
+escapedDiscardedArgument :: Unit
+escapedDiscardedArgument = discardValue (leak modify)
+
+escapedEvidenceOnly = leak pokeWithoutWitness

--- a/tests-integration/fixtures/checking/1786636800_expected_forall_skolem_escape/Main.snap
+++ b/tests-integration/fixtures/checking/1786636800_expected_forall_skolem_escape/Main.snap
@@ -135,3 +135,37 @@ Token = [Phantom]
 Effect = [Representational]
 Proxy = [Phantom]
 Map = [Phantom, Phantom]
+
+Diagnostics
+error[EscapedSkolem]: Type variable '(scope :: (t0 :: Type))' has escaped its scope, appearing in type 'forall (t0 :: Type). Token @(t0 :: Type) (scope :: (t0 :: Type))'
+  --> 99:1..99:28
+   |
+99 | escapedResult = leak modify
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(value :: Type)' has escaped its scope, appearing in type '((value :: Type) -> (value :: Type)) -> Unit'
+  --> 101:1..101:54
+    |
+101 | escapedBinder = \callback -> consumeIdentity callback
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope1 :: (t1 :: Type))' has escaped its scope, appearing in type 'forall (t1 :: Type). Token @(t1 :: Type) (scope1 :: (t1 :: Type))'
+  --> 103:1..103:42
+    |
+103 | escapedNestedUse = identity (leak modify)
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope2 :: (t2 :: Type))' has escaped its scope, appearing in type 'forall (t3 :: Type) (t2 :: Type). (t3 :: Type) -> Token @(t2 :: Type) (scope2 :: (t2 :: Type))'
+  --> 105:1..105:46
+    |
+105 | escapedDiscardedOuterArgument _ = leak modify
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope3 :: ?111)' has escaped its scope, appearing in type 'Token @?111 (scope3 :: ?111)'
+  --> 107:1..107:33
+    |
+107 | escapedDiscardedArgument :: Unit
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope4 :: (t4 :: Type))' has escaped its scope, appearing in type 'forall (t4 :: Type) (t5 :: Type) (t6 :: (t5 :: Type)).
+  EscapingEvidence @(t4 :: Type) @(t5 :: Type) (scope4 :: (t4 :: Type)) (t6 :: (t5 :: Type)) =>
+  Proxy @(t5 :: Type) (t6 :: (t5 :: Type))'
+  --> 110:1..110:46
+    |
+110 | escapedEvidenceOnly = leak pokeWithoutWitness
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786636800_expected_forall_skolem_escape/Main.snap
+++ b/tests-integration/fixtures/checking/1786636800_expected_forall_skolem_escape/Main.snap
@@ -1,0 +1,137 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Unit :: Main.Unit
+Token ::
+  forall (t0 :: Prim.Type) (@scope :: (t0 :: Prim.Type)).
+    Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type))
+Effect :: forall (@value :: Prim.Type). (value :: Prim.Type) -> Main.Effect (value :: Prim.Type)
+Proxy ::
+  forall (t0 :: Prim.Type) (@value :: (t0 :: Prim.Type)).
+    Main.Proxy @(t0 :: Prim.Type) (value :: (t0 :: Prim.Type))
+Map ::
+  forall (t0 :: Prim.Type) (t1 :: Prim.Type) (@key :: (t0 :: Prim.Type))
+    (@value :: (t1 :: Prim.Type)).
+    Main.Map @(t0 :: Prim.Type) @(t1 :: Prim.Type)
+      (key :: (t0 :: Prim.Type))
+      (value :: (t1 :: Prim.Type))
+identity :: forall (value :: Prim.Type). (value :: Prim.Type) -> (value :: Prim.Type)
+modify ::
+  forall (t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)).
+    Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) ->
+    Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type))
+consumeIdentity ::
+  (forall (value :: Prim.Type). (value :: Prim.Type) -> (value :: Prim.Type)) -> Main.Unit
+discardValue :: forall (value :: Prim.Type). (value :: Prim.Type) -> Main.Unit
+leak ::
+  forall (t0 :: Prim.Type) (result :: Prim.Type).
+    (forall (scope :: (t0 :: Prim.Type)).
+      Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) -> (result :: Prim.Type)) ->
+    (result :: Prim.Type)
+mutate ::
+  forall (t0 :: Prim.Type) (discarded :: Prim.Type).
+    (forall (scope :: (t0 :: Prim.Type)).
+      Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) ->
+      Main.Effect (discarded :: Prim.Type)) ->
+    Main.Unit
+mutateConstrained ::
+  forall (t0 :: Prim.Type).
+    (forall (scope :: (t0 :: Prim.Type)).
+      Main.Witness @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) =>
+      Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) -> Main.Effect Main.Unit) ->
+    Main.Unit
+poke ::
+  forall (t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)).
+    Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) -> Main.Effect Main.Unit
+pokeReturningToken ::
+  forall (t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)).
+    Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) ->
+    Main.Effect (Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)))
+pokeConstrained ::
+  forall (t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)).
+    Main.Witness @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) =>
+    Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) -> Main.Effect Main.Unit
+pokeWithoutWitness ::
+  forall (t0 :: Prim.Type) (t1 :: Prim.Type) (scope :: (t0 :: Prim.Type))
+    (result :: (t1 :: Prim.Type)).
+    Main.EscapingEvidence @(t0 :: Prim.Type) @(t1 :: Prim.Type)
+      (scope :: (t0 :: Prim.Type))
+      (result :: (t1 :: Prim.Type)) =>
+    Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) ->
+    Main.Proxy @(t1 :: Prim.Type) (result :: (t1 :: Prim.Type))
+mutateMap ::
+  forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (key :: (t0 :: Prim.Type))
+    (value :: (t1 :: Prim.Type)) (discarded :: Prim.Type).
+    Main.Witness @(t0 :: Prim.Type) (key :: (t0 :: Prim.Type)) =>
+    (forall (scope :: (t2 :: Prim.Type)).
+      Main.Token @(t2 :: Prim.Type) (scope :: (t2 :: Prim.Type)) ->
+      Main.Effect (discarded :: Prim.Type)) ->
+    Main.Map @(t0 :: Prim.Type) @(t1 :: Prim.Type)
+      (key :: (t0 :: Prim.Type))
+      (value :: (t1 :: Prim.Type)) ->
+    Main.Map @(t0 :: Prim.Type) @(t1 :: Prim.Type)
+      (key :: (t0 :: Prim.Type))
+      (value :: (t1 :: Prim.Type))
+pokeMap ::
+  forall (t0 :: Prim.Type) (key :: Prim.Type) (value :: Prim.Type) (scope :: (t0 :: Prim.Type)).
+    Main.Witness @Prim.Type (key :: Prim.Type) =>
+    (key :: Prim.Type) ->
+    (value :: Prim.Type) ->
+    Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) ->
+    Main.Effect (Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)))
+validRankTwoCallback ::
+  (forall (value :: Prim.Type). (value :: Prim.Type) -> (value :: Prim.Type)) -> Main.Unit
+validDirectPolymorphicExpression :: Main.Unit
+validDiscardedHigherRankResult :: Main.Unit
+validDiscardedScopedHigherRankResult :: Main.Unit
+validDiscardedConstrainedHigherRankResult :: Main.Unit
+validConstrainedTypeErasingCallback ::
+  forall (key :: Prim.Type) (value :: Prim.Type).
+    Main.Witness @Prim.Type (key :: Prim.Type) =>
+    (key :: Prim.Type) ->
+    (value :: Prim.Type) ->
+    Main.Map @Prim.Type @Prim.Type (key :: Prim.Type) (value :: Prim.Type) ->
+    Main.Map @Prim.Type @Prim.Type (key :: Prim.Type) (value :: Prim.Type)
+escapedResult ::
+  forall (t0 :: Prim.Type). Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type))
+escapedBinder :: ((value :: Prim.Type) -> (value :: Prim.Type)) -> Main.Unit
+escapedNestedUse ::
+  forall (t0 :: Prim.Type). Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type))
+escapedDiscardedOuterArgument ::
+  forall (t0 :: Prim.Type) (t1 :: Prim.Type).
+    (t0 :: Prim.Type) -> Main.Token @(t1 :: Prim.Type) (scope :: (t1 :: Prim.Type))
+escapedDiscardedArgument :: Main.Unit
+escapedEvidenceOnly ::
+  forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: (t1 :: Prim.Type)).
+    Main.EscapingEvidence @(t0 :: Prim.Type) @(t1 :: Prim.Type)
+      (scope :: (t0 :: Prim.Type))
+      (t2 :: (t1 :: Prim.Type)) =>
+    Main.Proxy @(t1 :: Prim.Type) (t2 :: (t1 :: Prim.Type))
+
+Types
+Unit :: Prim.Type
+Token :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> Prim.Type
+Effect :: Prim.Type -> Prim.Type
+Proxy :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> Prim.Type
+Map ::
+  forall (t0 :: Prim.Type) (t1 :: Prim.Type). (t0 :: Prim.Type) -> (t1 :: Prim.Type) -> Prim.Type
+Witness :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> Prim.Constraint
+EscapingEvidence ::
+  forall (t0 :: Prim.Type) (t1 :: Prim.Type).
+    (t0 :: Prim.Type) -> (t1 :: Prim.Type) -> Prim.Constraint
+
+Classes
+class forall (t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)). Main.Witness @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type))
+class forall (t0 :: Prim.Type) (t1 :: Prim.Type) (scope :: (t0 :: Prim.Type)) (result :: (t1 :: Prim.Type)). Main.EscapingEvidence @(t0 :: Prim.Type) @(t1 :: Prim.Type)
+  (scope :: (t0 :: Prim.Type))
+  (result :: (t1 :: Prim.Type))
+
+Roles
+Unit = []
+Token = [Phantom]
+Effect = [Representational]
+Proxy = [Phantom]
+Map = [Phantom, Phantom]

--- a/tests-integration/fixtures/checking/1786636860_expected_forall_local_bindings/Main.purs
+++ b/tests-integration/fixtures/checking/1786636860_expected_forall_local_bindings/Main.purs
@@ -1,0 +1,67 @@
+module Main where
+
+data Unit = Unit
+
+data Spec = Spec
+
+data Token scope = Token
+
+class Witness value
+
+instance witnessValue :: Witness value
+
+identity :: forall value. value -> value
+identity value = value
+
+modify :: forall scope. Token scope -> Token scope
+modify token = token
+
+foreign import mkEval :: forall value. Spec -> value -> value
+
+foreign import constrainedEval
+  :: forall value
+   . Witness value
+  => Spec
+  -> value
+  -> value
+
+foreign import consumeIdentity :: (forall value. value -> value) -> Unit
+
+foreign import leak
+  :: forall result
+   . (forall scope. Token scope -> result)
+  -> result
+
+validLocalEval :: Unit
+validLocalEval = consumeIdentity eval
+  where
+  eval = mkEval Spec
+
+validNestedLocalEval :: Unit
+validNestedLocalEval = consumeIdentity outer
+  where
+  outer = inner
+    where
+    inner = mkEval Spec
+
+escapedLocalEvidence :: Unit
+escapedLocalEvidence = consumeIdentity eval
+  where
+  eval = constrainedEval Spec
+
+escapedLocalAlias = escaped
+  where
+  escaped = leak modify
+
+escapedEtaExpansion = leak (\token -> modify token)
+
+escapedIdentityWrapper = identity (leak modify)
+
+escapedArrayWrapper = [leak modify]
+
+escapedConditionalWrapper = leak (\token -> if true then modify token else modify token)
+
+escapedUnusedLocal :: Int
+escapedUnusedLocal = 0
+  where
+  escaped = leak modify

--- a/tests-integration/fixtures/checking/1786636860_expected_forall_local_bindings/Main.snap
+++ b/tests-integration/fixtures/checking/1786636860_expected_forall_local_bindings/Main.snap
@@ -58,3 +58,40 @@ Roles
 Unit = []
 Spec = []
 Token = [Phantom]
+
+Diagnostics
+error[EscapedSkolem]: Type variable '(scope :: (t0 :: Type))' has escaped its scope, appearing in type 'Token @(t0 :: Type) (scope :: (t0 :: Type))'
+  --> 54:3..54:24
+   |
+54 |   escaped = leak modify
+   |   ^~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope1 :: ?61)' has escaped its scope, appearing in type 'Token @?61 (scope1 :: ?61)'
+  --> 67:3..67:24
+   |
+67 |   escaped = leak modify
+   |   ^~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(value :: Type)' has escaped its scope, appearing in type 'Witness @Type (value :: Type)'
+  --> 50:3..50:30
+   |
+50 |   eval = constrainedEval Spec
+   |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope2 :: (t1 :: Type))' has escaped its scope, appearing in type 'forall (t1 :: Type). Token @(t1 :: Type) (scope2 :: (t1 :: Type))'
+  --> 56:1..56:52
+   |
+56 | escapedEtaExpansion = leak (\token -> modify token)
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope3 :: (t2 :: Type))' has escaped its scope, appearing in type 'forall (t2 :: Type). Token @(t2 :: Type) (scope3 :: (t2 :: Type))'
+  --> 58:1..58:48
+   |
+58 | escapedIdentityWrapper = identity (leak modify)
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope4 :: (t3 :: Type))' has escaped its scope, appearing in type 'forall (t3 :: Type). Array (Token @(t3 :: Type) (scope4 :: (t3 :: Type)))'
+  --> 60:1..60:36
+   |
+60 | escapedArrayWrapper = [leak modify]
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope5 :: (t4 :: Type))' has escaped its scope, appearing in type 'forall (t4 :: Type). Token @(t4 :: Type) (scope5 :: (t4 :: Type))'
+  --> 62:1..62:89
+   |
+62 | escapedConditionalWrapper = leak (\token -> if true then modify token else modify token)
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786636860_expected_forall_local_bindings/Main.snap
+++ b/tests-integration/fixtures/checking/1786636860_expected_forall_local_bindings/Main.snap
@@ -1,0 +1,60 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Unit :: Main.Unit
+Spec :: Main.Spec
+Token ::
+  forall (t0 :: Prim.Type) (@scope :: (t0 :: Prim.Type)).
+    Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type))
+identity :: forall (value :: Prim.Type). (value :: Prim.Type) -> (value :: Prim.Type)
+modify ::
+  forall (t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)).
+    Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) ->
+    Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type))
+mkEval :: forall (value :: Prim.Type). Main.Spec -> (value :: Prim.Type) -> (value :: Prim.Type)
+constrainedEval ::
+  forall (value :: Prim.Type).
+    Main.Witness @Prim.Type (value :: Prim.Type) =>
+    Main.Spec -> (value :: Prim.Type) -> (value :: Prim.Type)
+consumeIdentity ::
+  (forall (value :: Prim.Type). (value :: Prim.Type) -> (value :: Prim.Type)) -> Main.Unit
+leak ::
+  forall (t0 :: Prim.Type) (result :: Prim.Type).
+    (forall (scope :: (t0 :: Prim.Type)).
+      Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) -> (result :: Prim.Type)) ->
+    (result :: Prim.Type)
+validLocalEval :: Main.Unit
+validNestedLocalEval :: Main.Unit
+escapedLocalEvidence :: Main.Unit
+escapedLocalAlias ::
+  forall (t0 :: Prim.Type). Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type))
+escapedEtaExpansion ::
+  forall (t0 :: Prim.Type). Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type))
+escapedIdentityWrapper ::
+  forall (t0 :: Prim.Type). Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type))
+escapedArrayWrapper ::
+  forall (t0 :: Prim.Type). Prim.Array (Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)))
+escapedConditionalWrapper ::
+  forall (t0 :: Prim.Type). Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type))
+escapedUnusedLocal :: Prim.Int
+
+Types
+Unit :: Prim.Type
+Spec :: Prim.Type
+Token :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> Prim.Type
+Witness :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> Prim.Constraint
+
+Classes
+class forall (t0 :: Prim.Type) (value :: (t0 :: Prim.Type)). Main.Witness @(t0 :: Prim.Type) (value :: (t0 :: Prim.Type))
+
+Instances
+instance forall (t0 :: Prim.Type) (value :: (t0 :: Prim.Type)).
+  Main.Witness @(t0 :: Prim.Type) (value :: (t0 :: Prim.Type))
+
+Roles
+Unit = []
+Spec = []
+Token = [Phantom]

--- a/tests-integration/fixtures/checking/1786636920_expected_forall_expression_forms/Main.purs
+++ b/tests-integration/fixtures/checking/1786636920_expected_forall_expression_forms/Main.purs
@@ -1,0 +1,69 @@
+module Main where
+
+data Token scope = Token
+
+data Effect value = Effect value
+
+identity :: forall value. value -> value
+identity value = value
+
+modify :: forall scope. Token scope -> Token scope
+modify token = token
+
+foreign import leak
+  :: forall result
+   . (forall scope. Token scope -> result)
+  -> result
+
+foreign import pure :: forall value. value -> Effect value
+
+foreign import bind
+  :: forall value result
+   . Effect value
+  -> (value -> Effect result)
+  -> Effect result
+
+foreign import discard
+  :: forall value result
+   . Effect value
+  -> (value -> Effect result)
+  -> Effect result
+
+foreign import map
+  :: forall value result
+   . (value -> result)
+  -> Effect value
+  -> Effect result
+
+foreign import apply
+  :: forall value result
+   . Effect (value -> result)
+  -> Effect value
+  -> Effect result
+
+applyValue :: forall value result. value -> (value -> result) -> result
+applyValue value function = function value
+
+infixl 1 applyValue as #
+
+escapedOperator = leak modify # identity
+
+escapedSection = (leak modify # _)
+
+escapedDo = do
+  token <- pure (leak modify)
+  pure token
+
+escapedAdo = ado
+  token <- pure (leak modify)
+  in token
+
+escapedRecord = { token: leak modify }
+
+escapedRecordUpdate record = record { token = leak modify }
+
+escapedPatternGuard value
+  | token <- leak modify = value
+
+escapedCase value = case value of
+  token -> { token: leak modify }

--- a/tests-integration/fixtures/checking/1786636920_expected_forall_expression_forms/Main.snap
+++ b/tests-integration/fixtures/checking/1786636920_expected_forall_expression_forms/Main.snap
@@ -1,0 +1,77 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Token ::
+  forall (t0 :: Prim.Type) (@scope :: (t0 :: Prim.Type)).
+    Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type))
+Effect :: forall (@value :: Prim.Type). (value :: Prim.Type) -> Main.Effect (value :: Prim.Type)
+identity :: forall (value :: Prim.Type). (value :: Prim.Type) -> (value :: Prim.Type)
+modify ::
+  forall (t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)).
+    Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) ->
+    Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type))
+leak ::
+  forall (t0 :: Prim.Type) (result :: Prim.Type).
+    (forall (scope :: (t0 :: Prim.Type)).
+      Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) -> (result :: Prim.Type)) ->
+    (result :: Prim.Type)
+pure :: forall (value :: Prim.Type). (value :: Prim.Type) -> Main.Effect (value :: Prim.Type)
+bind ::
+  forall (value :: Prim.Type) (result :: Prim.Type).
+    Main.Effect (value :: Prim.Type) ->
+    ((value :: Prim.Type) -> Main.Effect (result :: Prim.Type)) ->
+    Main.Effect (result :: Prim.Type)
+discard ::
+  forall (value :: Prim.Type) (result :: Prim.Type).
+    Main.Effect (value :: Prim.Type) ->
+    ((value :: Prim.Type) -> Main.Effect (result :: Prim.Type)) ->
+    Main.Effect (result :: Prim.Type)
+map ::
+  forall (value :: Prim.Type) (result :: Prim.Type).
+    ((value :: Prim.Type) -> (result :: Prim.Type)) ->
+    Main.Effect (value :: Prim.Type) ->
+    Main.Effect (result :: Prim.Type)
+apply ::
+  forall (value :: Prim.Type) (result :: Prim.Type).
+    Main.Effect ((value :: Prim.Type) -> (result :: Prim.Type)) ->
+    Main.Effect (value :: Prim.Type) ->
+    Main.Effect (result :: Prim.Type)
+applyValue ::
+  forall (value :: Prim.Type) (result :: Prim.Type).
+    (value :: Prim.Type) -> ((value :: Prim.Type) -> (result :: Prim.Type)) -> (result :: Prim.Type)
+# ::
+  forall (value :: Prim.Type) (result :: Prim.Type).
+    (value :: Prim.Type) -> ((value :: Prim.Type) -> (result :: Prim.Type)) -> (result :: Prim.Type)
+escapedOperator ::
+  forall (t0 :: Prim.Type). Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type))
+escapedSection ::
+  forall (t0 :: Prim.Type) (t1 :: Prim.Type).
+    (Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) -> (t1 :: Prim.Type)) ->
+    (t1 :: Prim.Type)
+escapedDo ::
+  forall (t0 :: Prim.Type). Main.Effect (Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)))
+escapedAdo ::
+  forall (t0 :: Prim.Type). Main.Effect (Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)))
+escapedRecord ::
+  forall (t0 :: Prim.Type). { token :: Main.Token @(t0 :: Prim.Type) (scope :: (t0 :: Prim.Type)) }
+escapedRecordUpdate ::
+  forall (t0 :: Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Type).
+    { token :: (t0 :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } ->
+    { token :: Main.Token @(t2 :: Prim.Type) (scope :: (t2 :: Prim.Type))
+    | (t1 :: Prim.Row Prim.Type)
+    }
+escapedPatternGuard :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> (t0 :: Prim.Type)
+escapedCase ::
+  forall (t0 :: Prim.Type) (t1 :: Prim.Type).
+    (t0 :: Prim.Type) -> { token :: Main.Token @(t1 :: Prim.Type) (scope :: (t1 :: Prim.Type)) }
+
+Types
+Token :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> Prim.Type
+Effect :: Prim.Type -> Prim.Type
+
+Roles
+Token = [Phantom]
+Effect = [Representational]

--- a/tests-integration/fixtures/checking/1786636920_expected_forall_expression_forms/Main.snap
+++ b/tests-integration/fixtures/checking/1786636920_expected_forall_expression_forms/Main.snap
@@ -75,3 +75,49 @@ Effect :: Prim.Type -> Prim.Type
 Roles
 Token = [Phantom]
 Effect = [Representational]
+
+Diagnostics
+error[EscapedSkolem]: Type variable '(scope :: (t0 :: Type))' has escaped its scope, appearing in type 'forall (t0 :: Type). Token @(t0 :: Type) (scope :: (t0 :: Type))'
+  --> 49:1..49:41
+   |
+49 | escapedOperator = leak modify # identity
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope1 :: (t1 :: Type))' has escaped its scope, appearing in type 'forall (t1 :: Type) (t2 :: Type).
+  (Token @(t1 :: Type) (scope1 :: (t1 :: Type)) -> (t2 :: Type)) -> (t2 :: Type)'
+  --> 51:1..51:35
+   |
+51 | escapedSection = (leak modify # _)
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope2 :: (t3 :: Type))' has escaped its scope, appearing in type 'forall (t3 :: Type). Effect (Token @(t3 :: Type) (scope2 :: (t3 :: Type)))'
+  --> 53:1..55:13
+   |
+53 | escapedDo = do
+   | ^~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope3 :: (t4 :: Type))' has escaped its scope, appearing in type 'forall (t4 :: Type). Effect (Token @(t4 :: Type) (scope3 :: (t4 :: Type)))'
+  --> 57:1..59:11
+   |
+57 | escapedAdo = ado
+   | ^~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope4 :: (t5 :: Type))' has escaped its scope, appearing in type 'forall (t5 :: Type). { token :: Token @(t5 :: Type) (scope4 :: (t5 :: Type)) }'
+  --> 61:1..61:39
+   |
+61 | escapedRecord = { token: leak modify }
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope5 :: (t6 :: Type))' has escaped its scope, appearing in type 'forall (t7 :: Type) (t8 :: Row Type) (t6 :: Type).
+  { token :: (t7 :: Type) | (t8 :: Row Type) } ->
+  { token :: Token @(t6 :: Type) (scope5 :: (t6 :: Type)) | (t8 :: Row Type) }'
+  --> 63:1..63:60
+   |
+63 | escapedRecordUpdate record = record { token = leak modify }
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope6 :: ?83)' has escaped its scope, appearing in type 'Token @?83 (scope6 :: ?83)'
+  --> 65:1..66:33
+   |
+65 | escapedPatternGuard value
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~
+error[EscapedSkolem]: Type variable '(scope7 :: (t9 :: Type))' has escaped its scope, appearing in type 'forall (t10 :: Type) (t9 :: Type).
+  (t10 :: Type) -> { token :: Token @(t9 :: Type) (scope7 :: (t9 :: Type)) }'
+  --> 68:1..69:34
+   |
+68 | escapedCase value = case value of
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

- preserve lexical scopes introduced while checking expressions against expected `forall` types
- reject skolems that appear in retained checked judgments outside the expression that owns their scope
- audit local declarations and exact zonked evidence constraints without introducing let generalisation or syntax-specific exemptions
- keep generated elaboration nodes separate from retained source judgments so valid constrained higher-rank callbacks remain accepted

## Test plan

- `cargo check -p checking --tests`
- `cargo check -p diagnostics --tests`
- `cargo nextest run -p checking`
- `just t checking`
- `cargo nextest run -p tests-compatibility`
- `just format`
- `git diff --check`
- core + Acme compatibility comparison against `177a56248df3ccf64a6a240fd4ef05d33331532b`: 630 packages / 7,344 files, 0 introduced errors or warnings; `js-maps@0.1.2` remains green