### PR TITLE
[lexing] Preserve escaped quotes after string gaps

### DIFF
--- a/compiler-core/lexing/src/lexer.rs
+++ b/compiler-core/lexing/src/lexer.rs
@@ -418,7 +418,14 @@ impl Lexer<'_> {
                 '"' => {
                     break;
                 }
-                '\\' if self.first() == '\\' || self.first() == '"' => {
+                '\\' if self.second().is_whitespace() => {
+                    self.take();
+                    self.take_while(char::is_whitespace);
+                    if self.first() == '\\' {
+                        self.take();
+                    }
+                }
+                '\\' if self.second() == '\\' || self.second() == '"' => {
                     self.take();
                     self.take();
                 }

--- a/compiler-core/lexing/tests/lexer/string_gap_escaped_quote.txt
+++ b/compiler-core/lexing/tests/lexer/string_gap_escaped_quote.txt
@@ -1,0 +1,2 @@
+"hello\
+\\"world"

--- a/compiler-core/lexing/tests/snapshots/lexer__string_gap_escaped_quote.snap
+++ b/compiler-core/lexing/tests/snapshots/lexer__string_gap_escaped_quote.snap
@@ -1,0 +1,32 @@
+---
+source: compiler-core/lexing/tests/lexer.rs
+description: "\"hello\\\n\\\\\"world\"\n"
+expression: snapshot
+---
+annotation : ""
+ qualifier : ""
+      kind : STRING
+      text : "\"hello\\\n\\\\\""
+  position : Position { line: 1, column: 1 }
+     error : None
+
+annotation : ""
+ qualifier : ""
+      kind : LOWER
+      text : "world"
+  position : Position { line: 2, column: 4 }
+     error : None
+
+annotation : ""
+ qualifier : ""
+      kind : STRING
+      text : "\"\n"
+  position : Position { line: 2, column: 9 }
+     error : Some("Unterminated single quoted string literal")
+
+annotation : ""
+ qualifier : ""
+      kind : END_OF_FILE
+      text : ""
+  position : Position { line: 3, column: 1 }
+     error : None

--- a/compiler-core/lexing/tests/snapshots/lexer__string_gap_escaped_quote.snap
+++ b/compiler-core/lexing/tests/snapshots/lexer__string_gap_escaped_quote.snap
@@ -6,25 +6,11 @@ expression: snapshot
 annotation : ""
  qualifier : ""
       kind : STRING
-      text : "\"hello\\\n\\\\\""
+      text : "\"hello\\\n\\\\\"world\""
   position : Position { line: 1, column: 1 }
      error : None
 
-annotation : ""
- qualifier : ""
-      kind : LOWER
-      text : "world"
-  position : Position { line: 2, column: 4 }
-     error : None
-
-annotation : ""
- qualifier : ""
-      kind : STRING
-      text : "\"\n"
-  position : Position { line: 2, column: 9 }
-     error : Some("Unterminated single quoted string literal")
-
-annotation : ""
+annotation : "\n"
  qualifier : ""
       kind : END_OF_FILE
       text : ""


### PR DESCRIPTION
## Problem

Normal string scanning treated every backslash as the start of a two-character escape. When a string gap was immediately followed by an escaped quote, the gap-closing backslash was consumed with the escape backslash, leaving the quote to terminate the token early. The remainder was then lexed as a lower name and an unterminated string.

## Change

Scan a backslash followed by whitespace as a string gap before handling ordinary escaped backslashes and quotes. This preserves the following backslash so it can escape the quote.

Add a focused lexer fixture whose first line ends with a backslash and whose continuation begins with two backslashes followed by a quote. The commit history first records the incorrect token split, then updates the snapshot to one `STRING` token with no error.

## Verification

- `cargo nextest run -p lexing` (65 passed)
- `cargo +nightly fmt --all -- --check`