### PR TITLE
[tests] Cover diagnostic and documentation rendering

### DIFF
--- a/tests-integration/fixtures/checking/1786810320_not_in_scope_diagnostic_rendering/Main.purs
+++ b/tests-integration/fixtures/checking/1786810320_not_in_scope_diagnostic_rendering/Main.purs
@@ -1,0 +1,31 @@
+module Main where
+
+-- Unresolved names in each lowering syntax position.
+missingVariable = absent
+missingConstructor = Missing
+missingOperator = 1 + 2
+missingNegate = -1
+
+missingDo = do
+  value <- absent
+  value
+
+missingDiscard = do
+  absent
+  absent
+
+missingAdo = ado
+  value <- absent
+  second <- absent
+  in value
+
+missingPure = ado
+  in 1
+
+missingType :: MissingType
+missingType = absent
+
+type MissingTypeOperator = Int + String
+
+infix 5 missingOperatorName as <+>
+infix 5 type MissingTypeOperatorName as +

--- a/tests-integration/fixtures/checking/1786810320_not_in_scope_diagnostic_rendering/Main.snap
+++ b/tests-integration/fixtures/checking/1786810320_not_in_scope_diagnostic_rendering/Main.snap
@@ -1,0 +1,158 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+missingVariable :: ?[missing expression]
+missingConstructor :: ?[missing expression]
+missingOperator :: forall t0. t0
+missingNegate :: ?[missing expression]
+missingDo :: forall (t0 :: Prim.Type -> Prim.Type) t1. (t0 :: Prim.Type -> Prim.Type) t1
+missingDiscard :: forall (t0 :: Prim.Type -> Prim.Type) t1. (t0 :: Prim.Type -> Prim.Type) t1
+missingAdo :: forall (t0 :: Prim.Type -> Prim.Type) t1. (t0 :: Prim.Type -> Prim.Type) t1
+missingPure :: forall (t0 :: Prim.Type -> Prim.Type). (t0 :: Prim.Type -> Prim.Type) Prim.Int
+missingType :: ?[missing constructor]
+
+Types
+MissingTypeOperator :: ?[invalid operator kind]
+
+Synonyms
+type MissingTypeOperator = ?[invalid operator chain]
+
+Diagnostics
+error[NotInScope]: 'absent' is not in scope
+  --> 4:19..4:25
+  |
+4 | missingVariable = absent
+  |                   ^~~~~~
+error[NotInScope]: 'Missing' is not in scope
+  --> 5:22..5:29
+  |
+5 | missingConstructor = Missing
+  |                      ^~~~~~~
+error[NotInScope]: '+' is not in scope
+  --> 6:21..6:22
+  |
+6 | missingOperator = 1 + 2
+  |                     ^
+error[NotInScope]: 'negate' is not in scope
+  --> 7:17..7:19
+  |
+7 | missingNegate = -1
+  |                 ^~
+error[NotInScope]: 'bind' is not in scope
+  --> 9:13..11:8
+  |
+9 | missingDo = do
+  |             ^~
+error[NotInScope]: 'absent' is not in scope
+  --> 10:12..10:18
+   |
+10 |   value <- absent
+   |            ^~~~~~
+error[NotInScope]: 'discard' is not in scope
+  --> 13:18..15:9
+   |
+13 | missingDiscard = do
+   |                  ^~
+error[NotInScope]: 'absent' is not in scope
+  --> 14:3..14:9
+   |
+14 |   absent
+   |   ^~~~~~
+error[NotInScope]: 'absent' is not in scope
+  --> 15:3..15:9
+   |
+15 |   absent
+   |   ^~~~~~
+error[NotInScope]: 'map' is not in scope
+  --> 17:14..20:11
+   |
+17 | missingAdo = ado
+   |              ^~~
+error[NotInScope]: 'apply' is not in scope
+  --> 17:14..20:11
+   |
+17 | missingAdo = ado
+   |              ^~~
+error[NotInScope]: 'absent' is not in scope
+  --> 18:12..18:18
+   |
+18 |   value <- absent
+   |            ^~~~~~
+error[NotInScope]: 'absent' is not in scope
+  --> 19:13..19:19
+   |
+19 |   second <- absent
+   |             ^~~~~~
+error[NotInScope]: 'pure' is not in scope
+  --> 22:15..23:7
+   |
+22 | missingPure = ado
+   |               ^~~
+error[NotInScope]: 'MissingType' is not in scope
+  --> 25:16..25:27
+   |
+25 | missingType :: MissingType
+   |                ^~~~~~~~~~~
+error[NotInScope]: 'absent' is not in scope
+  --> 26:15..26:21
+   |
+26 | missingType = absent
+   |               ^~~~~~
+error[CannotUnify]: Cannot unify 'Type' with '?[invalid kind]'
+  --> 28:28..28:40
+   |
+28 | type MissingTypeOperator = Int + String
+   |                            ^~~~~~~~~~~~
+error[CannotUnify]: Cannot unify 'Type' with '?[invalid kind]'
+  --> 4:19..4:25
+  |
+4 | missingVariable = absent
+  |                   ^~~~~~
+error[CannotUnify]: Cannot unify 'Type' with '?[invalid kind]'
+  --> 5:22..5:29
+  |
+5 | missingConstructor = Missing
+  |                      ^~~~~~~
+error[CannotUnify]: Cannot unify 'Type' with '?[invalid kind]'
+  --> 7:17..7:19
+  |
+7 | missingNegate = -1
+  |                 ^~
+error[CannotUnify]: Cannot unify '?[missing expression]' with '(t0 :: Type -> Type) ((t0 :: Type -> Type) t1)'
+  --> 10:3..10:18
+   |
+10 |   value <- absent
+   |   ^~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify '?[missing expression]' with '(t2 :: Type -> Type) ?24'
+  --> 14:3..14:9
+   |
+14 |   absent
+   |   ^~~~~~
+error[CannotUnify]: Cannot unify '?[missing expression]' with '(t2 :: Type -> Type) t3'
+  --> 15:3..15:9
+   |
+15 |   absent
+   |   ^~~~~~
+error[CannotUnify]: Cannot unify '?[missing expression]' with '(t4 :: Type -> Type) t5'
+  --> 18:3..18:18
+   |
+18 |   value <- absent
+   |   ^~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify '?[missing expression]' with '(t4 :: Type -> Type) ?34'
+  --> 19:3..19:19
+   |
+19 |   second <- absent
+   |   ^~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify '?[missing constructor]' with 'Type'
+  --> 25:16..25:27
+   |
+25 | missingType :: MissingType
+   |                ^~~~~~~~~~~
+error[CannotUnify]: Cannot unify '?[missing expression]' with '?[missing constructor]'
+  --> 26:15..26:21
+   |
+26 | missingType = absent
+   |               ^~~~~~

--- a/tests-integration/fixtures/docs/1786810380_documentation_annotation_surfaces/Main.purs
+++ b/tests-integration/fixtures/docs/1786810380_documentation_annotation_surfaces/Main.purs
@@ -1,0 +1,45 @@
+-- | Documentation across
+-- | multiple module lines.
+module Main where
+
+foreign import data Proxy :: forall k. k -> Type
+
+-- | Foreign value documentation.
+foreign import foreignValue :: Int
+
+-- | Pair type documentation.
+data Pair a b = Pair a b
+
+-- | Type operator documentation.
+infixr 6 type Pair as :+:
+
+-- | Choice type documentation.
+data Choice
+  -- | First constructor documentation.
+  = First
+  -- | Second constructor documentation.
+  | Second
+
+append :: String -> String -> String
+append left _ = left
+
+-- | Value operator documentation.
+infixr 5 append as <>
+
+equationDocumented :: Int
+-- | Equation documentation.
+equationDocumented = 1
+
+-- | Signature documentation takes precedence.
+signatureDocumented :: Int
+-- | Ignored equation documentation.
+signatureDocumented = 2
+
+-- | Type literals and open rows.
+foreign import typeShapes
+  :: forall row
+   . Proxy (field :: Int | row)
+  -> Proxy 42
+  -> Proxy "label"
+  -> Proxy (Int :: Type)
+  -> Int

--- a/tests-integration/fixtures/docs/1786810380_documentation_annotation_surfaces/Main.snap
+++ b/tests-integration/fixtures/docs/1786810380_documentation_annotation_surfaces/Main.snap
@@ -1,0 +1,643 @@
+---
+source: tests-integration/src/fixtures.rs
+expression: report
+---
+{
+  "manifest": {
+    "dependencies": {},
+    "description": null,
+    "license": null,
+    "location": null,
+    "modules": [
+      "Main"
+    ],
+    "name": "docs-fixture",
+    "version": "0.0.0"
+  },
+  "modules": [
+    {
+      "documentation": "Documentation across\nmultiple module lines.",
+      "name": "Main",
+      "terms": [
+        {
+          "documentation": "Foreign value documentation.",
+          "kind": "Foreign",
+          "name": "foreignValue",
+          "signature": {
+            "reference": {
+              "module": "Prim",
+              "name": "Int",
+              "package": null
+            },
+            "tag": "constructor"
+          }
+        },
+        {
+          "documentation": null,
+          "kind": "Value",
+          "name": "append",
+          "signature": {
+            "argument": {
+              "reference": {
+                "module": "Prim",
+                "name": "String",
+                "package": null
+              },
+              "tag": "constructor"
+            },
+            "result": {
+              "argument": {
+                "reference": {
+                  "module": "Prim",
+                  "name": "String",
+                  "package": null
+                },
+                "tag": "constructor"
+              },
+              "result": {
+                "reference": {
+                  "module": "Prim",
+                  "name": "String",
+                  "package": null
+                },
+                "tag": "constructor"
+              },
+              "tag": "function"
+            },
+            "tag": "function"
+          }
+        },
+        {
+          "documentation": "Value operator documentation.",
+          "kind": "Operator",
+          "name": "<>",
+          "signature": {
+            "argument": {
+              "reference": {
+                "module": "Prim",
+                "name": "String",
+                "package": null
+              },
+              "tag": "constructor"
+            },
+            "result": {
+              "argument": {
+                "reference": {
+                  "module": "Prim",
+                  "name": "String",
+                  "package": null
+                },
+                "tag": "constructor"
+              },
+              "result": {
+                "reference": {
+                  "module": "Prim",
+                  "name": "String",
+                  "package": null
+                },
+                "tag": "constructor"
+              },
+              "tag": "function"
+            },
+            "tag": "function"
+          }
+        },
+        {
+          "documentation": "Equation documentation.",
+          "kind": "Value",
+          "name": "equationDocumented",
+          "signature": {
+            "reference": {
+              "module": "Prim",
+              "name": "Int",
+              "package": null
+            },
+            "tag": "constructor"
+          }
+        },
+        {
+          "documentation": "Signature documentation takes precedence.",
+          "kind": "Value",
+          "name": "signatureDocumented",
+          "signature": {
+            "reference": {
+              "module": "Prim",
+              "name": "Int",
+              "package": null
+            },
+            "tag": "constructor"
+          }
+        },
+        {
+          "documentation": "Type literals and open rows.",
+          "kind": "Foreign",
+          "name": "typeShapes",
+          "signature": {
+            "binder": {
+              "kind": {
+                "argument": {
+                  "reference": {
+                    "module": "Prim",
+                    "name": "Type",
+                    "package": null
+                  },
+                  "tag": "constructor"
+                },
+                "function": {
+                  "reference": {
+                    "module": "Prim",
+                    "name": "Row",
+                    "package": null
+                  },
+                  "tag": "constructor"
+                },
+                "tag": "application"
+              },
+              "name": "row",
+              "visible": false
+            },
+            "body": {
+              "argument": {
+                "argument": {
+                  "fields": [
+                    {
+                      "label": "field",
+                      "type": {
+                        "reference": {
+                          "module": "Prim",
+                          "name": "Int",
+                          "package": null
+                        },
+                        "tag": "constructor"
+                      }
+                    }
+                  ],
+                  "tag": "row",
+                  "tail": {
+                    "kind": {
+                      "argument": {
+                        "reference": {
+                          "module": "Prim",
+                          "name": "Type",
+                          "package": null
+                        },
+                        "tag": "constructor"
+                      },
+                      "function": {
+                        "reference": {
+                          "module": "Prim",
+                          "name": "Row",
+                          "package": null
+                        },
+                        "tag": "constructor"
+                      },
+                      "tag": "application"
+                    },
+                    "name": "row",
+                    "tag": "rigid"
+                  }
+                },
+                "function": {
+                  "argument": {
+                    "argument": {
+                      "reference": {
+                        "module": "Prim",
+                        "name": "Type",
+                        "package": null
+                      },
+                      "tag": "constructor"
+                    },
+                    "function": {
+                      "reference": {
+                        "module": "Prim",
+                        "name": "Row",
+                        "package": null
+                      },
+                      "tag": "constructor"
+                    },
+                    "tag": "application"
+                  },
+                  "function": {
+                    "reference": {
+                      "module": "Main",
+                      "name": "Proxy",
+                      "package": "docs-fixture"
+                    },
+                    "tag": "constructor"
+                  },
+                  "tag": "kindApplication"
+                },
+                "tag": "application"
+              },
+              "result": {
+                "argument": {
+                  "argument": {
+                    "tag": "integer",
+                    "value": 42
+                  },
+                  "function": {
+                    "argument": {
+                      "reference": {
+                        "module": "Prim",
+                        "name": "Int",
+                        "package": null
+                      },
+                      "tag": "constructor"
+                    },
+                    "function": {
+                      "reference": {
+                        "module": "Main",
+                        "name": "Proxy",
+                        "package": "docs-fixture"
+                      },
+                      "tag": "constructor"
+                    },
+                    "tag": "kindApplication"
+                  },
+                  "tag": "application"
+                },
+                "result": {
+                  "argument": {
+                    "argument": {
+                      "kind": "string",
+                      "tag": "string",
+                      "value": "label"
+                    },
+                    "function": {
+                      "argument": {
+                        "reference": {
+                          "module": "Prim",
+                          "name": "Symbol",
+                          "package": null
+                        },
+                        "tag": "constructor"
+                      },
+                      "function": {
+                        "reference": {
+                          "module": "Main",
+                          "name": "Proxy",
+                          "package": "docs-fixture"
+                        },
+                        "tag": "constructor"
+                      },
+                      "tag": "kindApplication"
+                    },
+                    "tag": "application"
+                  },
+                  "result": {
+                    "argument": {
+                      "argument": {
+                        "reference": {
+                          "module": "Prim",
+                          "name": "Int",
+                          "package": null
+                        },
+                        "tag": "constructor"
+                      },
+                      "function": {
+                        "argument": {
+                          "reference": {
+                            "module": "Prim",
+                            "name": "Type",
+                            "package": null
+                          },
+                          "tag": "constructor"
+                        },
+                        "function": {
+                          "reference": {
+                            "module": "Main",
+                            "name": "Proxy",
+                            "package": "docs-fixture"
+                          },
+                          "tag": "constructor"
+                        },
+                        "tag": "kindApplication"
+                      },
+                      "tag": "application"
+                    },
+                    "result": {
+                      "reference": {
+                        "module": "Prim",
+                        "name": "Int",
+                        "package": null
+                      },
+                      "tag": "constructor"
+                    },
+                    "tag": "function"
+                  },
+                  "tag": "function"
+                },
+                "tag": "function"
+              },
+              "tag": "function"
+            },
+            "tag": "forall"
+          }
+        }
+      ],
+      "types": [
+        {
+          "documentation": null,
+          "form": {
+            "instances": [],
+            "signature": {
+              "binder": {
+                "kind": {
+                  "reference": {
+                    "module": "Prim",
+                    "name": "Type",
+                    "package": null
+                  },
+                  "tag": "constructor"
+                },
+                "name": "k",
+                "visible": false
+              },
+              "body": {
+                "argument": {
+                  "kind": {
+                    "reference": {
+                      "module": "Prim",
+                      "name": "Type",
+                      "package": null
+                    },
+                    "tag": "constructor"
+                  },
+                  "name": "k",
+                  "tag": "rigid"
+                },
+                "result": {
+                  "reference": {
+                    "module": "Prim",
+                    "name": "Type",
+                    "package": null
+                  },
+                  "tag": "constructor"
+                },
+                "tag": "function"
+              },
+              "tag": "forall"
+            },
+            "tag": "foreign"
+          },
+          "name": "Proxy"
+        },
+        {
+          "documentation": "Pair type documentation.",
+          "form": {
+            "constructors": [
+              {
+                "documentation": null,
+                "kind": "Constructor",
+                "name": "Pair",
+                "signature": {
+                  "binder": {
+                    "kind": {
+                      "reference": {
+                        "module": "Prim",
+                        "name": "Type",
+                        "package": null
+                      },
+                      "tag": "constructor"
+                    },
+                    "name": "a",
+                    "visible": true
+                  },
+                  "body": {
+                    "binder": {
+                      "kind": {
+                        "reference": {
+                          "module": "Prim",
+                          "name": "Type",
+                          "package": null
+                        },
+                        "tag": "constructor"
+                      },
+                      "name": "b",
+                      "visible": true
+                    },
+                    "body": {
+                      "argument": {
+                        "kind": {
+                          "reference": {
+                            "module": "Prim",
+                            "name": "Type",
+                            "package": null
+                          },
+                          "tag": "constructor"
+                        },
+                        "name": "a",
+                        "tag": "rigid"
+                      },
+                      "result": {
+                        "argument": {
+                          "kind": {
+                            "reference": {
+                              "module": "Prim",
+                              "name": "Type",
+                              "package": null
+                            },
+                            "tag": "constructor"
+                          },
+                          "name": "b",
+                          "tag": "rigid"
+                        },
+                        "result": {
+                          "argument": {
+                            "kind": {
+                              "reference": {
+                                "module": "Prim",
+                                "name": "Type",
+                                "package": null
+                              },
+                              "tag": "constructor"
+                            },
+                            "name": "b",
+                            "tag": "rigid"
+                          },
+                          "function": {
+                            "argument": {
+                              "kind": {
+                                "reference": {
+                                  "module": "Prim",
+                                  "name": "Type",
+                                  "package": null
+                                },
+                                "tag": "constructor"
+                              },
+                              "name": "a",
+                              "tag": "rigid"
+                            },
+                            "function": {
+                              "reference": {
+                                "module": "Main",
+                                "name": "Pair",
+                                "package": "docs-fixture"
+                              },
+                              "tag": "constructor"
+                            },
+                            "tag": "application"
+                          },
+                          "tag": "application"
+                        },
+                        "tag": "function"
+                      },
+                      "tag": "function"
+                    },
+                    "tag": "forall"
+                  },
+                  "tag": "forall"
+                }
+              }
+            ],
+            "declaration": {
+              "binders": [
+                {
+                  "kind": {
+                    "reference": {
+                      "module": "Prim",
+                      "name": "Type",
+                      "package": null
+                    },
+                    "tag": "constructor"
+                  },
+                  "name": "a",
+                  "visible": true
+                },
+                {
+                  "kind": {
+                    "reference": {
+                      "module": "Prim",
+                      "name": "Type",
+                      "package": null
+                    },
+                    "tag": "constructor"
+                  },
+                  "name": "b",
+                  "visible": true
+                }
+              ]
+            },
+            "instances": [],
+            "signature": {
+              "argument": {
+                "reference": {
+                  "module": "Prim",
+                  "name": "Type",
+                  "package": null
+                },
+                "tag": "constructor"
+              },
+              "result": {
+                "argument": {
+                  "reference": {
+                    "module": "Prim",
+                    "name": "Type",
+                    "package": null
+                  },
+                  "tag": "constructor"
+                },
+                "result": {
+                  "reference": {
+                    "module": "Prim",
+                    "name": "Type",
+                    "package": null
+                  },
+                  "tag": "constructor"
+                },
+                "tag": "function"
+              },
+              "tag": "function"
+            },
+            "tag": "data"
+          },
+          "name": "Pair"
+        },
+        {
+          "documentation": "Type operator documentation.",
+          "form": {
+            "signature": {
+              "argument": {
+                "reference": {
+                  "module": "Prim",
+                  "name": "Type",
+                  "package": null
+                },
+                "tag": "constructor"
+              },
+              "result": {
+                "argument": {
+                  "reference": {
+                    "module": "Prim",
+                    "name": "Type",
+                    "package": null
+                  },
+                  "tag": "constructor"
+                },
+                "result": {
+                  "reference": {
+                    "module": "Prim",
+                    "name": "Type",
+                    "package": null
+                  },
+                  "tag": "constructor"
+                },
+                "tag": "function"
+              },
+              "tag": "function"
+            },
+            "tag": "operator"
+          },
+          "name": ":+:"
+        },
+        {
+          "documentation": "Choice type documentation.",
+          "form": {
+            "constructors": [
+              {
+                "documentation": "First constructor documentation.",
+                "kind": "Constructor",
+                "name": "First",
+                "signature": {
+                  "reference": {
+                    "module": "Main",
+                    "name": "Choice",
+                    "package": "docs-fixture"
+                  },
+                  "tag": "constructor"
+                }
+              },
+              {
+                "documentation": "Second constructor documentation.",
+                "kind": "Constructor",
+                "name": "Second",
+                "signature": {
+                  "reference": {
+                    "module": "Main",
+                    "name": "Choice",
+                    "package": "docs-fixture"
+                  },
+                  "tag": "constructor"
+                }
+              }
+            ],
+            "declaration": {
+              "binders": []
+            },
+            "instances": [],
+            "signature": {
+              "reference": {
+                "module": "Prim",
+                "name": "Type",
+                "package": null
+              },
+              "tag": "constructor"
+            },
+            "tag": "data"
+          },
+          "name": "Choice"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Goal

Improve compiler integration coverage for diagnostic conversion and documentation rendering without changing production behavior or adding unit tests.

The existing suite exercised common checking diagnostics and baseline package documentation, but left several source-reachable lowering diagnostic variants and documentation annotation/type-rendering paths uncovered. These fixtures make those outputs reviewable at the compiler integration boundary.

## Fixtures

### Not-in-scope diagnostic rendering

Adds a checking fixture covering unresolved names in distinct lowering syntax positions:

- expression variables and constructors
- term and type operators
- numeric negation
- `do` support functions (`bind` and `discard`)
- `ado` support functions (`map`, `apply`, and `pure`)
- type constructors

The snapshot verifies diagnostic codes and messages, exact source spans, single-line caret markers, multi-line spans, and the checking recovery diagnostics emitted alongside lowering failures.

### Documentation annotation surfaces

Adds a docs fixture covering:

- multiline module documentation
- foreign term documentation
- value and type operator documentation
- constructor documentation placed before `=` and `|`
- value-equation documentation fallback
- signature documentation precedence over equation documentation
- open-row, integer literal, string literal, kind-application, and kinded-type JSON rendering

This exercises both `compiler-core/documenting` annotation association and `compiler-lsp/documentation` schema rendering.

## Integration-only coverage

Measured from clean `cargo llvm-cov` runs of `tests-integration` before and after the fixtures:

| Crate | Line coverage | Region coverage |
| --- | --- | --- |
| `compiler-core/diagnostics` | 551/801 (68.79%) → 578/801 (72.16%) | 743/1160 (64.05%) → 791/1160 (68.19%) |
| `compiler-core/documenting` | 181/211 (85.78%) → 193/211 (91.47%) | 327/388 (84.28%) → 356/388 (91.75%) |
| `compiler-lsp/documentation` | 417/516 (80.81%) → 442/516 (85.66%) | 752/1010 (74.46%) → 804/1010 (79.60%) |

Notable file deltas:

- `diagnostics/src/convert.rs`: 71.07% → 76.90% lines
- `diagnostics/src/context.rs`: 92.45% → 94.97% lines
- `documenting/src/annotation.rs`: 84.34% → 91.57% lines
- `documentation/src/render.rs`: 81.60% → 85.71% lines
- `compiler-lsp/documentation`: 51/54 → 54/54 functions covered

## Verification

- `just t checking` — all checking fixtures passed with no pending snapshots
- `cargo nextest run -p tests-integration --test docs` — 5/5 passed
- `cargo llvm-cov clean --workspace && cargo llvm-cov nextest --no-report -p tests-integration` — 708/708 passed
