### PR TITLE
[checking] Store exhaustiveness matrices contiguously

### DIFF
--- a/compiler-core/checking/src/core/exhaustive.rs
+++ b/compiler-core/checking/src/core/exhaustive.rs
@@ -170,8 +170,88 @@ pub type PatternId = interner::Id<Pattern>;
 pub type PatternInterner = interner::Interner<Pattern>;
 
 type PatternVector = Vec<PatternId>;
-type PatternMatrix = Vec<PatternVector>;
 pub type WitnessVector = Vec<PatternId>;
+
+struct PatternMatrix {
+    cells: Vec<PatternId>,
+    rows: usize,
+    columns: usize,
+}
+
+impl PatternMatrix {
+    fn new(columns: usize) -> PatternMatrix {
+        PatternMatrix { cells: vec![], rows: 0, columns }
+    }
+
+    fn with_capacity(columns: usize, rows: usize) -> PatternMatrix {
+        let cells = Vec::with_capacity(columns * rows);
+        PatternMatrix { cells, rows: 0, columns }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.rows == 0
+    }
+
+    fn row(&self, index: usize) -> &[PatternId] {
+        assert!(index < self.rows);
+        let start = index * self.columns;
+        let end = start + self.columns;
+        &self.cells[start..end]
+    }
+
+    fn iter(&self) -> PatternRows<'_> {
+        PatternRows { matrix: self, row: 0 }
+    }
+
+    fn push(&mut self, row: &[PatternId]) {
+        assert_eq!(row.len(), self.columns);
+        self.cells.extend_from_slice(row);
+        self.rows += 1;
+    }
+
+    fn normalise_recovery_row<F>(&self, row: &mut PatternVector, mut missing: F)
+    where
+        F: FnMut(usize) -> PatternId,
+    {
+        row.truncate(self.columns);
+        let missing_columns = row.len()..self.columns;
+        row.extend(missing_columns.map(&mut missing));
+    }
+}
+
+struct PatternRows<'a> {
+    matrix: &'a PatternMatrix,
+    row: usize,
+}
+
+impl<'a> Iterator for PatternRows<'a> {
+    type Item = &'a [PatternId];
+
+    fn next(&mut self) -> Option<&'a [PatternId]> {
+        if self.row == self.matrix.rows {
+            return None;
+        }
+        let row = self.matrix.row(self.row);
+        self.row += 1;
+        Some(row)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.matrix.rows - self.row;
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for PatternRows<'_> {}
+
+impl<'a> IntoIterator for &'a PatternMatrix {
+    type Item = &'a [PatternId];
+    type IntoIter = PatternRows<'a>;
+
+    fn into_iter(self) -> PatternRows<'a> {
+        self.iter()
+    }
+}
 
 /// Determines if a [`PatternVector`] is useful with respect to a [`PatternMatrix`].
 ///
@@ -184,7 +264,7 @@ fn algorithm_u<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     matrix: &PatternMatrix,
-    vector: &PatternVector,
+    vector: &[PatternId],
 ) -> QueryResult<bool>
 where
     Q: ExternalQueries,
@@ -220,7 +300,7 @@ fn algorithm_u_constructor<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     matrix: &PatternMatrix,
-    vector: &PatternVector,
+    vector: &[PatternId],
     constructor: PatternConstructor,
 ) -> QueryResult<bool>
 where
@@ -253,7 +333,7 @@ fn algorithm_u_wildcard<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     matrix: &PatternMatrix,
-    vector: &PatternVector,
+    vector: &[PatternId],
     t: TypeId,
 ) -> QueryResult<bool>
 where
@@ -273,7 +353,7 @@ fn algorithm_u_wildcard_complete<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     matrix: &PatternMatrix,
-    vector: &PatternVector,
+    vector: &[PatternId],
     sigma: Sigma,
 ) -> QueryResult<bool>
 where
@@ -297,7 +377,7 @@ fn algorithm_u_wildcard_incomplete<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     matrix: &PatternMatrix,
-    vector: &PatternVector,
+    vector: &[PatternId],
 ) -> QueryResult<bool>
 where
     Q: ExternalQueries,
@@ -329,14 +409,14 @@ fn algorithm_m<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     matrix: &PatternMatrix,
-    vector: &PatternVector,
+    vector: &[PatternId],
 ) -> QueryResult<Option<Vec<WitnessVector>>>
 where
     Q: ExternalQueries,
 {
     // Base case: any pattern is its own witness against an empty matrix
     if matrix.is_empty() {
-        let vector = vector.clone();
+        let vector = vector.to_vec();
         return Ok(Some(vec![vector]));
     }
 
@@ -372,7 +452,7 @@ fn algorithm_m_constructor<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     matrix: &PatternMatrix,
-    vector: &PatternVector,
+    vector: &[PatternId],
     constructor: PatternConstructor,
     t: TypeId,
 ) -> QueryResult<Option<Vec<WitnessVector>>>
@@ -436,7 +516,7 @@ fn algorithm_m_wildcard<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     matrix: &PatternMatrix,
-    vector: &PatternVector,
+    vector: &[PatternId],
     t: TypeId,
 ) -> QueryResult<Option<Vec<WitnessVector>>>
 where
@@ -455,7 +535,7 @@ fn algorithm_m_wildcard_complete<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     matrix: &PatternMatrix,
-    vector: &PatternVector,
+    vector: &[PatternId],
     t: TypeId,
     sigma: &Sigma,
 ) -> QueryResult<Option<Vec<WitnessVector>>>
@@ -496,7 +576,7 @@ fn algorithm_m_wildcard_incomplete<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     matrix: &PatternMatrix,
-    vector: &PatternVector,
+    vector: &[PatternId],
     t: TypeId,
     sigma: &Sigma,
 ) -> QueryResult<Option<Vec<WitnessVector>>>
@@ -590,7 +670,41 @@ fn specialise_matrix(
     expected: &PatternConstructor,
     matrix: &PatternMatrix,
 ) -> PatternMatrix {
-    matrix.iter().filter_map(|row| specialise_vector(state, expected, row)).collect()
+    let columns = matrix.columns - 1 + expected.arity();
+    let mut specialised_matrix = if columns == 0 {
+        PatternMatrix::new(0)
+    } else {
+        let matching_rows =
+            matrix.iter().filter(|row| vector_matches_constructor(state, expected, row)).count();
+        PatternMatrix::with_capacity(columns, matching_rows)
+    };
+    for row in matrix {
+        let initial_length = specialised_matrix.cells.len();
+        if specialise_vector_into(state, expected, row, &mut specialised_matrix.cells) {
+            debug_assert_eq!(
+                specialised_matrix.cells.len() - initial_length,
+                specialised_matrix.columns
+            );
+            specialised_matrix.rows += 1;
+        } else {
+            specialised_matrix.cells.truncate(initial_length);
+        }
+    }
+    specialised_matrix
+}
+
+fn vector_matches_constructor(
+    state: &CheckState,
+    expected: &PatternConstructor,
+    vector: &[PatternId],
+) -> bool {
+    let [first_column_id, ..] = vector else {
+        unreachable!("invariant violated: vector_matches_constructor processed empty row");
+    };
+    match &state.patterns[*first_column_id].kind {
+        PatternKind::Wildcard => true,
+        PatternKind::Constructor { constructor } => constructor.matches(expected),
+    }
 }
 
 /// Specialises a [`PatternVector`] given a [`PatternConstructor`].
@@ -608,8 +722,22 @@ fn specialise_matrix(
 fn specialise_vector(
     state: &mut CheckState,
     expected: &PatternConstructor,
-    vector: &PatternVector,
+    vector: &[PatternId],
 ) -> Option<PatternVector> {
+    let mut specialised = Vec::with_capacity(vector.len() - 1 + expected.arity());
+    if specialise_vector_into(state, expected, vector, &mut specialised) {
+        Some(specialised)
+    } else {
+        None
+    }
+}
+
+fn specialise_vector_into(
+    state: &mut CheckState,
+    expected: &PatternConstructor,
+    vector: &[PatternId],
+    specialised: &mut PatternVector,
+) -> bool {
     let [first_column_id, ref tail_columns @ ..] = vector[..] else {
         unreachable!("invariant violated: specialise_vector processed empty row");
     };
@@ -627,45 +755,52 @@ fn specialise_vector(
                     let t = state.patterns[pattern_id].t;
                     state.allocate_wildcard(t)
                 });
-                let tail_columns = tail_columns.iter().copied();
-                return Some(iter::chain(wildcards, tail_columns).collect());
+                specialised.extend(wildcards);
             }
             PatternConstructor::Array { fields } => {
                 let wildcards = fields.iter().map(|&pattern_id| {
                     let t = state.patterns[pattern_id].t;
                     state.allocate_wildcard(t)
                 });
-                let tail_columns = tail_columns.iter().copied();
-                return Some(iter::chain(wildcards, tail_columns).collect());
+                specialised.extend(wildcards);
             }
-            _ => {
-                return Some(tail_columns.to_vec());
-            }
+            _ => {}
         }
+        specialised.extend_from_slice(tail_columns);
+        return true;
     }
 
     let PatternKind::Constructor { constructor } = first_pattern.kind else {
-        return Some(tail_columns.to_vec());
+        specialised.extend_from_slice(tail_columns);
+        return true;
     };
 
     // Check if constructors match
     if !constructor.matches(expected) {
-        return None;
+        return false;
     }
 
     // Splat fields for constructors with arity
     match &constructor {
         PatternConstructor::DataConstructor { fields, .. } => {
-            Some(fields.iter().copied().chain(tail_columns.iter().copied()).collect())
+            specialised.extend_from_slice(fields);
         }
         PatternConstructor::Record { labels: actual_labels, fields: actual_fields } => {
-            specialise_record_fields(state, expected, actual_labels, actual_fields, tail_columns)
+            specialise_record_fields_into(
+                state,
+                expected,
+                actual_labels,
+                actual_fields,
+                specialised,
+            );
         }
         PatternConstructor::Array { fields } => {
-            Some(fields.iter().copied().chain(tail_columns.iter().copied()).collect())
+            specialised.extend_from_slice(fields);
         }
-        _ => Some(tail_columns.to_vec()),
+        _ => {}
     }
+    specialised.extend_from_slice(tail_columns);
+    true
 }
 
 /// Maps the fields of an actual record pattern to the expected (canonical) label set.
@@ -675,52 +810,55 @@ fn specialise_vector(
 /// This function aligns the actual fields to the expected label positions, inserting
 /// wildcard patterns for any labels present in the expected set but absent from the
 /// actual pattern.
-fn specialise_record_fields(
+fn specialise_record_fields_into(
     state: &mut CheckState,
     expected: &PatternConstructor,
     actual_labels: &[SmolStr],
     actual_fields: &[PatternId],
-    tail_columns: &[PatternId],
-) -> Option<PatternVector> {
+    specialised: &mut PatternVector,
+) {
     let PatternConstructor::Record { labels: expected_labels, fields: expected_fields } = expected
     else {
-        return Some(
-            iter::chain(actual_fields.iter().copied(), tail_columns.iter().copied()).collect(),
-        );
+        specialised.extend_from_slice(actual_fields);
+        return;
     };
 
     // Fast path: labels match exactly.
     if actual_labels == expected_labels.as_slice() {
-        return Some(
-            iter::chain(actual_fields.iter().copied(), tail_columns.iter().copied()).collect(),
-        );
+        specialised.extend_from_slice(actual_fields);
+        return;
     }
 
-    let mut mapped_fields = Vec::with_capacity(expected_labels.len());
     for (expected_label, &expected_field) in expected_labels.iter().zip(expected_fields.iter()) {
         if let Some(position) = actual_labels.iter().position(|label| label == expected_label) {
-            mapped_fields.push(actual_fields[position]);
+            specialised.push(actual_fields[position]);
         } else {
             let t = state.patterns[expected_field].t;
-            mapped_fields.push(state.allocate_wildcard(t));
+            specialised.push(state.allocate_wildcard(t));
         }
     }
-
-    Some(mapped_fields.into_iter().chain(tail_columns.iter().copied()).collect())
 }
 
 fn default_matrix(state: &CheckState, matrix: &PatternMatrix) -> PatternMatrix {
-    let filter_map = matrix.iter().filter_map(|row| {
+    let columns = matrix.columns - 1;
+    let mut default = if columns == 0 {
+        PatternMatrix::new(0)
+    } else {
+        let default_rows = matrix
+            .iter()
+            .filter(|row| matches!(state.patterns[row[0]].kind, PatternKind::Wildcard))
+            .count();
+        PatternMatrix::with_capacity(columns, default_rows)
+    };
+    for row in matrix {
         let [first_column, ref default_columns @ ..] = row[..] else {
             unreachable!("invariant violated: default_matrix processed empty row");
         };
         if let PatternKind::Wildcard = state.patterns[first_column].kind {
-            Some(default_columns.to_vec())
-        } else {
-            None
+            default.push(default_columns);
         }
-    });
-    filter_map.collect()
+    }
+    default
 }
 
 /// Key for identifying a unique constructor.
@@ -1227,12 +1365,12 @@ fn collect_unconditional_rows<Q, T, F>(
     items: &[T],
     pattern_types: &[TypeId],
     to_binders: F,
-) -> QueryResult<Vec<PatternVector>>
+) -> QueryResult<PatternMatrix>
 where
     Q: ExternalQueries,
     F: Fn(&T) -> (&[lowering::BinderId], &Option<lowering::GuardedExpression>),
 {
-    let mut pattern_rows = vec![];
+    let mut pattern_rows = PatternMatrix::new(pattern_types.len());
     for item in items {
         let (binders, guarded) = to_binders(item);
 
@@ -1250,11 +1388,12 @@ where
             pattern_row.push(convert::convert_binder(state, context, binder_id)?);
         }
 
-        let additional = pattern_types.iter().skip(pattern_row.len());
-        pattern_row.extend(additional.map(|&t| state.allocate_wildcard(t)));
+        pattern_rows.normalise_recovery_row(&mut pattern_row, |column| {
+            state.allocate_wildcard(pattern_types[column])
+        });
 
         if !pattern_row.is_empty() {
-            pattern_rows.push(pattern_row);
+            pattern_rows.push(&pattern_row);
         }
     }
     Ok(pattern_rows)
@@ -1270,17 +1409,17 @@ where
     Q: ExternalQueries,
 {
     let mut redundant = vec![];
-    let mut matrix = vec![];
+    let mut matrix = PatternMatrix::new(unconditional.columns);
     for vector in &unconditional {
         let useful = algorithm_u(state, context, &matrix, vector)?;
         if useful {
-            matrix.push(PatternVector::clone(vector));
+            matrix.push(vector);
         } else {
             redundant.push(pretty::pretty_witness(context, state, vector));
         }
     }
 
-    let query = pattern_types.iter().map(|&t| state.allocate_wildcard(t)).collect();
+    let query: PatternVector = pattern_types.iter().map(|&t| state.allocate_wildcard(t)).collect();
     let witnesses = algorithm_m(state, context, &unconditional, &query)?;
     let missing = witnesses.map(|witnesses| {
         witnesses
@@ -1291,4 +1430,64 @@ where
     });
 
     Ok(ExhaustivenessReport { missing, redundant })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use super::{PatternId, PatternMatrix};
+
+    fn pattern_id(value: u32) -> PatternId {
+        PatternId::new(NonZeroU32::new(value).unwrap())
+    }
+
+    #[test]
+    fn nonempty_zero_column_matrix_preserves_its_row() {
+        let mut matrix = PatternMatrix::new(0);
+        matrix.push(&[]);
+        matrix.push(&[]);
+
+        assert!(!matrix.is_empty());
+        assert_eq!(matrix.rows, 2);
+        assert_eq!(matrix.iter().collect::<Vec<_>>(), vec![&[][..], &[][..]]);
+    }
+
+    #[test]
+    fn ragged_recovery_row_preserves_the_declared_width() {
+        let mut matrix = PatternMatrix::new(2);
+        let mut short_row = vec![pattern_id(1)];
+        let mut long_row = vec![pattern_id(2), pattern_id(3), pattern_id(4)];
+
+        matrix.normalise_recovery_row(&mut short_row, |column| pattern_id(column as u32 + 4));
+        matrix.normalise_recovery_row(&mut long_row, |_| unreachable!());
+        matrix.push(&short_row);
+        matrix.push(&long_row);
+
+        assert_eq!(short_row, vec![pattern_id(1), pattern_id(5)]);
+        assert_eq!(long_row, vec![pattern_id(2), pattern_id(3)]);
+        assert_eq!(matrix.iter().collect::<Vec<_>>(), vec![short_row, long_row]);
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion `left == right` failed")]
+    fn matrix_rejects_nonrectangular_rows() {
+        let mut matrix = PatternMatrix::new(2);
+        matrix.push(&[pattern_id(1)]);
+    }
+
+    #[test]
+    fn row_iterator_reports_its_remaining_length() {
+        let mut matrix = PatternMatrix::new(1);
+        matrix.push(&[pattern_id(1)]);
+        matrix.push(&[pattern_id(2)]);
+
+        let mut rows = matrix.iter();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows.next(), Some(&[pattern_id(1)][..]));
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows.next(), Some(&[pattern_id(2)][..]));
+        assert_eq!(rows.len(), 0);
+        assert_eq!(rows.next(), None);
+    }
 }

--- a/compiler-core/checking/src/core/exhaustive.rs
+++ b/compiler-core/checking/src/core/exhaustive.rs
@@ -676,10 +676,7 @@ fn specialise_matrix(
     for row in matrix {
         let initial_length = specialised_matrix.cells.len();
         if specialise_vector_into(state, expected, row, &mut specialised_matrix.cells) {
-            debug_assert_eq!(
-                specialised_matrix.cells.len() - initial_length,
-                specialised_matrix.columns
-            );
+            assert_eq!(specialised_matrix.cells.len() - initial_length, specialised_matrix.columns);
             specialised_matrix.rows += 1;
         } else {
             specialised_matrix.cells.truncate(initial_length);
@@ -740,32 +737,16 @@ fn specialise_vector_into(
     // Clone to release any borrow on state.patterns, allowing mutable
     // access later when allocating wildcard patterns for record padding.
     let first_pattern = state.patterns[first_column_id].clone();
+    let initial_length = specialised.len();
 
     if let PatternKind::Wildcard = first_pattern.kind {
-        // Expand wildcard to the expected constructor's arity
-        match expected {
-            PatternConstructor::DataConstructor { fields, .. }
-            | PatternConstructor::Record { fields, .. } => {
-                let wildcards = fields.iter().map(|&pattern_id| {
-                    let t = state.patterns[pattern_id].t;
-                    state.allocate_wildcard(t)
-                });
-                specialised.extend(wildcards);
-            }
-            PatternConstructor::Array { fields } => {
-                let wildcards = fields.iter().map(|&pattern_id| {
-                    let t = state.patterns[pattern_id].t;
-                    state.allocate_wildcard(t)
-                });
-                specialised.extend(wildcards);
-            }
-            _ => {}
-        }
+        normalise_specialised_fields(state, expected, initial_length, specialised);
         specialised.extend_from_slice(tail_columns);
         return true;
     }
 
     let PatternKind::Constructor { constructor } = first_pattern.kind else {
+        normalise_specialised_fields(state, expected, initial_length, specialised);
         specialised.extend_from_slice(tail_columns);
         return true;
     };
@@ -794,8 +775,25 @@ fn specialise_vector_into(
         }
         _ => {}
     }
+    normalise_specialised_fields(state, expected, initial_length, specialised);
     specialised.extend_from_slice(tail_columns);
     true
+}
+
+fn normalise_specialised_fields(
+    state: &mut CheckState,
+    expected: &PatternConstructor,
+    initial_length: usize,
+    specialised: &mut PatternVector,
+) {
+    let expected_fields = expected.fields();
+    specialised.truncate(initial_length + expected_fields.len());
+
+    let actual_fields = specialised.len() - initial_length;
+    for &expected_field in &expected_fields[actual_fields..] {
+        let t = state.patterns[expected_field].t;
+        specialised.push(state.allocate_wildcard(t));
+    }
 }
 
 /// Maps the fields of an actual record pattern to the expected (canonical) label set.
@@ -825,8 +823,12 @@ fn specialise_record_fields_into(
     }
 
     for (expected_label, &expected_field) in expected_labels.iter().zip(expected_fields.iter()) {
-        if let Some(position) = actual_labels.iter().position(|label| label == expected_label) {
-            specialised.push(actual_fields[position]);
+        let actual_field = actual_labels
+            .iter()
+            .position(|label| label == expected_label)
+            .and_then(|position| actual_fields.get(position));
+        if let Some(&actual_field) = actual_field {
+            specialised.push(actual_field);
         } else {
             let t = state.patterns[expected_field].t;
             specialised.push(state.allocate_wildcard(t));

--- a/compiler-core/checking/src/core/exhaustive.rs
+++ b/compiler-core/checking/src/core/exhaustive.rs
@@ -192,15 +192,8 @@ impl PatternMatrix {
         self.rows == 0
     }
 
-    fn row(&self, index: usize) -> &[PatternId] {
-        assert!(index < self.rows);
-        let start = index * self.columns;
-        let end = start + self.columns;
-        &self.cells[start..end]
-    }
-
     fn iter(&self) -> PatternRows<'_> {
-        PatternRows { matrix: self, row: 0 }
+        PatternRows { matrix: self, remaining: self.rows, cell: 0 }
     }
 
     fn push(&mut self, row: &[PatternId]) {
@@ -221,24 +214,26 @@ impl PatternMatrix {
 
 struct PatternRows<'a> {
     matrix: &'a PatternMatrix,
-    row: usize,
+    remaining: usize,
+    cell: usize,
 }
 
 impl<'a> Iterator for PatternRows<'a> {
     type Item = &'a [PatternId];
 
     fn next(&mut self) -> Option<&'a [PatternId]> {
-        if self.row == self.matrix.rows {
+        if self.remaining == 0 {
             return None;
         }
-        let row = self.matrix.row(self.row);
-        self.row += 1;
+        let end = self.cell + self.matrix.columns;
+        let row = &self.matrix.cells[self.cell..end];
+        self.cell = end;
+        self.remaining -= 1;
         Some(row)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.matrix.rows - self.row;
-        (remaining, Some(remaining))
+        (self.remaining, Some(self.remaining))
     }
 }
 

--- a/compiler-core/checking/src/core/exhaustive/pretty.rs
+++ b/compiler-core/checking/src/core/exhaustive/pretty.rs
@@ -6,13 +6,13 @@ use smol_str::{SmolStr, SmolStrBuilder};
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
-use crate::core::exhaustive::{PatternConstructor, PatternId, PatternKind, WitnessVector};
+use crate::core::exhaustive::{PatternConstructor, PatternId, PatternKind};
 use crate::state::CheckState;
 
 pub fn pretty_witness<Q>(
     context: &CheckContext<Q>,
     state: &CheckState,
-    witness: &WitnessVector,
+    witness: &[PatternId],
 ) -> SmolStr
 where
     Q: ExternalQueries,

--- a/tests-integration/fixtures/checking/1786686300_exhaustive_recovered_constructor_arity/Main.purs
+++ b/tests-integration/fixtures/checking/1786686300_exhaustive_recovered_constructor_arity/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+data Box a = Box a | Other
+
+test (Box _) = 0
+test Box = 1
+
+test2 Box = 0
+test2 (Box _) = 1

--- a/tests-integration/fixtures/checking/1786686300_exhaustive_recovered_constructor_arity/Main.snap
+++ b/tests-integration/fixtures/checking/1786686300_exhaustive_recovered_constructor_arity/Main.snap
@@ -1,0 +1,70 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Box :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Box (a :: Prim.Type)
+Other :: forall (@a :: Prim.Type). Main.Box (a :: Prim.Type)
+test :: forall (t0 :: Prim.Type). Prim.Partial => Main.Box (t0 :: Prim.Type) -> Prim.Int
+test2 ::
+  forall (t0 :: Prim.Type).
+    Prim.Partial => ((t0 :: Prim.Type) -> Main.Box (t0 :: Prim.Type)) -> Prim.Int
+
+Types
+Box :: Prim.Type -> Prim.Type
+
+Roles
+Box = [Representational]
+
+Diagnostics
+error[CannotUnify]: Cannot unify 'Box' with 'Function ?4'
+  --> 5:1..5:17
+  |
+5 | test (Box _) = 0
+  | ^~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify 'Box (t0 :: Type)' with 'Function ?4 (Box ?4)'
+  --> 5:1..5:17
+  |
+5 | test (Box _) = 0
+  | ^~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify 'Box (t0 :: Type)' with '?4 -> Box ?4'
+  --> 5:1..5:17
+  |
+5 | test (Box _) = 0
+  | ^~~~~~~~~~~~~~~~
+warning[RedundantPattern]: Pattern match has redundant patterns: Box
+  --> 5:1..5:17
+  |
+5 | test (Box _) = 0
+  | ^~~~~~~~~~~~~~~~
+warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Other
+  --> 5:1..5:17
+  |
+5 | test (Box _) = 0
+  | ^~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify 'Function (t1 :: Type)' with 'Box'
+  --> 8:1..8:14
+  |
+8 | test2 Box = 0
+  | ^~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify 'Function (t1 :: Type) (Box (t1 :: Type))' with 'Box ?8'
+  --> 8:1..8:14
+  |
+8 | test2 Box = 0
+  | ^~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify '(t1 :: Type) -> Box (t1 :: Type)' with 'Box ?8'
+  --> 8:1..8:14
+  |
+8 | test2 Box = 0
+  | ^~~~~~~~~~~~~
+warning[RedundantPattern]: Pattern match has redundant patterns: Box _
+  --> 8:1..8:14
+  |
+8 | test2 Box = 0
+  | ^~~~~~~~~~~~~
+warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Other
+  --> 8:1..8:14
+  |
+8 | test2 Box = 0
+  | ^~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

- store private exhaustiveness matrices as one contiguous cell buffer with explicit row and column counts
- construct specialised and default matrices directly in flat storage while preserving rectangular rows, including nonempty zero-column matrices
- normalise ragged recovery rows to their declared width and cover matrix, recovery, and exact-size iteration invariants with focused tests

The follow-up iterator commit walks the flat storage directly because that is the simpler representation-specific implementation. It is not presented as an independent performance improvement.

## Measurements

Deterministic allocator-counter comparisons for the contiguous-matrix change found:

- Core checking: 15,291 fewer allocation calls (0.67%) and 1,621,512 fewer allocated bytes (1.11%)
- Acme subset checking: 217,052 fewer allocation calls (0.34%) and 22,516,944 fewer allocated bytes (0.57%)

These measurements used release binaries in fresh single-threaded processes across seven alternating forward/reverse rounds. Core covered 59/59 packages (294 files); the Acme subset covered 629/632 preset packages (7,343 files).

Whole-checker wall time and peak RSS were neutral within measurement noise. The final Acme timing trend was -1.46% with a paired 95% interval of [-3.28%, +0.36%], and RSS was effectively unchanged, so this PR makes no end-to-end speed or memory-residency claim.

The allocator instrumentation and corpora used for measurement are intentionally not included in this PR.

## Validation

- `cargo nextest run -p checking` (34 passed)
- `cargo check -p checking --tests`
- `just t checking` (all tests passed, no pending snapshots)
- `just format`