### PR TITLE
[lowering] Cover compiler pipeline syntax forms

### DIFF
--- a/tests-integration/fixtures/lowering/1786810320_binder_and_guard_forms/Main.purs
+++ b/tests-integration/fixtures/lowering/1786810320_binder_and_guard_forms/Main.purs
@@ -1,0 +1,23 @@
+module Main where
+
+data Maybe a = Just a | Nothing
+
+data List a = Cons a (List a) | Nil
+
+infixr 6 Cons as :
+
+binders (whole@(Just { name, value: (value :: Int) })) [true, false] (head : tail) =
+  { whole, name, value, head, tail }
+
+literals 42 = 1
+literals (-1.5) = 2
+literals "text" = 3
+literals 'x' = 4
+literals false = 5
+literals _ = 6
+
+guarded input
+  | Just value <- input, value = value
+  | true = fallback
+  where
+  fallback = 0

--- a/tests-integration/fixtures/lowering/1786810320_binder_and_guard_forms/Main.snap
+++ b/tests-integration/fixtures/lowering/1786810320_binder_and_guard_forms/Main.snap
@@ -1,0 +1,50 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 85
+expression: report
+---
+module Main
+
+Expressions:
+
+{ whole, name, value, head, tail }@8:84
+  -> binder@8:9
+{ whole, name, value, head, tail }@8:84
+  -> record pun@8:22
+{ whole, name, value, head, tail }@8:84
+  -> binder@8:37
+{ whole, name, value, head, tail }@8:84
+  -> binder@8:70
+{ whole, name, value, head, tail }@8:84
+  -> binder@8:76
+1@11:13
+  -> integer 1
+2@12:17
+  -> integer 2
+input@19:17
+  -> binder@18:7
+5@15:16
+  -> integer 5
+value@19:32
+  -> binder@19:8
+0@22:12
+  -> integer 0
+3@13:17
+  -> integer 3
+6@16:12
+  -> integer 6
+value@19:24
+  -> binder@19:8
+fallback@20:10
+  -> equation@21:7
+4@14:14
+  -> integer 4
+
+Types:
+
+a@4:26
+  -> forall@4:9
+a@2:19
+  -> forall@2:10
+a@4:18
+  -> forall@4:9

--- a/tests-integration/fixtures/lowering/1786810320_record_expression_forms/Main.purs
+++ b/tests-integration/fixtures/lowering/1786810320_record_expression_forms/Main.purs
@@ -1,0 +1,18 @@
+module Main where
+
+add left right = left
+
+infixl 6 add as +++
+
+negate value = value
+
+record value = { value, nested: { current: value } }
+
+access input = input.nested.current
+
+update input value = input { value = value, nested { current = -value } }
+
+conditional condition left right =
+  if condition then left +++ right else left `add` right
+
+operator = (+++)

--- a/tests-integration/fixtures/lowering/1786810320_record_expression_forms/Main.snap
+++ b/tests-integration/fixtures/lowering/1786810320_record_expression_forms/Main.snap
@@ -1,0 +1,39 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 85
+expression: report
+---
+module Main
+
+Expressions:
+
+left@2:16
+  -> binder@2:3
+right@15:50
+  -> binder@14:26
+input@10:14
+  -> binder@10:6
+condition@15:4
+  -> binder@14:11
+left@15:19
+  -> binder@14:21
+right@15:28
+  -> binder@14:26
+value@6:14
+  -> binder@6:6
+value@8:42
+  -> binder@8:6
+left@15:39
+  -> binder@14:21
+value@12:64
+  -> binder@12:12
+add@15:46
+  -> top-level
+{ value, nested: { current: value } }@8:14
+  -> binder@8:6
+input@12:20
+  -> binder@12:6
+value@12:36
+  -> binder@12:12
+
+Types:

--- a/tests-integration/fixtures/lowering/1786810320_type_operator_forms/Main.purs
+++ b/tests-integration/fixtures/lowering/1786810320_type_operator_forms/Main.purs
@@ -1,0 +1,22 @@
+module Main where
+
+foreign import data Pair :: Type -> Type -> Type
+foreign import data SymbolProxy :: Symbol -> Type
+foreign import data IntProxy :: Int -> Type
+
+infixr 6 type Pair as :*:
+
+class Convert input output | input -> output
+
+foreign import convert :: forall input output. Convert input output => input -> output
+
+type Nested left right = left :*: (right :*: left)
+
+symbols :: SymbolProxy "hello"
+symbols = symbols
+
+integers :: IntProxy 42
+integers = integers
+
+record :: forall row. { value :: Int | row } -> (value :: Int | row)
+record value = value

--- a/tests-integration/fixtures/lowering/1786810320_type_operator_forms/Main.snap
+++ b/tests-integration/fixtures/lowering/1786810320_type_operator_forms/Main.snap
@@ -1,0 +1,40 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 85
+expression: report
+---
+module Main
+
+Expressions:
+
+integers@18:10
+  -> top-level
+value@21:14
+  -> binder@21:6
+symbols@15:9
+  -> top-level
+
+Types:
+
+left@12:24
+  -> forall@12:11
+output@8:37
+  -> forall@8:19
+right@12:35
+  -> forall@12:16
+left@12:44
+  -> forall@12:11
+row@20:38
+  -> forall@20:16
+output@10:60
+  -> forall@10:38
+output@10:79
+  -> forall@10:38
+input@8:28
+  -> forall@8:13
+input@10:54
+  -> forall@10:32
+input@10:70
+  -> forall@10:32
+row@20:63
+  -> forall@20:16


### PR DESCRIPTION
## Goal

Improve integration-test coverage for lowering and the source-reachable parsing, lexing, and syntax paths exercised by lowering fixtures. The added cases target substantive previously uncovered syntax branches without changing compiler behavior or adding unit tests.

Each fixture was measured independently against a clean lowering-only coverage baseline and retained only when it contributed coverage not supplied by the baseline or either other candidate.

## Fixtures

- **Binder and guard forms** covers named, typed, operator, array, record, and literal binders together with binder and expression pattern guards and a guarded `where` binding.
- **Record expression forms** covers term operator declarations and names, operator and infix chains, conditionals, negation, record puns, multi-label access, and nested record updates.
- **Type operator forms** covers foreign type and term declarations, type operator declarations and chains, functional dependencies, symbol and integer type literals, and open record and row types.

The fixtures are intentionally split by lowering responsibility so each snapshot remains focused and each commit is independently reviewable.

## Coverage

Clean lowering-only LLVM line coverage before and after:

| Crate | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `lowering` | 1404/2234 (62.85%) | 1825/2234 (81.69%) | +421 lines, +18.84 pp |
| `parsing` | 1206/1874 (64.35%) | 1456/1874 (77.69%) | +250 lines, +13.34 pp |
| `lexing` | 685/935 (73.26%) | 757/935 (80.96%) | +72 lines, +7.70 pp |
| `syntax` | 270/527 (51.23%) | 294/527 (55.79%) | +24 lines, +4.56 pp |

The lowering harness does not execute the `sugar` stage, so these fixtures do not claim coverage there.

Notable file-level changes:

- `lowering/src/algorithm.rs`: 81.18% → 94.96% (+112 lines)
- `lowering/src/algorithm/recursive.rs`: 61.06% → 89.31% (+309)
- `parsing/src/parser/expressions.rs`: 66.04% → 84.91% (+80)
- `parsing/src/parser/generic.rs`: 45.54% → 89.11% (+44)
- `parsing/src/parser/types.rs`: 62.03% → 79.32% (+41)
- `parsing/src/parser/binders.rs`: 55.64% → 83.46% (+37)
- `lexing/src/layout.rs`: 77.31% → 88.78% (+46)
- `lexing/src/lexer.rs`: 75.06% → 81.29% (+26)

## Verification

- `cargo llvm-cov clean --workspace`
- `cargo llvm-cov nextest --no-report -p tests-integration --test lowering` — baseline 17/17 passed; after 20/20 passed
- Isolated clean coverage runs for each new fixture — all passed and each contributed unique executable lines
- `just t lowering 1786810320 --diff` — generated snapshots inspected before acceptance
- `just t lowering` — all tests passed with no pending snapshots