### PR TITLE
[tests] Establish shared backend feature corpus

### DIFF
--- a/compiler-scripts/src/main.rs
+++ b/compiler-scripts/src/main.rs
@@ -9,7 +9,7 @@ use compiler_scripts::test_runner::{
 #[derive(Parser)]
 #[command(about = "Compiler development scripts")]
 struct Cli {
-    /// Test category: checking (c), semantic (s), lowering (l), resolving (r), lsp, docs
+    /// Test category: backend (b), checking (c), semantic (s), lowering (l), resolving (r), lsp, docs
     category: TestCategory,
 
     #[command(flatten)]

--- a/compiler-scripts/src/test_runner/category.rs
+++ b/compiler-scripts/src/test_runner/category.rs
@@ -4,6 +4,7 @@ use anyhow::bail;
 
 #[derive(Copy, Clone, Debug)]
 pub enum TestCategory {
+    Backend,
     Checking,
     Semantic,
     Lowering,
@@ -15,6 +16,7 @@ pub enum TestCategory {
 impl TestCategory {
     pub fn as_str(&self) -> &'static str {
         match self {
+            TestCategory::Backend => "backend",
             TestCategory::Checking => "checking",
             TestCategory::Semantic => "semantic",
             TestCategory::Lowering => "lowering",
@@ -41,6 +43,7 @@ impl FromStr for TestCategory {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
+            "backend" | "b" => Ok(TestCategory::Backend),
             "checking" | "c" => Ok(TestCategory::Checking),
             "semantic" | "s" => Ok(TestCategory::Semantic),
             "lowering" | "l" => Ok(TestCategory::Lowering),
@@ -48,7 +51,7 @@ impl FromStr for TestCategory {
             "lsp" => Ok(TestCategory::Lsp),
             "docs" => Ok(TestCategory::Docs),
             _ => bail!(
-                "unknown test category '{}', expected: checking (c), semantic (s), lowering (l), resolving (r), lsp, docs",
+                "unknown test category '{}', expected: backend (b), checking (c), semantic (s), lowering (l), resolving (r), lsp, docs",
                 s
             ),
         }

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ coverage-html:
 @integration *args="":
   cargo nextest run -p tests-integration "$@" --status-level=fail --final-status-level=fail --failure-output=final
 
-[doc("Run integration tests with snapshot diffing: checking|semantic|lowering|resolving|lsp")]
+[doc("Run integration tests with snapshot diffing: backend|checking|semantic|lowering|resolving|lsp")]
 @t *args="":
   cargo run -q -p compiler-scripts --release -- "$@"
 

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -33,6 +33,10 @@ url = "2.5.8"
 datatest-stable = "0.3"
 
 [[test]]
+name = "backend"
+harness = false
+
+[[test]]
 name = "checking"
 harness = false
 

--- a/tests-integration/fixtures/backend/1787021280_literals_arrays_and_records/Main.purs
+++ b/tests-integration/fixtures/backend/1787021280_literals_arrays_and_records/Main.purs
@@ -1,0 +1,25 @@
+module Main where
+
+integer :: Int
+integer = 42
+
+number :: Number
+number = 1.5
+
+character :: Char
+character = 'a'
+
+string :: String
+string = "alexandrite"
+
+boolean :: Boolean
+boolean = true
+
+array :: Array Int
+array = [1, 2, 3]
+
+record :: { integer :: Int, nested :: { value :: String } }
+record = { integer: 42, nested: { value: "nested" } }
+
+projection :: String
+projection = record.nested.value

--- a/tests-integration/fixtures/backend/1787021280_literals_arrays_and_records/Main.snap
+++ b/tests-integration/fixtures/backend/1787021280_literals_arrays_and_records/Main.snap
@@ -1,0 +1,16 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+integer :: Prim.Int
+number :: Prim.Number
+character :: Prim.Char
+string :: Prim.String
+boolean :: Prim.Boolean
+array :: Prim.Array Prim.Int
+record :: { integer :: Prim.Int, nested :: { value :: Prim.String } }
+projection :: Prim.String
+
+Types

--- a/tests-integration/fixtures/backend/1787021340_record_updates/Main.purs
+++ b/tests-integration/fixtures/backend/1787021340_record_updates/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+type Model =
+  { count :: Int
+  , nested :: { enabled :: Boolean, label :: String }
+  }
+
+model :: Model
+model = { count: 0, nested: { enabled: true, label: "before" } }
+
+updated :: Model
+updated = model { count = 1, nested { enabled = false, label = "after" } }

--- a/tests-integration/fixtures/backend/1787021340_record_updates/Main.snap
+++ b/tests-integration/fixtures/backend/1787021340_record_updates/Main.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+model :: Main.Model
+updated :: Main.Model
+
+Types
+Model :: Prim.Type
+
+Synonyms
+type Model = { count :: Prim.Int, nested :: { enabled :: Prim.Boolean, label :: Prim.String } }

--- a/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.purs
+++ b/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.purs
@@ -1,0 +1,21 @@
+module Main where
+
+integer :: Int -> Boolean
+integer 0 = true
+integer _ = false
+
+number :: Number -> Boolean
+number 1.5 = true
+number _ = false
+
+character :: Char -> Boolean
+character 'a' = true
+character _ = false
+
+string :: String -> Boolean
+string "alexandrite" = true
+string _ = false
+
+boolean :: Boolean -> Boolean
+boolean true = true
+boolean false = false

--- a/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.snap
+++ b/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+integer :: Prim.Int -> Prim.Boolean
+number :: Prim.Number -> Prim.Boolean
+character :: Prim.Char -> Prim.Boolean
+string :: Prim.String -> Prim.Boolean
+boolean :: Prim.Boolean -> Prim.Boolean
+
+Types

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.purs
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+data Choice a = Empty | One a | Pair a a
+
+newtype Identity a = Identity a
+
+first :: forall a. Choice a -> Choice a
+first Empty = Empty
+first (One value) = One value
+first whole@(Pair left _) = case whole of
+  Pair _ _ -> One left
+  _ -> Empty
+
+unwrap :: forall a. Identity a -> a
+unwrap (Identity value) = value

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.snap
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Empty :: forall @a. Main.Choice a
+One :: forall @a. a -> Main.Choice a
+Pair :: forall @a. a -> a -> Main.Choice a
+Identity :: forall @a. a -> Main.Identity a
+first :: forall a. Main.Choice a -> Main.Choice a
+unwrap :: forall a. Main.Identity a -> a
+
+Types
+Choice :: Prim.Type -> Prim.Type
+Identity :: Prim.Type -> Prim.Type
+
+Roles
+Choice = [Representational]
+Identity = [Representational]

--- a/tests-integration/fixtures/backend/1787021520_array_patterns/Main.purs
+++ b/tests-integration/fixtures/backend/1787021520_array_patterns/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+describe :: Array Int -> Int
+describe [] = 0
+describe [value] = value
+describe [first, second] = first
+describe _ = 3

--- a/tests-integration/fixtures/backend/1787021520_array_patterns/Main.snap
+++ b/tests-integration/fixtures/backend/1787021520_array_patterns/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+describe :: Prim.Array Prim.Int -> Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787021580_record_patterns/Main.purs
+++ b/tests-integration/fixtures/backend/1787021580_record_patterns/Main.purs
@@ -1,0 +1,4 @@
+module Main where
+
+select :: { first :: Int, nested :: { second :: String } } -> String
+select { first, nested: { second } } = second

--- a/tests-integration/fixtures/backend/1787021580_record_patterns/Main.snap
+++ b/tests-integration/fixtures/backend/1787021580_record_patterns/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+select :: { first :: Prim.Int, nested :: { second :: Prim.String } } -> Prim.String
+
+Types

--- a/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/Main.purs
+++ b/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+choose :: Boolean -> Boolean -> Int
+choose first second = case first, second of
+  true, true -> 2
+  true, false -> 1
+  false, _ -> 0

--- a/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/Main.snap
+++ b/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+choose :: Prim.Boolean -> Prim.Boolean -> Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787021700_guards/Main.purs
+++ b/tests-integration/fixtures/backend/1787021700_guards/Main.purs
@@ -1,0 +1,13 @@
+module Main where
+
+data Choice a = Empty | One a
+
+booleanGuard :: Boolean -> Int
+booleanGuard value
+  | value = 1
+  | true = 0
+
+patternGuard :: Choice Int -> Int
+patternGuard choice
+  | One value <- choice = value
+  | true = 0

--- a/tests-integration/fixtures/backend/1787021700_guards/Main.snap
+++ b/tests-integration/fixtures/backend/1787021700_guards/Main.snap
@@ -1,0 +1,16 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Empty :: forall @a. Main.Choice a
+One :: forall @a. a -> Main.Choice a
+booleanGuard :: Prim.Boolean -> Prim.Int
+patternGuard :: Main.Choice Prim.Int -> Prim.Int
+
+Types
+Choice :: Prim.Type -> Prim.Type
+
+Roles
+Choice = [Representational]

--- a/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.purs
+++ b/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+newtype Identity a = Identity a
+
+unwrap :: forall a. Identity a -> a
+unwrap wrapped =
+  let
+    Identity value = wrapped
+  in
+    value
+
+select :: { first :: Int, second :: String } -> String
+select record =
+  let
+    { first, second } = record
+  in
+    second

--- a/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.snap
+++ b/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Identity :: forall @a. a -> Main.Identity a
+unwrap :: forall a. Main.Identity a -> a
+select :: { first :: Prim.Int, second :: Prim.String } -> Prim.String
+
+Types
+Identity :: Prim.Type -> Prim.Type
+
+Roles
+Identity = [Representational]

--- a/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/Main.purs
+++ b/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+mutual :: Boolean -> Int
+mutual condition = first condition
+  where
+  first :: Boolean -> Int
+  first true = 1
+  first false = second true
+
+  second :: Boolean -> Int
+  second true = 2
+  second false = first true

--- a/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/Main.snap
+++ b/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+mutual :: Prim.Boolean -> Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/Main.purs
+++ b/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+forward :: Int
+forward = later
+
+later :: Int
+later = 42
+
+first :: Boolean -> Int
+first true = 1
+first false = second true
+
+second :: Boolean -> Int
+second true = 2
+second false = first true

--- a/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/Main.snap
+++ b/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/Main.snap
@@ -1,0 +1,12 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+forward :: Prim.Int
+later :: Prim.Int
+first :: Prim.Boolean -> Prim.Int
+second :: Prim.Boolean -> Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.purs
+++ b/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.purs
@@ -1,0 +1,28 @@
+module Main where
+
+class Equal a where
+  equal :: a -> a -> Boolean
+
+class Equal a <= Ordered a where
+  lessThan :: a -> a -> Boolean
+
+foreign import equalInt :: Int -> Int -> Boolean
+foreign import lessThanInt :: Int -> Int -> Boolean
+
+instance Equal Int where
+  equal = equalInt
+
+instance Ordered Int where
+  lessThan = lessThanInt
+
+genericEqual :: forall a. Equal a => a -> a -> Boolean
+genericEqual left right = equal left right
+
+concreteEqual :: Boolean
+concreteEqual = equal 1 2
+
+concreteLessThan :: Boolean
+concreteLessThan = lessThan 1 2
+
+superclassEqual :: forall a. Ordered a => a -> a -> Boolean
+superclassEqual left right = equal left right

--- a/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.snap
+++ b/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.snap
@@ -1,0 +1,28 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+equal :: forall @a. Main.Equal a => a -> a -> Prim.Boolean
+lessThan :: forall @a. Main.Ordered a => a -> a -> Prim.Boolean
+equalInt :: Prim.Int -> Prim.Int -> Prim.Boolean
+lessThanInt :: Prim.Int -> Prim.Int -> Prim.Boolean
+genericEqual :: forall a. Main.Equal a => a -> a -> Prim.Boolean
+concreteEqual :: Prim.Boolean
+concreteLessThan :: Prim.Boolean
+superclassEqual :: forall a. Main.Ordered a => a -> a -> Prim.Boolean
+
+Types
+Equal :: Prim.Type -> Prim.Constraint
+Ordered :: Prim.Type -> Prim.Constraint
+
+Classes
+class forall (a :: Prim.Type). Main.Equal a
+  equal :: forall @a. Main.Equal a => a -> a -> Prim.Boolean
+class forall (a :: Prim.Type). Main.Equal a <= Main.Ordered a
+  lessThan :: forall @a. Main.Ordered a => a -> a -> Prim.Boolean
+
+Instances
+instance Main.Equal Prim.Int
+instance Main.Ordered Prim.Int

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.purs
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.purs
@@ -1,0 +1,22 @@
+module Main where
+
+import Control.Applicative (pure)
+import Control.Apply (apply)
+import Control.Bind (bind, discard)
+import Data.Functor (map)
+import Effect (Effect)
+
+foreign import firstAction :: Effect Int
+foreign import secondAction :: Int -> Effect String
+foreign import independentAction :: Effect Boolean
+
+sequential :: Effect String
+sequential = do
+  first <- firstAction
+  secondAction first
+
+independent :: Effect { first :: Int, second :: Boolean }
+independent = ado
+  first <- firstAction
+  second <- independentAction
+  in { first, second }

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.snap
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+firstAction :: Effect.Effect Prim.Int
+secondAction :: Prim.Int -> Effect.Effect Prim.String
+independentAction :: Effect.Effect Prim.Boolean
+sequential :: Effect.Effect Prim.String
+independent :: Effect.Effect { first :: Prim.Int, second :: Prim.Boolean }
+
+Types

--- a/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.purs
+++ b/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+foreign import data Opaque :: Type
+
+foreign import foreignValue :: Opaque
+foreign import foreignFunction :: Opaque -> Int
+
+value :: Int
+value = foreignFunction foreignValue

--- a/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.snap
+++ b/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+foreignValue :: Main.Opaque
+foreignFunction :: Main.Opaque -> Prim.Int
+value :: Prim.Int
+
+Types
+Opaque :: Prim.Type
+
+Roles
+Opaque = []

--- a/tests-integration/fixtures/backend/1787022120_cross_module_references/Library.purs
+++ b/tests-integration/fixtures/backend/1787022120_cross_module_references/Library.purs
@@ -1,0 +1,9 @@
+module Library where
+
+data Box a = Box a
+
+libraryValue :: Int
+libraryValue = 42
+
+box :: Box Int
+box = Box libraryValue

--- a/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.purs
+++ b/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+import Library (Box(..), box, libraryValue)
+
+unbox :: Box Int -> Int
+unbox (Box value) = value
+
+fromLibrary :: Int
+fromLibrary = unbox box
+
+directReference :: Int
+directReference = libraryValue

--- a/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.snap
+++ b/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+unbox :: Library.Box Prim.Int -> Prim.Int
+fromLibrary :: Prim.Int
+directReference :: Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787022180_desugared_source_forms/Main.purs
+++ b/tests-integration/fixtures/backend/1787022180_desugared_source_forms/Main.purs
@@ -1,0 +1,21 @@
+module Main where
+
+add :: Int -> Int -> Int
+add left right = left
+
+infixl 6 add as +
+
+identity :: forall @a. a -> a
+identity value = value
+
+operatorApplication :: Int
+operatorApplication = 1 + 2
+
+visibleTypeApplication :: Int
+visibleTypeApplication = identity @Int 42
+
+increment :: Int -> Int
+increment = _ + 1
+
+accessValue :: forall value row. { value :: value | row } -> value
+accessValue = _.value

--- a/tests-integration/fixtures/backend/1787022180_desugared_source_forms/Main.snap
+++ b/tests-integration/fixtures/backend/1787022180_desugared_source_forms/Main.snap
@@ -1,0 +1,17 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+add :: Prim.Int -> Prim.Int -> Prim.Int
++ :: Prim.Int -> Prim.Int -> Prim.Int
+identity :: forall @a. a -> a
+operatorApplication :: Prim.Int
+visibleTypeApplication :: Prim.Int
+increment :: Prim.Int -> Prim.Int
+accessValue ::
+  forall value (row :: Prim.Row Prim.Type).
+    { value :: value | (row :: Prim.Row Prim.Type) } -> value
+
+Types

--- a/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/Main.purs
+++ b/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/Main.purs
@@ -1,0 +1,21 @@
+module Main where
+
+apply :: forall a b. (a -> b) -> a -> b
+apply function value = function value
+
+capture :: Int -> Int -> Int
+capture captured = \_ -> captured
+
+choose :: Boolean -> Int -> Int -> Int
+choose condition left right = if condition then left else right
+
+partial :: Int -> Int
+partial = choose true 42
+
+literalCase :: Int -> String
+literalCase value = case value of
+  0 -> "zero"
+  _ -> "other"
+
+higherOrder :: Int
+higherOrder = apply (capture 42) 0

--- a/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/Main.snap
+++ b/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/Main.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+apply :: forall a b. (a -> b) -> a -> b
+capture :: Prim.Int -> Prim.Int -> Prim.Int
+choose :: Prim.Boolean -> Prim.Int -> Prim.Int -> Prim.Int
+partial :: Prim.Int -> Prim.Int
+literalCase :: Prim.Int -> Prim.String
+higherOrder :: Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.purs
+++ b/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.purs
@@ -1,0 +1,16 @@
+module Main where
+
+foreign import addInt :: Int -> Int -> Int
+foreign import multiplyInt :: Int -> Int -> Int
+
+constantAdd :: Int
+constantAdd = addInt 20 22
+
+constantMultiply :: Int
+constantMultiply = multiplyInt 6 7
+
+overflowAdd :: Int
+overflowAdd = addInt 2147483647 1
+
+unknownAdd :: Int -> Int -> Int
+unknownAdd = addInt

--- a/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.snap
+++ b/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+addInt :: Prim.Int -> Prim.Int -> Prim.Int
+multiplyInt :: Prim.Int -> Prim.Int -> Prim.Int
+constantAdd :: Prim.Int
+constantMultiply :: Prim.Int
+overflowAdd :: Prim.Int
+unknownAdd :: Prim.Int -> Prim.Int -> Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.purs
+++ b/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+foreign import await :: Int
+
+arguments :: Int
+arguments = await
+
+default :: { "hyphen-label" :: Int }
+default = { "hyphen-label": arguments }
+
+readLabel :: { "hyphen-label" :: Int } -> Int
+readLabel record = record."hyphen-label"
+
+data Tagged = Tagged { "hyphen-label" :: Int }
+
+tagged :: Tagged
+tagged = Tagged default

--- a/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.snap
+++ b/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+await :: Prim.Int
+arguments :: Prim.Int
+default :: { hyphen-label :: Prim.Int }
+readLabel :: { hyphen-label :: Prim.Int } -> Prim.Int
+Tagged :: { hyphen-label :: Prim.Int } -> Main.Tagged
+tagged :: Main.Tagged
+
+Types
+Tagged :: Prim.Type
+
+Roles
+Tagged = []

--- a/tests-integration/fixtures/backend/1787080920_derived_instance/Main.purs
+++ b/tests-integration/fixtures/backend/1787080920_derived_instance/Main.purs
@@ -1,0 +1,18 @@
+module Main where
+
+import Data.Eq (class Eq, eq)
+import Data.Show (class Show, show)
+
+data Box = Box
+
+derive instance Eq Box
+
+equal :: Boolean
+equal = eq Box Box
+
+newtype Identity a = Identity a
+
+derive newtype instance Show a => Show (Identity a)
+
+rendered :: String
+rendered = show (Identity 42)

--- a/tests-integration/fixtures/backend/1787080920_derived_instance/Main.snap
+++ b/tests-integration/fixtures/backend/1787080920_derived_instance/Main.snap
@@ -1,0 +1,22 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 55
+expression: checking_report
+---
+Terms
+Box :: Main.Box
+equal :: Prim.Boolean
+Identity :: forall @a. a -> Main.Identity a
+rendered :: Prim.String
+
+Types
+Box :: Prim.Type
+Identity :: Prim.Type -> Prim.Type
+
+Derived
+derive Data.Eq.Eq Main.Box
+derive forall a. Data.Show.Show a => Data.Show.Show (Main.Identity a)
+
+Roles
+Box = []
+Identity = [Representational]

--- a/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.purs
+++ b/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.purs
@@ -1,0 +1,32 @@
+module Main where
+
+import Data.Ordering (Ordering)
+import Data.Reflectable (reflectType)
+import Data.Symbol (reflectSymbol)
+import Prim.Boolean (False, True)
+import Prim.Ordering (EQ, GT, LT)
+import Type.Proxy (Proxy(..))
+
+symbol :: String
+symbol = reflectSymbol (Proxy :: Proxy "alexandrite")
+
+reflectedString :: String
+reflectedString = reflectType (Proxy :: Proxy "reflected")
+
+reflectedInteger :: Int
+reflectedInteger = reflectType (Proxy :: Proxy 42)
+
+reflectedTrue :: Boolean
+reflectedTrue = reflectType (Proxy :: Proxy True)
+
+reflectedFalse :: Boolean
+reflectedFalse = reflectType (Proxy :: Proxy False)
+
+reflectedLess :: Ordering
+reflectedLess = reflectType (Proxy :: Proxy LT)
+
+reflectedEqual :: Ordering
+reflectedEqual = reflectType (Proxy :: Proxy EQ)
+
+reflectedGreater :: Ordering
+reflectedGreater = reflectType (Proxy :: Proxy GT)

--- a/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.snap
+++ b/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.snap
@@ -1,0 +1,16 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 55
+expression: checking_report
+---
+Terms
+symbol :: Prim.String
+reflectedString :: Prim.String
+reflectedInteger :: Prim.Int
+reflectedTrue :: Prim.Boolean
+reflectedFalse :: Prim.Boolean
+reflectedLess :: Data.Ordering.Ordering
+reflectedEqual :: Data.Ordering.Ordering
+reflectedGreater :: Data.Ordering.Ordering
+
+Types

--- a/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.purs
+++ b/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+sequence :: Int -> Int
+sequence input =
+  let
+    first = input
+    second = first
+  in
+    second

--- a/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.snap
+++ b/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 55
+expression: checking_report
+---
+Terms
+sequence :: Prim.Int -> Prim.Int
+
+Types

--- a/tests-integration/src/fixtures.rs
+++ b/tests-integration/src/fixtures.rs
@@ -34,6 +34,24 @@ fn missing_module(path: &Path, module: &str) -> io::Error {
     ))
 }
 
+pub fn backend(path: &Path) -> FixtureResult {
+    let folder = fixture_folder(path)?;
+    let file = module_name(path)?;
+    let (engine, _) = crate::load_compiler(folder);
+    let Some(id) = engine.module_file(&file) else {
+        return Err(missing_module(path, &file).into());
+    };
+
+    let report = crate::generated::basic::report_checked(&engine, id);
+
+    let mut settings = insta::Settings::clone_current();
+    settings.set_snapshot_path(snapshot_path(folder));
+    settings.set_prepend_module_to_snapshot(false);
+    settings.bind(|| insta::assert_snapshot!(file, report));
+
+    Ok(())
+}
+
 pub fn checking(path: &Path) -> FixtureResult {
     let folder = fixture_folder(path)?;
     let file = module_name(path)?;

--- a/tests-integration/src/lib.rs
+++ b/tests-integration/src/lib.rs
@@ -60,7 +60,10 @@ pub fn load_compiler(folder: &Path) -> (QueryEngine, Files) {
     let mut files = Files::default();
     configure_materialized_prim(&engine, &mut files);
 
-    if folder.starts_with("fixtures/checking/") || folder.starts_with("fixtures/semantic/") {
+    if folder.starts_with("fixtures/backend/")
+        || folder.starts_with("fixtures/checking/")
+        || folder.starts_with("fixtures/semantic/")
+    {
         let prelude = Path::new("fixtures/checking/prelude");
         load_folder(prelude).for_each(|path| {
             load_file(&mut engine, &mut files, &path);

--- a/tests-integration/tests/backend.rs
+++ b/tests-integration/tests/backend.rs
@@ -1,0 +1,7 @@
+fn backend(path: &std::path::Path) -> datatest_stable::Result<()> {
+    tests_integration::fixtures::backend(path)
+}
+
+datatest_stable::harness! {
+    { test = backend, root = "fixtures/backend", pattern = r".*/Main\.purs$" },
+}


### PR DESCRIPTION
## Summary

- add a shared `backend` integration category covering the language forms required by downstream code generation
- keep fixtures implementation-independent so NbE, SSA, and JavaScript reporters consume the same PureScript sources
- expose the category through `just t backend`

The corpus covers literals, arrays, records and updates, all pattern families, closures, recursion, evidence, foreign and cross-module references, desugared source forms, integer primitives, and hostile JavaScript names.

## Stack

This is 1/7 in the backend stack. The next layer is #344.

## Validation

```text
just format --check
just t backend
cargo check -p tests-integration --tests
cargo clippy -p compiler-scripts -p tests-integration --tests -- -D warnings
```

Closes #329.

Amp-Thread-ID: https://ampcode.com/threads/T-01a015b1-dd0c-761d-9f62-5f25ca77586e

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
