### PR TITLE
[meta] Prepare 0.0.18 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "purescript-alexandrite"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "analyzer",
  "async-lsp",

--- a/compiler-bin/Cargo.toml
+++ b/compiler-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "purescript-alexandrite"
-version = "0.0.17"
+version = "0.0.18"
 edition = "2024"
 authors = ["Justin Garcia <git@purefunctor.me>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

Prepare Alexandrite 0.0.18 by updating the CLI package version and lockfile. Internal compiler crates remain independently versioned.

## Verification

- `cargo check -p purescript-alexandrite --tests --locked`
- `cargo run -p purescript-alexandrite --locked --bin purescript-alexandrite -- --version` → `purescript-alexandrite 0.0.18`
- `git diff --check`