### PR TITLE
[syntax] Reduce syntax traversal materialization

### DIFF
--- a/compiler-core/stabilizing/src/lib.rs
+++ b/compiler-core/stabilizing/src/lib.rs
@@ -4,7 +4,7 @@ mod map;
 pub use id::*;
 pub use map::*;
 
-use syntax::{SyntaxKind, SyntaxNode, WalkEvent};
+use syntax::{SyntaxKind, SyntaxNode};
 
 /// Allocates stable IDs for text ranges.
 ///
@@ -21,15 +21,12 @@ use syntax::{SyntaxKind, SyntaxNode, WalkEvent};
 pub fn stabilize_module(node: &SyntaxNode) -> StabilizedModule {
     let mut ast_ptr_map = StabilizedModule::default();
 
-    for event in node.preorder() {
-        if let WalkEvent::Enter(node) = event
-            && let kind = node.kind()
-            && !matches!(
-                kind,
-                SyntaxKind::Annotation | SyntaxKind::QualifiedName | SyntaxKind::LabelName
-            )
-        {
-            ast_ptr_map.allocate(&node);
+    for pointer in node.preorder_pointers() {
+        if !matches!(
+            pointer.kind(),
+            SyntaxKind::Annotation | SyntaxKind::QualifiedName | SyntaxKind::LabelName
+        ) {
+            ast_ptr_map.allocate_ptr(pointer);
         }
     }
 

--- a/compiler-core/stabilizing/src/map.rs
+++ b/compiler-core/stabilizing/src/map.rs
@@ -25,6 +25,10 @@ impl Default for StabilizedModule {
 impl StabilizedModule {
     pub fn allocate(&mut self, node: &SyntaxNode) {
         let ptr = SyntaxNodePtr::new(node);
+        self.allocate_ptr(ptr);
+    }
+
+    pub(crate) fn allocate_ptr(&mut self, ptr: SyntaxNodePtr) {
         let hash = FxBuildHasher.hash_one(ptr);
 
         let id = {

--- a/compiler-core/syntax/src/ast.rs
+++ b/compiler-core/syntax/src/ast.rs
@@ -6,8 +6,8 @@ pub trait AstNode: Clone {
     fn can_cast(kind: SyntaxKind) -> bool;
     fn cast(node: SyntaxNode) -> Option<Self>;
     #[doc(hidden)]
-    fn cast_with_kind(node: SyntaxNode, kind: SyntaxKind) -> Option<Self> {
-        if Self::can_cast(kind) { Self::cast(node) } else { None }
+    fn cast_with_kind(node: SyntaxNode, _kind: SyntaxKind) -> Option<Self> {
+        Self::cast(node)
     }
     fn syntax(&self) -> &SyntaxNode;
 }
@@ -64,8 +64,15 @@ pub mod support {
     use super::*;
 
     pub fn child<N: AstNode>(node: &SyntaxNode) -> Option<N> {
-        let (node, kind) = node.child_matching(N::can_cast)?;
-        N::cast_with_kind(node, kind)
+        let mut child = node.first_child();
+        while let Some(node) = child {
+            child = node.next_sibling();
+            let kind = node.kind();
+            if let Some(node) = N::cast_with_kind(node, kind) {
+                return Some(node);
+            }
+        }
+        None
     }
 
     pub fn children<N: AstNode>(node: &SyntaxNode) -> AstChildren<N> {

--- a/compiler-core/syntax/src/ast.rs
+++ b/compiler-core/syntax/src/ast.rs
@@ -5,6 +5,10 @@ use crate::{SyntaxKind, SyntaxNode, SyntaxNodePtr, SyntaxToken};
 pub trait AstNode: Clone {
     fn can_cast(kind: SyntaxKind) -> bool;
     fn cast(node: SyntaxNode) -> Option<Self>;
+    #[doc(hidden)]
+    fn cast_with_kind(node: SyntaxNode, kind: SyntaxKind) -> Option<Self> {
+        if Self::can_cast(kind) { Self::cast(node) } else { None }
+    }
     fn syntax(&self) -> &SyntaxNode;
 }
 
@@ -60,7 +64,8 @@ pub mod support {
     use super::*;
 
     pub fn child<N: AstNode>(node: &SyntaxNode) -> Option<N> {
-        node.children().find_map(N::cast)
+        let (node, kind) = node.child_matching(N::can_cast)?;
+        N::cast_with_kind(node, kind)
     }
 
     pub fn children<N: AstNode>(node: &SyntaxNode) -> AstChildren<N> {
@@ -68,8 +73,6 @@ pub mod support {
     }
 
     pub fn token(node: &SyntaxNode, kind: SyntaxKind) -> Option<SyntaxToken> {
-        node.children_with_tokens()
-            .filter_map(|element| element.into_token())
-            .find(|token| token.kind() == kind)
+        node.token(kind)
     }
 }

--- a/compiler-core/syntax/src/ast.rs
+++ b/compiler-core/syntax/src/ast.rs
@@ -5,10 +5,6 @@ use crate::{SyntaxKind, SyntaxNode, SyntaxNodePtr, SyntaxToken};
 pub trait AstNode: Clone {
     fn can_cast(kind: SyntaxKind) -> bool;
     fn cast(node: SyntaxNode) -> Option<Self>;
-    #[doc(hidden)]
-    fn cast_with_kind(node: SyntaxNode, _kind: SyntaxKind) -> Option<Self> {
-        Self::cast(node)
-    }
     fn syntax(&self) -> &SyntaxNode;
 }
 
@@ -67,8 +63,7 @@ pub mod support {
         let mut child = node.first_child();
         while let Some(node) = child {
             child = node.next_sibling();
-            let kind = node.kind();
-            if let Some(node) = N::cast_with_kind(node, kind) {
+            if let Some(node) = N::cast(node) {
                 return Some(node);
             }
         }

--- a/compiler-core/syntax/src/cst/macros.rs
+++ b/compiler-core/syntax/src/cst/macros.rs
@@ -18,15 +18,7 @@ macro_rules! create_cst_struct {
                 where
                     Self: Sized,
                 {
-                    let kind = node.kind();
-                    Self::cast_with_kind(node, kind)
-                }
-
-                fn cast_with_kind(node: crate::SyntaxNode, kind: crate::SyntaxKind) -> Option<Self>
-                where
-                    Self: Sized,
-                {
-                    if Self::can_cast(kind) {
+                    if Self::can_cast(node.kind()) {
                         Some(Self { node })
                     } else {
                         None
@@ -69,17 +61,10 @@ macro_rules! create_cst_enum {
                 Self: Sized,
             {
                 let kind = node.kind();
-                Self::cast_with_kind(node, kind)
-            }
-
-            fn cast_with_kind(node: crate::SyntaxNode, kind: crate::SyntaxKind) -> Option<Self>
-            where
-                Self: Sized,
-            {
                 if $key_0::can_cast(kind) {
-                    Some($kind::$key_0($key_0::cast_with_kind(node, kind)?))
+                    Some($kind::$key_0($key_0 { node }))
                 } $(else if $key::can_cast(kind) {
-                    Some($kind::$key($key::cast_with_kind(node, kind)?))
+                    Some($kind::$key($key { node }))
                 })* else {
                     None
                 }

--- a/compiler-core/syntax/src/cst/macros.rs
+++ b/compiler-core/syntax/src/cst/macros.rs
@@ -18,7 +18,15 @@ macro_rules! create_cst_struct {
                 where
                     Self: Sized,
                 {
-                    if Self::can_cast(node.kind()) {
+                    let kind = node.kind();
+                    Self::cast_with_kind(node, kind)
+                }
+
+                fn cast_with_kind(node: crate::SyntaxNode, kind: crate::SyntaxKind) -> Option<Self>
+                where
+                    Self: Sized,
+                {
+                    if Self::can_cast(kind) {
                         Some(Self { node })
                     } else {
                         None
@@ -60,10 +68,18 @@ macro_rules! create_cst_enum {
             where
                 Self: Sized,
             {
-                if $key_0::can_cast(node.kind()) {
-                    Some($kind::$key_0($key_0::cast(node)?))
-                } $(else if $key::can_cast(node.kind()) {
-                    Some($kind::$key($key::cast(node)?))
+                let kind = node.kind();
+                Self::cast_with_kind(node, kind)
+            }
+
+            fn cast_with_kind(node: crate::SyntaxNode, kind: crate::SyntaxKind) -> Option<Self>
+            where
+                Self: Sized,
+            {
+                if $key_0::can_cast(kind) {
+                    Some($kind::$key_0($key_0::cast_with_kind(node, kind)?))
+                } $(else if $key::can_cast(kind) {
+                    Some($kind::$key($key::cast_with_kind(node, kind)?))
                 })* else {
                     None
                 }
@@ -98,10 +114,7 @@ macro_rules! has_token_set {
         impl $kind {
             $(
                 pub fn $name(&self) -> Option<crate::SyntaxToken> {
-                    self.syntax()
-                        .children_with_tokens()
-                        .filter_map(|element| element.into_token())
-                        .find(|token| $set.contains(token.kind()))
+                    self.syntax().token_in_set($set)
                 }
             )+
         }

--- a/compiler-core/syntax/src/tree.rs
+++ b/compiler-core/syntax/src/tree.rs
@@ -163,20 +163,6 @@ impl SyntaxNode {
         SyntaxElementChildren(self.elements(true).into_iter())
     }
 
-    pub(crate) fn child_matching(
-        &self,
-        predicate: fn(SyntaxKind) -> bool,
-    ) -> Option<(SyntaxNode, SyntaxKind)> {
-        let tree = self.owner.tree.lock();
-        let child = tree.get(self.id)?.children().find(|child| {
-            let value = child.value();
-            value.category == ElementCategory::Node && predicate(value.kind)
-        })?;
-        let kind = child.value().kind;
-        let node = SyntaxNode { owner: Arc::clone(&self.owner), id: child.id() };
-        Some((node, kind))
-    }
-
     pub(crate) fn token(&self, kind: SyntaxKind) -> Option<SyntaxToken> {
         let tree = self.owner.tree.lock();
         let token = tree.get(self.id)?.children().find(|child| {
@@ -434,12 +420,17 @@ fn collect_node_events(
     node: syntree::Node<'_, SyntaxValue, syntree::FlavorDefault>,
     out: &mut Vec<WalkEvent<SyntaxNode>>,
 ) {
-    let current = SyntaxNode { owner: Arc::clone(owner), id: node.id() };
-    out.push(WalkEvent::Enter(current.clone()));
-    for child in node.children().filter(|child| child.value().category == ElementCategory::Node) {
+    let current = (node.value().category == ElementCategory::Node)
+        .then(|| SyntaxNode { owner: Arc::clone(owner), id: node.id() });
+    if let Some(current) = &current {
+        out.push(WalkEvent::Enter(current.clone()));
+    }
+    for child in node.children() {
         collect_node_events(owner, child, out);
     }
-    out.push(WalkEvent::Leave(current));
+    if let Some(current) = current {
+        out.push(WalkEvent::Leave(current));
+    }
 }
 
 fn sibling(owner: &Arc<TreeOwner>, id: PointerUsize, next: bool) -> Option<SyntaxElement> {
@@ -703,5 +694,33 @@ mod tests {
 
         assert!(root.first_child().is_none());
         assert_eq!(root.token(SyntaxKind::UPPER).unwrap().kind(), SyntaxKind::UPPER);
+    }
+
+    #[test]
+    fn preorder_finds_nodes_nested_under_raw_token_elements() {
+        let mut builder = syntree::Builder::new();
+        builder.open(SyntaxValue::node(SyntaxKind::Module)).unwrap();
+        builder.open(SyntaxValue::token(SyntaxKind::TEXT)).unwrap();
+        builder.open(SyntaxValue::node(SyntaxKind::ModuleHeader)).unwrap();
+        builder.close().unwrap();
+        builder.close().unwrap();
+        builder.close().unwrap();
+        let root = SyntaxNode::new_root(TreeOwner::new(builder.build().unwrap()));
+
+        let events = root.preorder().map(|event| match event {
+            WalkEvent::Enter(node) => WalkEvent::Enter(node.kind()),
+            WalkEvent::Leave(node) => WalkEvent::Leave(node.kind()),
+        });
+        let events = events.collect::<Vec<_>>();
+
+        assert_eq!(
+            events,
+            vec![
+                WalkEvent::Enter(SyntaxKind::Module),
+                WalkEvent::Enter(SyntaxKind::ModuleHeader),
+                WalkEvent::Leave(SyntaxKind::ModuleHeader),
+                WalkEvent::Leave(SyntaxKind::Module),
+            ]
+        );
     }
 }

--- a/compiler-core/syntax/src/tree.rs
+++ b/compiler-core/syntax/src/tree.rs
@@ -163,6 +163,38 @@ impl SyntaxNode {
         SyntaxElementChildren(self.elements(true).into_iter())
     }
 
+    pub(crate) fn child_matching(
+        &self,
+        predicate: fn(SyntaxKind) -> bool,
+    ) -> Option<(SyntaxNode, SyntaxKind)> {
+        let tree = self.owner.tree.lock();
+        let child = tree.get(self.id)?.children().find(|child| {
+            let value = child.value();
+            value.category == ElementCategory::Node && predicate(value.kind)
+        })?;
+        let kind = child.value().kind;
+        let node = SyntaxNode { owner: Arc::clone(&self.owner), id: child.id() };
+        Some((node, kind))
+    }
+
+    pub(crate) fn token(&self, kind: SyntaxKind) -> Option<SyntaxToken> {
+        let tree = self.owner.tree.lock();
+        let token = tree.get(self.id)?.children().find(|child| {
+            let value = child.value();
+            value.category == ElementCategory::Token && value.kind == kind
+        })?;
+        Some(SyntaxToken { owner: Arc::clone(&self.owner), id: token.id() })
+    }
+
+    pub(crate) fn token_in_set(&self, set: crate::TokenSet) -> Option<SyntaxToken> {
+        let tree = self.owner.tree.lock();
+        let token = tree.get(self.id)?.children().find(|child| {
+            let value = child.value();
+            value.category == ElementCategory::Token && set.contains(value.kind)
+        })?;
+        Some(SyntaxToken { owner: Arc::clone(&self.owner), id: token.id() })
+    }
+
     fn elements(&self, tokens: bool) -> Vec<SyntaxElement> {
         let tree = self.owner.tree.lock();
         tree.get(self.id)
@@ -177,7 +209,12 @@ impl SyntaxNode {
     }
 
     pub fn first_child(&self) -> Option<SyntaxNode> {
-        self.children().next()
+        let tree = self.owner.tree.lock();
+        let child = tree
+            .get(self.id)?
+            .children()
+            .find(|child| child.value().category == ElementCategory::Node)?;
+        Some(SyntaxNode { owner: Arc::clone(&self.owner), id: child.id() })
     }
 
     pub fn first_token(&self) -> Option<SyntaxToken> {
@@ -205,15 +242,21 @@ impl SyntaxNode {
     }
 
     pub fn preorder(&self) -> Preorder {
-        Preorder(
-            self.preorder_with_tokens()
-                .filter_map(|event| match event {
-                    WalkEvent::Enter(e) => e.into_node().map(WalkEvent::Enter),
-                    WalkEvent::Leave(e) => e.into_node().map(WalkEvent::Leave),
-                })
-                .collect::<Vec<_>>()
-                .into_iter(),
-        )
+        let tree = self.owner.tree.lock();
+        let mut events = Vec::new();
+        collect_node_events(&self.owner, tree.get(self.id).unwrap(), &mut events);
+        Preorder(events.into_iter())
+    }
+
+    /// Returns compact node metadata in preorder without materializing token events.
+    pub fn preorder_pointers(&self) -> PreorderPointers {
+        let tree = self.owner.tree.lock();
+        let root = tree.get(self.id).unwrap();
+        let pointers = root.walk().inside().filter_map(|node| {
+            let value = node.value();
+            (value.category == ElementCategory::Node).then(|| SyntaxNodePtr::from_raw(&node))
+        });
+        PreorderPointers(pointers.collect::<Vec<_>>().into_iter())
     }
 
     pub fn preorder_with_tokens(&self) -> PreorderWithTokens {
@@ -352,6 +395,16 @@ impl Iterator for Preorder {
     }
 }
 
+pub struct PreorderPointers(std::vec::IntoIter<SyntaxNodePtr>);
+
+impl Iterator for PreorderPointers {
+    type Item = SyntaxNodePtr;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
 pub struct PreorderWithTokens(std::vec::IntoIter<WalkEvent<SyntaxElement>>);
 
 impl Iterator for PreorderWithTokens {
@@ -372,6 +425,19 @@ fn collect_events(
     out.push(WalkEvent::Enter(current.clone()));
     for child in node.children() {
         collect_events(owner, child, out);
+    }
+    out.push(WalkEvent::Leave(current));
+}
+
+fn collect_node_events(
+    owner: &Arc<TreeOwner>,
+    node: syntree::Node<'_, SyntaxValue, syntree::FlavorDefault>,
+    out: &mut Vec<WalkEvent<SyntaxNode>>,
+) {
+    let current = SyntaxNode { owner: Arc::clone(owner), id: node.id() };
+    out.push(WalkEvent::Enter(current.clone()));
+    for child in node.children().filter(|child| child.value().category == ElementCategory::Node) {
+        collect_node_events(owner, child, out);
     }
     out.push(WalkEvent::Leave(current));
 }
@@ -468,6 +534,14 @@ pub struct SyntaxNodePtr {
 impl SyntaxNodePtr {
     pub fn new(node: &SyntaxNode) -> SyntaxNodePtr {
         SyntaxNodePtr { id: node.id, kind: node.kind(), range: node.text_range() }
+    }
+
+    fn from_raw(node: &syntree::Node<'_, SyntaxValue, syntree::FlavorDefault>) -> SyntaxNodePtr {
+        SyntaxNodePtr { id: node.id(), kind: node.value().kind, range: range(node) }
+    }
+
+    pub fn kind(&self) -> SyntaxKind {
+        self.kind
     }
 
     pub fn try_to_node(&self, root: &SyntaxNode) -> Option<SyntaxNode> {
@@ -609,5 +683,25 @@ mod tests {
             root.token_at_offset(TextSize::new(3)),
             TokenAtOffset::Single(token) if token.kind() == SyntaxKind::UPPER
         ));
+    }
+
+    #[test]
+    fn preorder_pointers_match_preorder_enter_events() {
+        let root = root_with_boundary_tokens();
+        let preorder = root.preorder().filter_map(|event| match event {
+            WalkEvent::Enter(node) => Some(SyntaxNodePtr::new(&node)),
+            WalkEvent::Leave(_) => None,
+        });
+        let pointers = root.preorder_pointers();
+
+        assert!(preorder.eq(pointers));
+    }
+
+    #[test]
+    fn direct_child_lookup_skips_tokens() {
+        let root = root_with_boundary_tokens();
+
+        assert!(root.first_child().is_none());
+        assert_eq!(root.token(SyntaxKind::UPPER).unwrap().kind(), SyntaxKind::UPPER);
     }
 }

--- a/compiler-core/syntax/tests/ast_support.rs
+++ b/compiler-core/syntax/tests/ast_support.rs
@@ -1,0 +1,91 @@
+use std::cell::RefCell;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use syntax::ast::{self, AstNode};
+use syntax::{SyntaxKind, SyntaxNode, SyntaxValue, TreeOwner};
+
+thread_local! {
+    static REENTRANT_ROOT: RefCell<Option<SyntaxNode>> = const { RefCell::new(None) };
+}
+
+#[derive(Clone)]
+struct ReentrantAstNode {
+    node: SyntaxNode,
+}
+
+impl AstNode for ReentrantAstNode {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        REENTRANT_ROOT.with(|root| {
+            assert_eq!(root.borrow().as_ref().unwrap().kind(), SyntaxKind::Module);
+        });
+        kind == SyntaxKind::ModuleHeader
+    }
+
+    fn cast(node: SyntaxNode) -> Option<ReentrantAstNode> {
+        Self::can_cast(node.kind()).then_some(ReentrantAstNode { node })
+    }
+
+    fn syntax(&self) -> &SyntaxNode {
+        &self.node
+    }
+}
+
+#[derive(Clone)]
+struct FallibleAstNode {
+    node: SyntaxNode,
+}
+
+impl AstNode for FallibleAstNode {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        matches!(kind, SyntaxKind::ModuleHeader | SyntaxKind::ModuleImports)
+    }
+
+    fn cast(node: SyntaxNode) -> Option<FallibleAstNode> {
+        let kind = node.kind();
+        (Self::can_cast(kind) && kind == SyntaxKind::ModuleImports)
+            .then_some(FallibleAstNode { node })
+    }
+
+    fn syntax(&self) -> &SyntaxNode {
+        &self.node
+    }
+}
+
+fn root_with_children() -> SyntaxNode {
+    let mut builder = syntree::Builder::new();
+    builder.open(SyntaxValue::node(SyntaxKind::Module)).unwrap();
+    builder.open(SyntaxValue::node(SyntaxKind::ModuleHeader)).unwrap();
+    builder.close().unwrap();
+    builder.open(SyntaxValue::node(SyntaxKind::ModuleImports)).unwrap();
+    builder.close().unwrap();
+    builder.close().unwrap();
+    SyntaxNode::new_root(TreeOwner::new(builder.build().unwrap()))
+}
+
+#[test]
+fn child_cast_callback_can_reenter_tree_metadata() {
+    let root = root_with_children();
+    let (sender, receiver) = mpsc::channel();
+
+    let handle = std::thread::spawn(move || {
+        REENTRANT_ROOT.with(|stored| *stored.borrow_mut() = Some(root.clone()));
+        let child = ast::support::child::<ReentrantAstNode>(&root).unwrap();
+        sender.send(child.syntax().kind()).unwrap();
+    });
+
+    let kind = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("custom AST callback deadlocked while re-entering tree metadata");
+    assert_eq!(kind, SyntaxKind::ModuleHeader);
+    handle.join().unwrap();
+}
+
+#[test]
+fn child_cast_continues_after_matching_kind_returns_none() {
+    let root = root_with_children();
+
+    let child = ast::support::child::<FallibleAstNode>(&root).unwrap();
+
+    assert_eq!(child.syntax().kind(), SyntaxKind::ModuleImports);
+}

--- a/compiler-core/syntax/tests/ast_support.rs
+++ b/compiler-core/syntax/tests/ast_support.rs
@@ -3,7 +3,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use syntax::ast::{self, AstNode};
-use syntax::{SyntaxKind, SyntaxNode, SyntaxValue, TreeOwner};
+use syntax::{SyntaxKind, SyntaxNode, SyntaxValue, TreeOwner, cst};
 
 thread_local! {
     static REENTRANT_ROOT: RefCell<Option<SyntaxNode>> = const { RefCell::new(None) };
@@ -52,6 +52,25 @@ impl AstNode for FallibleAstNode {
     }
 }
 
+#[derive(Clone)]
+struct DivergentAstNode {
+    node: SyntaxNode,
+}
+
+impl AstNode for DivergentAstNode {
+    fn can_cast(_kind: SyntaxKind) -> bool {
+        false
+    }
+
+    fn cast(node: SyntaxNode) -> Option<DivergentAstNode> {
+        (node.kind() == SyntaxKind::ModuleHeader).then_some(DivergentAstNode { node })
+    }
+
+    fn syntax(&self) -> &SyntaxNode {
+        &self.node
+    }
+}
+
 fn root_with_children() -> SyntaxNode {
     let mut builder = syntree::Builder::new();
     builder.open(SyntaxValue::node(SyntaxKind::Module)).unwrap();
@@ -88,4 +107,22 @@ fn child_cast_continues_after_matching_kind_returns_none() {
     let child = ast::support::child::<FallibleAstNode>(&root).unwrap();
 
     assert_eq!(child.syntax().kind(), SyntaxKind::ModuleImports);
+}
+
+#[test]
+fn child_cast_does_not_filter_with_can_cast() {
+    let root = root_with_children();
+
+    let child = ast::support::child::<DivergentAstNode>(&root).unwrap();
+
+    assert_eq!(child.syntax().kind(), SyntaxKind::ModuleHeader);
+}
+
+#[test]
+fn generated_casts_validate_the_node_kind() {
+    let root = root_with_children();
+    let header = root.first_child().unwrap();
+
+    assert!(cst::ModuleImports::cast(header.clone()).is_none());
+    assert!(cst::Declaration::cast(header).is_none());
 }


### PR DESCRIPTION
## Summary

- avoid building token walk events when callers request node-only preorder traversal
- add a compact pointer preorder path and use it while assigning stable syntax IDs
- avoid materializing complete child collections for first-child and generated single-child/token accessors
- preserve preorder, direct-child, token lookup, and stable-ID allocation semantics with focused tests
- keep external AST callbacks outside the tree mutex and preserve traversal through unusual raw token-category containers

## Motivation

A prior strict Core-corpus comparison covered 59 packages, 294 modules, and 1,034,898 source bytes. Across 10 balanced alternating runs per revision, with fresh processes and query engines and single-threaded query execution, mean cold-query time changed as follows:

- stabilizing: 56.633 ms → 17.670 ms (−68.80%)
- indexing, including cold stabilization: 69.558 ms → 28.028 ms (−59.71%)
- lowering, including cold stabilization, indexing, and resolving: 171.540 ms → 84.672 ms (−50.64%)

Cumulative requested allocation bytes in those measured query loops changed from 171,390,064 → 37,673,840 for stabilizing, 180,884,597 → 42,890,325 for indexing, and 246,487,255 → 85,281,079 for lowering. All 294 queries succeeded in every run. Candidate indexing timings had several outliers, but allocation counts were deterministic and every run was faster.

These measurements cover only the named cold query phases on the Core corpus. They do not claim end-to-end compiler improvements or allocation-free traversal: `children`, `children_with_tokens`, and `preorder_with_tokens` still materialize vectors, and node-only `preorder` still eagerly traverses the full subtree.

The experimental Criterion/counting-allocator harness and corpus fixtures used during investigation are intentionally not included in this production change.

## API compatibility

Existing public method signatures, iterator ordering, and item semantics remain unchanged. The patch adds `SyntaxNode::preorder_pointers`, its `PreorderPointers` iterator, and `SyntaxNodePtr::kind`.

Typed single-child lookup invokes the existing `AstNode::cast` method after releasing the tree mutex, preserving the previous `find_map(N::cast)` behavior even when `can_cast` and `cast` differ. Generated enum casts read the node’s actual kind once internally and construct only the corresponding private wrapper; no trusted-kind construction path is exposed through the public trait.

## Validation

- `just format --check`
- `cargo check -p syntax --tests`
- `cargo check -p stabilizing --tests`
- `cargo check -p indexing --tests`
- `cargo check -p lowering --tests`
- `cargo check -p checking --tests`
- `cargo check --workspace --tests`
- `cargo nextest run -p syntax -p stabilizing -p indexing -p lowering -p checking` — 41 passed
- `just t semantic` — passed, no pending snapshots
- `just t lowering` — passed, no pending snapshots
- `just t checking` — passed, no pending snapshots
- `just compatibility` — 630 core and Acme packages, no introduced compiler errors, verifier errors, or warning changes
- `git diff --check`