### PR TITLE
[lowering] Use arena maps for lowered module items

### DIFF
--- a/compiler-core/lowering/src/tree.rs
+++ b/compiler-core/lowering/src/tree.rs
@@ -448,8 +448,8 @@ pub struct LoweredTree {
     pub(crate) binders: FxHashMap<BinderId, BinderKind>,
     pub(crate) expressions: FxHashMap<ExpressionId, ExpressionKind>,
     pub(crate) types: FxHashMap<TypeId, TypeKind>,
-    pub(crate) term_items: FxHashMap<TermItemId, TermItemKind>,
-    pub(crate) type_items: FxHashMap<TypeItemId, TypeItemKind>,
+    pub(crate) term_items: ArenaMap<TermItemId, TermItemKind>,
+    pub(crate) type_items: ArenaMap<TypeItemId, TypeItemKind>,
 
     pub(crate) do_statements: FxHashMap<DoStatementId, DoStatement>,
     pub(crate) let_binding_groups: Arena<LetBindingNameGroup>,
@@ -508,11 +508,11 @@ impl LoweredTree {
     }
 
     pub fn get_term_item_kind(&self, id: TermItemId) -> Option<&TermItemKind> {
-        self.term_items.get(&id)
+        self.term_items.get(id)
     }
 
     pub fn get_type_item_kind(&self, id: TypeItemId) -> Option<&TypeItemKind> {
-        self.type_items.get(&id)
+        self.type_items.get(id)
     }
 
     pub fn get_let_binding_group(&self, id: LetBindingNameGroupId) -> &LetBindingNameGroup {


### PR DESCRIPTION
## Summary

Replace the lowered tree's term-item and type-item `FxHashMap`s with `ArenaMap`s.

`TermItemId` and `TypeItemId` are typed, module-local indices allocated by the indexing arenas, so an index-addressed representation matches their domain. Lowering does not necessarily produce an entry for every indexed term item: missing constructor or class-member syntax can leave sparse IDs. `ArenaMap` preserves those holes, and the existing getters retain their `Option<&...>` contract and continue to return `None` for absent entries.

This is intentionally limited to durable production code. It adds no benchmark harness, allocator instrumentation, or corpus artifacts.

## Measurement context

A focused deterministic representation measurement with 256 dense, 64-byte `TermItemKind` values retained 16,384 bytes with `ArenaMap`, compared with 37,392 bytes with `FxHashMap` (56.2% less retained storage).

A broader seven-run Core-corpus experiment also observed 27,407 fewer cold-pipeline allocations (2,831,101 to 2,803,694; 0.968%). That corpus revision included a separate parent-pointer lowering change, so the corpus allocation delta is directional context rather than an isolated attribution to this PR.

Corpus wall time and RSS were neutral: alternating process-isolated runs varied in both directions, with cold wall-time means of 682.70 ms and 677.08 ms and paired deltas ranging from -5.86% to +4.45%. This PR therefore does not claim an end-to-end speedup; it adopts a representation aligned with the typed ID domain while preserving lookup behavior.

## Validation

- `just format --check`
- `cargo check -p lowering --tests`
- `cargo check -p checking --tests`
- `cargo nextest run -p checking --no-tests=pass` (30 passed)
- `just t lowering` (all passed, no pending snapshots)
- `just t checking` (all passed, no pending snapshots)
