### PR TITLE
[checking] Cover source-reachable checking paths

### DIFF
--- a/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Bifoldable.purs
+++ b/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Bifoldable.purs
@@ -1,0 +1,3 @@
+module Data.Bifoldable where
+
+class Bifoldable f extra

--- a/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Bifunctor.purs
+++ b/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Bifunctor.purs
@@ -1,0 +1,3 @@
+module Data.Bifunctor where
+
+class Bifunctor f extra

--- a/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Bitraversable.purs
+++ b/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Bitraversable.purs
@@ -1,0 +1,3 @@
+module Data.Bitraversable where
+
+class Bitraversable f extra

--- a/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Eq.purs
+++ b/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Eq.purs
@@ -1,0 +1,4 @@
+module Data.Eq where
+
+class Eq a extra
+class Eq1 f extra

--- a/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Foldable.purs
+++ b/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Foldable.purs
@@ -1,0 +1,3 @@
+module Data.Foldable where
+
+class Foldable f extra

--- a/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Functor.Contravariant.purs
+++ b/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Functor.Contravariant.purs
@@ -1,0 +1,3 @@
+module Data.Functor.Contravariant where
+
+class Contravariant f extra

--- a/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Functor.purs
+++ b/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Functor.purs
@@ -1,0 +1,3 @@
+module Data.Functor where
+
+class Functor f extra

--- a/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Ord.purs
+++ b/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Ord.purs
@@ -1,0 +1,4 @@
+module Data.Ord where
+
+class Ord a extra
+class Ord1 f extra

--- a/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Profunctor.purs
+++ b/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Profunctor.purs
@@ -1,0 +1,3 @@
+module Data.Profunctor where
+
+class Profunctor f extra

--- a/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Traversable.purs
+++ b/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Data.Traversable.purs
@@ -1,0 +1,3 @@
+module Data.Traversable where
+
+class Traversable f extra

--- a/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Main.purs
+++ b/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Main.purs
@@ -1,0 +1,27 @@
+module Main where
+
+import Data.Bifoldable (class Bifoldable)
+import Data.Bifunctor (class Bifunctor)
+import Data.Bitraversable (class Bitraversable)
+import Data.Eq (class Eq, class Eq1)
+import Data.Foldable (class Foldable)
+import Data.Functor (class Functor)
+import Data.Functor.Contravariant (class Contravariant)
+import Data.Ord (class Ord, class Ord1)
+import Data.Profunctor (class Profunctor)
+import Data.Traversable (class Traversable)
+
+data Pair a b = Pair a b
+
+derive instance Eq Pair Int
+derive instance Ord Pair Int
+derive instance Functor Pair Int
+derive instance Bifunctor Pair Int
+derive instance Foldable Pair Int
+derive instance Bifoldable Pair Int
+derive instance Traversable Pair Int
+derive instance Bitraversable Pair Int
+derive instance Contravariant Pair Int
+derive instance Profunctor Pair Int
+derive instance Eq1 Pair Int
+derive instance Ord1 Pair Int

--- a/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Main.snap
+++ b/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Main.snap
@@ -1,0 +1,93 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Pair :: forall @a @b. a -> b -> Main.Pair a b
+
+Types
+Pair :: Prim.Type -> Prim.Type -> Prim.Type
+
+Derived
+derive Data.Eq.Eq @(Prim.Type -> Prim.Type -> Prim.Type) @Prim.Type Main.Pair Prim.Int
+derive Data.Ord.Ord @(Prim.Type -> Prim.Type -> Prim.Type) @Prim.Type Main.Pair Prim.Int
+derive Data.Functor.Functor @(Prim.Type -> Prim.Type -> Prim.Type) @Prim.Type Main.Pair Prim.Int
+derive Data.Bifunctor.Bifunctor @(Prim.Type -> Prim.Type -> Prim.Type) @Prim.Type Main.Pair Prim.Int
+derive Data.Foldable.Foldable @(Prim.Type -> Prim.Type -> Prim.Type) @Prim.Type Main.Pair Prim.Int
+derive Data.Bifoldable.Bifoldable @(Prim.Type -> Prim.Type -> Prim.Type) @Prim.Type Main.Pair Prim.Int
+derive Data.Traversable.Traversable @(Prim.Type -> Prim.Type -> Prim.Type) @Prim.Type Main.Pair Prim.Int
+derive Data.Bitraversable.Bitraversable @(Prim.Type -> Prim.Type -> Prim.Type) @Prim.Type
+  Main.Pair
+  Prim.Int
+derive Data.Functor.Contravariant.Contravariant @(Prim.Type -> Prim.Type -> Prim.Type) @Prim.Type
+  Main.Pair
+  Prim.Int
+derive Data.Profunctor.Profunctor @(Prim.Type -> Prim.Type -> Prim.Type) @Prim.Type Main.Pair Prim.Int
+derive Data.Eq.Eq1 @(Prim.Type -> Prim.Type -> Prim.Type) @Prim.Type Main.Pair Prim.Int
+derive Data.Ord.Ord1 @(Prim.Type -> Prim.Type -> Prim.Type) @Prim.Type Main.Pair Prim.Int
+
+Roles
+Pair = [Representational, Representational]
+
+Diagnostics
+error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
+  --> 16:1..16:28
+   |
+16 | derive instance Eq Pair Int
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
+  --> 17:1..17:29
+   |
+17 | derive instance Ord Pair Int
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
+  --> 18:1..18:33
+   |
+18 | derive instance Functor Pair Int
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
+  --> 19:1..19:35
+   |
+19 | derive instance Bifunctor Pair Int
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
+  --> 20:1..20:34
+   |
+20 | derive instance Foldable Pair Int
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
+  --> 21:1..21:36
+   |
+21 | derive instance Bifoldable Pair Int
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
+  --> 22:1..22:37
+   |
+22 | derive instance Traversable Pair Int
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
+  --> 23:1..23:39
+   |
+23 | derive instance Bitraversable Pair Int
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
+  --> 24:1..24:39
+   |
+24 | derive instance Contravariant Pair Int
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
+  --> 25:1..25:36
+   |
+25 | derive instance Profunctor Pair Int
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
+  --> 26:1..26:29
+   |
+26 | derive instance Eq1 Pair Int
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
+  --> 27:1..27:30
+   |
+27 | derive instance Ord1 Pair Int
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/semantic/1784873220_do_expression_recovery/Main.purs
+++ b/tests-integration/fixtures/semantic/1784873220_do_expression_recovery/Main.purs
@@ -17,3 +17,9 @@ finalLet = do
 missingDoAction = do
   value <-
   pure value
+
+missingFinalBindAction = do
+  value <-
+
+missingFinalDiscardAction = do
+  (

--- a/tests-integration/fixtures/semantic/1784873220_do_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873220_do_expression_recovery/Main.snap
@@ -25,3 +25,9 @@ finalLet =
 
 missingDoAction :: forall t0. t0
 missingDoAction = <error> \value -> pure value
+
+missingFinalBindAction :: ?[empty do block]
+missingFinalBindAction = <error>
+
+missingFinalDiscardAction :: ?[empty do block]
+missingFinalDiscardAction = <error>

--- a/tests-integration/fixtures/semantic/1784873221_ado_expression_recovery/Main.purs
+++ b/tests-integration/fixtures/semantic/1784873221_ado_expression_recovery/Main.purs
@@ -15,3 +15,8 @@ missingAdoAction = ado
 missingAdoResult = ado
   value <- pure 1
   in
+
+missingAdoActionBeforeValidAction = ado
+  missing <-
+  value <- pure 1
+  in value

--- a/tests-integration/fixtures/semantic/1784873221_ado_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873221_ado_expression_recovery/Main.snap
@@ -17,3 +17,6 @@ missingAdoAction = <error> <error>
 
 missingAdoResult :: forall t0. Main.Effect t0
 missingAdoResult = map (\value -> <error>) (pure 1)
+
+missingAdoActionBeforeValidAction :: Main.Effect Prim.Int
+missingAdoActionBeforeValidAction = map (\value -> <error>) (pure 1)

--- a/tests-integration/fixtures/semantic/1784904720_reflectable_evidence_variants/Main.purs
+++ b/tests-integration/fixtures/semantic/1784904720_reflectable_evidence_variants/Main.purs
@@ -1,0 +1,20 @@
+module Main where
+
+import Data.Reflectable (reflectType)
+import Prim.Boolean (False, True)
+import Prim.Ordering (EQ, GT, LT)
+import Type.Proxy (Proxy(..))
+
+symbol = reflectType (Proxy :: Proxy "symbol")
+
+integer = reflectType (Proxy :: Proxy 42)
+
+booleanTrue = reflectType (Proxy :: Proxy True)
+
+booleanFalse = reflectType (Proxy :: Proxy False)
+
+orderingLess = reflectType (Proxy :: Proxy LT)
+
+orderingEqual = reflectType (Proxy :: Proxy EQ)
+
+orderingGreater = reflectType (Proxy :: Proxy GT)

--- a/tests-integration/fixtures/semantic/1784904720_reflectable_evidence_variants/Main.snap
+++ b/tests-integration/fixtures/semantic/1784904720_reflectable_evidence_variants/Main.snap
@@ -1,0 +1,25 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+symbol :: Prim.String
+symbol = reflectType {reflectable("symbol")} Proxy
+
+integer :: Prim.Int
+integer = reflectType {reflectable(42)} Proxy
+
+booleanTrue :: Prim.Boolean
+booleanTrue = reflectType {reflectable(true)} Proxy
+
+booleanFalse :: Prim.Boolean
+booleanFalse = reflectType {reflectable(false)} Proxy
+
+orderingLess :: Data.Ordering.Ordering
+orderingLess = reflectType {reflectable(LT)} Proxy
+
+orderingEqual :: Data.Ordering.Ordering
+orderingEqual = reflectType {reflectable(EQ)} Proxy
+
+orderingGreater :: Data.Ordering.Ordering
+orderingGreater = reflectType {reflectable(GT)} Proxy

--- a/tests-integration/fixtures/semantic/1784904900_parenthesized_constructor_argument_types/Main.purs
+++ b/tests-integration/fixtures/semantic/1784904900_parenthesized_constructor_argument_types/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+class Marker a
+
+data Complex = Complex
+  (Int -> Int)
+  (forall value. value -> value)
+  (Marker Int => Int)
+  (Int :: Type)

--- a/tests-integration/fixtures/semantic/1784904900_parenthesized_constructor_argument_types/Main.snap
+++ b/tests-integration/fixtures/semantic/1784904900_parenthesized_constructor_argument_types/Main.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Marker :: forall k0. k0 -> Prim.Constraint
+interface Marker a where
+
+data Complex :: Prim.Type
+data Complex
+  | Complex ::
+    (Prim.Int -> Prim.Int) ->
+      (forall value. value -> value) ->
+        (Main.Marker @Prim.Type Prim.Int => Prim.Int) -> Prim.Int -> Main.Complex


### PR DESCRIPTION
## Goal

Add focused integration coverage for source-reachable checking and semantic rendering paths that remained absent from the current test corpus.

The fixtures were selected from a prior coverage-guided audit, re-measured against the current default branch, and retained only when they contributed unique executable coverage.

## Changes

- cover recovery for malformed final bind and discard actions in `do`
- cover recovery for a malformed `ado` action followed by a valid action
- render synthesized `Reflectable` evidence for symbols, integers, booleans, and ordering values
- render function, rank-n, constrained, and kind-annotated constructor arguments
- validate derive-class arity dispatch for all supported standard deriving classes using fixture-local class modules

Each semantic scenario is kept in a separate atomic commit so its snapshot and coverage contribution can be reviewed independently.

## Coverage

Clean coverage across `compiler-core/checking/src` changed as follows:

- lines: 19,517 / 21,508 (90.7430%) → 19,625 / 21,508 (91.2451%), +108
- regions: 32,993 / 37,979 (86.8717%) → 33,110 / 37,979 (87.1798%), +117
- functions: 1,345 / 1,440 (93.4028%) → 1,348 / 1,440 (93.6111%), +3

Incremental covered-line contributions were +17 for `do` recovery, +1 for `ado` recovery, +13 for reflected evidence, +7 for constructor argument types, and +70 for derive arity validation.

## Verification

- `just t checking`
- `just t semantic`
- `just coverage` — 709 / 709 integration tests passed
- `git diff --check origin/main..HEAD`

All snapshots were reviewed and accepted, with no pending snapshot files.