### PR TITLE
[indexing] Separate instance and derive indexing identities

### DIFF
--- a/compiler-core/checking/src/core/constraint/instances.rs
+++ b/compiler-core/checking/src/core/constraint/instances.rs
@@ -5,8 +5,7 @@ use std::sync::Arc;
 use building_types::QueryResult;
 use files::FileId;
 use indexing::{
-    DeriveId, IndexedModule, IndexedTermItemKind, InstanceChainId, InstanceId, TermItemId,
-    TypeItemId,
+    DeriveId, IndexedModule, InstanceChainId, InstanceId, InstanceSourceItemId, TypeItemId,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -56,7 +55,7 @@ pub struct InstanceChains {
 pub fn validate_declared_instance_overlap<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    item_id: TermItemId,
+    item_id: InstanceSourceItemId,
 ) -> QueryResult<()>
 where
     Q: ExternalQueries,
@@ -74,8 +73,9 @@ where
     let Some(current_position) = context
         .indexed
         .items
-        .iter_terms()
-        .position(|(candidate_item_id, _)| candidate_item_id == item_id)
+        .instance_sources()
+        .iter()
+        .position(|&candidate_item_id| candidate_item_id == item_id)
     else {
         return Ok(());
     };
@@ -96,23 +96,24 @@ where
 fn declared_instance_candidate<Q>(
     state: &CheckState,
     context: &CheckContext<Q>,
-    item_id: TermItemId,
+    item_id: InstanceSourceItemId,
 ) -> Option<(InstanceCandidateOrigin, CheckedInstance)>
 where
     Q: ExternalQueries,
 {
-    match context.indexed.items[item_id].kind {
-        IndexedTermItemKind::Instance { id } => {
+    match item_id {
+        InstanceSourceItemId::Instance(item_id) => {
+            let id = context.indexed.items[item_id].id;
             let instance = state.checked.lookup_instance(id)?;
             let origin = InstanceCandidateOrigin::Instance(context.id, id);
             Some((origin, instance))
         }
-        IndexedTermItemKind::Derive { id } => {
+        InstanceSourceItemId::Derive(item_id) => {
+            let id = context.indexed.items[item_id].id;
             let instance = state.checked.lookup_derived_instance(id)?;
             let origin = InstanceCandidateOrigin::Derive(context.id, id);
             Some((origin, instance))
         }
-        _ => None,
     }
 }
 
@@ -278,17 +279,22 @@ fn instance_candidate_position<Q>(
 where
     Q: ExternalQueries,
 {
-    context.indexed.items.iter_terms().position(|(_, item)| match (origin, &item.kind) {
-        (
-            InstanceCandidateOrigin::Instance(file_id, origin_id),
-            IndexedTermItemKind::Instance { id },
-        ) => file_id == context.id && origin_id == *id,
-        (
-            InstanceCandidateOrigin::Derive(file_id, origin_id),
-            IndexedTermItemKind::Derive { id },
-        ) => file_id == context.id && origin_id == *id,
-        _ => false,
-    })
+    if match origin {
+        InstanceCandidateOrigin::Instance(file_id, _)
+        | InstanceCandidateOrigin::Derive(file_id, _) => file_id != context.id,
+    } {
+        return None;
+    }
+
+    let item_id = match origin {
+        InstanceCandidateOrigin::Instance(_, id) => {
+            InstanceSourceItemId::Instance(context.indexed.pairs.instance_to_item(id)?)
+        }
+        InstanceCandidateOrigin::Derive(_, id) => {
+            InstanceSourceItemId::Derive(context.indexed.pairs.derive_to_item(id)?)
+        }
+    };
+    context.indexed.items.instance_sources().iter().position(|&id| id == item_id)
 }
 
 fn should_report_overlap<Q>(

--- a/compiler-core/checking/src/core/skolem.rs
+++ b/compiler-core/checking/src/core/skolem.rs
@@ -133,7 +133,15 @@ where
             let crumb = ErrorCrumb::TermDeclaration(source);
             Task::Term(&checked.tree[declaration], crumb)
         });
-        tasks.collect_vec()
+        let instances = checked.tree.iter_instances().map(|(source, declaration)| {
+            let crumb = ErrorCrumb::InstanceDeclaration(source);
+            Task::Term(&checked.tree[declaration], crumb)
+        });
+        let derives = checked.tree.iter_derives().map(|(source, declaration)| {
+            let crumb = ErrorCrumb::DeriveDeclaration(source);
+            Task::Term(&checked.tree[declaration], crumb)
+        });
+        tasks.chain(instances).chain(derives).collect_vec()
     };
     tasks.reverse();
 

--- a/compiler-core/checking/src/error.rs
+++ b/compiler-core/checking/src/error.rs
@@ -10,6 +10,8 @@ use crate::core::{SmolStrId, TypeId};
 pub enum ErrorCrumb {
     TermDeclaration(indexing::TermItemId),
     TypeDeclaration(indexing::TypeItemId),
+    InstanceDeclaration(indexing::InstanceItemId),
+    DeriveDeclaration(indexing::DeriveItemId),
     ConstructorArgument(lowering::TypeId),
 
     InferringKind(lowering::TypeId),

--- a/compiler-core/checking/src/source/derive.rs
+++ b/compiler-core/checking/src/source/derive.rs
@@ -17,7 +17,7 @@ pub mod variance;
 
 use building_types::QueryResult;
 use files::FileId;
-use indexing::{TermItemId, TypeItemId};
+use indexing::{DeriveItemId, TypeItemId};
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
@@ -70,7 +70,7 @@ pub(super) enum DeriveStrategy {
 
 pub struct DeriveHeadResult {
     derive_id: indexing::DeriveId,
-    item_id: TermItemId,
+    item_id: DeriveItemId,
     signature: TypeId,
     constraints: Vec<TypeId>,
     class_file: FileId,

--- a/compiler-core/checking/src/source/derive/head.rs
+++ b/compiler-core/checking/src/source/derive/head.rs
@@ -1,7 +1,6 @@
 use building_types::QueryResult;
 use files::FileId;
-use indexing::{IndexedTermItemKind, TermItemId, TypeItemId};
-use lowering::TermItemKind;
+use indexing::{DeriveItemId, TypeItemId};
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
@@ -26,28 +25,17 @@ where
 {
     let mut results = vec![];
 
-    for scc in &context.grouped.term_scc {
-        let items = scc.as_slice();
-
-        let items = items.iter().filter_map(|&item_id| {
-            let item = context.lowered.tree.get_term_item_kind(item_id)?;
-            let TermItemKind::Derive { newtype, constraints, resolution, arguments } = item else {
-                return None;
-            };
-            let resolution = *resolution;
-            Some(CheckDeriveDeclaration {
-                item_id,
-                newtype: *newtype,
-                constraints,
-                resolution,
-                arguments,
-            })
-        });
-
-        for item in items {
-            if let Some(result) = check_derive_declaration(state, context, item)? {
-                results.push(result);
-            }
+    for &item_id in &context.grouped.derive_items {
+        let Some(item) = context.lowered.tree.get_derive_item(item_id) else { continue };
+        let item = CheckDeriveDeclaration {
+            item_id,
+            newtype: item.newtype,
+            constraints: &item.constraints,
+            resolution: item.resolution,
+            arguments: &item.arguments,
+        };
+        if let Some(result) = check_derive_declaration(state, context, item)? {
+            results.push(result);
         }
     }
 
@@ -55,7 +43,7 @@ where
 }
 
 struct CheckDeriveDeclaration<'a> {
-    item_id: TermItemId,
+    item_id: DeriveItemId,
     newtype: bool,
     constraints: &'a [lowering::TypeId],
     resolution: Option<(FileId, TypeItemId)>,
@@ -64,7 +52,7 @@ struct CheckDeriveDeclaration<'a> {
 
 struct CheckDeriveDeclarationCore<'a> {
     derive_id: indexing::DeriveId,
-    item_id: TermItemId,
+    item_id: DeriveItemId,
     newtype: bool,
     class_file: FileId,
     class_id: TypeItemId,
@@ -86,11 +74,9 @@ where
         return Ok(None);
     };
 
-    let IndexedTermItemKind::Derive { id: derive_id } = context.indexed.items[item_id].kind else {
-        return Ok(None);
-    };
+    let derive_id = context.indexed.items[item_id].id;
 
-    state.with_error_crumb(ErrorCrumb::TermDeclaration(item_id), |state| {
+    state.with_error_crumb(ErrorCrumb::DeriveDeclaration(item_id), |state| {
         check_derive_declaration_core(
             state,
             context,

--- a/compiler-core/checking/src/source/derive/member.rs
+++ b/compiler-core/checking/src/source/derive/member.rs
@@ -17,7 +17,7 @@ where
     Q: ExternalQueries,
 {
     for result in derives {
-        state.with_error_crumb(ErrorCrumb::TermDeclaration(result.item_id), |state| {
+        state.with_error_crumb(ErrorCrumb::DeriveDeclaration(result.item_id), |state| {
             state.with_implication(|state| check_derive_member(state, context, result))
         })?;
     }
@@ -105,7 +105,7 @@ where
             tools::solve_and_report_constraints(state, context)?
             && let Some(declaration) = declaration
         {
-            state.checked.tree.insert_term(result.item_id, declaration);
+            state.checked.tree.insert_derive(result.item_id, declaration);
         }
     }
 

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use building_types::QueryResult;
 use files::FileId;
-use indexing::{IndexedTermItemKind, TermItemId, TypeItemId};
+use indexing::{IndexedTermItemKind, InstanceItemId, InstanceSourceItemId, TermItemId, TypeItemId};
 use lowering::TermItemKind;
 use rustc_hash::FxHashMap;
 
@@ -57,21 +57,16 @@ pub fn check_instance_declarations<Q>(
 where
     Q: ExternalQueries,
 {
-    for scc in &context.grouped.term_scc {
-        let items = scc.as_slice();
-
-        let items = items.iter().filter_map(|&item_id| {
-            let item = context.lowered.tree.get_term_item_kind(item_id)?;
-            let TermItemKind::Instance { constraints, resolution, arguments, .. } = item else {
-                return None;
-            };
-            let resolution = *resolution;
-            Some(CheckInstanceDeclaration { item_id, constraints, resolution, arguments })
-        });
-
-        for item in items {
-            check_instance_declaration(state, context, item)?;
-        }
+    for &item_id in &context.grouped.instance_items {
+        let Some(item) = context.lowered.tree.get_instance_item(item_id) else { continue };
+        let resolution = item.resolution;
+        let item = CheckInstanceDeclaration {
+            item_id,
+            constraints: &item.constraints,
+            resolution,
+            arguments: &item.arguments,
+        };
+        check_instance_declaration(state, context, item)?;
     }
 
     Ok(())
@@ -84,19 +79,21 @@ fn check_overlapping_instance_declarations<Q>(
 where
     Q: ExternalQueries,
 {
-    for scc in &context.grouped.term_scc {
-        for &item_id in scc.as_slice() {
-            state.with_error_crumb(ErrorCrumb::TermDeclaration(item_id), |state| {
-                constraint::instances::validate_declared_instance_overlap(state, context, item_id)
-            })?;
-        }
+    for &item_id in &context.grouped.instance_sources {
+        let crumb = match item_id {
+            InstanceSourceItemId::Instance(id) => ErrorCrumb::InstanceDeclaration(id),
+            InstanceSourceItemId::Derive(id) => ErrorCrumb::DeriveDeclaration(id),
+        };
+        state.with_error_crumb(crumb, |state| {
+            constraint::instances::validate_declared_instance_overlap(state, context, item_id)
+        })?;
     }
 
     Ok(())
 }
 
 struct CheckInstanceDeclaration<'a> {
-    item_id: TermItemId,
+    item_id: InstanceItemId,
     constraints: &'a [lowering::TypeId],
     resolution: Option<(FileId, TypeItemId)>,
     arguments: &'a [lowering::TypeId],
@@ -116,10 +113,7 @@ where
         return Ok(());
     };
 
-    let IndexedTermItemKind::Instance { id: instance_id } = context.indexed.items[item_id].kind
-    else {
-        return Ok(());
-    };
+    let instance_id = context.indexed.items[item_id].id;
 
     let class_kind = toolkit::lookup_file_type(state, context, class_file, class_id)?;
 
@@ -215,48 +209,36 @@ fn check_instance_members<Q>(state: &mut CheckState, context: &CheckContext<Q>) 
 where
     Q: ExternalQueries,
 {
-    for scc in &context.grouped.term_scc {
-        for &item_id in scc.as_slice() {
-            let Some(TermItemKind::Instance { members, resolution, .. }) =
-                context.lowered.tree.get_term_item_kind(item_id)
-            else {
-                continue;
-            };
+    for &item_id in &context.grouped.instance_items {
+        let Some(item) = context.lowered.tree.get_instance_item(item_id) else { continue };
+        let Some((class_file, class_id)) = item.resolution else {
+            continue;
+        };
+        let instance_id = context.indexed.items[item_id].id;
 
-            let Some((class_file, class_id)) = *resolution else {
-                continue;
-            };
+        let Some(checked_instance) = state.checked.lookup_instance(instance_id) else {
+            continue;
+        };
 
-            let IndexedTermItemKind::Instance { id: instance_id } =
-                context.indexed.items[item_id].kind
-            else {
-                continue;
-            };
+        let Some(instance) = toolkit::instance_info(
+            state,
+            context,
+            checked_instance.signature,
+            checked_instance.resolution,
+        )?
+        else {
+            continue;
+        };
 
-            let Some(checked_instance) = state.checked.lookup_instance(instance_id) else {
-                continue;
-            };
-
-            let Some(instance) = toolkit::instance_info(
-                state,
-                context,
-                checked_instance.signature,
-                checked_instance.resolution,
-            )?
-            else {
-                continue;
-            };
-
-            check_instance_member_groups(
-                state,
-                context,
-                item_id,
-                members,
-                (class_file, class_id),
-                checked_instance.signature,
-                &instance,
-            )?;
-        }
+        check_instance_member_groups(
+            state,
+            context,
+            item_id,
+            &item.members,
+            (class_file, class_id),
+            checked_instance.signature,
+            &instance,
+        )?;
     }
 
     Ok(())
@@ -265,7 +247,7 @@ where
 fn check_instance_member_groups<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    instance_item_id: TermItemId,
+    instance_item_id: InstanceItemId,
     members: &[lowering::InstanceMemberGroup],
     (class_file, class_id): (FileId, TypeItemId),
     instance_signature: TypeId,
@@ -274,7 +256,7 @@ fn check_instance_member_groups<Q>(
 where
     Q: ExternalQueries,
 {
-    state.with_error_crumb(ErrorCrumb::TermDeclaration(instance_item_id), |state| {
+    state.with_error_crumb(ErrorCrumb::InstanceDeclaration(instance_item_id), |state| {
         state.with_implication(|state| {
             let FreshenedInstanceRigids {
                 constraints: instance_constraints,
@@ -383,7 +365,7 @@ where
                     type_id: instance_signature,
                     kind: tree::TermDeclarationKind::Instance(instance),
                 };
-                state.checked.tree.insert_term(instance_item_id, declaration);
+                state.checked.tree.insert_instance(instance_item_id, declaration);
                 Ok(())
             })
         })

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -9,7 +9,7 @@ use std::ops::Index;
 use std::sync::Arc;
 
 use files::FileId;
-use indexing::{DeriveId, EquationSourceId, TermItemId, TypeItemId};
+use indexing::{DeriveId, DeriveItemId, EquationSourceId, InstanceItemId, TermItemId, TypeItemId};
 use la_arena::{Arena, ArenaMap, Idx};
 use lowering::LetBindingNameGroupId;
 use rustc_hash::FxHashMap;
@@ -29,6 +29,8 @@ pub type LocalDeclarationId = Idx<LocalDeclaration>;
 pub struct CheckedTree {
     pub(crate) arena: CheckedTreeArena,
     terms: ArenaMap<TermItemId, TermDeclarationId>,
+    instances: ArenaMap<InstanceItemId, TermDeclarationId>,
+    derives: ArenaMap<DeriveItemId, TermDeclarationId>,
     types: ArenaMap<TypeItemId, TypeDeclarationId>,
     lets: ArenaMap<LetBindingNameGroupId, LocalDeclarationId>,
     sections: FxHashMap<lowering::ExpressionId, BinderId>,
@@ -417,8 +419,48 @@ impl CheckedTree {
         self.terms.get(source).copied()
     }
 
+    pub fn insert_instance(
+        &mut self,
+        source: InstanceItemId,
+        declaration: TermDeclaration,
+    ) -> TermDeclarationId {
+        let declaration = self.arena.terms.alloc(declaration);
+        self.instances.insert(source, declaration);
+        declaration
+    }
+
+    pub fn lookup_instance(&self, source: InstanceItemId) -> Option<TermDeclarationId> {
+        self.instances.get(source).copied()
+    }
+
+    pub fn insert_derive(
+        &mut self,
+        source: DeriveItemId,
+        declaration: TermDeclaration,
+    ) -> TermDeclarationId {
+        let declaration = self.arena.terms.alloc(declaration);
+        self.derives.insert(source, declaration);
+        declaration
+    }
+
+    pub fn lookup_derive(&self, source: DeriveItemId) -> Option<TermDeclarationId> {
+        self.derives.get(source).copied()
+    }
+
     pub(crate) fn iter_terms(&self) -> impl Iterator<Item = (TermItemId, TermDeclarationId)> + '_ {
         self.terms.iter().map(|(source, declaration)| (source, *declaration))
+    }
+
+    pub(crate) fn iter_instances(
+        &self,
+    ) -> impl Iterator<Item = (InstanceItemId, TermDeclarationId)> + '_ {
+        self.instances.iter().map(|(source, declaration)| (source, *declaration))
+    }
+
+    pub(crate) fn iter_derives(
+        &self,
+    ) -> impl Iterator<Item = (DeriveItemId, TermDeclarationId)> + '_ {
+        self.derives.iter().map(|(source, declaration)| (source, *declaration))
     }
 
     pub fn insert_let(&mut self, declaration: LocalDeclaration) -> LocalDeclarationId {

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use building_types::QueryResult;
 use files::FileId;
-use indexing::{IndexedTermItem, IndexedTermItemKind, IndexedTypeItem};
+use indexing::{IndexedTermItem, IndexedTypeItem, InstanceSourceItemId, OrderedTermItemId};
 use lowering::TermVariableResolution;
 use pretty::{Arena, DocAllocator, DocBuilder};
 use rustc_hash::FxHashMap;
@@ -25,7 +25,8 @@ use crate::tree::{
     ExpressionId, ExpressionKind, GuardedAlternative, GuardedExpression, InstanceDeclaration,
     InstanceImplementation, InstanceMember, LetBindingChunk, LetBindings, LocalDeclarationId,
     PatternGuard, RecordBinderField, RecordExpressionField, RecordExpressionUpdate,
-    TermDeclarationKind, TypeDeclarationKind, VariableResolution, WhereExpression,
+    TermDeclarationId, TermDeclarationKind, TypeDeclarationKind, VariableResolution,
+    WhereExpression,
 };
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
@@ -253,37 +254,64 @@ where
                 term_names.allocate_display_name(SmolStr::clone(name));
             }
         }
-
-        for (term_id, IndexedTermItem { name, .. }) in self.indexed.items.iter_terms() {
-            let Some(declaration_id) = self.checked.tree.lookup_term(term_id) else {
-                continue;
+        for item_id in self.indexed.items.instance_sources() {
+            let name = match item_id {
+                InstanceSourceItemId::Instance(id) => &self.indexed.items[*id].name,
+                InstanceSourceItemId::Derive(id) => &self.indexed.items[*id].name,
             };
-            let declaration = &self.checked.tree[declaration_id];
-            match &declaration.kind {
-                TermDeclarationKind::Value(_) => {
-                    let Some(name) = name else { continue };
-                    let Some(declaration) = self.value_declaration(term_id, name)? else {
+            if let Some(name) = name {
+                term_names.allocate_display_name(SmolStr::clone(name));
+            }
+        }
+
+        for &item_id in self.indexed.items.ordered_terms() {
+            match item_id {
+                OrderedTermItemId::Term(term_id) => {
+                    let item = &self.indexed.items[term_id];
+                    let Some(declaration_id) = self.checked.tree.lookup_term(term_id) else {
                         continue;
                     };
-                    declarations.push(declaration);
+                    let declaration = &self.checked.tree[declaration_id];
+                    match &declaration.kind {
+                        TermDeclarationKind::Value(_) => {
+                            let Some(name) = &item.name else { continue };
+                            let Some(declaration) = self.value_declaration(term_id, name)? else {
+                                continue;
+                            };
+                            declarations.push(declaration);
+                        }
+                        TermDeclarationKind::Foreign => {
+                            let Some(name) = &item.name else { continue };
+                            let type_id = self.signature_type_pretty.render(declaration.type_id);
+                            let declaration =
+                                self.arena.text(format!("foreign import {name} :: {type_id}"));
+                            declarations.push(declaration);
+                        }
+                        TermDeclarationKind::Constructor(_) => {}
+                        TermDeclarationKind::Instance(_) => {
+                            unreachable!("invariant violated: instance stored as a term symbol")
+                        }
+                    }
                 }
-                TermDeclarationKind::Foreign => {
-                    let Some(name) = name else { continue };
-                    let type_id = self.signature_type_pretty.render(declaration.type_id);
-                    let declaration =
-                        self.arena.text(format!("foreign import {name} :: {type_id}"));
-                    declarations.push(declaration);
+                OrderedTermItemId::Instance(id) => {
+                    let name = &self.indexed.items[id].name;
+                    let declaration_id = self.checked.tree.lookup_instance(id);
+                    self.push_instance_declaration(
+                        &mut declarations,
+                        &mut term_names,
+                        name,
+                        declaration_id,
+                    )?;
                 }
-                TermDeclarationKind::Constructor(_) => {}
-                TermDeclarationKind::Instance(instance) => {
-                    let name = if let Some(name) = name {
-                        SmolStr::clone(name)
-                    } else {
-                        let base = self.dictionary_base_name(declaration.type_id, instance)?;
-                        term_names.allocate_display_name(base)
-                    };
-                    let declaration = self.instance_declaration(term_id, &name)?;
-                    declarations.push(declaration);
+                OrderedTermItemId::Derive(id) => {
+                    let name = &self.indexed.items[id].name;
+                    let declaration_id = self.checked.tree.lookup_derive(id);
+                    self.push_instance_declaration(
+                        &mut declarations,
+                        &mut term_names,
+                        name,
+                        declaration_id,
+                    )?;
                 }
             }
         }
@@ -299,6 +327,27 @@ where
         } else {
             Ok(self.arena.nil())
         }
+    }
+
+    fn push_instance_declaration(
+        &mut self,
+        declarations: &mut Vec<Doc<'arena>>,
+        term_names: &mut PrettyNames,
+        name: &Option<SmolStr>,
+        declaration_id: Option<TermDeclarationId>,
+    ) -> QueryResult<()> {
+        let Some(declaration_id) = declaration_id else { return Ok(()) };
+        let declaration = &self.checked.tree[declaration_id];
+        let TermDeclarationKind::Instance(instance) = &declaration.kind else { return Ok(()) };
+        let name = if let Some(name) = name {
+            SmolStr::clone(name)
+        } else {
+            let base = self.dictionary_base_name(declaration.type_id, instance)?;
+            term_names.allocate_display_name(base)
+        };
+        let declaration = self.instance_declaration(declaration_id, &name)?;
+        declarations.push(declaration);
+        Ok(())
     }
 
     fn data_declaration(
@@ -489,14 +538,9 @@ where
 
     fn instance_declaration(
         &mut self,
-        term_id: indexing::TermItemId,
+        declaration_id: TermDeclarationId,
         name: &str,
     ) -> QueryResult<Doc<'arena>> {
-        let declaration_id = self
-            .checked
-            .tree
-            .lookup_term(term_id)
-            .expect("invariant violated: missing checked instance declaration");
         let declaration = &self.checked.tree[declaration_id];
         let TermDeclarationKind::Instance(instance) = &declaration.kind else {
             unreachable!("invariant violated: term declaration is not an instance");
@@ -1709,25 +1753,22 @@ where
         let indexed =
             if file_id == self.file_id { None } else { Some(self.queries.indexed(file_id)?) };
         let indexed = indexed.as_deref().unwrap_or(self.indexed);
-        let mut term_items = indexed.items.iter_terms();
-        let term_id = term_items.find_map(|(term_id, item)| {
-            let matches = match (&item.kind, origin) {
-                (
-                    IndexedTermItemKind::Instance { id },
-                    InstanceCandidateOrigin::Instance(_, origin_id),
-                ) => *id == origin_id,
-                (
-                    IndexedTermItemKind::Derive { id },
-                    InstanceCandidateOrigin::Derive(_, origin_id),
-                ) => *id == origin_id,
-                (_, _) => false,
-            };
-            matches.then_some(term_id)
-        });
-        let Some(term_id) = term_id else {
+        let item_id = match origin {
+            InstanceCandidateOrigin::Instance(_, id) => {
+                indexed.pairs.instance_to_item(id).map(InstanceSourceItemId::Instance)
+            }
+            InstanceCandidateOrigin::Derive(_, id) => {
+                indexed.pairs.derive_to_item(id).map(InstanceSourceItemId::Derive)
+            }
+        };
+        let Some(item_id) = item_id else {
             return Ok(UNKNOWN_INSTANCE_EVIDENCE);
         };
-        if let Some(name) = &indexed.items[term_id].name {
+        let item_name = match item_id {
+            InstanceSourceItemId::Instance(id) => &indexed.items[id].name,
+            InstanceSourceItemId::Derive(id) => &indexed.items[id].name,
+        };
+        if let Some(name) = item_name {
             return Ok(SmolStr::clone(name));
         }
 
@@ -1740,20 +1781,35 @@ where
                 names.allocate_display_name(SmolStr::clone(name));
             }
         }
-        for (candidate_id, candidate) in indexed.items.iter_terms() {
-            if candidate.name.is_some() {
+        for &candidate_id in indexed.items.instance_sources() {
+            let name = match candidate_id {
+                InstanceSourceItemId::Instance(id) => &indexed.items[id].name,
+                InstanceSourceItemId::Derive(id) => &indexed.items[id].name,
+            };
+            if let Some(name) = name {
+                names.allocate_display_name(SmolStr::clone(name));
+            }
+        }
+        for &candidate_id in indexed.items.instance_sources() {
+            let (candidate_name, declaration_id) = match candidate_id {
+                InstanceSourceItemId::Instance(id) => {
+                    (&indexed.items[id].name, checked.tree.lookup_instance(id))
+                }
+                InstanceSourceItemId::Derive(id) => {
+                    (&indexed.items[id].name, checked.tree.lookup_derive(id))
+                }
+            };
+            if candidate_name.is_some() {
                 continue;
             }
-            let Some(declaration_id) = checked.tree.lookup_term(candidate_id) else {
-                continue;
-            };
+            let Some(declaration_id) = declaration_id else { continue };
             let declaration = &checked.tree[declaration_id];
             let TermDeclarationKind::Instance(instance) = &declaration.kind else {
                 continue;
             };
             let base = self.dictionary_base_name(declaration.type_id, instance)?;
             let name = names.allocate_display_name(base);
-            if candidate_id == term_id {
+            if candidate_id == item_id {
                 return Ok(name);
             }
         }

--- a/compiler-core/diagnostics/src/context.rs
+++ b/compiler-core/diagnostics/src/context.rs
@@ -200,6 +200,14 @@ where
             ErrorCrumb::TypeDeclaration(id) => {
                 self.indexed.type_item_ptr(self.stabilized, *id).next()?
             }
+            ErrorCrumb::InstanceDeclaration(id) => {
+                let source = self.indexed.items[*id].id;
+                self.stabilized.syntax_ptr(source)?
+            }
+            ErrorCrumb::DeriveDeclaration(id) => {
+                let source = self.indexed.items[*id].id;
+                self.stabilized.syntax_ptr(source)?
+            }
             ErrorCrumb::InferringDoBind(id)
             | ErrorCrumb::InferringDoDiscard(id)
             | ErrorCrumb::CheckingDoLet(id) => self.stabilized.syntax_ptr(*id)?,

--- a/compiler-core/documenting/src/algorithm.rs
+++ b/compiler-core/documenting/src/algorithm.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashMap;
 
-use indexing::{IndexedModule, TermItemId, TypeItemId};
+use indexing::{DeriveItemId, IndexedModule, InstanceItemId, TermItemId, TypeItemId};
 use parsing::ParsedModule;
 use stabilizing::StabilizedModule;
 
@@ -10,6 +10,8 @@ pub struct State {
     pub documentation: String,
     pub terms: FxHashMap<TermItemId, DocumentedTerm>,
     pub types: FxHashMap<TypeItemId, DocumentedType>,
+    pub instances: FxHashMap<InstanceItemId, DocumentedTerm>,
+    pub derives: FxHashMap<DeriveItemId, DocumentedTerm>,
 }
 
 pub fn document_module(
@@ -37,5 +39,17 @@ pub fn document_module(
 
     let types = types.collect();
 
-    State { documentation, terms, types }
+    let instances = indexed.items.iter_instances().map(|(id, item)| {
+        let documentation = annotation::instance_documentation(stabilized, &annotations, item.id);
+        (id, DocumentedTerm { documentation })
+    });
+    let instances = instances.collect();
+
+    let derives = indexed.items.iter_derives().map(|(id, item)| {
+        let documentation = annotation::derive_documentation(stabilized, &annotations, item.id);
+        (id, DocumentedTerm { documentation })
+    });
+    let derives = derives.collect();
+
+    State { documentation, terms, types, instances, derives }
 }

--- a/compiler-core/documenting/src/annotation.rs
+++ b/compiler-core/documenting/src/annotation.rs
@@ -61,19 +61,13 @@ pub fn term_documentation(
     item: &IndexedTermItem,
 ) -> String {
     match &item.kind {
-        IndexedTermItemKind::ClassMember { id } => {
+        IndexedTermItemKind::ClassMember { id, .. } => {
             signature_equation_documentation(stabilized, annotations, &Some(*id), &Some(*id))
         }
         IndexedTermItemKind::Constructor { id, .. } => {
             data_constructor_item_documentation(stabilized, annotations, *id)
         }
-        IndexedTermItemKind::Derive { id } => {
-            signature_equation_documentation(stabilized, annotations, &Some(*id), &Some(*id))
-        }
         IndexedTermItemKind::Foreign { id } => {
-            signature_equation_documentation(stabilized, annotations, &Some(*id), &Some(*id))
-        }
-        IndexedTermItemKind::Instance { id } => {
             signature_equation_documentation(stabilized, annotations, &Some(*id), &Some(*id))
         }
         IndexedTermItemKind::Operator { id } => {
@@ -84,6 +78,22 @@ pub fn term_documentation(
             signature_equation_documentation(stabilized, annotations, signature, &equation)
         }
     }
+}
+
+pub fn instance_documentation(
+    stabilized: &StabilizedModule,
+    annotations: &AnnotationIndex,
+    id: indexing::InstanceId,
+) -> String {
+    signature_equation_documentation(stabilized, annotations, &Some(id), &Some(id))
+}
+
+pub fn derive_documentation(
+    stabilized: &StabilizedModule,
+    annotations: &AnnotationIndex,
+    id: indexing::DeriveId,
+) -> String {
+    signature_equation_documentation(stabilized, annotations, &Some(id), &Some(id))
 }
 
 pub fn type_documentation(

--- a/compiler-core/documenting/src/lib.rs
+++ b/compiler-core/documenting/src/lib.rs
@@ -5,13 +5,15 @@ use std::sync::Arc;
 
 use rustc_hash::FxHashMap;
 
-use indexing::{TermItemId, TypeItemId};
+use indexing::{DeriveItemId, InstanceItemId, TermItemId, TypeItemId};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct DocumentedModule {
     pub documentation: String,
     pub terms: FxHashMap<TermItemId, DocumentedTerm>,
     pub types: FxHashMap<TypeItemId, DocumentedType>,
+    pub instances: FxHashMap<InstanceItemId, DocumentedTerm>,
+    pub derives: FxHashMap<DeriveItemId, DocumentedTerm>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,7 +32,7 @@ pub fn document_module(
     stabilized: &stabilizing::StabilizedModule,
     indexed: &indexing::IndexedModule,
 ) -> Arc<DocumentedModule> {
-    let algorithm::State { documentation, terms, types } =
+    let algorithm::State { documentation, terms, types, instances, derives } =
         algorithm::document_module(source, parsed, stabilized, indexed);
-    Arc::new(DocumentedModule { documentation, terms, types })
+    Arc::new(DocumentedModule { documentation, terms, types, instances, derives })
 }

--- a/compiler-core/indexing/src/algorithm.rs
+++ b/compiler-core/indexing/src/algorithm.rs
@@ -70,6 +70,7 @@ impl<'a> State<'a> {
 
     fn alloc_term(&mut self, item: IndexedTermItem) -> TermItemId {
         let id = self.items.terms.alloc(item);
+        self.items.ordered_terms.push(OrderedTermItemId::Term(id));
         self.open = Some(OpenItemGroup::Term(id));
         id
     }
@@ -77,6 +78,22 @@ impl<'a> State<'a> {
     fn alloc_type(&mut self, item: IndexedTypeItem) -> TypeItemId {
         let id = self.items.types.alloc(item);
         self.open = Some(OpenItemGroup::Type(id));
+        id
+    }
+
+    fn alloc_instance(&mut self, item: IndexedInstanceItem) -> InstanceItemId {
+        let id = self.items.instances.alloc(item);
+        self.items.instance_sources.push(InstanceSourceItemId::Instance(id));
+        self.items.ordered_terms.push(OrderedTermItemId::Instance(id));
+        self.open = None;
+        id
+    }
+
+    fn alloc_derive(&mut self, item: IndexedDeriveItem) -> DeriveItemId {
+        let id = self.items.derives.alloc(item);
+        self.items.instance_sources.push(InstanceSourceItemId::Derive(id));
+        self.items.ordered_terms.push(OrderedTermItemId::Derive(id));
+        self.open = None;
         id
     }
 }
@@ -146,7 +163,7 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
             let chain_id = stabilized.lookup_cst(cst).expect_id();
             for (position, cst) in cst.instance_declarations().enumerate() {
                 let instance_id = stabilized.lookup_cst(&cst).expect_id();
-                let term_id = index_instance(state, instance_id, &cst);
+                let item_id = index_instance(state, instance_id, &cst);
                 debug_assert!(
                     state
                         .pairs
@@ -156,8 +173,8 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                     "invariant violated: instance IDs are not in source order",
                 );
                 state.pairs.instance_chain.push((instance_id, chain_id, position as u32));
-                state.pairs.instance_to_term.push((instance_id, term_id));
-                state.pairs.declaration_to_term.push((declaration_id, term_id));
+                state.pairs.instance_to_item.push((instance_id, item_id));
+                state.pairs.declaration_to_instance.push((declaration_id, item_id));
                 if let Some(cst) = cst.instance_statements() {
                     for cst in cst.children() {
                         let m_id = stabilized.lookup_cst(&cst).expect_id();
@@ -267,7 +284,7 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
             if let Some(cst) = cst.class_statements() {
                 for cst in cst.children() {
                     let member_id = stabilized.lookup_cst(&cst).expect_id();
-                    let term_id = index_class_member(state, member_id, &cst);
+                    let term_id = index_class_member(state, type_id, member_id, &cst);
                     if let IndexedTypeItemKind::Class { members, .. } =
                         &mut state.items.types[type_id].kind
                     {
@@ -428,9 +445,9 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
         }
         cst::Declaration::DeriveDeclaration(cst) => {
             let id = stabilized.lookup_cst(cst).expect_id();
-            let term_id = index_derive(state, id, cst);
-            state.pairs.derive_to_term.push((id, term_id));
-            state.pairs.declaration_to_term.push((declaration_id, term_id));
+            let item_id = index_derive(state, id, cst);
+            state.pairs.derive_to_item.push((id, item_id));
+            state.pairs.declaration_to_derive.push((declaration_id, item_id));
         }
     }
 }
@@ -610,17 +627,22 @@ fn index_data_constructor(
 ) -> TermItemId {
     let name = name_from_token(state.source, cst.name_token());
     let kind = IndexedTermItemKind::Constructor { id, type_id };
-    state.items.terms.alloc(IndexedTermItem { name, kind, exported: false })
+    let item_id = state.items.terms.alloc(IndexedTermItem { name, kind, exported: false });
+    state.items.ordered_terms.push(OrderedTermItemId::Term(item_id));
+    item_id
 }
 
 fn index_class_member(
     state: &mut State,
+    parent: TypeItemId,
     id: ClassMemberId,
     cst: &cst::ClassMemberStatement,
 ) -> TermItemId {
     let name = name_from_token(state.source, cst.name_token());
-    let kind = IndexedTermItemKind::ClassMember { id };
-    state.items.terms.alloc(IndexedTermItem { name, kind, exported: false })
+    let kind = IndexedTermItemKind::ClassMember { id, parent };
+    let item_id = state.items.terms.alloc(IndexedTermItem { name, kind, exported: false });
+    state.items.ordered_terms.push(OrderedTermItemId::Term(item_id));
+    item_id
 }
 
 fn index_foreign_data(
@@ -646,30 +668,26 @@ fn index_foreign_value(
     })
 }
 
-fn index_instance(state: &mut State, id: InstanceId, cst: &cst::InstanceDeclaration) -> TermItemId {
+fn index_instance(
+    state: &mut State,
+    id: InstanceId,
+    cst: &cst::InstanceDeclaration,
+) -> InstanceItemId {
     let name = cst.instance_name().and_then(|n| {
         let token = n.name_token()?;
         let text = token.text(state.source);
         Some(SmolStr::from(text))
     });
-    state.alloc_term(IndexedTermItem {
-        name,
-        kind: IndexedTermItemKind::Instance { id },
-        exported: true,
-    })
+    state.alloc_instance(IndexedInstanceItem { name, id })
 }
 
-fn index_derive(state: &mut State, id: DeriveId, cst: &cst::DeriveDeclaration) -> TermItemId {
+fn index_derive(state: &mut State, id: DeriveId, cst: &cst::DeriveDeclaration) -> DeriveItemId {
     let name = cst.instance_name().and_then(|n| {
         let token = n.name_token()?;
         let text = token.text(state.source);
         Some(SmolStr::from(text))
     });
-    state.alloc_term(IndexedTermItem {
-        name,
-        kind: IndexedTermItemKind::Derive { id },
-        exported: true,
-    })
+    state.alloc_derive(IndexedDeriveItem { name, id })
 }
 
 fn validate_items(state: &mut State) {

--- a/compiler-core/indexing/src/items.rs
+++ b/compiler-core/indexing/src/items.rs
@@ -14,17 +14,50 @@ pub struct IndexedTermItem {
 /// The source declarations grouped into an [`IndexedTermItem`].
 #[derive(Debug, PartialEq, Eq)]
 pub enum IndexedTermItemKind {
-    ClassMember { id: ClassMemberId },
+    ClassMember { id: ClassMemberId, parent: TypeItemId },
     Constructor { id: DataConstructorId, type_id: Option<TypeItemId> },
-    Derive { id: DeriveId },
     Foreign { id: ForeignValueId },
-    Instance { id: InstanceId },
     Operator { id: InfixId },
     Value { signature: Option<ValueSignatureId>, equations: Vec<ValueEquationId> },
 }
 
 /// A module-local term identity preserved by later compiler representations.
 pub type TermItemId = Idx<IndexedTermItem>;
+
+/// An instance declaration that participates in instance checking but not the term namespace.
+#[derive(Debug, PartialEq, Eq)]
+pub struct IndexedInstanceItem {
+    pub name: Option<SmolStr>,
+    pub id: InstanceId,
+}
+
+/// A module-local identity for an instance declaration.
+pub type InstanceItemId = Idx<IndexedInstanceItem>;
+
+/// A derive declaration that participates in instance checking but not the term namespace.
+#[derive(Debug, PartialEq, Eq)]
+pub struct IndexedDeriveItem {
+    pub name: Option<SmolStr>,
+    pub id: DeriveId,
+}
+
+/// A module-local identity for a derive declaration.
+pub type DeriveItemId = Idx<IndexedDeriveItem>;
+
+/// The source order used when checking overlap between declared and derived instances.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstanceSourceItemId {
+    Instance(InstanceItemId),
+    Derive(DeriveItemId),
+}
+
+/// Term symbols, instance declarations, and derive declarations in source allocation order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrderedTermItemId {
+    Term(TermItemId),
+    Instance(InstanceItemId),
+    Derive(DeriveItemId),
+}
 
 /// A type item assembled from the source declarations that share its module-level identity.
 #[derive(Debug, PartialEq, Eq)]

--- a/compiler-core/indexing/src/lib.rs
+++ b/compiler-core/indexing/src/lib.rs
@@ -179,6 +179,10 @@ pub enum TypeSelection {
 pub struct IndexedItems {
     terms: Arena<IndexedTermItem>,
     types: Arena<IndexedTypeItem>,
+    instances: Arena<IndexedInstanceItem>,
+    derives: Arena<IndexedDeriveItem>,
+    instance_sources: Vec<InstanceSourceItemId>,
+    ordered_terms: Vec<OrderedTermItemId>,
 }
 
 impl IndexedItems {
@@ -188,6 +192,22 @@ impl IndexedItems {
 
     pub fn iter_types(&self) -> impl Iterator<Item = (TypeItemId, &IndexedTypeItem)> {
         self.types.iter()
+    }
+
+    pub fn iter_instances(&self) -> impl Iterator<Item = (InstanceItemId, &IndexedInstanceItem)> {
+        self.instances.iter()
+    }
+
+    pub fn iter_derives(&self) -> impl Iterator<Item = (DeriveItemId, &IndexedDeriveItem)> {
+        self.derives.iter()
+    }
+
+    pub fn instance_sources(&self) -> &[InstanceSourceItemId] {
+        &self.instance_sources
+    }
+
+    pub fn ordered_terms(&self) -> &[OrderedTermItemId] {
+        &self.ordered_terms
     }
 }
 
@@ -204,6 +224,22 @@ impl ops::Index<TypeItemId> for IndexedItems {
 
     fn index(&self, index: TypeItemId) -> &IndexedTypeItem {
         &self.types[index]
+    }
+}
+
+impl ops::Index<InstanceItemId> for IndexedItems {
+    type Output = IndexedInstanceItem;
+
+    fn index(&self, index: InstanceItemId) -> &IndexedInstanceItem {
+        &self.instances[index]
+    }
+}
+
+impl ops::Index<DeriveItemId> for IndexedItems {
+    type Output = IndexedDeriveItem;
+
+    fn index(&self, index: DeriveItemId) -> &IndexedDeriveItem {
+        &self.derives[index]
     }
 }
 
@@ -258,29 +294,31 @@ impl IndexedImport {
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct IndexedPairs {
-    derive_to_term: Vec<(DeriveId, TermItemId)>,
+    derive_to_item: Vec<(DeriveId, DeriveItemId)>,
     instance_chain: Vec<(InstanceId, InstanceChainId, u32)>,
-    instance_to_term: Vec<(InstanceId, TermItemId)>,
+    instance_to_item: Vec<(InstanceId, InstanceItemId)>,
     instance_members: Vec<(InstanceId, InstanceMemberId)>,
 
     declaration_to_term: Vec<(DeclarationId, TermItemId)>,
     declaration_to_type: Vec<(DeclarationId, TypeItemId)>,
+    declaration_to_instance: Vec<(DeclarationId, InstanceItemId)>,
+    declaration_to_derive: Vec<(DeclarationId, DeriveItemId)>,
     constructor_to_term: Vec<(DataConstructorId, TermItemId)>,
     class_member_to_term: Vec<(ClassMemberId, TermItemId)>,
 }
 
 impl IndexedPairs {
-    pub fn derive_to_term(&self, id: DeriveId) -> Option<TermItemId> {
-        self.derive_to_term.iter().find_map(
-            move |(derive_id, term_id)| {
-                if *derive_id == id { Some(*term_id) } else { None }
+    pub fn derive_to_item(&self, id: DeriveId) -> Option<DeriveItemId> {
+        self.derive_to_item.iter().find_map(
+            move |(derive_id, item_id)| {
+                if *derive_id == id { Some(*item_id) } else { None }
             },
         )
     }
 
-    pub fn instance_to_term(&self, id: InstanceId) -> Option<TermItemId> {
-        self.instance_to_term.iter().find_map(move |(instance_id, term_id)| {
-            if *instance_id == id { Some(*term_id) } else { None }
+    pub fn instance_to_item(&self, id: InstanceId) -> Option<InstanceItemId> {
+        self.instance_to_item.iter().find_map(move |(instance_id, item_id)| {
+            if *instance_id == id { Some(*item_id) } else { None }
         })
     }
 
@@ -293,6 +331,18 @@ impl IndexedPairs {
     pub fn declaration_to_type(&self, id: DeclarationId) -> Option<TypeItemId> {
         self.declaration_to_type.iter().find_map(move |(declaration_id, type_id)| {
             if *declaration_id == id { Some(*type_id) } else { None }
+        })
+    }
+
+    pub fn declaration_to_instance(&self, id: DeclarationId) -> Option<InstanceItemId> {
+        self.declaration_to_instance.iter().find_map(move |(declaration_id, item_id)| {
+            if *declaration_id == id { Some(*item_id) } else { None }
+        })
+    }
+
+    pub fn declaration_to_derive(&self, id: DeclarationId) -> Option<DeriveItemId> {
+        self.declaration_to_derive.iter().find_map(move |(declaration_id, item_id)| {
+            if *declaration_id == id { Some(*item_id) } else { None }
         })
     }
 

--- a/compiler-core/indexing/src/tests.rs
+++ b/compiler-core/indexing/src/tests.rs
@@ -1,6 +1,6 @@
 use la_arena::RawIdx;
 
-use crate::{IndexedModule, IndexedTermItemKind, InstanceId, TermItemId, index_module};
+use crate::{IndexedModule, InstanceId, TermItemId, index_module};
 
 fn index(source: &str) -> IndexedModule {
     let lexed = lexing::lex(source);
@@ -14,11 +14,10 @@ fn index(source: &str) -> IndexedModule {
 }
 
 fn instance_id(indexed: &IndexedModule, name: &str) -> InstanceId {
-    let term_id = indexed.names.terms.lookup(name).unwrap();
-    let IndexedTermItemKind::Instance { id } = indexed.items[term_id].kind else {
-        panic!("expected {name} to be an instance");
-    };
-    id
+    let mut instances = indexed.items.iter_instances();
+    let (_, instance) =
+        instances.find(|(_, instance)| instance.name.as_deref() == Some(name)).unwrap();
+    instance.id
 }
 
 #[test]

--- a/compiler-core/lowering/src/algorithm.rs
+++ b/compiler-core/lowering/src/algorithm.rs
@@ -5,8 +5,9 @@ use std::sync::Arc;
 
 use files::FileId;
 use indexing::{
-    EquationSourceId, IndexedModule, IndexedTermItem, IndexedTermItemKind, IndexedTypeItem,
-    IndexedTypeItemKind, TermItemId, TypeItemId, TypeRoleId,
+    DeriveItemId, EquationSourceId, IndexedDeriveItem, IndexedInstanceItem, IndexedModule,
+    IndexedTermItem, IndexedTermItemKind, IndexedTypeItem, IndexedTypeItemKind, InstanceItemId,
+    TermItemId, TypeItemId, TypeRoleId,
 };
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -77,6 +78,12 @@ impl State {
     fn begin_type(&mut self, id: TypeItemId) {
         self.current_term = None;
         self.current_type = Some(id);
+        self.current_synonym = None;
+    }
+
+    fn begin_instance_or_derive(&mut self) {
+        self.current_term = None;
+        self.current_type = None;
         self.current_synonym = None;
     }
 
@@ -401,6 +408,20 @@ pub(super) fn lower_module(
         });
     }
 
+    for (id, item) in context.indexed.items.iter_instances() {
+        state.with_scope(|state| {
+            state.begin_instance_or_derive();
+            lower_instance_item(state, &context, id, item);
+        });
+    }
+
+    for (id, item) in context.indexed.items.iter_derives() {
+        state.with_scope(|state| {
+            state.begin_instance_or_derive();
+            lower_derive_item(state, &context, id, item);
+        });
+    }
+
     for (id, item) in context.indexed.items.iter_types() {
         state.with_scope(|state| {
             state.begin_type(id);
@@ -440,41 +461,6 @@ fn lower_term_item(
 
         IndexedTermItemKind::Constructor { .. } => (), // See lower_type_item
 
-        IndexedTermItemKind::Derive { id } => {
-            let cst = context.stabilized.ast_ptr(*id).and_then(|cst| cst.try_to_node(context.root));
-
-            let newtype = cst.as_ref().map(|cst| cst.newtype_token().is_some()).unwrap_or(false);
-
-            let resolution = cst.as_ref().and_then(|cst| {
-                let head = cst.instance_head()?;
-                lower_instance_class_reference(state, context, &head)
-            });
-
-            state.push_implicit_scope();
-            let arguments = recover! {
-                let head = cst.as_ref()?.instance_head()?;
-
-                head
-                    .children()
-                    .map(|cst| recursive::lower_type(state, context, &cst))
-                    .collect()
-            };
-
-            state.in_constraint = true;
-            let constraints = recover! {
-                cst.as_ref()?
-                    .instance_constraints()?
-                    .children()
-                    .map(|cst| recursive::lower_type(state, context, &cst))
-                    .collect()
-            };
-            state.in_constraint = false;
-            state.finish_implicit_scope();
-
-            let kind = TermItemKind::Derive { newtype, constraints, resolution, arguments };
-            state.tree.term_items.insert(item_id, kind);
-        }
-
         IndexedTermItemKind::Foreign { id } => {
             let cst = context.stabilized.ast_ptr(*id).and_then(|cst| cst.try_to_node(context.root));
 
@@ -484,44 +470,6 @@ fn lower_term_item(
             });
 
             let kind = TermItemKind::Foreign { signature };
-            state.tree.term_items.insert(item_id, kind);
-        }
-
-        IndexedTermItemKind::Instance { id } => {
-            let cst = context.stabilized.ast_ptr(*id).and_then(|cst| cst.try_to_node(context.root));
-
-            let resolution = cst.as_ref().and_then(|cst| {
-                let head = cst.instance_head()?;
-                lower_instance_class_reference(state, context, &head)
-            });
-
-            state.push_implicit_scope();
-            let arguments = recover! {
-                let head = cst.as_ref()?.instance_head()?;
-
-                head
-                    .children()
-                    .map(|cst| recursive::lower_type(state, context, &cst))
-                    .collect()
-            };
-
-            state.in_constraint = true;
-            let constraints = recover! {
-                cst.as_ref()?
-                    .instance_constraints()?
-                    .children()
-                    .map(|cst| recursive::lower_type(state, context, &cst))
-                    .collect()
-            };
-            state.in_constraint = false;
-            state.finish_implicit_scope();
-
-            let members = recover! {
-                let statements = cst.as_ref()?.instance_statements()?;
-                lower_instance_statements(state, context, &statements, resolution)
-            };
-
-            let kind = TermItemKind::Instance { constraints, resolution, arguments, members };
             state.tree.term_items.insert(item_id, kind);
         }
 
@@ -594,6 +542,80 @@ fn lower_term_item(
             state.tree.term_items.insert(item_id, kind);
         }
     }
+}
+
+fn lower_instance_item(
+    state: &mut State,
+    context: &Context,
+    item_id: InstanceItemId,
+    item: &IndexedInstanceItem,
+) {
+    let cst = context.stabilized.ast_ptr(item.id).and_then(|cst| cst.try_to_node(context.root));
+
+    let resolution = cst.as_ref().and_then(|cst| {
+        let head = cst.instance_head()?;
+        lower_instance_class_reference(state, context, &head)
+    });
+
+    state.push_implicit_scope();
+    let arguments = recover! {
+        let head = cst.as_ref()?.instance_head()?;
+        head.children().map(|cst| recursive::lower_type(state, context, &cst)).collect()
+    };
+
+    state.in_constraint = true;
+    let constraints = recover! {
+        cst.as_ref()?
+            .instance_constraints()?
+            .children()
+            .map(|cst| recursive::lower_type(state, context, &cst))
+            .collect()
+    };
+    state.in_constraint = false;
+    state.finish_implicit_scope();
+
+    let members = recover! {
+        let statements = cst.as_ref()?.instance_statements()?;
+        lower_instance_statements(state, context, &statements, resolution)
+    };
+
+    let item = InstanceItem { constraints, resolution, arguments, members };
+    state.tree.instance_items.insert(item_id, item);
+}
+
+fn lower_derive_item(
+    state: &mut State,
+    context: &Context,
+    item_id: DeriveItemId,
+    item: &IndexedDeriveItem,
+) {
+    let cst = context.stabilized.ast_ptr(item.id).and_then(|cst| cst.try_to_node(context.root));
+
+    let newtype = cst.as_ref().map(|cst| cst.newtype_token().is_some()).unwrap_or(false);
+    let resolution = cst.as_ref().and_then(|cst| {
+        let head = cst.instance_head()?;
+        lower_instance_class_reference(state, context, &head)
+    });
+
+    state.push_implicit_scope();
+    let arguments = recover! {
+        let head = cst.as_ref()?.instance_head()?;
+        head.children().map(|cst| recursive::lower_type(state, context, &cst)).collect()
+    };
+
+    state.in_constraint = true;
+    let constraints = recover! {
+        cst.as_ref()?
+            .instance_constraints()?
+            .children()
+            .map(|cst| recursive::lower_type(state, context, &cst))
+            .collect()
+    };
+    state.in_constraint = false;
+    state.finish_implicit_scope();
+
+    let item = DeriveItem { newtype, constraints, resolution, arguments };
+    state.tree.derive_items.insert(item_id, item);
 }
 
 fn lower_type_item(
@@ -834,7 +856,8 @@ fn lower_constructors(state: &mut State, context: &Context, id: TypeItemId) {
 
 fn lower_class_members(state: &mut State, context: &Context, id: TypeItemId) {
     for item_id in context.indexed.class_members(id) {
-        let IndexedTermItemKind::ClassMember { id } = context.indexed.items[item_id].kind else {
+        let IndexedTermItemKind::ClassMember { id, .. } = context.indexed.items[item_id].kind
+        else {
             unreachable!("invariant violated: expected IndexedTermItemKind::ClassMember");
         };
 

--- a/compiler-core/lowering/src/lib.rs
+++ b/compiler-core/lowering/src/lib.rs
@@ -18,7 +18,9 @@ pub use source::*;
 pub use tree::*;
 
 use files::FileId;
-use indexing::{IndexedModule, TermItemId, TypeItemId};
+use indexing::{
+    DeriveItemId, IndexedModule, InstanceItemId, InstanceSourceItemId, TermItemId, TypeItemId,
+};
 use petgraph::algo::tarjan_scc;
 use petgraph::prelude::DiGraphMap;
 use resolving::ResolvedModule;
@@ -42,6 +44,9 @@ pub struct LoweredModule {
 pub struct GroupedModule {
     pub term_scc: Vec<Scc<TermItemId>>,
     pub type_scc: Vec<Scc<TypeItemId>>,
+    pub instance_items: Vec<InstanceItemId>,
+    pub derive_items: Vec<DeriveItemId>,
+    pub instance_sources: Vec<InstanceSourceItemId>,
     pub cycle_errors: Vec<LoweringError>,
 }
 
@@ -98,6 +103,9 @@ pub fn group_module(indexed: &IndexedModule, lowered: &LoweredModule) -> Grouped
 
     let term_scc = compute_scc(term_nodes(), &lowered.term_edges);
     let type_scc = compute_scc(type_nodes(), &lowered.type_edges);
+    let instance_items = indexed.items.iter_instances().map(|(id, _)| id).collect();
+    let derive_items = indexed.items.iter_derives().map(|(id, _)| id).collect();
+    let instance_sources = indexed.items.instance_sources().to_vec();
 
     let kind_cycles = find_cycles(type_nodes(), &lowered.kind_edges);
     let synonym_cycles = find_cycles(type_nodes(), &lowered.synonym_edges);
@@ -111,7 +119,14 @@ pub fn group_module(indexed: &IndexedModule, lowered: &LoweredModule) -> Grouped
         .map(|group| LoweringError::RecursiveSynonym(RecursiveGroup { group }));
 
     let cycle_errors = kind_cycles.chain(synonym_cycles).collect();
-    GroupedModule { term_scc, type_scc, cycle_errors }
+    GroupedModule {
+        term_scc,
+        type_scc,
+        instance_items,
+        derive_items,
+        instance_sources,
+        cycle_errors,
+    }
 }
 
 fn compute_scc<N>(nodes: impl Iterator<Item = N>, edges: &FxHashSet<(N, N)>) -> Vec<Scc<N>>

--- a/compiler-core/lowering/src/tree.rs
+++ b/compiler-core/lowering/src/tree.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use files::FileId;
-use indexing::{EquationSourceId, TermItemId, TypeItemId};
+use indexing::{DeriveItemId, EquationSourceId, InstanceItemId, TermItemId, TypeItemId};
 use la_arena::{Arena, ArenaMap, Idx};
 use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
@@ -343,20 +343,8 @@ pub enum TermItemKind {
     Constructor {
         arguments: Arc<[TypeId]>,
     },
-    Derive {
-        newtype: bool,
-        constraints: Arc<[TypeId]>,
-        resolution: Option<(FileId, TypeItemId)>,
-        arguments: Arc<[TypeId]>,
-    },
     Foreign {
         signature: Option<TypeId>,
-    },
-    Instance {
-        constraints: Arc<[TypeId]>,
-        resolution: Option<(FileId, TypeItemId)>,
-        arguments: Arc<[TypeId]>,
-        members: Arc<[InstanceMemberGroup]>,
     },
     Operator {
         associativity: Option<Associativity>,
@@ -367,6 +355,22 @@ pub enum TermItemKind {
         signature: Option<TypeId>,
         equations: Arc<[Equation]>,
     },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct InstanceItem {
+    pub constraints: Arc<[TypeId]>,
+    pub resolution: Option<(FileId, TypeItemId)>,
+    pub arguments: Arc<[TypeId]>,
+    pub members: Arc<[InstanceMemberGroup]>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct DeriveItem {
+    pub newtype: bool,
+    pub constraints: Arc<[TypeId]>,
+    pub resolution: Option<(FileId, TypeItemId)>,
+    pub arguments: Arc<[TypeId]>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -450,6 +454,8 @@ pub struct LoweredTree {
     pub(crate) types: FxHashMap<TypeId, TypeKind>,
     pub(crate) term_items: ArenaMap<TermItemId, TermItemKind>,
     pub(crate) type_items: ArenaMap<TypeItemId, TypeItemKind>,
+    pub(crate) instance_items: ArenaMap<InstanceItemId, InstanceItem>,
+    pub(crate) derive_items: ArenaMap<DeriveItemId, DeriveItem>,
 
     pub(crate) do_statements: FxHashMap<DoStatementId, DoStatement>,
     pub(crate) let_binding_groups: Arena<LetBindingNameGroup>,
@@ -515,6 +521,14 @@ impl LoweredTree {
         self.type_items.get(id)
     }
 
+    pub fn get_instance_item(&self, id: InstanceItemId) -> Option<&InstanceItem> {
+        self.instance_items.get(id)
+    }
+
+    pub fn get_derive_item(&self, id: DeriveItemId) -> Option<&DeriveItem> {
+        self.derive_items.get(id)
+    }
+
     pub fn get_let_binding_group(&self, id: LetBindingNameGroupId) -> &LetBindingNameGroup {
         &self.let_binding_groups[id]
     }
@@ -578,10 +592,8 @@ impl LoweredTree {
         &self,
         statement_id: InstanceMemberId,
     ) -> Option<(FileId, TermItemId)> {
-        self.term_items.values().find_map(|item| {
-            let TermItemKind::Instance { members, .. } = item else {
-                return None;
-            };
+        self.instance_items.values().find_map(|item| {
+            let members = &item.members;
             let member = members.iter().find(|member| member.statements.contains(&statement_id))?;
             member.resolution
         })

--- a/compiler-core/resolving/src/algorithm.rs
+++ b/compiler-core/resolving/src/algorithm.rs
@@ -2,7 +2,7 @@ use building_types::QueryResult;
 use files::FileId;
 use indexing::{
     ExportKind, ImplicitItems, ImportItemId, ImportKind, IndexedImport, IndexedModule,
-    IndexedTermItemKind, IndexedTypeItemKind, TermItemId, TypeItemId,
+    IndexedTypeItemKind, TermItemId, TypeItemId,
 };
 use smol_str::SmolStr;
 
@@ -348,18 +348,7 @@ fn add_local_class(
 }
 
 fn export_module_items(state: &mut State, indexed: &IndexedModule, file: FileId) {
-    let local_terms = indexed.names.terms.iter().filter_map(|(name, id)| {
-        let item = &indexed.items[id];
-        // Instances cannot be referred to directly by their given name yet.
-        // They're simply assumed to exist in a global context for coherence.
-        if matches!(
-            item.kind,
-            IndexedTermItemKind::Instance { .. } | IndexedTermItemKind::Derive { .. }
-        ) {
-            return None;
-        }
-        Some((name, file, id))
-    });
+    let local_terms = indexed.names.terms.iter().map(|(name, id)| (name, file, id));
 
     let local_types = indexed.names.types.iter().map(|(name, id)| {
         let item = &indexed.items[id];
@@ -378,12 +367,6 @@ fn export_module_items(state: &mut State, indexed: &IndexedModule, file: FileId)
 
     let exported_terms = indexed.names.terms.iter().filter_map(|(name, id)| {
         let item = &indexed.items[id];
-        if matches!(
-            item.kind,
-            IndexedTermItemKind::Instance { .. } | IndexedTermItemKind::Derive { .. }
-        ) {
-            return None;
-        }
         if matches!(indexed.kind, ExportKind::Explicit) && !item.exported {
             return None;
         }

--- a/compiler-lsp/analyzer/src/common.rs
+++ b/compiler-lsp/analyzer/src/common.rs
@@ -1,7 +1,8 @@
 use building_types::QueryProxy;
 use files::FileId;
-use indexing::{TermItemId, TypeItemId};
+use indexing::{DeriveItemId, InstanceItemId, TermItemId, TypeItemId};
 use lsp_types::*;
+use syntax::ast::AstNode;
 use syntax::{SyntaxNode, SyntaxNodePtr};
 
 use crate::position::Utf8Range;
@@ -49,6 +50,42 @@ pub fn file_type_location(
     let range = position::utf8_range_to_protocol(&content, range, context.position_encoding())
         .ok_or(AnalyzerError::NonFatal)?;
 
+    Ok(Location { uri, range })
+}
+
+pub fn file_instance_location(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    uri: Url,
+    file_id: FileId,
+    item_id: InstanceItemId,
+) -> Result<Location, AnalyzerError> {
+    let indexed = context.queries().indexed(file_id)?;
+    file_source_location(context, uri, file_id, indexed.items[item_id].id)
+}
+
+pub fn file_derive_location(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    uri: Url,
+    file_id: FileId,
+    item_id: DeriveItemId,
+) -> Result<Location, AnalyzerError> {
+    let indexed = context.queries().indexed(file_id)?;
+    file_source_location(context, uri, file_id, indexed.items[item_id].id)
+}
+
+fn file_source_location<T: AstNode>(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    uri: Url,
+    file_id: FileId,
+    source_id: stabilizing::AstId<T>,
+) -> Result<Location, AnalyzerError> {
+    let content = context.queries().content(file_id);
+    let stabilized = context.queries().stabilized(file_id)?;
+    let range =
+        locate::id_range(&content, &context.queries().parsed(file_id)?.0, &stabilized, source_id)
+            .ok_or(AnalyzerError::NonFatal)?;
+    let range = position::utf8_range_to_protocol(&content, range, context.position_encoding())
+        .ok_or(AnalyzerError::NonFatal)?;
     Ok(Location { uri, range })
 }
 

--- a/compiler-lsp/analyzer/src/definition.rs
+++ b/compiler-lsp/analyzer/src/definition.rs
@@ -70,6 +70,16 @@ pub fn implementation(
         }
         locate::Located::TermItem(term_id) => definition_file_term(context, current_file, term_id),
         locate::Located::TypeItem(type_id) => definition_file_type(context, current_file, type_id),
+        locate::Located::InstanceItem(item_id) => {
+            let uri = common::file_uri(context, current_file)?;
+            let location = common::file_instance_location(context, uri, current_file, item_id)?;
+            Ok(Some(GotoDefinitionResponse::Scalar(location)))
+        }
+        locate::Located::DeriveItem(item_id) => {
+            let uri = common::file_uri(context, current_file)?;
+            let location = common::file_derive_location(context, uri, current_file, item_id)?;
+            Ok(Some(GotoDefinitionResponse::Scalar(location)))
+        }
         locate::Located::LetBinding(let_id) => {
             definition_let_binding(context, current_file, let_id)
         }

--- a/compiler-lsp/analyzer/src/document_highlight.rs
+++ b/compiler-lsp/analyzer/src/document_highlight.rs
@@ -50,6 +50,30 @@ pub fn implementation(
         locate::Located::TypeItem(type_id) => {
             highlight_file_type(context, current_file, current_file, type_id)
         }
+        locate::Located::InstanceItem(item_id) => {
+            let indexed = context.queries().indexed(current_file)?;
+            let mut highlights = vec![];
+            push_name_highlight(
+                context,
+                current_file,
+                &mut highlights,
+                Some(indexed.items[item_id].id),
+                position::instance_declaration_name_range,
+            )?;
+            Ok(finish_highlights(highlights))
+        }
+        locate::Located::DeriveItem(item_id) => {
+            let indexed = context.queries().indexed(current_file)?;
+            let mut highlights = vec![];
+            push_name_highlight(
+                context,
+                current_file,
+                &mut highlights,
+                Some(indexed.items[item_id].id),
+                position::declaration_name_range,
+            )?;
+            Ok(finish_highlights(highlights))
+        }
         locate::Located::LetBinding(let_binding_id) => {
             highlight_let(context, current_file, let_binding_id)
         }
@@ -669,20 +693,14 @@ fn term_item_highlights(
     }
 
     match &indexed.items[term_id].kind {
-        IndexedTermItemKind::ClassMember { id } => {
+        IndexedTermItemKind::ClassMember { id, .. } => {
             push_name_highlights!(position::class_member_name_range; Some(*id));
         }
         IndexedTermItemKind::Constructor { id, .. } => {
             push_name_highlights!(position::data_constructor_name_range; Some(*id));
         }
-        IndexedTermItemKind::Derive { id } => {
-            push_name_highlights!(position::declaration_name_range; Some(*id));
-        }
         IndexedTermItemKind::Foreign { id } => {
             push_name_highlights!(position::declaration_name_range; Some(*id));
-        }
-        IndexedTermItemKind::Instance { id } => {
-            push_name_highlights!(position::instance_declaration_name_range; Some(*id));
         }
         IndexedTermItemKind::Operator { id } => {
             push_name_highlights!(position::infix_operator_range; Some(*id));

--- a/compiler-lsp/analyzer/src/extract.rs
+++ b/compiler-lsp/analyzer/src/extract.rs
@@ -111,19 +111,13 @@ impl AnnotationSyntaxRange {
         let item = &indexed.items[term_id];
 
         let range = match &item.kind {
-            IndexedTermItemKind::ClassMember { id } => {
+            IndexedTermItemKind::ClassMember { id, .. } => {
                 signature_equation_range(&stabilized, &root, &Some(*id), &Some(*id))
             }
             IndexedTermItemKind::Constructor { id, .. } => {
                 signature_equation_range(&stabilized, &root, &Some(*id), &Some(*id))
             }
-            IndexedTermItemKind::Derive { id } => {
-                signature_equation_range(&stabilized, &root, &Some(*id), &Some(*id))
-            }
             IndexedTermItemKind::Foreign { id } => {
-                signature_equation_range(&stabilized, &root, &Some(*id), &Some(*id))
-            }
-            IndexedTermItemKind::Instance { id } => {
                 signature_equation_range(&stabilized, &root, &Some(*id), &Some(*id))
             }
             IndexedTermItemKind::Operator { id } => {

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -81,6 +81,21 @@ pub fn implementation(
         }
         locate::Located::TermItem(term_id) => hover_file_term(engine, current_file, term_id),
         locate::Located::TypeItem(type_id) => hover_file_type(engine, current_file, type_id),
+        locate::Located::InstanceItem(item_id) => {
+            let indexed = engine.indexed(current_file)?;
+            let checked = engine.checked(current_file)?;
+            let item = &indexed.items[item_id];
+            let signature = checked.lookup_instance(item.id).map(|instance| instance.signature);
+            hover_instance_signature(engine, &checked, item.name.as_deref(), signature)
+        }
+        locate::Located::DeriveItem(item_id) => {
+            let indexed = engine.indexed(current_file)?;
+            let checked = engine.checked(current_file)?;
+            let item = &indexed.items[item_id];
+            let signature =
+                checked.lookup_derived_instance(item.id).map(|instance| instance.signature);
+            hover_instance_signature(engine, &checked, item.name.as_deref(), signature)
+        }
         locate::Located::LetBinding(let_id) => hover_let(engine, current_file, let_id),
         locate::Located::Nothing => Ok(None),
     }?;
@@ -89,6 +104,19 @@ pub fn implementation(
         hover.range = range;
         hover
     }))
+}
+
+fn hover_instance_signature(
+    engine: &impl AnalyzerQueries,
+    checked: &checking::CheckedModule,
+    name: Option<&str>,
+    signature: Option<checking::TypeId>,
+) -> Result<Option<Hover>, AnalyzerError> {
+    let signature = signature.ok_or(AnalyzerError::NonFatal)?;
+    let pretty = Pretty::with_config(engine, checked, PRETTY_CONFIG);
+    let value = pretty.render_signature(name.unwrap_or("<unknown>"), signature).to_string();
+    let value = MarkedString::from_language_code("purescript".to_string(), value);
+    Ok(Some(Hover { contents: HoverContents::Scalar(value), range: None }))
 }
 
 fn hover_name_range(token: Option<SyntaxToken>, offset: TextSize) -> Option<TextRange> {

--- a/compiler-lsp/analyzer/src/locate.rs
+++ b/compiler-lsp/analyzer/src/locate.rs
@@ -339,6 +339,10 @@ fn locate_node(
             };
         let (file_id, type_id) = resolution?;
         Some(Located::InstanceHead(file_id, type_id))
+    } else if cst::InstanceDeclaration::can_cast(kind) {
+        let ptr = ptr.cast()?;
+        let id = stabilized.lookup_ptr(&ptr)?;
+        indexed.pairs.instance_to_item(id).map(Located::InstanceItem)
     } else if cst::Declaration::can_cast(kind) {
         let ptr = ptr.cast()?;
         let id = stabilized.lookup_ptr(&ptr)?;

--- a/compiler-lsp/analyzer/src/locate.rs
+++ b/compiler-lsp/analyzer/src/locate.rs
@@ -4,7 +4,8 @@ use std::iter;
 
 use files::FileId;
 use indexing::{
-    ImportItemId, IndexedModule, IndexedTermItemKind, IndexedTypeItemKind, TermItemId, TypeItemId,
+    DeriveItemId, ImportItemId, IndexedModule, IndexedTermItemKind, IndexedTypeItemKind,
+    InstanceItemId, TermItemId, TypeItemId,
 };
 use lowering::{
     BinderId, ExpressionId, LetBindingNameGroupId, LoweredModule, RecordAccessLabelId, RecordPunId,
@@ -46,26 +47,22 @@ pub fn instance_head_ranges(
     target: (FileId, TypeItemId),
 ) -> Vec<Utf8Range> {
     let root = parsed.syntax_node();
-    let ranges = indexed.items.iter_terms().filter_map(|(term_id, item)| {
-        let kind = lowered.tree.get_term_item_kind(term_id)?;
-        let resolution = match kind {
-            TermItemKind::Instance { resolution, .. } | TermItemKind::Derive { resolution, .. } => {
-                resolution.as_ref()
+    let ranges = indexed.items.instance_sources().iter().filter_map(|item_id| match item_id {
+        indexing::InstanceSourceItemId::Instance(id) => {
+            let item = &indexed.items[*id];
+            let lowered = lowered.tree.get_instance_item(*id)?;
+            if lowered.resolution != Some(target) {
+                return None;
             }
-            _ => None,
-        }?;
-        if *resolution != target {
-            return None;
+            instance_head_range(content, &root, stabilized, item.id)
         }
-
-        match &item.kind {
-            IndexedTermItemKind::Instance { id } => {
-                instance_head_range(content, &root, stabilized, *id)
+        indexing::InstanceSourceItemId::Derive(id) => {
+            let item = &indexed.items[*id];
+            let lowered = lowered.tree.get_derive_item(*id)?;
+            if lowered.resolution != Some(target) {
+                return None;
             }
-            IndexedTermItemKind::Derive { id } => {
-                instance_head_range(content, &root, stabilized, *id)
-            }
-            _ => None,
+            instance_head_range(content, &root, stabilized, item.id)
         }
     });
     ranges.collect()
@@ -206,6 +203,8 @@ pub enum Located {
     InstanceMember(FileId, TermItemId),
     TermItem(TermItemId),
     TypeItem(TypeItemId),
+    InstanceItem(InstanceItemId),
+    DeriveItem(DeriveItemId),
     LetBinding(LetBindingNameGroupId),
     Nothing,
 }
@@ -325,31 +324,28 @@ fn locate_node(
         let id = stabilized.lookup_ptr(&ptr)?;
         Some(Located::TypeOperator(id))
     } else if cst::InstanceHead::can_cast(kind) {
-        let term_id =
+        let resolution =
             if let Some(instance) = node.ancestors().find_map(cst::InstanceDeclaration::cast) {
                 let ptr = AstPtr::new(&instance);
                 let instance_id = stabilized.lookup_ptr(&ptr)?;
-                indexed.pairs.instance_to_term(instance_id)?
+                let item_id = indexed.pairs.instance_to_item(instance_id)?;
+                lowered.tree.get_instance_item(item_id)?.resolution
             } else {
                 let derive = node.ancestors().find_map(cst::DeriveDeclaration::cast)?;
                 let ptr = AstPtr::new(&derive);
                 let derive_id = stabilized.lookup_ptr(&ptr)?;
-                indexed.pairs.derive_to_term(derive_id)?
+                let item_id = indexed.pairs.derive_to_item(derive_id)?;
+                lowered.tree.get_derive_item(item_id)?.resolution
             };
-        let kind = lowered.tree.get_term_item_kind(term_id)?;
-        let resolution = match kind {
-            TermItemKind::Instance { resolution, .. } | TermItemKind::Derive { resolution, .. } => {
-                resolution.as_ref()
-            }
-            _ => None,
-        }?;
-        let (file_id, type_id) = resolution;
-        Some(Located::InstanceHead(*file_id, *type_id))
+        let (file_id, type_id) = resolution?;
+        Some(Located::InstanceHead(file_id, type_id))
     } else if cst::Declaration::can_cast(kind) {
         let ptr = ptr.cast()?;
         let id = stabilized.lookup_ptr(&ptr)?;
         None.or_else(|| indexed.pairs.declaration_to_term(id).map(Located::TermItem))
             .or_else(|| indexed.pairs.declaration_to_type(id).map(Located::TypeItem))
+            .or_else(|| indexed.pairs.declaration_to_instance(id).map(Located::InstanceItem))
+            .or_else(|| indexed.pairs.declaration_to_derive(id).map(Located::DeriveItem))
     } else if cst::LetBinding::can_cast(kind) {
         let node = cst::LetBinding::cast(node)?;
         match node {

--- a/compiler-lsp/analyzer/src/references.rs
+++ b/compiler-lsp/analyzer/src/references.rs
@@ -72,6 +72,16 @@ pub fn implementation(
         locate::Located::TypeItem(type_id) => {
             references_file_type(context, current_file, current_file, type_id)
         }
+        locate::Located::InstanceItem(item_id) => {
+            let uri = common::file_uri(context, current_file)?;
+            let location = common::file_instance_location(context, uri, current_file, item_id)?;
+            Ok(Some(vec![location]))
+        }
+        locate::Located::DeriveItem(item_id) => {
+            let uri = common::file_uri(context, current_file)?;
+            let location = common::file_derive_location(context, uri, current_file, item_id)?;
+            Ok(Some(vec![location]))
+        }
         locate::Located::LetBinding(let_id) => references_let(context, current_file, let_id),
         locate::Located::BinderPun(pun_id) => references_binder_pun(context, current_file, pun_id),
         locate::Located::ExpressionPun(pun_id) => {

--- a/compiler-lsp/analyzer/src/rename.rs
+++ b/compiler-lsp/analyzer/src/rename.rs
@@ -1,8 +1,8 @@
 use building_types::QueryProxy;
 use files::FileId;
 use indexing::{
-    ImportId, ImportItemId, ImportKind, IndexedTermItemKind, IndexedTypeItemKind, TermItemId,
-    TypeItemId,
+    DeriveItemId, ImportId, ImportItemId, ImportKind, IndexedTermItemKind, IndexedTypeItemKind,
+    InstanceItemId, TermItemId, TypeItemId,
 };
 use lowering::{
     BinderId, BinderKind, ExpressionKind, LetBindingNameGroupId, RecordPunId,
@@ -20,6 +20,8 @@ mod edit;
 enum RenameTarget {
     Term(FileId, TermItemId),
     Type(FileId, TypeItemId),
+    Instance(FileId, InstanceItemId),
+    Derive(FileId, DeriveItemId),
     Binder(FileId, BinderId),
     LetBinding(FileId, LetBindingNameGroupId),
     RecordPun(FileId, RecordPunId),
@@ -32,6 +34,8 @@ impl RenameTarget {
         match self {
             RenameTarget::Term(file_id, _)
             | RenameTarget::Type(file_id, _)
+            | RenameTarget::Instance(file_id, _)
+            | RenameTarget::Derive(file_id, _)
             | RenameTarget::Binder(file_id, _)
             | RenameTarget::LetBinding(file_id, _)
             | RenameTarget::RecordPun(file_id, _)
@@ -96,6 +100,9 @@ pub fn implementation(
             edits.collect_declaration(target, &new_name)?;
             edits.collect_item_surfaces(target, &old_name, &new_name)?;
         }
+        RenameTarget::Instance(_, _) | RenameTarget::Derive(_, _) => {
+            edits.collect_declaration(target, &new_name)?;
+        }
         RenameTarget::Binder(_, _)
         | RenameTarget::LetBinding(_, _)
         | RenameTarget::RecordPun(_, _) => {
@@ -132,7 +139,10 @@ fn rename_conflicts(
             let target = TermVariableResolution::RecordPun(pun_id);
             local_rename_conflicts(context, file_id, target, new_name)
         }
-        RenameTarget::Qualifier(_, _) | RenameTarget::Module(_) => Ok(false),
+        RenameTarget::Instance(_, _)
+        | RenameTarget::Derive(_, _)
+        | RenameTarget::Qualifier(_, _)
+        | RenameTarget::Module(_) => Ok(false),
     }
 }
 
@@ -630,6 +640,8 @@ fn rename_target(
         locate::Located::InstanceHead(file_id, type_id) => RenameTarget::Type(file_id, type_id),
         locate::Located::TermItem(term_id) => RenameTarget::Term(current_file, term_id),
         locate::Located::TypeItem(type_id) => RenameTarget::Type(current_file, type_id),
+        locate::Located::InstanceItem(item_id) => RenameTarget::Instance(current_file, item_id),
+        locate::Located::DeriveItem(item_id) => RenameTarget::Derive(current_file, item_id),
         locate::Located::LetBinding(binding_id) => {
             RenameTarget::LetBinding(current_file, binding_id)
         }
@@ -786,9 +798,6 @@ fn target_name(
             let kind = match item.kind {
                 IndexedTermItemKind::Constructor { .. } => NameKind::Upper,
                 IndexedTermItemKind::Operator { .. } => NameKind::Operator,
-                IndexedTermItemKind::Derive { .. } | IndexedTermItemKind::Instance { .. } => {
-                    return Ok(None);
-                }
                 _ => NameKind::Lower,
             };
 
@@ -808,6 +817,14 @@ fn target_name(
             };
 
             Some((name.to_string(), kind))
+        }
+        RenameTarget::Instance(file_id, item_id) => {
+            let indexed = context.queries().indexed(file_id)?;
+            indexed.items[item_id].name.as_ref().map(|name| (name.to_string(), NameKind::Lower))
+        }
+        RenameTarget::Derive(file_id, item_id) => {
+            let indexed = context.queries().indexed(file_id)?;
+            indexed.items[item_id].name.as_ref().map(|name| (name.to_string(), NameKind::Lower))
         }
         RenameTarget::Binder(file_id, binder_id) => {
             let lowered = context.queries().lowered(file_id)?;

--- a/compiler-lsp/analyzer/src/rename/edit.rs
+++ b/compiler-lsp/analyzer/src/rename/edit.rs
@@ -440,6 +440,16 @@ where
             RenameTarget::Type(file_id, type_id) => {
                 self.type_declaration_edits(file_id, type_id, new_name)
             }
+            RenameTarget::Instance(file_id, item_id) => {
+                let indexed = self.context.queries().indexed(file_id)?;
+                push_name_edits!(self, file_id, new_name, position::instance_declaration_name_range; Some(indexed.items[item_id].id));
+                Ok(())
+            }
+            RenameTarget::Derive(file_id, item_id) => {
+                let indexed = self.context.queries().indexed(file_id)?;
+                push_name_edits!(self, file_id, new_name, position::declaration_name_range; Some(indexed.items[item_id].id));
+                Ok(())
+            }
             RenameTarget::Binder(file_id, binder_id) => {
                 self.binder_declaration_edit(file_id, binder_id, new_name)
             }
@@ -543,20 +553,14 @@ where
         let indexed = self.context.queries().indexed(file_id)?;
 
         match &indexed.items[term_id].kind {
-            IndexedTermItemKind::ClassMember { id } => {
+            IndexedTermItemKind::ClassMember { id, .. } => {
                 push_name_edits!(self, file_id, new_name, position::class_member_name_range; Some(*id));
             }
             IndexedTermItemKind::Constructor { id, .. } => {
                 push_name_edits!(self, file_id, new_name, position::data_constructor_name_range; Some(*id));
             }
-            IndexedTermItemKind::Derive { id } => {
-                push_name_edits!(self, file_id, new_name, position::declaration_name_range; Some(*id));
-            }
             IndexedTermItemKind::Foreign { id } => {
                 push_name_edits!(self, file_id, new_name, position::declaration_name_range; Some(*id));
-            }
-            IndexedTermItemKind::Instance { id } => {
-                push_name_edits!(self, file_id, new_name, position::instance_declaration_name_range; Some(*id));
             }
             IndexedTermItemKind::Operator { id } => {
                 push_name_edits!(self, file_id, new_name, position::infix_operator_range; Some(*id));
@@ -680,6 +684,8 @@ where
                     }
                 }
                 RenameTarget::Binder(_, _)
+                | RenameTarget::Instance(_, _)
+                | RenameTarget::Derive(_, _)
                 | RenameTarget::LetBinding(_, _)
                 | RenameTarget::RecordPun(_, _)
                 | RenameTarget::Qualifier(_, _)
@@ -780,6 +786,8 @@ where
                 }
             }
             RenameTarget::Binder(_, _)
+            | RenameTarget::Instance(_, _)
+            | RenameTarget::Derive(_, _)
             | RenameTarget::LetBinding(_, _)
             | RenameTarget::RecordPun(_, _)
             | RenameTarget::Qualifier(_, _)

--- a/compiler-lsp/analyzer/src/symbols.rs
+++ b/compiler-lsp/analyzer/src/symbols.rs
@@ -12,10 +12,9 @@ fn term_symbol_kind(kind: &IndexedTermItemKind) -> SymbolKind {
         IndexedTermItemKind::Constructor { .. } => SymbolKind::CONSTRUCTOR,
         IndexedTermItemKind::ClassMember { .. } => SymbolKind::METHOD,
         IndexedTermItemKind::Operator { .. } => SymbolKind::OPERATOR,
-        IndexedTermItemKind::Value { .. }
-        | IndexedTermItemKind::Foreign { .. }
-        | IndexedTermItemKind::Derive { .. }
-        | IndexedTermItemKind::Instance { .. } => SymbolKind::FUNCTION,
+        IndexedTermItemKind::Value { .. } | IndexedTermItemKind::Foreign { .. } => {
+            SymbolKind::FUNCTION
+        }
     }
 }
 

--- a/compiler-lsp/documentation/src/render.rs
+++ b/compiler-lsp/documentation/src/render.rs
@@ -251,11 +251,44 @@ impl<'a> ModuleEncoder<'a> {
         let name = term_item.name.as_ref().map(|name| name.to_string());
         let documentation =
             term_documentation.and_then(|term| optional_string(&term.documentation));
-        let signature = term_signature(term_id, term_item, &self.checked)
+        let signature = term_signature(term_id, &self.checked)
             .map(|signature| self.type_encoder.encode_signature(signature))
             .transpose()?;
 
         Ok(schema::TermItem { name, documentation, signature, kind: term_kind(&term_item.kind) })
+    }
+
+    fn encode_instance_item(
+        &mut self,
+        item_id: InstanceDocumentItemId,
+    ) -> Result<schema::TermItem, Error> {
+        let (name, documentation, signature, kind) = match item_id {
+            InstanceDocumentItemId::Instance(id) => {
+                let item = &self.indexed.items[id];
+                let documentation = self.documented.instances.get(&id);
+                let signature = self.checked.lookup_instance(item.id).map(|item| item.signature);
+                (&item.name, documentation, signature, schema::TermKind::Instance)
+            }
+            InstanceDocumentItemId::Derive(id) => {
+                let item = &self.indexed.items[id];
+                let documentation = self.documented.derives.get(&id);
+                let signature =
+                    self.checked.lookup_derived_instance(item.id).map(|item| item.signature);
+                (&item.name, documentation, signature, schema::TermKind::Derive)
+            }
+        };
+        let name = name.as_ref().map(ToString::to_string);
+        let documentation = documentation.and_then(|item| optional_string(&item.documentation));
+        let signature =
+            signature.map(|signature| self.type_encoder.encode_signature(signature)).transpose()?;
+        Ok(schema::TermItem { name, documentation, signature, kind })
+    }
+
+    fn encode_instance_items(
+        &mut self,
+        items: impl IntoIterator<Item = InstanceDocumentItemId>,
+    ) -> Result<Vec<schema::TermItem>, Error> {
+        items.into_iter().map(|item| self.encode_instance_item(item)).collect()
     }
 
     fn encode_functional_dependencies(
@@ -290,7 +323,7 @@ impl<'a> ModuleEncoder<'a> {
     fn encode_type_item(
         &mut self,
         type_id: indexing::TypeItemId,
-        instances: impl IntoIterator<Item = indexing::TermItemId>,
+        instances: impl IntoIterator<Item = InstanceDocumentItemId>,
     ) -> Result<schema::TypeItem, Error> {
         let indexed = Arc::clone(&self.indexed);
         let type_item = &indexed.items[type_id];
@@ -313,7 +346,7 @@ impl<'a> ModuleEncoder<'a> {
                 };
 
                 let constructors = self.encode_term_items(constructors.iter().copied())?;
-                let instances = self.encode_term_items(instance_ids.iter().copied())?;
+                let instances = self.encode_instance_items(instance_ids.iter().copied())?;
 
                 schema::TypeItemForm::Data { signature, declaration, constructors, instances }
             }
@@ -327,7 +360,7 @@ impl<'a> ModuleEncoder<'a> {
                 };
 
                 let constructors = self.encode_term_items(constructors.iter().copied())?;
-                let instances = self.encode_term_items(instance_ids.iter().copied())?;
+                let instances = self.encode_instance_items(instance_ids.iter().copied())?;
 
                 schema::TypeItemForm::Newtype { signature, declaration, constructors, instances }
             }
@@ -338,7 +371,7 @@ impl<'a> ModuleEncoder<'a> {
                     None
                 };
 
-                let instances = self.encode_term_items(instance_ids.iter().copied())?;
+                let instances = self.encode_instance_items(instance_ids.iter().copied())?;
 
                 schema::TypeItemForm::Synonym { signature, equation, instances }
             }
@@ -355,7 +388,7 @@ impl<'a> ModuleEncoder<'a> {
                     };
 
                 let members = self.encode_term_items(members.iter().copied())?;
-                let instances = self.encode_term_items(instance_ids.iter().copied())?;
+                let instances = self.encode_instance_items(instance_ids.iter().copied())?;
 
                 schema::TypeItemForm::Class {
                     signature,
@@ -367,7 +400,7 @@ impl<'a> ModuleEncoder<'a> {
                 }
             }
             indexing::IndexedTypeItemKind::Foreign { .. } => {
-                let instances = self.encode_term_items(instance_ids.iter().copied())?;
+                let instances = self.encode_instance_items(instance_ids.iter().copied())?;
 
                 schema::TypeItemForm::Foreign { signature, instances }
             }
@@ -416,15 +449,30 @@ pub fn render_module(
     let mut types = vec![];
 
     let mut nested_terms = NestedTerms::new();
-    let mut instances_of = collect_instances_of(&encoder, &mut nested_terms);
+    let mut nested_instances = NestedInstances::new();
+    let mut instances_of = collect_instances_of(&encoder, &mut nested_instances);
     collect_constructors_members(&encoder, &mut nested_terms);
 
     let indexed = Arc::clone(&encoder.indexed);
-    for (term_id, _) in indexed.items.iter_terms() {
-        if nested_terms.contains(&term_id) {
-            continue;
+    for &item_id in indexed.items.ordered_terms() {
+        match item_id {
+            indexing::OrderedTermItemId::Term(id) if !nested_terms.contains(&id) => {
+                terms.push(encoder.encode_term_item(id)?);
+            }
+            indexing::OrderedTermItemId::Instance(id) => {
+                let id = InstanceDocumentItemId::Instance(id);
+                if !nested_instances.contains(&id) {
+                    terms.push(encoder.encode_instance_item(id)?);
+                }
+            }
+            indexing::OrderedTermItemId::Derive(id) => {
+                let id = InstanceDocumentItemId::Derive(id);
+                if !nested_instances.contains(&id) {
+                    terms.push(encoder.encode_instance_item(id)?);
+                }
+            }
+            indexing::OrderedTermItemId::Term(_) => {}
         }
-        terms.push(encoder.encode_term_item(term_id)?);
     }
     for (type_id, _) in indexed.items.iter_types() {
         let instances = instances_of.remove(&type_id).unwrap_or_default();
@@ -457,9 +505,7 @@ fn term_kind(kind: &indexing::IndexedTermItemKind) -> schema::TermKind {
     match kind {
         indexing::IndexedTermItemKind::ClassMember { .. } => schema::TermKind::ClassMember,
         indexing::IndexedTermItemKind::Constructor { .. } => schema::TermKind::Constructor,
-        indexing::IndexedTermItemKind::Derive { .. } => schema::TermKind::Derive,
         indexing::IndexedTermItemKind::Foreign { .. } => schema::TermKind::Foreign,
-        indexing::IndexedTermItemKind::Instance { .. } => schema::TermKind::Instance,
         indexing::IndexedTermItemKind::Operator { .. } => schema::TermKind::Operator,
         indexing::IndexedTermItemKind::Value { .. } => schema::TermKind::Value,
     }
@@ -467,47 +513,41 @@ fn term_kind(kind: &indexing::IndexedTermItemKind) -> schema::TermKind {
 
 fn term_signature(
     term_id: indexing::TermItemId,
-    term_item: &indexing::IndexedTermItem,
     checked: &checking::CheckedModule,
 ) -> Option<checking::TypeId> {
-    match &term_item.kind {
-        indexing::IndexedTermItemKind::Instance { id } => {
-            checked.lookup_instance(*id).map(|instance| instance.signature)
-        }
-        indexing::IndexedTermItemKind::Derive { id } => {
-            checked.lookup_derived_instance(*id).map(|instance| instance.signature)
-        }
-        _ => checked.lookup_term_item_type(term_id),
-    }
+    checked.lookup_term_item_type(term_id)
 }
 
 type NestedTerms = BTreeSet<indexing::TermItemId>;
-type InstanceParentMap = BTreeMap<indexing::TypeItemId, Vec<indexing::TermItemId>>;
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum InstanceDocumentItemId {
+    Instance(indexing::InstanceItemId),
+    Derive(indexing::DeriveItemId),
+}
+
+type NestedInstances = BTreeSet<InstanceDocumentItemId>;
+type InstanceParentMap = BTreeMap<indexing::TypeItemId, Vec<InstanceDocumentItemId>>;
 type InstanceParents = BTreeSet<indexing::TypeItemId>;
 
 fn collect_instances_of(
     encoder: &ModuleEncoder<'_>,
-    nested_terms: &mut NestedTerms,
+    nested_instances: &mut NestedInstances,
 ) -> InstanceParentMap {
     let mut instances_by_parent = InstanceParentMap::new();
 
-    for (term_id, term_item) in encoder.indexed.items.iter_terms() {
-        if !matches!(
-            term_item.kind,
-            indexing::IndexedTermItemKind::Instance { .. }
-                | indexing::IndexedTermItemKind::Derive { .. }
-        ) {
-            continue;
-        }
-
-        let parents = instance_parents(encoder, term_id, term_item);
+    for &item_id in encoder.indexed.items.instance_sources() {
+        let item_id = match item_id {
+            indexing::InstanceSourceItemId::Instance(id) => InstanceDocumentItemId::Instance(id),
+            indexing::InstanceSourceItemId::Derive(id) => InstanceDocumentItemId::Derive(id),
+        };
+        let parents = instance_parents(encoder, item_id);
         if parents.is_empty() {
             continue;
         }
 
-        nested_terms.insert(term_id);
+        nested_instances.insert(item_id);
         for parent in parents {
-            instances_by_parent.entry(parent).or_default().push(term_id);
+            instances_by_parent.entry(parent).or_default().push(item_id);
         }
     }
 
@@ -516,17 +556,23 @@ fn collect_instances_of(
 
 fn instance_parents(
     encoder: &ModuleEncoder<'_>,
-    term_id: indexing::TermItemId,
-    term_item: &indexing::IndexedTermItem,
+    item_id: InstanceDocumentItemId,
 ) -> InstanceParents {
     let mut parents = InstanceParents::new();
 
-    let checked_instance = match &term_item.kind {
-        indexing::IndexedTermItemKind::Instance { id } => encoder.checked.lookup_instance(*id),
-        indexing::IndexedTermItemKind::Derive { id } => {
-            encoder.checked.lookup_derived_instance(*id)
+    let (checked_instance, arguments) = match item_id {
+        InstanceDocumentItemId::Instance(id) => {
+            let item = &encoder.indexed.items[id];
+            let checked = encoder.checked.lookup_instance(item.id);
+            let arguments = encoder.lowered.tree.get_instance_item(id).map(|item| &item.arguments);
+            (checked, arguments)
         }
-        _ => None,
+        InstanceDocumentItemId::Derive(id) => {
+            let item = &encoder.indexed.items[id];
+            let checked = encoder.checked.lookup_derived_instance(item.id);
+            let arguments = encoder.lowered.tree.get_derive_item(id).map(|item| &item.arguments);
+            (checked, arguments)
+        }
     };
 
     if let Some(instance) = checked_instance
@@ -536,15 +582,7 @@ fn instance_parents(
         parents.insert(parent_type);
     }
 
-    let Some(term_item) = encoder.lowered.tree.get_term_item_kind(term_id) else {
-        return parents;
-    };
-
-    let arguments = match term_item {
-        lowering::TermItemKind::Instance { arguments, .. }
-        | lowering::TermItemKind::Derive { arguments, .. } => arguments,
-        _ => return parents,
-    };
+    let Some(arguments) = arguments else { return parents };
 
     for &argument in arguments.iter() {
         collect_instance_type_parents(encoder, &mut parents, argument);

--- a/tests-integration/fixtures/lsp/1786691700_locate_named_instance_chain_members/Main.purs
+++ b/tests-integration/fixtures/lsp/1786691700_locate_named_instance_chain_members/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+class Example a
+
+data First = First
+
+data Second = Second
+
+instance first :: Example First
+else instance second :: Example Second
+--            $@%&/?

--- a/tests-integration/fixtures/lsp/1786691700_locate_named_instance_chain_members/Main.snap
+++ b/tests-integration/fixtures/lsp/1786691700_locate_named_instance_chain_members/Main.snap
@@ -1,0 +1,77 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Hover at Position { line: 9, character: 14 }
+
+```
+else instance second :: Example Second
+--            $@%&/?
+```
+
+Range: <none>
+
+```purescript
+second :: Example @Type Second
+```
+
+
+GotoDefinition at Position { line: 9, character: 15 }
+
+```
+else instance second :: Example Second
+--            $@%&/?
+```
+
+file:///tests-integration/fixtures/lsp/1786691700_locate_named_instance_chain_members/Main.purs @ 9:0..9:38
+
+
+References at Position { line: 9, character: 16 }
+
+```
+else instance second :: Example Second
+--            $@%&/?
+```
+
+file:///tests-integration/fixtures/lsp/1786691700_locate_named_instance_chain_members/Main.purs @ 9:0..9:38
+
+
+DocumentHighlight at Position { line: 9, character: 17 }
+
+```
+else instance second :: Example Second
+--            $@%&/?
+```
+
+9:14..9:20
+
+
+Rename at Position { line: 9, character: 18 }
+
+```
+else instance second :: Example Second
+--            $@%&/?
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -7,5 +7,5 @@
+ data Second = Second
+
+ instance first :: Example First
+-else instance second :: Example Second
++else instance renamed :: Example Second
+ --            $@%&/?
+```
+
+
+PrepareRename at Position { line: 9, character: 19 }
+
+```
+else instance second :: Example Second
+--            $@%&/?
+```
+
+9:14..9:20 second


### PR DESCRIPTION
## Summary

Instances and derives participate in instance checking, but they are not term-namespace symbols. Keeping them in the term arena made term identities describe unrelated declarations and required downstream consumers to repeatedly filter them out.

This change gives explicit and derived instances dedicated indexing identities and carries those identities through lowering, checking, diagnostics, documentation, and LSP features. Term SCCs and resolver exports now contain only genuine term symbols.

Source-sensitive behavior remains explicit through two schedules:

- `InstanceSourceItemId` and `instance_sources` preserve declared/derived instance order for overlap checking and source attribution.
- `OrderedTermItemId` and `ordered_terms` preserve output order across terms, instances, and derives.

Constructors and class members remain term symbols. Class members retain their owning type identity, while constructors preserve recovery by storing an optional owning type identity.

## Verification

- `just format`
- `cargo check -p indexing --tests`
- `cargo check -p lowering --tests`
- `cargo check -p checking --tests`
- `cargo check -p analyzer --tests`
- `cargo check -p documentation --tests`
- `cargo nextest run -p indexing -p lowering -p checking -p documenting -p analyzer -p documentation --no-tests=pass` (78 passed)
- Full checking, semantic, lowering, resolving, and LSP integration suites passed before the final identity-only naming cleanup.