### PR TITLE
[resolving] Improve resolver pipeline integration coverage

### DIFF
--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/DuplicateClasses.purs
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/DuplicateClasses.purs
@@ -1,0 +1,7 @@
+module DuplicateClasses where
+
+class Shared a
+
+data Between
+
+class Shared a

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/DuplicateClasses.snap
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/DuplicateClasses.snap
@@ -1,0 +1,32 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 102
+expression: report
+---
+module DuplicateClasses
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+
+Exported Types:
+  - Between
+
+Exported Classes:
+  - Shared
+
+Local Terms:
+
+Local Types:
+  - Between
+
+Local Classes:
+  - Shared
+
+Class Members:
+
+Errors:
+  - ExistingType { existing: (Idx::<File>(9), Idx::<IndexedTypeItem>(0)), duplicate: (Idx::<File>(9), Idx::<IndexedTypeItem>(2)) }
+  - TypeExportConflict { existing: (Idx::<File>(9), Idx::<IndexedTypeItem>(0), Local), duplicate: (Idx::<File>(9), Idx::<IndexedTypeItem>(2), Local) }

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/HiddenReExport.purs
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/HiddenReExport.purs
@@ -1,0 +1,3 @@
+module HiddenReExport (module LibraryA) where
+
+import LibraryA hiding (class Shared)

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/HiddenReExport.snap
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/HiddenReExport.snap
@@ -1,0 +1,34 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 102
+expression: report
+---
+module HiddenReExport
+
+Unqualified Imports:
+
+Terms:
+  - sharedA is Implicit
+
+Types:
+
+Classes:
+
+Qualified Imports:
+
+Exported Terms:
+  - sharedA
+
+Exported Types:
+
+Exported Classes:
+
+Local Terms:
+
+Local Types:
+
+Local Classes:
+
+Class Members:
+
+Errors:

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/LibraryA.purs
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/LibraryA.purs
@@ -1,0 +1,4 @@
+module LibraryA where
+
+class Shared a where
+  sharedA :: a -> a

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/LibraryA.snap
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/LibraryA.snap
@@ -1,0 +1,31 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 102
+expression: report
+---
+module LibraryA
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+  - sharedA
+
+Exported Types:
+
+Exported Classes:
+  - Shared
+
+Local Terms:
+  - sharedA
+
+Local Types:
+
+Local Classes:
+  - Shared
+
+Class Members:
+  - Shared.sharedA
+
+Errors:

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/LibraryB.purs
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/LibraryB.purs
@@ -1,0 +1,4 @@
+module LibraryB where
+
+class Shared a where
+  sharedB :: a -> a

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/LibraryB.snap
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/LibraryB.snap
@@ -1,0 +1,31 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 102
+expression: report
+---
+module LibraryB
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+  - sharedB
+
+Exported Types:
+
+Exported Classes:
+  - Shared
+
+Local Terms:
+  - sharedB
+
+Local Types:
+
+Local Classes:
+  - Shared
+
+Class Members:
+  - Shared.sharedB
+
+Errors:

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/Main.purs
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/Main.purs
@@ -1,0 +1,4 @@
+module Main (module First, module Second) where
+
+import LibraryA as First
+import LibraryB as Second

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/Main.snap
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/Main.snap
@@ -1,0 +1,48 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 102
+expression: report
+---
+module Main
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Second Terms:
+  - sharedB is Implicit
+
+Second Types:
+
+Second Classes:
+  - Shared is Implicit
+
+First Terms:
+  - sharedA is Implicit
+
+First Types:
+
+First Classes:
+  - Shared is Implicit
+
+Exported Terms:
+  - sharedB
+  - sharedA
+
+Exported Types:
+
+Exported Classes:
+  - Shared
+
+Local Terms:
+
+Local Types:
+
+Local Classes:
+
+Class Members:
+  - Shared.sharedA (imported)
+  - Shared.sharedB (imported)
+
+Errors:
+  - TypeExportConflict { existing: (Idx::<File>(12), Idx::<IndexedTypeItem>(0), Import(AstId<syntax::cst::ImportStatement>(14))), duplicate: (Idx::<File>(11), Idx::<IndexedTypeItem>(0), Import(AstId<syntax::cst::ImportStatement>(10))) }

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/SameItem.purs
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/SameItem.purs
@@ -1,0 +1,4 @@
+module SameItem (module First, module Again) where
+
+import LibraryA as First
+import LibraryA as Again

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/SameItem.snap
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/SameItem.snap
@@ -1,0 +1,45 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 102
+expression: report
+---
+module SameItem
+
+Unqualified Imports:
+
+Qualified Imports:
+
+First Terms:
+  - sharedA is Implicit
+
+First Types:
+
+First Classes:
+  - Shared is Implicit
+
+Again Terms:
+  - sharedA is Implicit
+
+Again Types:
+
+Again Classes:
+  - Shared is Implicit
+
+Exported Terms:
+  - sharedA
+
+Exported Types:
+
+Exported Classes:
+  - Shared
+
+Local Terms:
+
+Local Types:
+
+Local Classes:
+
+Class Members:
+  - Shared.sharedA (imported)
+
+Errors:

--- a/tests-integration/fixtures/resolving/1786810320_duplicate_import_selections/Library.purs
+++ b/tests-integration/fixtures/resolving/1786810320_duplicate_import_selections/Library.purs
@@ -1,0 +1,5 @@
+module Library where
+
+value = 123
+
+data Choice = First | Second

--- a/tests-integration/fixtures/resolving/1786810320_duplicate_import_selections/Library.snap
+++ b/tests-integration/fixtures/resolving/1786810320_duplicate_import_selections/Library.snap
@@ -1,0 +1,34 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 102
+expression: report
+---
+module Library
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+  - value
+  - Second
+  - First
+
+Exported Types:
+  - Choice
+
+Exported Classes:
+
+Local Terms:
+  - value
+  - Second
+  - First
+
+Local Types:
+  - Choice
+
+Local Classes:
+
+Class Members:
+
+Errors:

--- a/tests-integration/fixtures/resolving/1786810320_duplicate_import_selections/Main.purs
+++ b/tests-integration/fixtures/resolving/1786810320_duplicate_import_selections/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Library
+  ( value
+  , value
+  , Choice(First)
+  , Choice(Second)
+  , Choice(..)
+  , Choice(First, First)
+  )

--- a/tests-integration/fixtures/resolving/1786810320_duplicate_import_selections/Main.snap
+++ b/tests-integration/fixtures/resolving/1786810320_duplicate_import_selections/Main.snap
@@ -1,0 +1,36 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 102
+expression: report
+---
+module Main
+
+Unqualified Imports:
+
+Terms:
+  - value is Explicit
+  - Second is Explicit
+  - First is Explicit
+
+Types:
+  - Choice is Explicit
+
+Classes:
+
+Qualified Imports:
+
+Exported Terms:
+
+Exported Types:
+
+Exported Classes:
+
+Local Terms:
+
+Local Types:
+
+Local Classes:
+
+Class Members:
+
+Errors:

--- a/tests-integration/fixtures/resolving/1786810320_operator_imports_and_exports/Library.purs
+++ b/tests-integration/fixtures/resolving/1786810320_operator_imports_and_exports/Library.purs
@@ -1,0 +1,9 @@
+module Library (append, Product, (<>), type (:*:)) where
+
+append left _ = left
+
+infixr 5 append as <>
+
+type Product a b = a
+
+infixr 6 type Product as :*:

--- a/tests-integration/fixtures/resolving/1786810320_operator_imports_and_exports/Library.snap
+++ b/tests-integration/fixtures/resolving/1786810320_operator_imports_and_exports/Library.snap
@@ -1,0 +1,34 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 102
+expression: report
+---
+module Library
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+  - append
+  - <>
+
+Exported Types:
+  - Product
+  - :*:
+
+Exported Classes:
+
+Local Terms:
+  - append
+  - <>
+
+Local Types:
+  - Product
+  - :*:
+
+Local Classes:
+
+Class Members:
+
+Errors:

--- a/tests-integration/fixtures/resolving/1786810320_operator_imports_and_exports/Main.purs
+++ b/tests-integration/fixtures/resolving/1786810320_operator_imports_and_exports/Main.purs
@@ -1,0 +1,3 @@
+module Main where
+
+import Library ((<>), type (:*:))

--- a/tests-integration/fixtures/resolving/1786810320_operator_imports_and_exports/Main.snap
+++ b/tests-integration/fixtures/resolving/1786810320_operator_imports_and_exports/Main.snap
@@ -1,0 +1,34 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 102
+expression: report
+---
+module Main
+
+Unqualified Imports:
+
+Terms:
+  - <> is Explicit
+
+Types:
+  - :*: is Explicit
+
+Classes:
+
+Qualified Imports:
+
+Exported Terms:
+
+Exported Types:
+
+Exported Classes:
+
+Local Terms:
+
+Local Types:
+
+Local Classes:
+
+Class Members:
+
+Errors:

--- a/tests-integration/fixtures/resolving/1786810320_type_declaration_grouping/Main.purs
+++ b/tests-integration/fixtures/resolving/1786810320_type_declaration_grouping/Main.purs
@@ -1,0 +1,21 @@
+module Main (Data, Newtype, Synonym, class Example, Foreign, foreignValue) where
+
+data Data :: Type -> Type
+data Data a = Data a
+type role Data representational
+
+newtype Newtype :: Type -> Type
+newtype Newtype a = Newtype a
+type role Newtype representational
+
+type Synonym :: Type -> Type
+type Synonym a = a
+
+class Example :: Type -> Constraint
+class Example a where
+  example :: a -> a
+
+foreign import data Foreign :: Type -> Type
+type role Foreign representational
+
+foreign import foreignValue :: Foreign Int

--- a/tests-integration/fixtures/resolving/1786810320_type_declaration_grouping/Main.snap
+++ b/tests-integration/fixtures/resolving/1786810320_type_declaration_grouping/Main.snap
@@ -1,0 +1,43 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 102
+expression: report
+---
+module Main
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+  - foreignValue
+  - example
+
+Exported Types:
+  - Foreign
+  - Data
+  - Newtype
+  - Synonym
+
+Exported Classes:
+  - Example
+
+Local Terms:
+  - foreignValue
+  - Data
+  - Newtype
+  - example
+
+Local Types:
+  - Foreign
+  - Data
+  - Newtype
+  - Synonym
+
+Local Classes:
+  - Example
+
+Class Members:
+  - Example.example
+
+Errors:

--- a/tests-integration/fixtures/resolving/1786810380_explicit_constructor_visibility/Library.purs
+++ b/tests-integration/fixtures/resolving/1786810380_explicit_constructor_visibility/Library.purs
@@ -1,0 +1,3 @@
+module Library (Hidden) where
+
+data Hidden = Hidden

--- a/tests-integration/fixtures/resolving/1786810380_explicit_constructor_visibility/Library.snap
+++ b/tests-integration/fixtures/resolving/1786810380_explicit_constructor_visibility/Library.snap
@@ -1,0 +1,29 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 102
+expression: report
+---
+module Library
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+
+Exported Types:
+  - Hidden
+
+Exported Classes:
+
+Local Terms:
+  - Hidden
+
+Local Types:
+  - Hidden
+
+Local Classes:
+
+Class Members:
+
+Errors:

--- a/tests-integration/fixtures/resolving/1786810380_explicit_constructor_visibility/Main.purs
+++ b/tests-integration/fixtures/resolving/1786810380_explicit_constructor_visibility/Main.purs
@@ -1,0 +1,3 @@
+module Main where
+
+import Library (Hidden(Hidden))

--- a/tests-integration/fixtures/resolving/1786810380_explicit_constructor_visibility/Main.snap
+++ b/tests-integration/fixtures/resolving/1786810380_explicit_constructor_visibility/Main.snap
@@ -1,0 +1,34 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 102
+expression: report
+---
+module Main
+
+Unqualified Imports:
+
+Terms:
+
+Types:
+  - Hidden is Explicit
+
+Classes:
+
+Qualified Imports:
+
+Exported Terms:
+
+Exported Types:
+
+Exported Classes:
+
+Local Terms:
+
+Local Types:
+
+Local Classes:
+
+Class Members:
+
+Errors:
+  - InvalidImportItem { id: AstId<syntax::cst::ImportItem>(8) }


### PR DESCRIPTION
## Goal

Improve integration-test coverage for the indexing and resolving stages through source-level PureScript scenarios in the resolving fixture suite. The fixtures target substantive compiler branches that were reachable from source but absent from the existing suite, without adding unit tests or changing production behavior.

## Scenarios

- Resolve term and type operators through explicit exports and imports.
- Group kind signatures and equations for data, newtype, synonym, and class declarations into their module identities, including roles and foreign declarations.
- Merge duplicate value imports and enumerated/everything constructor selections.
- Distinguish identical class re-exports from conflicting ones, filter hidden class re-exports, and diagnose duplicate local classes.
- Reject an enumerated constructor import when the constructor is hidden by an explicit export list.

## Coverage

Measured from clean, resolving-suite-only runs on the base revision and this branch:

| Crate/file | Baseline | After | Delta |
| --- | ---: | ---: | ---: |
| `indexing/src/algorithm.rs` | 552/837 (65.95%) | 756/837 (90.32%) | +204 lines, +24.37 pp |
| `indexing/src/lib.rs` | 54/178 (30.34%) | 54/178 (30.34%) | unchanged |
| `indexing` total | 606/1015 (59.70%) | 810/1015 (79.80%) | +204 lines, +20.10 pp |
| `resolving/src/algorithm.rs` | 448/465 (96.34%) | 459/465 (98.71%) | +11 lines, +2.37 pp |
| `resolving/src/lib.rs` | 75/308 (24.35%) | 75/308 (24.35%) | unchanged |
| `resolving` total | 523/773 (67.66%) | 534/773 (69.08%) | +11 lines, +1.42 pp |

The unchanged `lib.rs` APIs are downstream lookup and scope consumers that the resolving report path does not invoke. Remaining uncovered resolver algorithm paths are error-propagation or invariant-only paths and were intentionally not targeted.

## Verification

- Focused resolving runs for every new fixture, with all generated snapshots reviewed.
- `cargo llvm-cov clean --workspace && cargo llvm-cov nextest --no-report -p tests-integration --test resolving` — 48 tests passed.
- `just t resolving` — all tests passed with no pending snapshots.