### PR TITLE
[lowering] Use parent pointers for scope traversal

### DIFF
--- a/compiler-core/lowering/src/scope.rs
+++ b/compiler-core/lowering/src/scope.rs
@@ -11,7 +11,6 @@
 //! [`BinderId`].
 //!
 //! [scope graph]: https://pl.ewi.tudelft.nl/research/projects/scope-graphs/
-use std::collections::VecDeque;
 use std::ops;
 
 use files::FileId;
@@ -155,8 +154,8 @@ impl LoweringGraph {
     /// Initialise a traversal starting from a [`GraphNodeId`].
     pub fn traverse(&self, id: GraphNodeId) -> GraphIter<'_> {
         let inner = &self.inner;
-        let queue = VecDeque::from([id]);
-        GraphIter { inner, queue }
+        let next = Some(id);
+        GraphIter { inner, next }
     }
 
     pub fn resolve_term(&self, id: GraphNodeId, name: &str) -> Option<TermVariableResolution> {
@@ -225,23 +224,21 @@ impl LoweringGraphNodes {
 /// An iterator that traverses the [`LoweringGraph`].
 pub struct GraphIter<'a> {
     inner: &'a Arena<GraphNode>,
-    queue: VecDeque<GraphNodeId>,
+    next: Option<GraphNodeId>,
 }
 
 impl<'a> Iterator for GraphIter<'a> {
     type Item = (Idx<GraphNode>, &'a GraphNode);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let id = self.queue.pop_back()?;
+        let id = self.next.take()?;
         let item = &self.inner[id];
         match &item {
             GraphNode::Binder { parent, .. }
             | GraphNode::Forall { parent, .. }
             | GraphNode::Let { parent, .. }
             | GraphNode::Implicit { parent, .. } => {
-                parent.map(|id| {
-                    self.queue.push_front(id);
-                });
+                self.next = *parent;
             }
         };
         Some((id, item))


### PR DESCRIPTION
## Summary

- represent scope traversal state as the next parent node instead of a `VecDeque`
- preserve current-to-outer scope ordering and nearest-shadow resolution
- simplify traversal around the graph's sole-parent invariant

## Rationale

Corpus measurements showed neutral wall time and RSS. This adopts the change for simpler iterator state and direct traversal of the sole-parent chain, not as a speed claim.

## Validation

- `just format`
- `git diff --check`
- `cargo check -p lowering --tests`
- `cargo check -p checking --tests`
- `cargo nextest run -p lowering -p checking` (30 passed)
- `just t lowering` (all passed, no pending snapshots)
- `just t checking` (all passed, no pending snapshots)

The existing nested `forall value` checking fixture exercises nearest-shadow behavior. Inspection of every `GraphIter` consumer confirms they rely on the preserved current-to-parent ordering: resolution stops at the first match, and hole-binding collection keeps the first seen name.
