### PR TITLE
[checking] Generate unnamed instance dictionary names

### DIFF
--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -149,6 +149,26 @@ where
             .expect("critical failure: failed to render checked semantic tree");
         Ok(output.finish())
     }
+
+    pub fn render_instance_name(
+        &self,
+        file_id: FileId,
+        origin: InstanceCandidateOrigin,
+    ) -> QueryResult<SmolStr> {
+        let indexed = self.queries.indexed(file_id)?;
+        let lowered = self.queries.lowered(file_id)?;
+        let arena = Arena::new();
+        let printer = Printer::new(
+            &arena,
+            self.queries,
+            file_id,
+            &indexed,
+            &lowered,
+            self.checked,
+            self.config,
+        );
+        printer.instance_dictionary_name(origin)
+    }
 }
 
 struct Printer<'arena, 'context, 'module, Q>
@@ -248,19 +268,14 @@ where
             declarations.push(signature.append(self.arena.hardline()).append(declaration));
         }
 
-        let mut term_names = PrettyNames::new();
-        for (_, IndexedTermItem { name, .. }) in self.indexed.items.iter_terms() {
-            if let Some(name) = name {
-                term_names.allocate_display_name(SmolStr::clone(name));
-            }
-        }
+        let mut dictionary_names = PrettyNames::new();
         for item_id in self.indexed.items.instance_sources() {
             let name = match item_id {
                 InstanceSourceItemId::Instance(id) => &self.indexed.items[*id].name,
                 InstanceSourceItemId::Derive(id) => &self.indexed.items[*id].name,
             };
             if let Some(name) = name {
-                term_names.allocate_display_name(SmolStr::clone(name));
+                dictionary_names.allocate_display_name(SmolStr::clone(name));
             }
         }
 
@@ -298,7 +313,7 @@ where
                     let declaration_id = self.checked.tree.lookup_instance(id);
                     self.push_instance_declaration(
                         &mut declarations,
-                        &mut term_names,
+                        &mut dictionary_names,
                         name,
                         declaration_id,
                     )?;
@@ -308,7 +323,7 @@ where
                     let declaration_id = self.checked.tree.lookup_derive(id);
                     self.push_instance_declaration(
                         &mut declarations,
-                        &mut term_names,
+                        &mut dictionary_names,
                         name,
                         declaration_id,
                     )?;
@@ -796,40 +811,62 @@ where
         let mut base = format!("{first}{}", characters.as_str());
 
         let mut current = type_id;
+        let mut arguments = vec![];
         loop {
             match self.queries.lookup_type(current) {
                 Type::Forall(_, inner) | Type::Constrained(_, inner) | Type::Kinded(inner, _) => {
                     current = inner;
                 }
-                Type::Application(_, argument) => {
-                    if let Some(argument_name) = self.outer_type_constructor_name(argument)? {
-                        base.push_str(&argument_name);
-                    }
-                    break;
+                Type::Application(function, argument) => {
+                    arguments.push(argument);
+                    current = function;
                 }
-                Type::KindApplication(function, _) => current = function,
+                Type::KindApplication(function, argument) => {
+                    arguments.push(argument);
+                    current = function;
+                }
                 _ => break,
             }
+        }
+        for argument in arguments.into_iter().rev() {
+            self.append_type_constructor_names(&mut base, argument)?;
         }
 
         Ok(SmolStr::new(base))
     }
 
-    fn outer_type_constructor_name(
+    fn append_type_constructor_names(
         &self,
-        mut type_id: crate::TypeId,
-    ) -> QueryResult<Option<String>> {
-        loop {
-            match self.queries.lookup_type(type_id) {
-                Type::Application(function, _)
-                | Type::KindApplication(function, _)
-                | Type::Kinded(function, _) => type_id = function,
-                Type::Constructor(file_id, item_id) => {
-                    return self.type_name(file_id, item_id);
-                }
-                _ => return Ok(None),
+        name: &mut String,
+        type_id: crate::TypeId,
+    ) -> QueryResult<()> {
+        match self.queries.lookup_type(type_id) {
+            Type::Application(function, argument) | Type::KindApplication(function, argument) => {
+                self.append_type_constructor_names(name, function)?;
+                self.append_type_constructor_names(name, argument)?;
             }
+            Type::Forall(_, inner) | Type::Kinded(inner, _) => {
+                self.append_type_constructor_names(name, inner)?;
+            }
+            Type::Constrained(_, inner) => {
+                self.append_type_constructor_names(name, inner)?;
+            }
+            Type::Function(parameter, result) => {
+                name.push_str("Function");
+                self.append_type_constructor_names(name, parameter)?;
+                self.append_type_constructor_names(name, result)?;
+            }
+            Type::Constructor(file_id, item_id) => {
+                if let Some(constructor_name) = self.type_name(file_id, item_id)? {
+                    name.push_str(&constructor_name);
+                }
+            }
+            Type::Integer(value) => name.push_str(&value.to_string()),
+            Type::String(_, value) => name.push_str(&self.queries.lookup_smol_str(value)),
+            Type::Row(_) => name.push_str("Row"),
+            Type::Rigid(..) | Type::Unification(_) | Type::Free(_) | Type::Unknown(_) => {}
         }
+        Ok(())
     }
 
     fn equation_declarations(
@@ -1776,11 +1813,6 @@ where
             if file_id == self.file_id { None } else { Some(self.queries.checked(file_id)?) };
         let checked = checked.as_deref().unwrap_or(self.checked);
         let mut names = PrettyNames::new();
-        for (_, item) in indexed.items.iter_terms() {
-            if let Some(name) = &item.name {
-                names.allocate_display_name(SmolStr::clone(name));
-            }
-        }
         for &candidate_id in indexed.items.instance_sources() {
             let name = match candidate_id {
                 InstanceSourceItemId::Instance(id) => &indexed.items[id].name,

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -861,10 +861,13 @@ where
                     name.push_str(&constructor_name);
                 }
             }
-            Type::Integer(value) => name.push_str(&value.to_string()),
-            Type::String(_, value) => name.push_str(&self.queries.lookup_smol_str(value)),
             Type::Row(_) => name.push_str("Row"),
-            Type::Rigid(..) | Type::Unification(_) | Type::Free(_) | Type::Unknown(_) => {}
+            Type::Integer(_)
+            | Type::String(..)
+            | Type::Rigid(..)
+            | Type::Unification(_)
+            | Type::Free(_)
+            | Type::Unknown(_) => {}
         }
         Ok(())
     }

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -269,6 +269,12 @@ where
         }
 
         let mut dictionary_names = PrettyNames::new();
+        for (_, IndexedTermItem { name, .. }) in self.indexed.items.iter_terms() {
+            if let Some(name) = name {
+                dictionary_names.allocate_display_name(SmolStr::clone(name));
+            }
+        }
+
         for item_id in self.indexed.items.instance_sources() {
             let name = match item_id {
                 InstanceSourceItemId::Instance(id) => &self.indexed.items[*id].name,
@@ -803,10 +809,12 @@ where
         let Some(class_name) = class_name else {
             return Ok(SmolStr::new("dictionary"));
         };
+
         let mut characters = class_name.chars();
         let Some(first) = characters.next() else {
             return Ok(SmolStr::new("dictionary"));
         };
+
         let first = first.to_lowercase().collect::<String>();
         let mut base = format!("{first}{}", characters.as_str());
 
@@ -828,6 +836,7 @@ where
                 _ => break,
             }
         }
+
         for argument in arguments.into_iter().rev() {
             self.append_type_constructor_names(&mut base, argument)?;
         }
@@ -869,6 +878,7 @@ where
             | Type::Free(_)
             | Type::Unknown(_) => {}
         }
+
         Ok(())
     }
 
@@ -1793,6 +1803,7 @@ where
         let indexed =
             if file_id == self.file_id { None } else { Some(self.queries.indexed(file_id)?) };
         let indexed = indexed.as_deref().unwrap_or(self.indexed);
+
         let item_id = match origin {
             InstanceCandidateOrigin::Instance(_, id) => {
                 indexed.pairs.instance_to_item(id).map(InstanceSourceItemId::Instance)
@@ -1804,6 +1815,7 @@ where
         let Some(item_id) = item_id else {
             return Ok(UNKNOWN_INSTANCE_EVIDENCE);
         };
+
         let item_name = match item_id {
             InstanceSourceItemId::Instance(id) => &indexed.items[id].name,
             InstanceSourceItemId::Derive(id) => &indexed.items[id].name,
@@ -1815,7 +1827,14 @@ where
         let checked =
             if file_id == self.file_id { None } else { Some(self.queries.checked(file_id)?) };
         let checked = checked.as_deref().unwrap_or(self.checked);
+
         let mut names = PrettyNames::new();
+        for (_, item) in indexed.items.iter_terms() {
+            if let Some(name) = &item.name {
+                names.allocate_display_name(SmolStr::clone(name));
+            }
+        }
+
         for &candidate_id in indexed.items.instance_sources() {
             let name = match candidate_id {
                 InstanceSourceItemId::Instance(id) => &indexed.items[id].name,
@@ -1825,6 +1844,7 @@ where
                 names.allocate_display_name(SmolStr::clone(name));
             }
         }
+
         for &candidate_id in indexed.items.instance_sources() {
             let (candidate_name, declaration_id) = match candidate_id {
                 InstanceSourceItemId::Instance(id) => {

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -1,5 +1,7 @@
 use building_types::QueryProxy;
 use checking::core::pretty::{Pretty, PrettyConfig};
+use checking::evidence::InstanceCandidateOrigin;
+use checking::tree::pretty::Pretty as TreePretty;
 use files::FileId;
 use indexing::{ImportItemId, TermItemId, TypeItemId};
 use itertools::Itertools;
@@ -88,7 +90,10 @@ pub fn implementation(
             let checked = engine.checked(current_file)?;
             let item = &indexed.items[item_id];
             let signature = checked.lookup_instance(item.id).map(|instance| instance.signature);
-            hover_instance_signature(engine, &checked, item.name.as_deref(), signature)
+            let pretty = TreePretty::new(engine, &checked);
+            let origin = InstanceCandidateOrigin::Instance(current_file, item.id);
+            let name = pretty.render_instance_name(current_file, origin)?;
+            hover_instance_signature(engine, &checked, Some(&name), signature)
         }
         locate::Located::DeriveItem(item_id) => {
             let indexed = engine.indexed(current_file)?;
@@ -96,7 +101,10 @@ pub fn implementation(
             let item = &indexed.items[item_id];
             let signature =
                 checked.lookup_derived_instance(item.id).map(|instance| instance.signature);
-            hover_instance_signature(engine, &checked, item.name.as_deref(), signature)
+            let pretty = TreePretty::new(engine, &checked);
+            let origin = InstanceCandidateOrigin::Derive(current_file, item.id);
+            let name = pretty.render_instance_name(current_file, origin)?;
+            hover_instance_signature(engine, &checked, Some(&name), signature)
         }
         locate::Located::LetBinding(let_id) => hover_let(engine, current_file, let_id),
         locate::Located::Nothing => Ok(None),

--- a/tests-integration/fixtures/lsp/1786808460_unnamed_instance_dictionary_hover/Main.purs
+++ b/tests-integration/fixtures/lsp/1786808460_unnamed_instance_dictionary_hover/Main.purs
@@ -1,0 +1,14 @@
+module Main where
+
+data Pair a b = Pair a b
+
+infixr 6 type Pair as :+:
+
+class Convert :: Type -> Type -> Constraint
+class Convert source target
+
+instance Convert Int String
+-- $
+
+instance Convert (Int :+: String) Boolean
+-- $

--- a/tests-integration/fixtures/lsp/1786808460_unnamed_instance_dictionary_hover/Main.purs
+++ b/tests-integration/fixtures/lsp/1786808460_unnamed_instance_dictionary_hover/Main.purs
@@ -12,3 +12,9 @@ instance Convert Int String
 
 instance Convert (Int :+: String) Boolean
 -- $
+
+instance Convert value value
+-- $
+
+instance Convert value (value :+: value)
+-- $

--- a/tests-integration/fixtures/lsp/1786808460_unnamed_instance_dictionary_hover/Main.snap
+++ b/tests-integration/fixtures/lsp/1786808460_unnamed_instance_dictionary_hover/Main.snap
@@ -13,7 +13,7 @@ instance Convert Int String
 Range: <none>
 
 ```purescript
-<unknown> :: Convert Int String
+convertIntString :: Convert Int String
 ```
 
 
@@ -27,5 +27,33 @@ instance Convert (Int :+: String) Boolean
 Range: <none>
 
 ```purescript
-<unknown> :: Convert (Pair Int String) Boolean
+convertPairIntStringBoolean :: Convert (Pair Int String) Boolean
+```
+
+
+Hover at Position { line: 15, character: 3 }
+
+```
+instance Convert value value
+-- $
+```
+
+Range: <none>
+
+```purescript
+convert :: forall value. Convert value value
+```
+
+
+Hover at Position { line: 18, character: 3 }
+
+```
+instance Convert value (value :+: value)
+-- $
+```
+
+Range: <none>
+
+```purescript
+convertPair :: forall value. Convert value (Pair value value)
 ```

--- a/tests-integration/fixtures/lsp/1786808460_unnamed_instance_dictionary_hover/Main.snap
+++ b/tests-integration/fixtures/lsp/1786808460_unnamed_instance_dictionary_hover/Main.snap
@@ -1,0 +1,31 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Hover at Position { line: 9, character: 3 }
+
+```
+instance Convert Int String
+-- $
+```
+
+Range: <none>
+
+```purescript
+<unknown> :: Convert Int String
+```
+
+
+Hover at Position { line: 12, character: 3 }
+
+```
+instance Convert (Int :+: String) Boolean
+-- $
+```
+
+Range: <none>
+
+```purescript
+<unknown> :: Convert (Pair Int String) Boolean
+```

--- a/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
@@ -7,7 +7,7 @@ data Wrap :: forall k0. (k0 -> Prim.Type) -> k0 -> Prim.Type
 data Wrap @f @a
   | Wrap :: f a -> Main.Wrap f a
 
-dictionary eqWrap ::
+dictionary eqWrapType ::
   forall f a.
   { eq1Dict :: Data.Eq.Eq1 f } =>
   { eqDict :: Data.Eq.Eq a } =>
@@ -19,18 +19,21 @@ dictionary eqWrap ::
       (Wrap left0), (Wrap right0) ->
         if eq1 {eq1Dict} {eqDict} left0 right0 then true else false
 
-dictionary eq1Wrap :: forall f. { eq1Dict :: Data.Eq.Eq1 f } => Data.Eq.Eq1 (Main.Wrap @Prim.Type f)
+dictionary eq1WrapType ::
+  forall f.
+  { eq1Dict :: Data.Eq.Eq1 f } =>
+  Data.Eq.Eq1 (Main.Wrap @Prim.Type f)
   where
   eq1 :: forall a. Data.Eq.Eq a => Main.Wrap @Prim.Type f a -> Main.Wrap @Prim.Type f a -> Prim.Boolean
-  eq1 = \{eqDict} -> eq {eqWrap {eq1Dict} {eqDict}}
+  eq1 = \{eqDict} -> eq {eqWrapType {eq1Dict} {eqDict}}
 
-dictionary ordWrap ::
+dictionary ordWrapType ::
   forall f a.
   { ord1Dict :: Data.Ord.Ord1 f } =>
   { ordDict :: Data.Ord.Ord a } =>
   Data.Ord.Ord (Main.Wrap @Prim.Type f a)
   where
-  superclass eqDict = eqWrap {ord1Dict.eq1Dict} {ordDict.eqDict}
+  superclass eqDict = eqWrapType {ord1Dict.eq1Dict} {ordDict.eqDict}
   compare :: Main.Wrap @Prim.Type f a -> Main.Wrap @Prim.Type f a -> Data.Ordering.Ordering
   compare = \left right ->
     case left, right of
@@ -39,12 +42,12 @@ dictionary ordWrap ::
           EQ -> EQ
           ordering -> ordering
 
-dictionary ord1Wrap ::
+dictionary ord1WrapType ::
   forall f.
   { ord1Dict :: Data.Ord.Ord1 f } =>
   Data.Ord.Ord1 (Main.Wrap @Prim.Type f)
   where
-  superclass eq1Dict = eq1Wrap {ord1Dict.eq1Dict}
+  superclass eq1Dict = eq1WrapType {ord1Dict.eq1Dict}
   compare1 :: forall a.
   Data.Ord.Ord a => Main.Wrap @Prim.Type f a -> Main.Wrap @Prim.Type f a -> Data.Ordering.Ordering
-  compare1 = \{ordDict} -> compare {ordWrap {ord1Dict} {ordDict}}
+  compare1 = \{ordDict} -> compare {ordWrapType {ord1Dict} {ordDict}}

--- a/tests-integration/fixtures/semantic/1785263040_derive_functor_generated_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785263040_derive_functor_generated_bodies/Main.snap
@@ -50,7 +50,7 @@ dictionary functorIdentity :: Data.Functor.Functor Main.Identity where
     case value of
       (Identity field0) -> Identity (function field0)
 
-dictionary functorConst :: forall e. Data.Functor.Functor (Main.Const @Prim.Type e) where
+dictionary functorConstType :: forall e. Data.Functor.Functor (Main.Const @Prim.Type e) where
   map :: forall a b. (a -> b) -> Main.Const @Prim.Type e a -> Main.Const @Prim.Type e b
   map = \function value ->
     case value of
@@ -63,7 +63,7 @@ dictionary functorMaybe :: Data.Functor.Functor Main.Maybe where
       Nothing -> Nothing
       (Just field0) -> Just (function field0)
 
-dictionary functorWrap ::
+dictionary functorWrapType ::
   forall f.
   { functorDict :: Data.Functor.Functor f } =>
   Data.Functor.Functor (Main.Wrap @Prim.Type f)
@@ -73,7 +73,7 @@ dictionary functorWrap ::
     case value of
       (Wrap field0) -> Wrap (map {functorDict} (\element -> function element) field0)
 
-dictionary functorCompose ::
+dictionary functorComposeTypeType ::
   forall f g.
   { functorDict :: Data.Functor.Functor f } =>
   { functorDict1 :: Data.Functor.Functor g } =>

--- a/tests-integration/fixtures/semantic/1785318540_derive_bifunctor_generated_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785318540_derive_bifunctor_generated_bodies/Main.snap
@@ -74,7 +74,7 @@ dictionary bifunctorPair :: Data.Bifunctor.Bifunctor Main.Pair where
     case value of
       (Pair field0 field1) -> Pair (firstFunction field0) (secondFunction field1)
 
-dictionary bifunctorConst2 ::
+dictionary bifunctorConst2TypeType ::
   forall value.
   Data.Bifunctor.Bifunctor (Main.Const2 @Prim.Type @Prim.Type value)
   where
@@ -87,7 +87,7 @@ dictionary bifunctorConst2 ::
     case value of
       (Const2 field0) -> Const2 field0
 
-dictionary bifunctorWrapBoth ::
+dictionary bifunctorWrapBothTypeType ::
   forall f g.
   { functorDict :: Data.Functor.Functor f } =>
   { functorDict1 :: Data.Functor.Functor g } =>
@@ -174,7 +174,8 @@ dictionary bifunctorNestedTriple :: Data.Bifunctor.Bifunctor Main.NestedTriple w
           (\element -> secondFunction element)
           field0)
 
-dictionary bifunctorNestedTripleLast :: Data.Bifunctor.Bifunctor (Main.NestedTripleLast @Prim.Type)
+dictionary bifunctorNestedTripleLastType ::
+  Data.Bifunctor.Bifunctor (Main.NestedTripleLast @Prim.Type)
   where
   bimap :: forall a b c d.
   (a -> b) ->

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_binary_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_binary_body/Main.snap
@@ -7,7 +7,7 @@ data Nested :: forall k0 k1. (k0 -> k1 -> Prim.Type) -> k0 -> k1 -> Prim.Type
 data Nested @p @a @b
   | Nested :: p a b -> Main.Nested p a b
 
-dictionary bifunctorNested ::
+dictionary bifunctorNestedTypeType ::
   forall p.
   { bifunctorDict :: Data.Bifunctor.Bifunctor p } =>
   Data.Bifunctor.Bifunctor (Main.Nested @Prim.Type @Prim.Type p)
@@ -24,7 +24,7 @@ dictionary bifunctorNested ::
           (\element -> secondFunction element)
           field0)
 
-dictionary bifoldableNested ::
+dictionary bifoldableNestedTypeType ::
   forall p.
   { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
   Data.Bifoldable.Bifoldable (Main.Nested @Prim.Type @Prim.Type p)
@@ -55,13 +55,13 @@ dictionary bifoldableNested ::
           (\element -> secondFunction element)
           field0
 
-dictionary bitraversableNested ::
+dictionary bitraversableNestedTypeType ::
   forall p.
   { bitraversableDict :: Data.Bitraversable.Bitraversable p } =>
   Data.Bitraversable.Bitraversable (Main.Nested @Prim.Type @Prim.Type p)
   where
-  superclass bifunctorDict = bifunctorNested {bitraversableDict.bifunctorDict}
-  superclass bifoldableDict = bifoldableNested {bitraversableDict.bifoldableDict}
+  superclass bifunctorDict = bifunctorNestedTypeType {bitraversableDict.bifunctorDict}
+  superclass bifoldableDict = bifoldableNestedTypeType {bitraversableDict.bifoldableDict}
   bitraverse :: forall (f :: Prim.Type -> Prim.Type) a b c d.
   Control.Applicative.Applicative f =>
   (a -> f c) ->
@@ -81,6 +81,7 @@ dictionary bitraversableNested ::
   Main.Nested @Prim.Type @Prim.Type p (f a) (f b) -> f (Main.Nested @Prim.Type @Prim.Type p a b)
   bisequence = \{applicativeDict} ->
     \value ->
-      bitraverse {bitraversableNested {bitraversableDict}} {applicativeDict} (\effect0 -> effect0)
+      bitraverse {bitraversableNestedTypeType {bitraversableDict}} {applicativeDict}
+        (\effect0 -> effect0)
         (\effect1 -> effect1)
         value

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_unary_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_unary_body/Main.snap
@@ -7,7 +7,7 @@ data Wrap :: forall k0 k1. (k0 -> Prim.Type) -> (k1 -> Prim.Type) -> k0 -> k1 ->
 data Wrap @f @g @a @b
   | Wrap :: f a -> g b -> Main.Wrap f g a b
 
-dictionary bifunctorWrap ::
+dictionary bifunctorWrapTypeType ::
   forall f g.
   { functorDict :: Data.Functor.Functor f } =>
   { functorDict1 :: Data.Functor.Functor g } =>
@@ -23,7 +23,7 @@ dictionary bifunctorWrap ::
       (Wrap field0 field1) -> Wrap (map {functorDict} (\element -> firstFunction element) field0)
         (map {functorDict1} (\element -> secondFunction element) field1)
 
-dictionary bifoldableWrap ::
+dictionary bifoldableWrapTypeType ::
   forall f g.
   { foldableDict :: Data.Foldable.Foldable f } =>
   { foldableDict1 :: Data.Foldable.Foldable g } =>
@@ -56,14 +56,14 @@ dictionary bifoldableWrap ::
           (foldMap {foldableDict} {monoidDict} (\element -> firstFunction element) field0)
           (foldMap {foldableDict1} {monoidDict} (\element -> secondFunction element) field1)
 
-dictionary bitraversableWrap ::
+dictionary bitraversableWrapTypeType ::
   forall f g.
   { traversableDict :: Data.Traversable.Traversable f } =>
   { traversableDict1 :: Data.Traversable.Traversable g } =>
   Data.Bitraversable.Bitraversable (Main.Wrap @Prim.Type @Prim.Type f g)
   where
-  superclass bifunctorDict = bifunctorWrap {traversableDict.functorDict} {traversableDict1.functorDict}
-  superclass bifoldableDict = bifoldableWrap {traversableDict.foldableDict} {traversableDict1.foldableDict}
+  superclass bifunctorDict = bifunctorWrapTypeType {traversableDict.functorDict} {traversableDict1.functorDict}
+  superclass bifoldableDict = bifoldableWrapTypeType {traversableDict.foldableDict} {traversableDict1.foldableDict}
   bitraverse :: forall (f1 :: Prim.Type -> Prim.Type) a b c d.
   Control.Applicative.Applicative f1 =>
   (a -> f1 c) ->
@@ -85,7 +85,7 @@ dictionary bitraversableWrap ::
   Main.Wrap @Prim.Type @Prim.Type f g (f1 a) (f1 b) -> f1 (Main.Wrap @Prim.Type @Prim.Type f g a b)
   bisequence = \{applicativeDict} ->
     \value ->
-      bitraverse {bitraversableWrap {traversableDict} {traversableDict1}} {applicativeDict}
+      bitraverse {bitraversableWrapTypeType {traversableDict} {traversableDict1}} {applicativeDict}
         (\effect0 -> effect0)
         (\effect1 -> effect1)
         value

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_both_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_both_body/Main.snap
@@ -7,7 +7,7 @@ data Duplicate :: forall k0. (k0 -> k0 -> Prim.Type) -> k0 -> Prim.Type
 data Duplicate @p @a
   | Duplicate :: p a a -> Main.Duplicate p a
 
-dictionary functorDuplicate ::
+dictionary functorDuplicateType ::
   forall p.
   { bifunctorDict :: Data.Bifunctor.Bifunctor p } =>
   Data.Functor.Functor (Main.Duplicate @Prim.Type p)
@@ -15,7 +15,7 @@ dictionary functorDuplicate ::
   map :: forall a b. (a -> b) -> Main.Duplicate @Prim.Type p a -> Main.Duplicate @Prim.Type p b
   map = \function -> \(Duplicate value) -> Duplicate (bimap {bifunctorDict} function function value)
 
-dictionary foldableDuplicate ::
+dictionary foldableDuplicateType ::
   forall p.
   { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
   Data.Foldable.Foldable (Main.Duplicate @Prim.Type p)
@@ -30,13 +30,13 @@ dictionary foldableDuplicate ::
   foldMap = \{monoidDict} -> \function -> \(Duplicate value) ->
     bifoldMap {bifoldableDict} {monoidDict} function function value
 
-dictionary traversableDuplicate ::
+dictionary traversableDuplicateType ::
   forall p.
   { bitraversableDict :: Data.Bitraversable.Bitraversable p } =>
   Data.Traversable.Traversable (Main.Duplicate @Prim.Type p)
   where
-  superclass functorDict = functorDuplicate {bitraversableDict.bifunctorDict}
-  superclass foldableDict = foldableDuplicate {bitraversableDict.bifoldableDict}
+  superclass functorDict = functorDuplicateType {bitraversableDict.bifunctorDict}
+  superclass foldableDict = foldableDuplicateType {bitraversableDict.bifoldableDict}
   traverse :: forall a b (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   (a -> m b) -> Main.Duplicate @Prim.Type p a -> m (Main.Duplicate @Prim.Type p b)
@@ -53,5 +53,6 @@ dictionary traversableDuplicate ::
   Main.Duplicate @Prim.Type p (m a) -> m (Main.Duplicate @Prim.Type p a)
   sequence = \{applicativeDict} ->
     \value ->
-      traverse {traversableDuplicate {bitraversableDict}} {applicativeDict} (\effect0 -> effect0)
+      traverse {traversableDuplicateType {bitraversableDict}} {applicativeDict}
+        (\effect0 -> effect0)
         value

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_left_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_left_body/Main.snap
@@ -7,7 +7,7 @@ data LeftDuplicate :: forall k0. (k0 -> Prim.Type -> Prim.Type) -> k0 -> Prim.Ty
 data LeftDuplicate @p @a
   | LeftDuplicate :: p a Prim.Int -> Main.LeftDuplicate p a
 
-dictionary functorLeftDuplicate ::
+dictionary functorLeftDuplicateType ::
   forall p.
   { bifunctorDict :: Data.Bifunctor.Bifunctor p } =>
   Data.Functor.Functor (Main.LeftDuplicate @Prim.Type p)
@@ -16,7 +16,7 @@ dictionary functorLeftDuplicate ::
   map = \function -> \(LeftDuplicate value) ->
     LeftDuplicate (bimap {bifunctorDict} function (\fixed -> fixed) value)
 
-dictionary foldableLeftDuplicate ::
+dictionary foldableLeftDuplicateType ::
   forall p.
   { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
   Data.Foldable.Foldable (Main.LeftDuplicate @Prim.Type p)
@@ -31,13 +31,13 @@ dictionary foldableLeftDuplicate ::
   foldMap = \{monoidDict} -> \function -> \(LeftDuplicate value) ->
     bifoldMap {bifoldableDict} {monoidDict} function (\_ -> mempty {monoidDict}) value
 
-dictionary traversableLeftDuplicate ::
+dictionary traversableLeftDuplicateType ::
   forall p.
   { bitraversableDict :: Data.Bitraversable.Bitraversable p } =>
   Data.Traversable.Traversable (Main.LeftDuplicate @Prim.Type p)
   where
-  superclass functorDict = functorLeftDuplicate {bitraversableDict.bifunctorDict}
-  superclass foldableDict = foldableLeftDuplicate {bitraversableDict.bifoldableDict}
+  superclass functorDict = functorLeftDuplicateType {bitraversableDict.bifunctorDict}
+  superclass foldableDict = foldableLeftDuplicateType {bitraversableDict.bifoldableDict}
   traverse :: forall a b (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   (a -> m b) -> Main.LeftDuplicate @Prim.Type p a -> m (Main.LeftDuplicate @Prim.Type p b)
@@ -54,6 +54,6 @@ dictionary traversableLeftDuplicate ::
   Main.LeftDuplicate @Prim.Type p (m a) -> m (Main.LeftDuplicate @Prim.Type p a)
   sequence = \{applicativeDict} ->
     \value ->
-      traverse {traversableLeftDuplicate {bitraversableDict}} {applicativeDict}
+      traverse {traversableLeftDuplicateType {bitraversableDict}} {applicativeDict}
         (\effect0 -> effect0)
         value

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_const_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_const_body/Main.snap
@@ -7,13 +7,13 @@ data Const :: forall k0. Prim.Type -> k0 -> Prim.Type
 data Const @e @a
   | Const :: e -> Main.Const e a
 
-dictionary functorConst :: forall e. Data.Functor.Functor (Main.Const @Prim.Type e) where
+dictionary functorConstType :: forall e. Data.Functor.Functor (Main.Const @Prim.Type e) where
   map :: forall a b. (a -> b) -> Main.Const @Prim.Type e a -> Main.Const @Prim.Type e b
   map = \function value ->
     case value of
       (Const field0) -> Const field0
 
-dictionary foldableConst :: forall e. Data.Foldable.Foldable (Main.Const @Prim.Type e) where
+dictionary foldableConstType :: forall e. Data.Foldable.Foldable (Main.Const @Prim.Type e) where
   foldr :: forall a b. (a -> b -> b) -> b -> Main.Const @Prim.Type e a -> b
   foldr = \function accumulator value ->
     case value of
@@ -28,10 +28,10 @@ dictionary foldableConst :: forall e. Data.Foldable.Foldable (Main.Const @Prim.T
       case value of
         (Const field0) -> mempty {monoidDict}
 
-dictionary traversableConst :: forall e. Data.Traversable.Traversable (Main.Const @Prim.Type e)
+dictionary traversableConstType :: forall e. Data.Traversable.Traversable (Main.Const @Prim.Type e)
   where
-  superclass functorDict = functorConst
-  superclass foldableDict = foldableConst
+  superclass functorDict = functorConstType
+  superclass foldableDict = foldableConstType
   traverse :: forall a b (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   (a -> m b) -> Main.Const @Prim.Type e a -> m (Main.Const @Prim.Type e b)
@@ -43,4 +43,4 @@ dictionary traversableConst :: forall e. Data.Traversable.Traversable (Main.Cons
   Control.Applicative.Applicative m =>
   Main.Const @Prim.Type e (m a) -> m (Main.Const @Prim.Type e a)
   sequence = \{applicativeDict} ->
-    \value -> traverse {traversableConst} {applicativeDict} (\effect0 -> effect0) value
+    \value -> traverse {traversableConstType} {applicativeDict} (\effect0 -> effect0) value

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_nested_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_nested_body/Main.snap
@@ -7,7 +7,7 @@ data Compose :: forall k0 k1. (k0 -> Prim.Type) -> (k1 -> k0) -> k1 -> Prim.Type
 data Compose @f @g @a
   | Compose :: f (g a) -> Main.Compose f g a
 
-dictionary functorCompose ::
+dictionary functorComposeTypeType ::
   forall f g.
   { functorDict :: Data.Functor.Functor f } =>
   { functorDict1 :: Data.Functor.Functor g } =>
@@ -21,7 +21,7 @@ dictionary functorCompose ::
         (map {functorDict} (\element -> map {functorDict1} (\element -> function element) element)
           field0)
 
-dictionary foldableCompose ::
+dictionary foldableComposeTypeType ::
   forall f g.
   { foldableDict :: Data.Foldable.Foldable f } =>
   { foldableDict1 :: Data.Foldable.Foldable g } =>
@@ -53,14 +53,14 @@ dictionary foldableCompose ::
           (\element -> foldMap {foldableDict1} {monoidDict} (\element -> function element) element)
           field0
 
-dictionary traversableCompose ::
+dictionary traversableComposeTypeType ::
   forall f g.
   { traversableDict :: Data.Traversable.Traversable f } =>
   { traversableDict1 :: Data.Traversable.Traversable g } =>
   Data.Traversable.Traversable (Main.Compose @Prim.Type @Prim.Type f g)
   where
-  superclass functorDict = functorCompose {traversableDict.functorDict} {traversableDict1.functorDict}
-  superclass foldableDict = foldableCompose {traversableDict.foldableDict} {traversableDict1.foldableDict}
+  superclass functorDict = functorComposeTypeType {traversableDict.functorDict} {traversableDict1.functorDict}
+  superclass foldableDict = foldableComposeTypeType {traversableDict.foldableDict} {traversableDict1.foldableDict}
   traverse :: forall a b (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   (a -> m b) ->
@@ -80,6 +80,6 @@ dictionary traversableCompose ::
   Main.Compose @Prim.Type @Prim.Type f g (m a) -> m (Main.Compose @Prim.Type @Prim.Type f g a)
   sequence = \{applicativeDict} ->
     \value ->
-      traverse {traversableCompose {traversableDict} {traversableDict1}} {applicativeDict}
+      traverse {traversableComposeTypeType {traversableDict} {traversableDict1}} {applicativeDict}
         (\effect0 -> effect0)
         value

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_binary_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_binary_body/Main.snap
@@ -7,7 +7,7 @@ data Nested :: forall k0 k1. (k0 -> k1 -> Prim.Type) -> k0 -> k1 -> Prim.Type
 data Nested @p @a @b
   | Nested :: p a b -> Main.Nested p a b
 
-dictionary bifoldableNested ::
+dictionary bifoldableNestedTypeType ::
   forall p.
   { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
   Data.Bifoldable.Bifoldable (Main.Nested @Prim.Type @Prim.Type p)

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_unary_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_unary_body/Main.snap
@@ -7,7 +7,7 @@ data Wrap :: forall k0 k1. (k0 -> Prim.Type) -> (k1 -> Prim.Type) -> k0 -> k1 ->
 data Wrap @f @g @a @b
   | Wrap :: f a -> g b -> Main.Wrap f g a b
 
-dictionary bifoldableWrap ::
+dictionary bifoldableWrapTypeType ::
   forall f g.
   { foldableDict :: Data.Foldable.Foldable f } =>
   { foldableDict1 :: Data.Foldable.Foldable g } =>

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_both_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_both_body/Main.snap
@@ -7,7 +7,7 @@ data Duplicate :: forall k0. (k0 -> k0 -> Prim.Type) -> k0 -> Prim.Type
 data Duplicate @p @a
   | Duplicate :: p a a -> Main.Duplicate p a
 
-dictionary foldableDuplicate ::
+dictionary foldableDuplicateType ::
   forall p.
   { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
   Data.Foldable.Foldable (Main.Duplicate @Prim.Type p)

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_left_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_left_body/Main.snap
@@ -7,7 +7,7 @@ data LeftDuplicate :: forall k0. (k0 -> Prim.Type -> Prim.Type) -> k0 -> Prim.Ty
 data LeftDuplicate @p @a
   | LeftDuplicate :: p a Prim.Int -> Main.LeftDuplicate p a
 
-dictionary foldableLeftDuplicate ::
+dictionary foldableLeftDuplicateType ::
   forall p.
   { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
   Data.Foldable.Foldable (Main.LeftDuplicate @Prim.Type p)

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_right_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_right_body/Main.snap
@@ -7,7 +7,7 @@ data RightNested :: forall k0. (Prim.Type -> k0 -> Prim.Type) -> k0 -> Prim.Type
 data RightNested @p @a
   | RightNested :: p Prim.Int a -> Main.RightNested p a
 
-dictionary foldableRightNested ::
+dictionary foldableRightNestedType ::
   forall p.
   { foldableDict :: Data.Foldable.Foldable (p Prim.Int) } =>
   Data.Foldable.Foldable (Main.RightNested @Prim.Type p)

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_nested_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_nested_body/Main.snap
@@ -7,7 +7,7 @@ data Compose :: forall k0 k1. (k0 -> Prim.Type) -> (k1 -> k0) -> k1 -> Prim.Type
 data Compose @f @g @a
   | Compose :: f (g a) -> Main.Compose f g a
 
-dictionary foldableCompose ::
+dictionary foldableComposeTypeType ::
   forall f g.
   { foldableDict :: Data.Foldable.Foldable f } =>
   { foldableDict1 :: Data.Foldable.Foldable g } =>

--- a/tests-integration/fixtures/semantic/1785522600_derive_foldable_right_bifoldable_context/Main.snap
+++ b/tests-integration/fixtures/semantic/1785522600_derive_foldable_right_bifoldable_context/Main.snap
@@ -7,7 +7,7 @@ data RightNested :: forall k0. (Prim.Type -> k0 -> Prim.Type) -> k0 -> Prim.Type
 data RightNested @p @a
   | RightNested :: p Prim.Int a -> Main.RightNested p a
 
-dictionary foldableRightNested ::
+dictionary foldableRightNestedType ::
   forall p.
   { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
   Data.Foldable.Foldable (Main.RightNested @Prim.Type p)

--- a/tests-integration/fixtures/semantic/1785522600_derive_traversable_right_bitraversable_context/Main.snap
+++ b/tests-integration/fixtures/semantic/1785522600_derive_traversable_right_bitraversable_context/Main.snap
@@ -7,7 +7,7 @@ data RightNested :: forall k0. (Prim.Type -> k0 -> Prim.Type) -> k0 -> Prim.Type
 data RightNested @p @a
   | RightNested :: p Prim.Int a -> Main.RightNested p a
 
-dictionary functorRightNested ::
+dictionary functorRightNestedType ::
   forall p.
   { bifunctorDict :: Data.Bifunctor.Bifunctor p } =>
   Data.Functor.Functor (Main.RightNested @Prim.Type p)
@@ -16,7 +16,7 @@ dictionary functorRightNested ::
   map = \function -> \(RightNested value) ->
     RightNested (bimap {bifunctorDict} (\fixed -> fixed) function value)
 
-dictionary foldableRightNested ::
+dictionary foldableRightNestedType ::
   forall p.
   { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
   Data.Foldable.Foldable (Main.RightNested @Prim.Type p)
@@ -31,13 +31,13 @@ dictionary foldableRightNested ::
   foldMap = \{monoidDict} -> \function -> \(RightNested value) ->
     bifoldMap {bifoldableDict} {monoidDict} (\_ -> mempty {monoidDict}) function value
 
-dictionary traversableRightNested ::
+dictionary traversableRightNestedType ::
   forall p.
   { bitraversableDict :: Data.Bitraversable.Bitraversable p } =>
   Data.Traversable.Traversable (Main.RightNested @Prim.Type p)
   where
-  superclass functorDict = functorRightNested {bitraversableDict.bifunctorDict}
-  superclass foldableDict = foldableRightNested {bitraversableDict.bifoldableDict}
+  superclass functorDict = functorRightNestedType {bitraversableDict.bifunctorDict}
+  superclass foldableDict = foldableRightNestedType {bitraversableDict.bifoldableDict}
   traverse :: forall a b (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   (a -> m b) -> Main.RightNested @Prim.Type p a -> m (Main.RightNested @Prim.Type p b)
@@ -55,5 +55,6 @@ dictionary traversableRightNested ::
   Main.RightNested @Prim.Type p (m a) -> m (Main.RightNested @Prim.Type p a)
   sequence = \{applicativeDict} ->
     \value ->
-      traverse {traversableRightNested {bitraversableDict}} {applicativeDict} (\effect0 -> effect0)
+      traverse {traversableRightNestedType {bitraversableDict}} {applicativeDict}
+        (\effect0 -> effect0)
         value

--- a/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_binary_superclass_context/Main.snap
+++ b/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_binary_superclass_context/Main.snap
@@ -7,7 +7,7 @@ data RightNested :: forall k0. (Prim.Type -> k0 -> Prim.Type) -> k0 -> Prim.Type
 data RightNested @p @a
   | RightNested :: p Prim.Int a -> Main.RightNested p a
 
-dictionary foldableRightNested ::
+dictionary foldableRightNestedType ::
   forall p.
   { bitraversableDict :: Data.Bitraversable.Bitraversable p } =>
   Data.Foldable.Foldable (Main.RightNested @Prim.Type p)

--- a/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_concrete_instance_heads/Main.snap
+++ b/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_concrete_instance_heads/Main.snap
@@ -27,7 +27,7 @@ dictionary bifoldableProduct :: Data.Bifoldable.Bifoldable Main.Product where
         (Product field0 field1) -> append {monoidDict.semigroupDict} (firstFunction field0)
           (secondFunction field1)
 
-dictionary foldableProduct :: Data.Foldable.Foldable (Main.Product Prim.Int) where
+dictionary foldableProductInt :: Data.Foldable.Foldable (Main.Product Prim.Int) where
   foldr :: forall a b. (a -> b -> b) -> b -> Main.Product Prim.Int a -> b
   foldr = \function accumulator value ->
     case value of
@@ -46,14 +46,14 @@ dictionary foldableRightNested :: Data.Foldable.Foldable Main.RightNested where
   foldr :: forall a b. (a -> b -> b) -> b -> Main.RightNested a -> b
   foldr = \function accumulator value ->
     case value of
-      (RightNested field0) -> foldr {foldableProduct}
+      (RightNested field0) -> foldr {foldableProductInt}
         (\element accumulator -> function element accumulator)
         accumulator
         field0
   foldl :: forall a b. (b -> a -> b) -> b -> Main.RightNested a -> b
   foldl = \function accumulator value ->
     case value of
-      (RightNested field0) -> foldl {foldableProduct}
+      (RightNested field0) -> foldl {foldableProductInt}
         (\accumulator element -> function accumulator element)
         accumulator
         field0
@@ -61,6 +61,6 @@ dictionary foldableRightNested :: Data.Foldable.Foldable Main.RightNested where
   foldMap = \{monoidDict} ->
     \function value ->
       case value of
-        (RightNested field0) -> foldMap {foldableProduct} {monoidDict}
+        (RightNested field0) -> foldMap {foldableProductInt} {monoidDict}
           (\element -> function element)
           field0

--- a/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_prefers_unary_context/Main.snap
+++ b/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_prefers_unary_context/Main.snap
@@ -7,7 +7,7 @@ data RightNested :: forall k0. (Prim.Type -> k0 -> Prim.Type) -> k0 -> Prim.Type
 data RightNested @p @a
   | RightNested :: p Prim.Int a -> Main.RightNested p a
 
-dictionary foldableRightNested ::
+dictionary foldableRightNestedType ::
   forall p.
   { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
   { foldableDict :: Data.Foldable.Foldable (p Prim.Int) } =>

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_empty_data_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_empty_data_body/Main.snap
@@ -6,7 +6,8 @@ expression: report
 data Empty :: forall k0. k0 -> Prim.Type
 data Empty @a
 
-dictionary contravariantEmpty :: Data.Functor.Contravariant.Contravariant (Main.Empty @Prim.Type)
+dictionary contravariantEmptyType ::
+  Data.Functor.Contravariant.Contravariant (Main.Empty @Prim.Type)
   where
   cmap :: forall a b. (b -> a) -> Main.Empty @Prim.Type a -> Main.Empty @Prim.Type b
   cmap = \function value ->

--- a/tests-integration/fixtures/semantic/1785598200_derive_profunctor_nested_left_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_profunctor_nested_left_body/Main.snap
@@ -17,7 +17,7 @@ dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
     case value of
       (Function field0) -> Function \argument -> secondFunction (field0 (firstFunction argument))
 
-dictionary profunctorNestedLeft :: Data.Profunctor.Profunctor (Main.NestedLeft @Prim.Type) where
+dictionary profunctorNestedLeftType :: Data.Profunctor.Profunctor (Main.NestedLeft @Prim.Type) where
   dimap :: forall a b c d.
   (a -> b) -> (c -> d) -> Main.NestedLeft @Prim.Type b c -> Main.NestedLeft @Prim.Type a d
   dimap = \firstFunction secondFunction value ->

--- a/tests-integration/fixtures/semantic/1785598200_derive_profunctor_unary_preference_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_profunctor_unary_preference_body/Main.snap
@@ -23,7 +23,8 @@ dictionary functorFunction :: forall a. Data.Functor.Functor (Main.Function a) w
     case value of
       (Function field0) -> Function \argument -> function (field0 argument)
 
-dictionary profunctorNestedRight :: Data.Profunctor.Profunctor (Main.NestedRight @Prim.Type) where
+dictionary profunctorNestedRightType :: Data.Profunctor.Profunctor (Main.NestedRight @Prim.Type)
+  where
   dimap :: forall a b c d.
   (a -> b) -> (c -> d) -> Main.NestedRight @Prim.Type b c -> Main.NestedRight @Prim.Type a d
   dimap = \firstFunction secondFunction value ->

--- a/tests-integration/fixtures/semantic/1785598320_derive_contravariant_given_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598320_derive_contravariant_given_application_body/Main.snap
@@ -7,7 +7,7 @@ data Nested :: forall k0. (k0 -> Prim.Type) -> k0 -> Prim.Type
 data Nested @f @a
   | Nested :: f a -> Main.Nested f a
 
-dictionary contravariantNested ::
+dictionary contravariantNestedType ::
   forall f.
   { contravariantDict :: Data.Functor.Contravariant.Contravariant f } =>
   Data.Functor.Contravariant.Contravariant (Main.Nested @Prim.Type f)

--- a/tests-integration/fixtures/semantic/1785598320_derive_profunctor_given_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598320_derive_profunctor_given_application_body/Main.snap
@@ -7,7 +7,7 @@ data Nested :: forall k0 k1. (k0 -> k1 -> Prim.Type) -> k0 -> k1 -> Prim.Type
 data Nested @p @a @b
   | Nested :: p a b -> Main.Nested p a b
 
-dictionary profunctorNested ::
+dictionary profunctorNestedTypeType ::
   forall p.
   { profunctorDict :: Data.Profunctor.Profunctor p } =>
   Data.Profunctor.Profunctor (Main.Nested @Prim.Type @Prim.Type p)

--- a/tests-integration/fixtures/semantic/1785598320_derive_profunctor_nested_right_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598320_derive_profunctor_nested_right_body/Main.snap
@@ -17,7 +17,8 @@ dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
     case value of
       (Function field0) -> Function \argument -> secondFunction (field0 (firstFunction argument))
 
-dictionary profunctorNestedRight :: Data.Profunctor.Profunctor (Main.NestedRight @Prim.Type) where
+dictionary profunctorNestedRightType :: Data.Profunctor.Profunctor (Main.NestedRight @Prim.Type)
+  where
   dimap :: forall a b c d.
   (a -> b) -> (c -> d) -> Main.NestedRight @Prim.Type b c -> Main.NestedRight @Prim.Type a d
   dimap = \firstFunction secondFunction value ->

--- a/tests-integration/fixtures/semantic/1785598440_derive_contravariant_phantom_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598440_derive_contravariant_phantom_body/Main.snap
@@ -7,7 +7,7 @@ data Constant :: forall k0. Prim.Type -> k0 -> Prim.Type
 data Constant @value @a
   | Constant :: value -> Main.Constant value a
 
-dictionary contravariantConstant ::
+dictionary contravariantConstantType ::
   forall value.
   Data.Functor.Contravariant.Contravariant (Main.Constant @Prim.Type value)
   where

--- a/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.snap
+++ b/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.snap
@@ -26,7 +26,7 @@ dictionary convertFG :: Main.Convert Main.F Main.G where
   convertExplicit :: forall a. Main.F a -> Main.G a
   convertExplicit = unsafeCoerce
 
-dictionary clash :: forall f. Main.Clash f where
+dictionary clash1 :: forall f. Main.Clash f where
   clash :: forall a. f a -> f a
   clash = \(value :: f a) ->
     case value of

--- a/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.snap
+++ b/tests-integration/fixtures/semantic/1786336800_polymorphic_typed_instance_member/Main.snap
@@ -20,13 +20,13 @@ data G @a
 
 foreign import unsafeCoerce :: forall a b. a -> b
 
-dictionary convertG :: Main.Convert Main.F Main.G where
+dictionary convertFG :: Main.Convert Main.F Main.G where
   convert :: forall a. Main.F a -> Main.G a
   convert = unsafeCoerce
   convertExplicit :: forall a. Main.F a -> Main.G a
   convertExplicit = unsafeCoerce
 
-dictionary clash1 :: forall f. Main.Clash f where
+dictionary clash :: forall f. Main.Clash f where
   clash :: forall a. f a -> f a
   clash = \(value :: f a) ->
     case value of

--- a/tests-integration/fixtures/semantic/1786773420_instance_unsafe_partial_expression_sections/Main.snap
+++ b/tests-integration/fixtures/semantic/1786773420_instance_unsafe_partial_expression_sections/Main.snap
@@ -33,7 +33,7 @@ dictionary contentOverloadString :: Main.ContentOverload Prim.String where
       case content of
         (Sentence value) -> value
 
-dictionary contentOverloadArray :: Main.ContentOverload (Prim.Array Prim.String) where
+dictionary contentOverloadArrayString :: Main.ContentOverload (Prim.Array Prim.String) where
   fromContent :: Main.Content -> Prim.Array Prim.String
   fromContent =
     compose {semigroupoidFn} unsafePartial \v120 ->

--- a/tests-integration/fixtures/semantic/1786808340_unnamed_instance_dictionary_names/Main.purs
+++ b/tests-integration/fixtures/semantic/1786808340_unnamed_instance_dictionary_names/Main.purs
@@ -13,3 +13,9 @@ instance Convert Int String where
 
 instance Convert (Int :+: String) Boolean where
   convert _ = true
+
+instance Convert value value where
+  convert value = value
+
+instance Convert value (value :+: value) where
+  convert value = Pair value value

--- a/tests-integration/fixtures/semantic/1786808340_unnamed_instance_dictionary_names/Main.purs
+++ b/tests-integration/fixtures/semantic/1786808340_unnamed_instance_dictionary_names/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+data Pair a b = Pair a b
+
+infixr 6 type Pair as :+:
+
+class Convert :: Type -> Type -> Constraint
+class Convert source target where
+  convert :: source -> target
+
+instance Convert Int String where
+  convert _ = ""
+
+instance Convert (Int :+: String) Boolean where
+  convert _ = true

--- a/tests-integration/fixtures/semantic/1786808340_unnamed_instance_dictionary_names/Main.snap
+++ b/tests-integration/fixtures/semantic/1786808340_unnamed_instance_dictionary_names/Main.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Pair :: Prim.Type -> Prim.Type -> Prim.Type
+data Pair @a @b
+  | Pair :: a -> b -> Main.Pair a b
+
+interface Convert :: Prim.Type -> Prim.Type -> Prim.Constraint
+interface Convert source target where
+  convert :: source -> target
+
+dictionary convertString :: Main.Convert Prim.Int Prim.String where
+  convert :: Prim.Int -> Prim.String
+  convert = \_ -> ""
+
+dictionary convertBoolean :: Main.Convert (Main.Pair Prim.Int Prim.String) Prim.Boolean where
+  convert :: Main.Pair Prim.Int Prim.String -> Prim.Boolean
+  convert = \_ -> true

--- a/tests-integration/fixtures/semantic/1786808340_unnamed_instance_dictionary_names/Main.snap
+++ b/tests-integration/fixtures/semantic/1786808340_unnamed_instance_dictionary_names/Main.snap
@@ -20,7 +20,7 @@ dictionary convertPairIntStringBoolean :: Main.Convert (Main.Pair Prim.Int Prim.
   convert :: Main.Pair Prim.Int Prim.String -> Prim.Boolean
   convert = \_ -> true
 
-dictionary convert :: forall value. Main.Convert value value where
+dictionary convert1 :: forall value. Main.Convert value value where
   convert :: value -> value
   convert = \value -> value
 

--- a/tests-integration/fixtures/semantic/1786808340_unnamed_instance_dictionary_names/Main.snap
+++ b/tests-integration/fixtures/semantic/1786808340_unnamed_instance_dictionary_names/Main.snap
@@ -11,10 +11,19 @@ interface Convert :: Prim.Type -> Prim.Type -> Prim.Constraint
 interface Convert source target where
   convert :: source -> target
 
-dictionary convertString :: Main.Convert Prim.Int Prim.String where
+dictionary convertIntString :: Main.Convert Prim.Int Prim.String where
   convert :: Prim.Int -> Prim.String
   convert = \_ -> ""
 
-dictionary convertBoolean :: Main.Convert (Main.Pair Prim.Int Prim.String) Prim.Boolean where
+dictionary convertPairIntStringBoolean :: Main.Convert (Main.Pair Prim.Int Prim.String) Prim.Boolean
+  where
   convert :: Main.Pair Prim.Int Prim.String -> Prim.Boolean
   convert = \_ -> true
+
+dictionary convert :: forall value. Main.Convert value value where
+  convert :: value -> value
+  convert = \value -> value
+
+dictionary convertPair :: forall value. Main.Convert value (Main.Pair value value) where
+  convert :: value -> Main.Pair value value
+  convert = \value -> Pair value value

--- a/tests-integration/fixtures/semantic/1786809540_unnamed_instance_literal_dictionary_name/Main.purs
+++ b/tests-integration/fixtures/semantic/1786809540_unnamed_instance_literal_dictionary_name/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+class NamedSymbol :: Symbol -> Constraint
+class NamedSymbol symbol
+
+instance NamedSymbol "foo bar"

--- a/tests-integration/fixtures/semantic/1786809540_unnamed_instance_literal_dictionary_name/Main.snap
+++ b/tests-integration/fixtures/semantic/1786809540_unnamed_instance_literal_dictionary_name/Main.snap
@@ -6,4 +6,4 @@ expression: report
 interface NamedSymbol :: Prim.Symbol -> Prim.Constraint
 interface NamedSymbol symbol where
 
-dictionary namedSymbolfoo bar :: Main.NamedSymbol "foo bar"
+dictionary namedSymbol :: Main.NamedSymbol "foo bar"

--- a/tests-integration/fixtures/semantic/1786809540_unnamed_instance_literal_dictionary_name/Main.snap
+++ b/tests-integration/fixtures/semantic/1786809540_unnamed_instance_literal_dictionary_name/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface NamedSymbol :: Prim.Symbol -> Prim.Constraint
+interface NamedSymbol symbol where
+
+dictionary namedSymbolfoo bar :: Main.NamedSymbol "foo bar"

--- a/tests-integration/fixtures/semantic/1786809960_unnamed_instance_term_name_collision/Main.purs
+++ b/tests-integration/fixtures/semantic/1786809960_unnamed_instance_term_name_collision/Main.purs
@@ -1,0 +1,14 @@
+module Main where
+
+class Convert :: Type -> Constraint
+class Convert value where
+  convert :: value -> Int
+
+convertInt :: Int
+convertInt = 0
+
+instance Convert Int where
+  convert value = value
+
+test :: Int
+test = convert 42

--- a/tests-integration/fixtures/semantic/1786809960_unnamed_instance_term_name_collision/Main.snap
+++ b/tests-integration/fixtures/semantic/1786809960_unnamed_instance_term_name_collision/Main.snap
@@ -10,9 +10,9 @@ interface Convert value where
 convertInt :: Prim.Int
 convertInt = 0
 
-dictionary convertInt :: Main.Convert Prim.Int where
+dictionary convertInt1 :: Main.Convert Prim.Int where
   convert :: Prim.Int -> Prim.Int
   convert = \value -> value
 
 test :: Prim.Int
-test = convert {convertInt} 42
+test = convert {convertInt1} 42

--- a/tests-integration/fixtures/semantic/1786809960_unnamed_instance_term_name_collision/Main.snap
+++ b/tests-integration/fixtures/semantic/1786809960_unnamed_instance_term_name_collision/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Convert :: Prim.Type -> Prim.Constraint
+interface Convert value where
+  convert :: value -> Prim.Int
+
+convertInt :: Prim.Int
+convertInt = 0
+
+dictionary convertInt :: Main.Convert Prim.Int where
+  convert :: Prim.Int -> Prim.Int
+  convert = \value -> value
+
+test :: Prim.Int
+test = convert {convertInt} 42


### PR DESCRIPTION
## Summary

Unnamed instances currently appear as `<unknown>` in hover output, while checked semantic output derives names from only the final instance argument. Generate backend-neutral dictionary names from the lowercased class name and every resolved type constructor in the instance head.

This keeps type-variable spelling out of generated identities, resolves type operators to their backing constructors, and leaves target-specific prefixes such as `$dict` to future CoreFn or JavaScript backends.

## Testing

- `just t semantic`
- `just t lsp`
- `cargo nextest run -p checking`
- `cargo nextest run -p analyzer`
- `cargo check -p checking --tests`
- `cargo check -p analyzer --tests`