### PR TITLE
[tests] Cover lexer and parser recovery branches

### DIFF
--- a/tests-integration/fixtures/lowering/1786810440_parenthesized_kinded_type_variable/Main.purs
+++ b/tests-integration/fixtures/lowering/1786810440_parenthesized_kinded_type_variable/Main.purs
@@ -1,0 +1,4 @@
+module Main where
+
+kinded :: ((a) :: Type) -> a
+kinded value = value

--- a/tests-integration/fixtures/lowering/1786810440_parenthesized_kinded_type_variable/Main.snap
+++ b/tests-integration/fixtures/lowering/1786810440_parenthesized_kinded_type_variable/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 85
+expression: report
+---
+module Main
+
+Expressions:
+
+value@3:14
+  -> binder@3:6
+
+Types:
+
+a@2:12
+  -> nothing
+a@2:26
+  -> nothing

--- a/tests-integration/fixtures/lowering/1786810440_trailing_collection_separators/Main.purs
+++ b/tests-integration/fixtures/lowering/1786810440_trailing_collection_separators/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+arrayBinder [value,] = value
+recordBinder { value, } = value
+
+arrayExpression = [1,]
+recordExpression = { value: 1, }
+
+type Row = ( value :: Int, )
+type Record = { value :: Int, }

--- a/tests-integration/fixtures/lowering/1786810440_trailing_collection_separators/Main.snap
+++ b/tests-integration/fixtures/lowering/1786810440_trailing_collection_separators/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 85
+expression: report
+---
+module Main
+
+Expressions:
+
+value@3:25
+  -> record pun@3:14
+1@5:19
+  -> integer 1
+value@2:22
+  -> binder@2:13
+1@6:27
+  -> integer 1
+
+Types:

--- a/tests-integration/fixtures/lowering/1786810440_trailing_module_list_separators/Main.purs
+++ b/tests-integration/fixtures/lowering/1786810440_trailing_module_list_separators/Main.purs
@@ -1,0 +1,5 @@
+module Main (value,) where
+
+import Library (value,)
+
+value = 1

--- a/tests-integration/fixtures/lowering/1786810440_trailing_module_list_separators/Main.snap
+++ b/tests-integration/fixtures/lowering/1786810440_trailing_module_list_separators/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 85
+expression: report
+---
+module Main
+
+Expressions:
+
+1@4:7
+  -> integer 1
+
+Types:

--- a/tests-integration/fixtures/lowering/1786810440_unexpected_collection_tokens/Main.purs
+++ b/tests-integration/fixtures/lowering/1786810440_unexpected_collection_tokens/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+arrayBinder [class] = 0
+recordBinder { class } = 0
+
+arrayExpression = [class]
+recordExpression = { class }
+
+type Row = ( class )
+type Record = { class }

--- a/tests-integration/fixtures/lowering/1786810440_unexpected_collection_tokens/Main.purs
+++ b/tests-integration/fixtures/lowering/1786810440_unexpected_collection_tokens/Main.purs
@@ -1,10 +1,10 @@
 module Main where
 
 arrayBinder [class] = 0
-recordBinder { class } = 0
+recordBinder { @ } = 0
 
 arrayExpression = [class]
-recordExpression = { class }
+recordExpression = { @ }
 
-type Row = ( class )
-type Record = { class }
+type Row = ( value :: Int, @ )
+type Record = { value :: Int, @ }

--- a/tests-integration/fixtures/lowering/1786810440_unexpected_collection_tokens/Main.snap
+++ b/tests-integration/fixtures/lowering/1786810440_unexpected_collection_tokens/Main.snap
@@ -9,9 +9,7 @@ Expressions:
 
 0@2:21
   -> integer 0
-0@3:24
+0@3:20
   -> integer 0
-{ class }@6:18
-  -> nothing
 
 Types:

--- a/tests-integration/fixtures/lowering/1786810440_unexpected_collection_tokens/Main.snap
+++ b/tests-integration/fixtures/lowering/1786810440_unexpected_collection_tokens/Main.snap
@@ -1,0 +1,17 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 85
+expression: report
+---
+module Main
+
+Expressions:
+
+0@2:21
+  -> integer 0
+0@3:24
+  -> integer 0
+{ class }@6:18
+  -> nothing
+
+Types:

--- a/tests-integration/fixtures/lowering/1786810440_unicode_syntax_tokens/Main.purs
+++ b/tests-integration/fixtures/lowering/1786810440_unicode_syntax_tokens/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+class Parent a
+
+class Parent a ⇐ Child a
+
+identity ∷ ∀ a. Parent a ⇒ a → a
+identity value = value
+
+program = do
+  value ← action
+  pure value

--- a/tests-integration/fixtures/lowering/1786810440_unicode_syntax_tokens/Main.snap
+++ b/tests-integration/fixtures/lowering/1786810440_unicode_syntax_tokens/Main.snap
@@ -1,0 +1,28 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 85
+expression: report
+---
+module Main
+
+Expressions:
+
+action@10:11
+  -> nothing
+value@7:16
+  -> binder@7:8
+pure@10:18
+  -> nothing
+value@11:6
+  -> binder@9:12
+
+Types:
+
+a@6:26
+  -> forall@6:16
+a@6:38
+  -> forall@6:16
+a@4:12
+  -> forall@4:24
+a@6:32
+  -> forall@6:16

--- a/tests-integration/fixtures/lowering/1786810620_determined_only_functional_dependency/Main.purs
+++ b/tests-integration/fixtures/lowering/1786810620_determined_only_functional_dependency/Main.purs
@@ -1,0 +1,3 @@
+module Main where
+
+class Determines result | -> result

--- a/tests-integration/fixtures/lowering/1786810620_determined_only_functional_dependency/Main.snap
+++ b/tests-integration/fixtures/lowering/1786810620_determined_only_functional_dependency/Main.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 85
+expression: report
+---
+module Main
+
+Expressions:
+
+
+Types:
+
+result@2:28
+  -> forall@2:16

--- a/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/Main.purs
+++ b/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+{- outer {- nested -} outer -}
+leadingZeros = 00
+emptyRaw = """"""
+invalidToken = §

--- a/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/Main.snap
+++ b/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 85
+expression: report
+---
+module Main
+
+Expressions:
+
+00@3:14
+  -> integer 0
+""""""@4:10
+  -> string RawString ""
+
+Types:

--- a/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/UnterminatedCharacter.purs
+++ b/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/UnterminatedCharacter.purs
@@ -1,0 +1,3 @@
+module UnterminatedCharacter where
+
+value = '

--- a/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/UnterminatedCharacter.snap
+++ b/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/UnterminatedCharacter.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 85
+expression: report
+---
+module UnterminatedCharacter
+
+Expressions:
+
+'@2:7
+  -> char (missing)
+
+Types:

--- a/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/UnterminatedRawString.purs
+++ b/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/UnterminatedRawString.purs
@@ -1,0 +1,3 @@
+module UnterminatedRawString where
+
+value = """unterminated

--- a/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/UnterminatedRawString.snap
+++ b/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/UnterminatedRawString.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 85
+expression: report
+---
+module UnterminatedRawString
+
+Expressions:
+
+"""unterminated@2:7
+  -> string RawString "\"\"\"unterminated\n"
+
+Types:

--- a/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/UnterminatedString.purs
+++ b/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/UnterminatedString.purs
@@ -1,0 +1,3 @@
+module UnterminatedString where
+
+value = "unterminated

--- a/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/UnterminatedString.snap
+++ b/tests-integration/fixtures/lowering/1786810680_malformed_lexer_literals/UnterminatedString.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 85
+expression: report
+---
+module UnterminatedString
+
+Expressions:
+
+"unterminated@2:7
+  -> string String "\"unterminated\n"
+
+Types:


### PR DESCRIPTION
## Goal

Improve integration-test coverage of source-reachable lexer, parser, and syntax paths that were absent from the clean `origin/main` integration baseline. The fixtures use the lowering category only as the earliest available integration harness; they do not target lowering behavior and make no production changes.

Each retained fixture was measured independently with `cargo llvm-cov` and reaches baseline-zero regions not contributed by the other scenarios.

## Scenarios

- Exercise Unicode PureScript syntax tokens: `∷`, `∀`, `⇐`, `⇒`, `→`, and `←`.
- Cover nested block comments, excessive leading zeroes, six-quote empty raw strings, an invalid token, and unterminated character, normal-string, and raw-string literals.
- Recover from trailing separators in array and record binders, expressions, row types, record types, module exports, and import lists.
- Recover from unexpected tokens inside array and record binders, array and record expressions, row types, and record types.
- Parse a parenthesized kinded type variable, `((a) :: Type)`, reaching the previously unexecuted parser path.
- Traverse a determined-only functional dependency, `| -> result`, reaching both its parser branch and `FunctionalDependencyDetermined::children` in `syntax`.

## Clean integration coverage

| Source file | Line coverage before | Line coverage after | Region delta |
| --- | ---: | ---: | ---: |
| `lexing/src/lexer.rs` | 386/417 (92.57%) | 403/417 (96.64%) | +24 |
| `parsing/src/parser.rs` | 665/757 (87.85%) | 677/757 (89.43%) | +23 |
| `parsing/src/parser/binders.rs` | 115/133 (86.47%) | 123/133 (92.48%) | +12 |
| `parsing/src/parser/expressions.rs` | 379/424 (89.39%) | 387/424 (91.27%) | +12 |
| `parsing/src/parser/types.rs` | 206/237 (86.92%) | 231/237 (97.47%) | +59 |
| `syntax/src/cst.rs` | 18/21 (85.71%) | 21/21 (100.00%) | +5 |

The clean integration-only run increased from 706 to 716 passing tests. It also covered the final missing functions in `parser.rs`, `parser/types.rs`, and `syntax/cst.rs`.

## Verification

- Focused lowering runs for every new fixture, with generated snapshots reviewed and accepted.
- Independent clean coverage runs confirming a unique baseline-zero contribution from every retained fixture folder.
- `just t lowering` — all lowering integration tests passed with no pending snapshots.
- `cargo llvm-cov clean --workspace && cargo llvm-cov nextest --no-report -p tests-integration` — 716/716 tests passed.
- `git diff --check`.
