### PR TITLE
[checking] Match expression section constraints with lambdas

### DIFF
--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -200,7 +200,7 @@ fn check_sectioned_expression<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     expression: lowering::ExpressionId,
-    section_result: &sugar::SectionResult,
+    sections: &[lowering::ExpressionId],
     expected: TypeId,
 ) -> QueryResult<ElaboratedExpression>
 where
@@ -210,7 +210,18 @@ where
     let mut parameters = vec![];
     let mut binders = vec![];
 
-    for &section_id in section_result.iter() {
+    for &section_id in sections {
+        if !parameters.is_empty() {
+            let expanded = normalise::expand(state, context, current)?;
+            let requires_abstraction = matches!(
+                context.lookup_type(expanded),
+                Type::Forall(_, _) | Type::Constrained(_, _)
+            );
+            if requires_abstraction {
+                break;
+            }
+        }
+
         let decomposed = toolkit::decompose_function(state, context, current)?;
         let parameter = if let Some((argument_type, result_type)) = decomposed {
             current = result_type;
@@ -233,11 +244,19 @@ where
         binders.push(binder);
     }
 
-    let result = infer_expression_core(state, context, expression)?;
-    let ElaboratedExpression { type_id, expression } =
-        application::instantiate_expression(state, context, result)?;
-
-    unification::subtype(state, context, type_id, current)?;
+    let (_, remaining_sections) = sections.split_at(parameters.len());
+    let ElaboratedExpression { type_id, expression } = if remaining_sections.is_empty() {
+        check_expected_expression(state, context, current, |state, expected| {
+            let inferred = infer_expression_core(state, context, expression)?;
+            let inferred = application::instantiate_expression(state, context, inferred)?;
+            unification::subtype(state, context, inferred.type_id, expected)?;
+            Ok(inferred)
+        })?
+    } else {
+        check_expected_expression(state, context, current, |state, expected| {
+            check_sectioned_expression(state, context, expression, remaining_sections, expected)
+        })?
+    };
 
     let function_type = context.intern_function_list(&parameters, type_id);
     let kind = tree::ExpressionKind::Lambda { binders: Arc::from(binders), expression };

--- a/tests-integration/fixtures/checking/1786769760_instance_member_unsafe_partial_composition/Main.purs
+++ b/tests-integration/fixtures/checking/1786769760_instance_member_unsafe_partial_composition/Main.purs
@@ -1,0 +1,27 @@
+module Main where
+
+import Data.Semigroupoid ((<<<))
+import Partial.Unsafe (unsafePartial)
+
+data Content = Sentence String | Paragraph (Array String)
+
+class ContentOverload a where
+  fromContent :: Content -> a
+  fromContentPartialLambda :: Content -> a
+  fromContentLambdaPartial :: Content -> a
+
+instance ContentOverload String where
+  fromContent = unsafePartial <<< case _ of
+    Sentence content -> content
+  fromContentPartialLambda = unsafePartial \content -> case content of
+    Sentence value -> value
+  fromContentLambdaPartial = \content -> unsafePartial case content of
+    Sentence value -> value
+
+instance ContentOverload (Array String) where
+  fromContent = unsafePartial <<< case _ of
+    Paragraph content -> content
+  fromContentPartialLambda = unsafePartial \content -> case content of
+    Paragraph value -> value
+  fromContentLambdaPartial = \content -> unsafePartial case content of
+    Paragraph value -> value

--- a/tests-integration/fixtures/checking/1786769760_instance_member_unsafe_partial_composition/Main.snap
+++ b/tests-integration/fixtures/checking/1786769760_instance_member_unsafe_partial_composition/Main.snap
@@ -26,35 +26,3 @@ instance Main.ContentOverload (Prim.Array Prim.String)
 
 Roles
 Content = []
-
-Diagnostics
-error[CannotUnify]: Cannot unify 'String' with 'Partial => String'
-  --> 14:35..15:32
-   |
-14 |   fromContent = unsafePartial <<< case _ of
-   |                                   ^~~~~~~~~
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Paragraph _
-  --> 14:35..15:32
-   |
-14 |   fromContent = unsafePartial <<< case _ of
-   |                                   ^~~~~~~~~
-error[NoInstanceFound]: No instance found for: Partial
-  --> 13:1..19:28
-   |
-13 | instance ContentOverload String where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Array String' with 'Partial => Array String'
-  --> 22:35..23:33
-   |
-22 |   fromContent = unsafePartial <<< case _ of
-   |                                   ^~~~~~~~~
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Sentence _
-  --> 22:35..23:33
-   |
-22 |   fromContent = unsafePartial <<< case _ of
-   |                                   ^~~~~~~~~
-error[NoInstanceFound]: No instance found for: Partial
-  --> 21:1..27:29
-   |
-21 | instance ContentOverload (Array String) where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786769760_instance_member_unsafe_partial_composition/Main.snap
+++ b/tests-integration/fixtures/checking/1786769760_instance_member_unsafe_partial_composition/Main.snap
@@ -1,0 +1,60 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Sentence :: Prim.String -> Main.Content
+Paragraph :: Prim.Array Prim.String -> Main.Content
+fromContent :: forall @a. Main.ContentOverload a => Main.Content -> a
+fromContentPartialLambda :: forall @a. Main.ContentOverload a => Main.Content -> a
+fromContentLambdaPartial :: forall @a. Main.ContentOverload a => Main.Content -> a
+
+Types
+Content :: Prim.Type
+ContentOverload :: Prim.Type -> Prim.Constraint
+
+Classes
+class forall (a :: Prim.Type). Main.ContentOverload a
+  fromContent :: forall @a. Main.ContentOverload a => Main.Content -> a
+  fromContentPartialLambda :: forall @a. Main.ContentOverload a => Main.Content -> a
+  fromContentLambdaPartial :: forall @a. Main.ContentOverload a => Main.Content -> a
+
+Instances
+instance Main.ContentOverload Prim.String
+instance Main.ContentOverload (Prim.Array Prim.String)
+
+Roles
+Content = []
+
+Diagnostics
+error[CannotUnify]: Cannot unify 'String' with 'Partial => String'
+  --> 14:35..15:32
+   |
+14 |   fromContent = unsafePartial <<< case _ of
+   |                                   ^~~~~~~~~
+warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Paragraph _
+  --> 14:35..15:32
+   |
+14 |   fromContent = unsafePartial <<< case _ of
+   |                                   ^~~~~~~~~
+error[NoInstanceFound]: No instance found for: Partial
+  --> 13:1..19:28
+   |
+13 | instance ContentOverload String where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify 'Array String' with 'Partial => Array String'
+  --> 22:35..23:33
+   |
+22 |   fromContent = unsafePartial <<< case _ of
+   |                                   ^~~~~~~~~
+warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Sentence _
+  --> 22:35..23:33
+   |
+22 |   fromContent = unsafePartial <<< case _ of
+   |                                   ^~~~~~~~~
+error[NoInstanceFound]: No instance found for: Partial
+  --> 21:1..27:29
+   |
+21 | instance ContentOverload (Array String) where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786770660_section_lambda_constrained_parameter_parity/Main.purs
+++ b/tests-integration/fixtures/checking/1786770660_section_lambda_constrained_parameter_parity/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+data Unit = Unit
+
+foreign import consume :: (Unit -> Partial => Int -> Int) -> Unit
+foreign import use :: Unit -> Int -> Int
+
+sectioned :: Unit
+sectioned = consume (use _ _)
+
+lowered :: Unit
+lowered = consume (\unit value -> use unit value)

--- a/tests-integration/fixtures/checking/1786770660_section_lambda_constrained_parameter_parity/Main.snap
+++ b/tests-integration/fixtures/checking/1786770660_section_lambda_constrained_parameter_parity/Main.snap
@@ -15,15 +15,3 @@ Unit :: Prim.Type
 
 Roles
 Unit = []
-
-Diagnostics
-error[CannotUnify]: Cannot unify 'Int -> (Partial => Int -> Int)' with 'Partial => Int -> Int'
-  --> 9:22..9:29
-  |
-9 | sectioned = consume (use _ _)
-  |                      ^~~~~~~
-error[CannotUnify]: Cannot unify 'Int' with 'Partial => Int -> Int'
-  --> 9:22..9:29
-  |
-9 | sectioned = consume (use _ _)
-  |                      ^~~~~~~

--- a/tests-integration/fixtures/checking/1786770660_section_lambda_constrained_parameter_parity/Main.snap
+++ b/tests-integration/fixtures/checking/1786770660_section_lambda_constrained_parameter_parity/Main.snap
@@ -1,0 +1,29 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Unit :: Main.Unit
+consume :: (Main.Unit -> (Prim.Partial => Prim.Int -> Prim.Int)) -> Main.Unit
+use :: Main.Unit -> Prim.Int -> Prim.Int
+sectioned :: Main.Unit
+lowered :: Main.Unit
+
+Types
+Unit :: Prim.Type
+
+Roles
+Unit = []
+
+Diagnostics
+error[CannotUnify]: Cannot unify 'Int -> (Partial => Int -> Int)' with 'Partial => Int -> Int'
+  --> 9:22..9:29
+  |
+9 | sectioned = consume (use _ _)
+  |                      ^~~~~~~
+error[CannotUnify]: Cannot unify 'Int' with 'Partial => Int -> Int'
+  --> 9:22..9:29
+  |
+9 | sectioned = consume (use _ _)
+  |                      ^~~~~~~

--- a/tests-integration/fixtures/semantic/1786773420_instance_unsafe_partial_expression_sections/Main.purs
+++ b/tests-integration/fixtures/semantic/1786773420_instance_unsafe_partial_expression_sections/Main.purs
@@ -1,0 +1,27 @@
+module Main where
+
+import Data.Semigroupoid ((<<<))
+import Partial.Unsafe (unsafePartial)
+
+data Content = Sentence String | Paragraph (Array String)
+
+class ContentOverload a where
+  fromContent :: Content -> a
+  fromContentPartialLambda :: Content -> a
+  fromContentLambdaPartial :: Content -> a
+
+instance ContentOverload String where
+  fromContent = unsafePartial <<< case _ of
+    Sentence content -> content
+  fromContentPartialLambda = unsafePartial \content -> case content of
+    Sentence value -> value
+  fromContentLambdaPartial = \content -> unsafePartial case content of
+    Sentence value -> value
+
+instance ContentOverload (Array String) where
+  fromContent = unsafePartial <<< case _ of
+    Paragraph content -> content
+  fromContentPartialLambda = unsafePartial \content -> case content of
+    Paragraph value -> value
+  fromContentLambdaPartial = \content -> unsafePartial case content of
+    Paragraph value -> value

--- a/tests-integration/fixtures/semantic/1786773420_instance_unsafe_partial_expression_sections/Main.snap
+++ b/tests-integration/fixtures/semantic/1786773420_instance_unsafe_partial_expression_sections/Main.snap
@@ -1,0 +1,51 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Content :: Prim.Type
+data Content
+  | Sentence :: Prim.String -> Main.Content
+  | Paragraph :: Prim.Array Prim.String -> Main.Content
+
+interface ContentOverload :: Prim.Type -> Prim.Constraint
+interface ContentOverload a where
+  fromContent :: Main.Content -> a
+  fromContentPartialLambda :: Main.Content -> a
+  fromContentLambdaPartial :: Main.Content -> a
+
+dictionary contentOverloadString :: Main.ContentOverload Prim.String where
+  fromContent :: Main.Content -> Prim.String
+  fromContent =
+    compose {semigroupoidFn} unsafePartial \v54 ->
+      (case v54 of
+        (Sentence content) -> content) {error}
+  fromContentPartialLambda :: Main.Content -> Prim.String
+  fromContentPartialLambda =
+    unsafePartial \{partialDict} ->
+      \content ->
+        case content of
+          (Sentence value) -> value
+  fromContentLambdaPartial :: Main.Content -> Prim.String
+  fromContentLambdaPartial = \content ->
+    unsafePartial \{partialDict} ->
+      case content of
+        (Sentence value) -> value
+
+dictionary contentOverloadArray :: Main.ContentOverload (Prim.Array Prim.String) where
+  fromContent :: Main.Content -> Prim.Array Prim.String
+  fromContent =
+    compose {semigroupoidFn} unsafePartial \v120 ->
+      (case v120 of
+        (Paragraph content) -> content) {error}
+  fromContentPartialLambda :: Main.Content -> Prim.Array Prim.String
+  fromContentPartialLambda =
+    unsafePartial \{partialDict} ->
+      \content ->
+        case content of
+          (Paragraph value) -> value
+  fromContentLambdaPartial :: Main.Content -> Prim.Array Prim.String
+  fromContentLambdaPartial = \content ->
+    unsafePartial \{partialDict} ->
+      case content of
+        (Paragraph value) -> value

--- a/tests-integration/fixtures/semantic/1786773420_instance_unsafe_partial_expression_sections/Main.snap
+++ b/tests-integration/fixtures/semantic/1786773420_instance_unsafe_partial_expression_sections/Main.snap
@@ -18,8 +18,9 @@ dictionary contentOverloadString :: Main.ContentOverload Prim.String where
   fromContent :: Main.Content -> Prim.String
   fromContent =
     compose {semigroupoidFn} unsafePartial \v54 ->
-      (case v54 of
-        (Sentence content) -> content) {error}
+      \{partialDict} ->
+        (case v54 of
+          (Sentence content) -> content) {partialDict}
   fromContentPartialLambda :: Main.Content -> Prim.String
   fromContentPartialLambda =
     unsafePartial \{partialDict} ->
@@ -36,8 +37,9 @@ dictionary contentOverloadArray :: Main.ContentOverload (Prim.Array Prim.String)
   fromContent :: Main.Content -> Prim.Array Prim.String
   fromContent =
     compose {semigroupoidFn} unsafePartial \v120 ->
-      (case v120 of
-        (Paragraph content) -> content) {error}
+      \{partialDict} ->
+        (case v120 of
+          (Paragraph content) -> content) {partialDict}
   fromContentPartialLambda :: Main.Content -> Prim.Array Prim.String
   fromContentPartialLambda =
     unsafePartial \{partialDict} ->

--- a/tests-integration/fixtures/semantic/1786773540_section_lambda_constrained_parameter_parity/Main.purs
+++ b/tests-integration/fixtures/semantic/1786773540_section_lambda_constrained_parameter_parity/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+data Unit = Unit
+
+foreign import consume :: (Unit -> Partial => Int -> Int) -> Unit
+foreign import use :: Unit -> Int -> Int
+
+sectioned :: Unit
+sectioned = consume (use _ _)
+
+lowered :: Unit
+lowered = consume (\unit value -> use unit value)

--- a/tests-integration/fixtures/semantic/1786773540_section_lambda_constrained_parameter_parity/Main.snap
+++ b/tests-integration/fixtures/semantic/1786773540_section_lambda_constrained_parameter_parity/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Unit :: Prim.Type
+data Unit
+  | Unit :: Main.Unit
+
+foreign import consume :: (Main.Unit -> (Prim.Partial => Prim.Int -> Prim.Int)) -> Main.Unit
+
+foreign import use :: Main.Unit -> Prim.Int -> Prim.Int
+
+sectioned :: Main.Unit
+sectioned = consume \v36 v38 -> use v36 v38
+
+lowered :: Main.Unit
+lowered = consume \unit -> \{partialDict} -> \value -> use unit value

--- a/tests-integration/fixtures/semantic/1786773540_section_lambda_constrained_parameter_parity/Main.snap
+++ b/tests-integration/fixtures/semantic/1786773540_section_lambda_constrained_parameter_parity/Main.snap
@@ -12,7 +12,7 @@ foreign import consume :: (Main.Unit -> (Prim.Partial => Prim.Int -> Prim.Int)) 
 foreign import use :: Main.Unit -> Prim.Int -> Prim.Int
 
 sectioned :: Main.Unit
-sectioned = consume \v36 v38 -> use v36 v38
+sectioned = consume \v36 -> \{partialDict} -> \v38 -> use v36 v38
 
 lowered :: Main.Unit
 lowered = consume \unit -> \{partialDict} -> \value -> use unit value


### PR DESCRIPTION
## Summary

Expression sections were consuming every placeholder before introducing constraints from the expected result type. This caused sections such as `unsafePartial <<< case _ of ...` to lose the `Partial` evidence that the equivalent explicit lambda receives, and it also grouped multiple placeholders incorrectly when constraints or foralls occurred between function parameters.

This change makes section checking use the same abstraction boundaries as lambda checking: it stops after a parameter when the remaining expected type is constrained or polymorphic, introduces that abstraction, and recursively checks the remaining section parameters. The regression fixtures cover instance members, both placements of `unsafePartial`, and a multi-parameter section alongside its explicit lambda. Semantic snapshots verify the resulting evidence placement.

## Verification

- `just t checking`
- `just t semantic`
- `just compatibility` — 630 packages, no introduced errors or warnings
- PureScript 0.15.15 reference build with package set 80.5.0