### PR TITLE
[indexing] Store reverse module item metadata

### DIFF
--- a/compiler-core/checking/src/core/constraint/instances.rs
+++ b/compiler-core/checking/src/core/constraint/instances.rs
@@ -324,8 +324,10 @@ fn collect_instances_from_checked(
         .iter()
         .filter(|(_, instance)| instance.resolution == (class_file, class_id))
         .map(|(&id, &instance)| {
-            let chain = indexed.pairs.instance_chain_id(id).map(|chain_id| (file_id, chain_id));
-            let position = indexed.pairs.instance_chain_position(id).unwrap_or(0);
+            let (chain, position) = indexed
+                .pairs
+                .instance_chain_metadata(id)
+                .map_or((None, 0), |(chain_id, position)| (Some((file_id, chain_id)), position));
             let origin = InstanceCandidateOrigin::Instance(file_id, id);
             InstanceCandidate { chain, position, origin, instance }
         });

--- a/compiler-core/documenting/src/annotation.rs
+++ b/compiler-core/documenting/src/annotation.rs
@@ -64,7 +64,7 @@ pub fn term_documentation(
         IndexedTermItemKind::ClassMember { id } => {
             signature_equation_documentation(stabilized, annotations, &Some(*id), &Some(*id))
         }
-        IndexedTermItemKind::Constructor { id } => {
+        IndexedTermItemKind::Constructor { id, .. } => {
             data_constructor_item_documentation(stabilized, annotations, *id)
         }
         IndexedTermItemKind::Derive { id } => {

--- a/compiler-core/indexing/src/algorithm.rs
+++ b/compiler-core/indexing/src/algorithm.rs
@@ -336,7 +336,7 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
             );
             for cst in cst.data_constructors() {
                 let constructor_id = stabilized.lookup_cst(&cst).expect_id();
-                let term_id = index_data_constructor(state, constructor_id, &cst);
+                let term_id = index_data_constructor(state, type_id, constructor_id, &cst);
                 if let IndexedTypeItemKind::Newtype { constructors, .. } =
                     &mut state.items.types[type_id].kind
                 {
@@ -402,7 +402,7 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
             );
             for cst in cst.data_constructors() {
                 let constructor_id = stabilized.lookup_cst(&cst).expect_id();
-                let term_id = index_data_constructor(state, constructor_id, &cst);
+                let term_id = index_data_constructor(state, type_id, constructor_id, &cst);
                 if let IndexedTypeItemKind::Data { constructors, .. } =
                     &mut state.items.types[type_id].kind
                 {
@@ -590,11 +590,12 @@ fn index_type_declaration<T: AstNode>(
 
 fn index_data_constructor(
     state: &mut State,
+    type_id: TypeItemId,
     id: DataConstructorId,
     cst: &cst::DataConstructor,
 ) -> TermItemId {
     let name = name_from_token(state.source, cst.name_token());
-    let kind = IndexedTermItemKind::Constructor { id };
+    let kind = IndexedTermItemKind::Constructor { id, type_id };
     state.items.terms.alloc(IndexedTermItem { name, kind, exported: false })
 }
 

--- a/compiler-core/indexing/src/algorithm.rs
+++ b/compiler-core/indexing/src/algorithm.rs
@@ -144,10 +144,18 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
         }
         cst::Declaration::InstanceChain(cst) => {
             let chain_id = stabilized.lookup_cst(cst).expect_id();
-            for cst in cst.instance_declarations() {
+            for (position, cst) in cst.instance_declarations().enumerate() {
                 let instance_id = stabilized.lookup_cst(&cst).expect_id();
                 let term_id = index_instance(state, instance_id, &cst);
-                state.pairs.instance_chain.push((chain_id, instance_id));
+                debug_assert!(
+                    state
+                        .pairs
+                        .instance_chain
+                        .last()
+                        .is_none_or(|(previous_id, _, _)| *previous_id < instance_id),
+                    "invariant violated: instance IDs are not in source order",
+                );
+                state.pairs.instance_chain.push((instance_id, chain_id, position as u32));
                 state.pairs.instance_to_term.push((instance_id, term_id));
                 state.pairs.declaration_to_term.push((declaration_id, term_id));
                 if let Some(cst) = cst.instance_statements() {

--- a/compiler-core/indexing/src/algorithm.rs
+++ b/compiler-core/indexing/src/algorithm.rs
@@ -344,7 +344,10 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
             );
             for cst in cst.data_constructors() {
                 let constructor_id = stabilized.lookup_cst(&cst).expect_id();
-                let term_id = index_data_constructor(state, type_id, constructor_id, &cst);
+                let attached_type_id =
+                    matches!(state.items.types[type_id].kind, IndexedTypeItemKind::Newtype { .. })
+                        .then_some(type_id);
+                let term_id = index_data_constructor(state, attached_type_id, constructor_id, &cst);
                 if let IndexedTypeItemKind::Newtype { constructors, .. } =
                     &mut state.items.types[type_id].kind
                 {
@@ -410,7 +413,10 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
             );
             for cst in cst.data_constructors() {
                 let constructor_id = stabilized.lookup_cst(&cst).expect_id();
-                let term_id = index_data_constructor(state, type_id, constructor_id, &cst);
+                let attached_type_id =
+                    matches!(state.items.types[type_id].kind, IndexedTypeItemKind::Data { .. })
+                        .then_some(type_id);
+                let term_id = index_data_constructor(state, attached_type_id, constructor_id, &cst);
                 if let IndexedTypeItemKind::Data { constructors, .. } =
                     &mut state.items.types[type_id].kind
                 {
@@ -598,7 +604,7 @@ fn index_type_declaration<T: AstNode>(
 
 fn index_data_constructor(
     state: &mut State,
-    type_id: TypeItemId,
+    type_id: Option<TypeItemId>,
     id: DataConstructorId,
     cst: &cst::DataConstructor,
 ) -> TermItemId {

--- a/compiler-core/indexing/src/items.rs
+++ b/compiler-core/indexing/src/items.rs
@@ -15,7 +15,7 @@ pub struct IndexedTermItem {
 #[derive(Debug, PartialEq, Eq)]
 pub enum IndexedTermItemKind {
     ClassMember { id: ClassMemberId },
-    Constructor { id: DataConstructorId },
+    Constructor { id: DataConstructorId, type_id: TypeItemId },
     Derive { id: DeriveId },
     Foreign { id: ForeignValueId },
     Instance { id: InstanceId },

--- a/compiler-core/indexing/src/items.rs
+++ b/compiler-core/indexing/src/items.rs
@@ -15,7 +15,7 @@ pub struct IndexedTermItem {
 #[derive(Debug, PartialEq, Eq)]
 pub enum IndexedTermItemKind {
     ClassMember { id: ClassMemberId },
-    Constructor { id: DataConstructorId, type_id: TypeItemId },
+    Constructor { id: DataConstructorId, type_id: Option<TypeItemId> },
     Derive { id: DeriveId },
     Foreign { id: ForeignValueId },
     Instance { id: InstanceId },

--- a/compiler-core/indexing/src/lib.rs
+++ b/compiler-core/indexing/src/lib.rs
@@ -259,7 +259,7 @@ impl IndexedImport {
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct IndexedPairs {
     derive_to_term: Vec<(DeriveId, TermItemId)>,
-    instance_chain: Vec<(InstanceChainId, InstanceId)>,
+    instance_chain: Vec<(InstanceId, InstanceChainId, u32)>,
     instance_to_term: Vec<(InstanceId, TermItemId)>,
     instance_members: Vec<(InstanceId, InstanceMemberId)>,
 
@@ -309,20 +309,20 @@ impl IndexedPairs {
     }
 
     pub fn instance_chain_id(&self, id: InstanceId) -> Option<InstanceChainId> {
-        self.instance_chain.iter().find_map(
-            |(chain_id, instance_id)| {
-                if *instance_id == id { Some(*chain_id) } else { None }
-            },
-        )
+        self.instance_chain_metadata(id).map(|(chain_id, _)| chain_id)
     }
 
     pub fn instance_chain_position(&self, id: InstanceId) -> Option<u32> {
-        let chain_of_id = self.instance_chain_id(id)?;
-        self.instance_chain
-            .iter()
-            .filter(|(chain_id, _)| *chain_id == chain_of_id)
-            .position(|(_, instance_id)| *instance_id == id)
-            .map(|position| position as u32)
+        self.instance_chain_metadata(id).map(|(_, position)| position)
+    }
+
+    pub fn instance_chain_metadata(&self, id: InstanceId) -> Option<(InstanceChainId, u32)> {
+        self.instance_chain.binary_search_by_key(&id, |(instance_id, _, _)| *instance_id).ok().map(
+            |index| {
+                let (_, chain_id, position) = self.instance_chain[index];
+                (chain_id, position)
+            },
+        )
     }
 }
 

--- a/compiler-core/indexing/src/lib.rs
+++ b/compiler-core/indexing/src/lib.rs
@@ -2,6 +2,8 @@ mod algorithm;
 mod error;
 mod items;
 mod source;
+#[cfg(test)]
+mod tests;
 
 pub use error::*;
 pub use items::*;
@@ -72,13 +74,14 @@ impl IndexedModule {
     }
 
     pub fn constructor_type(&self, id: TermItemId) -> Option<TypeItemId> {
-        self.items.iter_types().find_map(|(type_id, _)| {
-            if self.data_constructors(type_id).any(|term_id| term_id == id) {
-                Some(type_id)
-            } else {
-                None
-            }
-        })
+        let index = id.into_raw().into_u32() as usize;
+        if index >= self.items.terms.len() {
+            return None;
+        }
+        let IndexedTermItemKind::Constructor { type_id, .. } = self.items[id].kind else {
+            return None;
+        };
+        Some(type_id)
     }
 
     pub fn class_members(&self, id: TypeItemId) -> impl Iterator<Item = TermItemId> + '_ {

--- a/compiler-core/indexing/src/lib.rs
+++ b/compiler-core/indexing/src/lib.rs
@@ -81,7 +81,7 @@ impl IndexedModule {
         let IndexedTermItemKind::Constructor { type_id, .. } = self.items[id].kind else {
             return None;
         };
-        Some(type_id)
+        type_id
     }
 
     pub fn class_members(&self, id: TypeItemId) -> impl Iterator<Item = TermItemId> + '_ {

--- a/compiler-core/indexing/src/tests.rs
+++ b/compiler-core/indexing/src/tests.rs
@@ -1,0 +1,42 @@
+use la_arena::RawIdx;
+
+use crate::{IndexedModule, TermItemId, index_module};
+
+fn index(source: &str) -> IndexedModule {
+    let lexed = lexing::lex(source);
+    let tokens = lexing::layout(&lexed);
+    let (parsed, errors) = parsing::parse(&lexed, &tokens);
+    assert!(errors.is_empty(), "test module must parse: {errors:?}");
+
+    let root = parsed.syntax_node();
+    let stabilized = stabilizing::stabilize_module(&root);
+    index_module(source, &parsed.cst(), &stabilized)
+}
+
+#[test]
+fn constructor_owners_preserve_type_and_constructor_ids() {
+    let indexed = index(
+        "module Main where\n\
+         data First = FirstA | FirstB\n\
+         newtype Second = Second Int\n\
+         value = 0\n",
+    );
+
+    let first_type = indexed.names.types.lookup("First").unwrap();
+    let second_type = indexed.names.types.lookup("Second").unwrap();
+    let first_a = indexed.names.terms.lookup("FirstA").unwrap();
+    let first_b = indexed.names.terms.lookup("FirstB").unwrap();
+    let second = indexed.names.terms.lookup("Second").unwrap();
+    let value = indexed.names.terms.lookup("value").unwrap();
+
+    let first_constructors = indexed.data_constructors(first_type);
+    let first_constructors = first_constructors.collect::<Vec<_>>();
+    assert_eq!(first_constructors, [first_a, first_b]);
+    assert_eq!(indexed.data_constructors(second_type).next(), Some(second));
+    assert_eq!(indexed.constructor_type(first_a), Some(first_type));
+    assert_eq!(indexed.constructor_type(first_b), Some(first_type));
+    assert_eq!(indexed.constructor_type(second), Some(second_type));
+    assert_eq!(indexed.constructor_type(value), None);
+    let out_of_range = TermItemId::from_raw(RawIdx::from_u32(u32::MAX));
+    assert_eq!(indexed.constructor_type(out_of_range), None);
+}

--- a/compiler-core/indexing/src/tests.rs
+++ b/compiler-core/indexing/src/tests.rs
@@ -50,6 +50,21 @@ fn constructor_owners_preserve_type_and_constructor_ids() {
 }
 
 #[test]
+fn constructor_owner_requires_attachment_to_the_recovered_type() {
+    let indexed = index(
+        "module Main where\n\
+         type Mismatch = Int\n\
+         data Mismatch = Constructor\n",
+    );
+
+    let mismatch = indexed.names.types.lookup("Mismatch").unwrap();
+    let constructor = indexed.names.terms.lookup("Constructor").unwrap();
+
+    assert_eq!(indexed.data_constructors(mismatch).next(), None);
+    assert_eq!(indexed.constructor_type(constructor), None);
+}
+
+#[test]
 fn instance_chain_metadata_preserves_chain_and_source_order() {
     let indexed = index(
         "module Main where\n\

--- a/compiler-core/indexing/src/tests.rs
+++ b/compiler-core/indexing/src/tests.rs
@@ -65,6 +65,21 @@ fn constructor_owner_requires_attachment_to_the_recovered_type() {
 }
 
 #[test]
+fn constructor_owner_requires_attachment_to_the_recovered_class() {
+    let indexed = index(
+        "module Main where\n\
+         class Clash a\n\
+         data Clash = Constructor\n",
+    );
+
+    let clash = indexed.names.types.lookup("Clash").unwrap();
+    let constructor = indexed.names.terms.lookup("Constructor").unwrap();
+
+    assert_eq!(indexed.data_constructors(clash).next(), None);
+    assert_eq!(indexed.constructor_type(constructor), None);
+}
+
+#[test]
 fn instance_chain_metadata_preserves_chain_and_source_order() {
     let indexed = index(
         "module Main where\n\

--- a/compiler-core/indexing/src/tests.rs
+++ b/compiler-core/indexing/src/tests.rs
@@ -1,6 +1,6 @@
 use la_arena::RawIdx;
 
-use crate::{IndexedModule, TermItemId, index_module};
+use crate::{IndexedModule, IndexedTermItemKind, InstanceId, TermItemId, index_module};
 
 fn index(source: &str) -> IndexedModule {
     let lexed = lexing::lex(source);
@@ -11,6 +11,14 @@ fn index(source: &str) -> IndexedModule {
     let root = parsed.syntax_node();
     let stabilized = stabilizing::stabilize_module(&root);
     index_module(source, &parsed.cst(), &stabilized)
+}
+
+fn instance_id(indexed: &IndexedModule, name: &str) -> InstanceId {
+    let term_id = indexed.names.terms.lookup(name).unwrap();
+    let IndexedTermItemKind::Instance { id } = indexed.items[term_id].kind else {
+        panic!("expected {name} to be an instance");
+    };
+    id
 }
 
 #[test]
@@ -39,4 +47,34 @@ fn constructor_owners_preserve_type_and_constructor_ids() {
     assert_eq!(indexed.constructor_type(value), None);
     let out_of_range = TermItemId::from_raw(RawIdx::from_u32(u32::MAX));
     assert_eq!(indexed.constructor_type(out_of_range), None);
+}
+
+#[test]
+fn instance_chain_metadata_preserves_chain_and_source_order() {
+    let indexed = index(
+        "module Main where\n\
+         foreign import data Subject :: Type\n\
+         class Example a\n\
+         instance first :: Example Subject\n\
+         else instance middle :: Example Subject\n\
+         else instance last :: Example Subject\n\
+         instance standalone :: Example Subject\n",
+    );
+
+    let first = instance_id(&indexed, "first");
+    let middle = instance_id(&indexed, "middle");
+    let last = instance_id(&indexed, "last");
+    let standalone = instance_id(&indexed, "standalone");
+    let first_chain = indexed.pairs.instance_chain_id(first).unwrap();
+    let standalone_chain = indexed.pairs.instance_chain_id(standalone).unwrap();
+
+    assert_ne!(first_chain, standalone_chain);
+    assert_eq!(indexed.pairs.instance_chain_metadata(first), Some((first_chain, 0)));
+    assert_eq!(indexed.pairs.instance_chain_metadata(middle), Some((first_chain, 1)));
+    assert_eq!(indexed.pairs.instance_chain_metadata(last), Some((first_chain, 2)));
+    assert_eq!(indexed.pairs.instance_chain_metadata(standalone), Some((standalone_chain, 0)),);
+    assert_eq!(indexed.pairs.instance_chain_position(first), Some(0));
+    assert_eq!(indexed.pairs.instance_chain_position(middle), Some(1));
+    assert_eq!(indexed.pairs.instance_chain_position(last), Some(2));
+    assert_eq!(indexed.pairs.instance_chain_position(standalone), Some(0));
 }

--- a/compiler-core/lowering/src/algorithm.rs
+++ b/compiler-core/lowering/src/algorithm.rs
@@ -814,7 +814,8 @@ fn lower_type_item(
 
 fn lower_constructors(state: &mut State, context: &Context, id: TypeItemId) {
     for item_id in context.indexed.data_constructors(id) {
-        let IndexedTermItemKind::Constructor { id } = context.indexed.items[item_id].kind else {
+        let IndexedTermItemKind::Constructor { id, .. } = context.indexed.items[item_id].kind
+        else {
             unreachable!("invariant violated: expected IndexedTermItemKind::Constructor");
         };
 

--- a/compiler-lsp/analyzer/src/document_highlight.rs
+++ b/compiler-lsp/analyzer/src/document_highlight.rs
@@ -672,7 +672,7 @@ fn term_item_highlights(
         IndexedTermItemKind::ClassMember { id } => {
             push_name_highlights!(position::class_member_name_range; Some(*id));
         }
-        IndexedTermItemKind::Constructor { id } => {
+        IndexedTermItemKind::Constructor { id, .. } => {
             push_name_highlights!(position::data_constructor_name_range; Some(*id));
         }
         IndexedTermItemKind::Derive { id } => {

--- a/compiler-lsp/analyzer/src/extract.rs
+++ b/compiler-lsp/analyzer/src/extract.rs
@@ -114,7 +114,7 @@ impl AnnotationSyntaxRange {
             IndexedTermItemKind::ClassMember { id } => {
                 signature_equation_range(&stabilized, &root, &Some(*id), &Some(*id))
             }
-            IndexedTermItemKind::Constructor { id } => {
+            IndexedTermItemKind::Constructor { id, .. } => {
                 signature_equation_range(&stabilized, &root, &Some(*id), &Some(*id))
             }
             IndexedTermItemKind::Derive { id } => {

--- a/compiler-lsp/analyzer/src/rename/edit.rs
+++ b/compiler-lsp/analyzer/src/rename/edit.rs
@@ -546,7 +546,7 @@ where
             IndexedTermItemKind::ClassMember { id } => {
                 push_name_edits!(self, file_id, new_name, position::class_member_name_range; Some(*id));
             }
-            IndexedTermItemKind::Constructor { id } => {
+            IndexedTermItemKind::Constructor { id, .. } => {
                 push_name_edits!(self, file_id, new_name, position::data_constructor_name_range; Some(*id));
             }
             IndexedTermItemKind::Derive { id } => {


### PR DESCRIPTION
## Summary

- store each constructor's attached owner in its indexed term item so `constructor_type` can use a checked direct lookup instead of scanning every indexed type and constructor list
- index instance-chain IDs and zero-based source positions by `InstanceId`, expose the combined `instance_chain_metadata` lookup, and consume both values with one lookup during checking
- cover valid data and newtype constructors, mismatched type-recovery constructors, non-constructors, invalid term IDs, multi-member chains, source order, and standalone one-member chains with focused indexing tests

## API and invariants

This adds `type_id: Option<TypeItemId>` to the public `IndexedTermItemKind::Constructor` enum variant. That is a source-breaking shape change for exhaustive field patterns; Alexandrite's documenting, lowering, and analyzer consumers have been updated to use `..` where they only need the constructor ID.

The optional owner preserves the existing inverse invariant: if `constructor_type(c)` returns `Some(t)`, then `data_constructors(t)` contains `c`. Indexing records `Some(t)` only when the active data or newtype item also accepts and stores the constructor. For mismatched recovery such as a type synonym followed by a data declaration of the same name, the recovery constructor remains indexed but has no attached owner, so `constructor_type` returns `None`. Invalid term IDs also continue to return `None`.

`instance_chain_metadata` is a new public convenience API. The existing `instance_chain_id` and `instance_chain_position` methods remain and delegate to it.

The binary search depends on `InstanceId` order matching source order. Stabilization allocates AST IDs in CST preorder, indexing visits declarations and each chain's members in source order, and indexing debug-asserts strict key ordering as entries are appended. Positions come from enumerating members within each chain. A standalone declaration is represented by its own chain at position 0. Checking now reads chain and position atomically; its fallback for absent metadata remains an unchained candidate at position 0, and derived-instance handling is unchanged.

## Evidence

The constructor change is supported by code-path and correctness evidence, not a runtime benchmark: the previous implementation scanned indexed types and their constructor lists, while the new implementation bounds-checks the term arena ID and reads the optional attached owner from the constructor variant. Focused tests verify multiple data constructors, a newtype constructor, a non-constructor, an out-of-range `TermItemId`, and mismatched type-declaration recovery without fabricating an owner. No temporary benchmark, allocator, generated corpus, or harness code is included.

The release-built compatibility comparison covered the repository's core and Acme presets: 630 packages from package set 80.4.0 for PureScript 0.15.15, with 0 introduced compiler errors, warnings, or verifier errors. A parser-aware audit of that corpus found 3,448 semantic chain-tail declarations across 194 files in 104 packages. This demonstrates real instance-chain coverage, but is not a performance measurement.

## Checks

- `just format`
- `cargo check -p indexing -p checking -p lowering -p documenting -p analyzer --tests`
- `cargo nextest run -p indexing -p checking -p lowering -p documenting -p analyzer` — 73 passed
- `just t checking` — no pending snapshots
- `just t lowering` — no pending snapshots
- `just t lsp` — no pending snapshots
- `just compatibility origin/main` — no introduced compatibility errors or warning changes
