### PR TITLE
[backend] Add arena-allocated NbE functional tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "nbe"
+version = "0.1.0"
+dependencies = [
+ "building-types",
+ "checking",
+ "files",
+ "indexing",
+ "itertools 0.15.0",
+ "la-arena",
+ "lowering",
+ "pretty",
+ "rustc-hash",
+ "smol_str",
+ "thiserror",
+]
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2803,6 +2820,7 @@ dependencies = [
  "line-index",
  "lowering",
  "lsp-types",
+ "nbe",
  "prim-constants",
  "serde_json",
  "similar 3.1.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "compiler-bin",
+  "compiler-backend/*",
   "compiler-core/*",
   "compiler-lsp/*",
   "compiler-scripts",
@@ -9,6 +10,7 @@ members = [
   "tests-integration",
 ]
 default-members = [
+  "compiler-backend/*",
   "compiler-core/*",
   "compiler-lsp/*",
 ]

--- a/compiler-backend/nbe/Cargo.toml
+++ b/compiler-backend/nbe/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "nbe"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+building-types = { version = "0.1.0", path = "../../compiler-core/building-types" }
+checking = { version = "0.1.0", path = "../../compiler-core/checking" }
+files = { version = "0.1.0", path = "../../compiler-core/files" }
+indexing = { version = "0.1.0", path = "../../compiler-core/indexing" }
+itertools = "0.15.0"
+la-arena = "0.3.1"
+lowering = { version = "0.1.0", path = "../../compiler-core/lowering" }
+pretty = "0.12"
+rustc-hash = "2.1.3"
+smol_str = "0.3.5"
+thiserror = "2.0.20"

--- a/compiler-backend/nbe/src/convert.rs
+++ b/compiler-backend/nbe/src/convert.rs
@@ -296,10 +296,13 @@ fn equations(
     let mut alternatives = Vec::with_capacity(equations.len());
     for equation in equations {
         let mut patterns = patterns(context, &equation.binders)?;
+        let supplied = patterns.len();
         while patterns.len() < arity {
             patterns.push(context.pattern(PatternKind::Wildcard));
         }
         let expression = guarded_expression(context, &equation.guarded_expression)?;
+        let remaining_arguments = scrutinees.iter().skip(supplied).copied();
+        let expression = context.application(expression, remaining_arguments);
         alternatives.push(CaseAlternative { patterns: patterns.into(), expression });
     }
     let body = context.expression(ExpressionKind::Case {

--- a/compiler-backend/nbe/src/convert.rs
+++ b/compiler-backend/nbe/src/convert.rs
@@ -46,6 +46,7 @@ struct Context<'c, Q> {
     lowered: Arc<lowering::LoweredModule>,
     checked: Arc<checking::CheckedModule>,
     recursive_groups: FxHashMap<TermItemId, RecursiveGroupId>,
+    record_pun_names: FxHashMap<lowering::RecordPunId, SmolStr>,
 
     parameters: FxHashMap<BindingSource, Parameter>,
     next_local: u32,
@@ -75,6 +76,20 @@ where
             }
         }
 
+        let binders = lowered.tree.iter_binder();
+        let mut binders = binders.collect_vec();
+        binders.sort_unstable_by_key(|(binder_id, _)| *binder_id);
+        let mut record_pun_names = FxHashMap::default();
+        for (_, binder) in binders {
+            let lowering::BinderKind::Record { record } = binder else { continue };
+            for field in record.iter() {
+                let lowering::BinderRecordItem::RecordPun { id, name: Some(name) } = field else {
+                    continue;
+                };
+                record_pun_names.insert(*id, SmolStr::clone(name));
+            }
+        }
+
         Ok(Context {
             queries,
             file_id,
@@ -82,6 +97,7 @@ where
             lowered,
             checked,
             recursive_groups,
+            record_pun_names,
 
             parameters: FxHashMap::default(),
             next_local: 0,
@@ -977,19 +993,10 @@ where
     }
 
     fn record_pun_name(&self, source: lowering::RecordPunId) -> SmolStr {
-        self.lowered
-            .tree
-            .iter_binder()
-            .find_map(|(_, binder)| {
-                let lowering::BinderKind::Record { record } = binder else { return None };
-                record.iter().find_map(|field| {
-                    let lowering::BinderRecordItem::RecordPun { id, name } = field else {
-                        return None;
-                    };
-                    (*id == source).then(|| name.clone()).flatten()
-                })
-            })
-            .unwrap_or_else(|| format_smolstr!("pun{:?}", source))
+        match self.record_pun_names.get(&source) {
+            Some(name) => SmolStr::clone(name),
+            None => format_smolstr!("pun{}", source.into_raw().get()),
+        }
     }
 
     fn term_fallback(&self, term_id: TermItemId) -> SmolStr {

--- a/compiler-backend/nbe/src/convert.rs
+++ b/compiler-backend/nbe/src/convert.rs
@@ -1,0 +1,1002 @@
+//! Conversion from the checked semantic tree into the owned functional tree.
+
+use std::sync::Arc;
+
+use building_types::QueryResult;
+use checking::evidence::{
+    Evidence, EvidenceBinderId, EvidenceId, EvidenceState, EvidenceVarId, InstanceCandidateOrigin,
+};
+use checking::tree as checking_tree;
+use files::FileId;
+use indexing::{DeriveItemId, IndexedTermItemKind, InstanceItemId, OrderedTermItemId, TermItemId};
+use itertools::Itertools;
+use rustc_hash::{FxHashMap, FxHashSet};
+use smol_str::{SmolStr, format_smolstr};
+
+use crate::error::{ConversionError, ConversionResult, UnsupportedState};
+use crate::tree::{
+    Binding, CaseAlternative, Declaration, DeclarationKind, Expression, ExpressionId,
+    ExpressionKind, Field, FieldIdentity, Global, GlobalId, Guard, GuardedAlternative,
+    InstanceIdentity, Literal, LocalId, Module, Parameter, Pattern, PatternId, PatternKind,
+    RecordField, RecordPatternField, RecordUpdate, RecursiveGroupId, ReflectableEvidence,
+    ReflectableOrdering, Storage, SuperclassIdentity, SynthesizedEvidence,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum BindingSource {
+    SourceBinder(lowering::BinderId),
+    CheckedBinder(checking_tree::BinderId),
+    Let(lowering::LetBindingNameGroupId),
+    RecordPun(lowering::RecordPunId),
+    Evidence(EvidenceBinderId),
+}
+
+pub fn convert_module(
+    queries: &impl checking::ExternalQueries,
+    file_id: FileId,
+) -> ConversionResult<Module> {
+    let context = Context::new(queries, file_id)?;
+    convert(context)
+}
+
+struct Context<'c, Q> {
+    queries: &'c Q,
+    file_id: FileId,
+    indexed: Arc<indexing::IndexedModule>,
+    lowered: Arc<lowering::LoweredModule>,
+    checked: Arc<checking::CheckedModule>,
+    recursive_groups: FxHashMap<TermItemId, RecursiveGroupId>,
+
+    parameters: FxHashMap<BindingSource, Parameter>,
+    next_local: u32,
+    lowering_evidence: FxHashSet<EvidenceVarId>,
+
+    storage: Storage,
+}
+
+impl<'c, Q> Context<'c, Q>
+where
+    Q: checking::ExternalQueries,
+{
+    fn new(queries: &'c Q, file_id: FileId) -> ConversionResult<Context<'c, Q>> {
+        let indexed = queries.indexed(file_id)?;
+        let lowered = queries.lowered(file_id)?;
+        let grouped = queries.grouped(file_id)?;
+        let checked = queries.checked(file_id)?;
+
+        let mut recursive_groups = FxHashMap::default();
+        for (position, group) in grouped.term_scc.iter().enumerate() {
+            if !group.is_recursive() {
+                continue;
+            }
+            let group_id = RecursiveGroupId(position as u32);
+            for &term_id in group.as_slice() {
+                recursive_groups.insert(term_id, group_id);
+            }
+        }
+
+        Ok(Context {
+            queries,
+            file_id,
+            indexed,
+            lowered,
+            checked,
+            recursive_groups,
+
+            parameters: FxHashMap::default(),
+            next_local: 0,
+            lowering_evidence: FxHashSet::default(),
+
+            storage: Storage::default(),
+        })
+    }
+}
+
+fn convert(mut context: Context<'_, impl checking::ExternalQueries>) -> ConversionResult<Module> {
+    let ordered_terms = context.indexed.items.ordered_terms().iter().copied();
+    let ordered_terms = ordered_terms.collect_vec();
+    let mut declarations = Vec::new();
+    for item_id in ordered_terms {
+        let declaration = match item_id {
+            OrderedTermItemId::Term(term_id) => term_declaration(&mut context, term_id)?,
+            OrderedTermItemId::Instance(instance_id) => {
+                Some(instance_declaration(&mut context, instance_id)?)
+            }
+            OrderedTermItemId::Derive(derive_id) => {
+                Some(derive_declaration(&mut context, derive_id)?)
+            }
+        };
+        declarations.extend(declaration);
+    }
+
+    Ok(Module {
+        file_id: context.file_id,
+        declarations: declarations.into(),
+        storage: context.storage,
+    })
+}
+
+fn term_declaration(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    term_id: TermItemId,
+) -> ConversionResult<Option<Declaration>> {
+    let indexed_module = Arc::clone(&context.indexed);
+    let checked = Arc::clone(&context.checked);
+    let indexed = &indexed_module.items[term_id];
+    match indexed.kind {
+        IndexedTermItemKind::Constructor { .. }
+        | IndexedTermItemKind::ClassMember { .. }
+        | IndexedTermItemKind::Operator { .. } => Ok(None),
+        IndexedTermItemKind::Foreign { .. } | IndexedTermItemKind::Value { .. } => {
+            let declaration_id = checked.tree.lookup_term(term_id).ok_or_else(|| {
+                context.unsupported(UnsupportedState::MissingTermDeclaration(term_id))
+            })?;
+            let declaration = &checked.tree[declaration_id];
+            let name = if let Some(name) = &indexed.name {
+                name.clone()
+            } else {
+                context.term_fallback(term_id)
+            };
+            let global = Global { id: GlobalId::Term(context.file_id, term_id), name };
+            let recursive_group = context.recursive_groups.get(&term_id).copied();
+            let kind = match &declaration.kind {
+                checking_tree::TermDeclarationKind::Value(value) => {
+                    DeclarationKind::Value(value_declaration(context, value)?)
+                }
+                checking_tree::TermDeclarationKind::Foreign => DeclarationKind::Foreign,
+                checking_tree::TermDeclarationKind::Constructor(_) => return Ok(None),
+                checking_tree::TermDeclarationKind::Instance(_) => {
+                    unreachable!("invariant violated: instance stored as a term declaration")
+                }
+            };
+            Ok(Some(Declaration { global, recursive_group, kind }))
+        }
+    }
+}
+
+fn instance_declaration(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    item_id: InstanceItemId,
+) -> ConversionResult<Declaration> {
+    let indexed = &context.indexed.items[item_id];
+    let identity = InstanceIdentity::Declared(context.file_id, indexed.id);
+    let declaration_id = context
+        .checked
+        .tree
+        .lookup_instance(item_id)
+        .ok_or_else(|| context.unsupported(UnsupportedState::MissingInstanceDeclaration))?;
+    convert_instance_declaration(context, identity, declaration_id)
+}
+
+fn derive_declaration(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    item_id: DeriveItemId,
+) -> ConversionResult<Declaration> {
+    let indexed = &context.indexed.items[item_id];
+    let identity = InstanceIdentity::Derived(context.file_id, indexed.id);
+    let declaration_id = context
+        .checked
+        .tree
+        .lookup_derive(item_id)
+        .ok_or_else(|| context.unsupported(UnsupportedState::MissingInstanceDeclaration))?;
+    convert_instance_declaration(context, identity, declaration_id)
+}
+
+fn convert_instance_declaration(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    identity: InstanceIdentity,
+    declaration_id: checking_tree::TermDeclarationId,
+) -> ConversionResult<Declaration> {
+    let checked = Arc::clone(&context.checked);
+    let declaration = &checked.tree[declaration_id];
+    let checking_tree::TermDeclarationKind::Instance(instance) = &declaration.kind else {
+        unreachable!("invariant violated: instance identity has non-instance declaration")
+    };
+
+    let parameters = instance.evidences.iter().map(|evidence| match evidence.evidence {
+        Evidence::Given(binder) => context.evidence_parameter(binder),
+        _ => Err(context.unsupported(UnsupportedState::InvalidInstancePrerequisite)),
+    });
+    let parameters = parameters.collect::<ConversionResult<Vec<_>>>()?;
+
+    let body = match &instance.implementation {
+        checking_tree::InstanceImplementation::Delegate { evidence, .. } => {
+            evidence_variable(context, *evidence)?
+        }
+        checking_tree::InstanceImplementation::Members(members) => {
+            let mut fields = Vec::new();
+            for superclass in instance.superclasses.iter() {
+                let expression = evidence_variable(context, superclass.evidence)?;
+                let field = context.superclass_field(superclass.id);
+                fields.push(RecordField { field, expression });
+            }
+            for member in members.iter() {
+                let expression = member_declaration(context, member)?;
+                let field = context.member_field(member.resolution)?;
+                fields.push(RecordField { field, expression });
+            }
+            context.expression(ExpressionKind::Record { fields: fields.into() })
+        }
+    };
+    let value = context.parameter_abstraction(parameters, body);
+    let name = context.instance_name(identity)?;
+    let global = Global { id: GlobalId::Instance(identity), name };
+    let kind = DeclarationKind::Value(value);
+    Ok(Declaration { global, recursive_group: None, kind })
+}
+
+fn member_declaration(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    member: &checking_tree::InstanceMember,
+) -> ConversionResult<ExpressionId> {
+    let value = checking_tree::ValueDeclaration {
+        abstractions: Arc::clone(&member.abstractions),
+        equations: Arc::clone(&member.equations),
+    };
+    value_declaration(context, &value)
+}
+
+fn value_declaration(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    value: &checking_tree::ValueDeclaration,
+) -> ConversionResult<ExpressionId> {
+    let body = equations(context, &value.equations)?;
+    let mut evidence_parameters = Vec::new();
+    for abstraction in value.abstractions.iter() {
+        if let checking_tree::DeclarationAbstraction::Evidence { evidence, .. } = abstraction {
+            let Evidence::Given(binder) = evidence else {
+                return Err(context.unsupported(UnsupportedState::InvalidInstancePrerequisite));
+            };
+            evidence_parameters.push(context.evidence_parameter(*binder)?);
+        }
+    }
+    Ok(context.parameter_abstraction(evidence_parameters, body))
+}
+
+fn equations(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    equations: &[checking_tree::Equation],
+) -> ConversionResult<ExpressionId> {
+    let Some(first) = equations.first() else {
+        return Err(context.unsupported(UnsupportedState::MissingEquation));
+    };
+    if equations.len() == 1 {
+        let body = guarded_expression(context, &first.guarded_expression)?;
+        let patterns = patterns(context, &first.binders)?;
+        return Ok(context.abstraction(patterns, body));
+    }
+
+    let arity = equations.iter().map(|equation| equation.binders.len()).max().unwrap_or(0);
+    let mut parameter_patterns = Vec::with_capacity(arity);
+    let mut scrutinees = Vec::with_capacity(arity);
+    for position in 0..arity {
+        let parameter = context.fresh_parameter(format_smolstr!("argument{position}"))?;
+        let pattern = context.pattern(PatternKind::Variable(parameter.clone()));
+        let scrutinee = context.expression(ExpressionKind::Local { parameter: parameter.clone() });
+        parameter_patterns.push(pattern);
+        scrutinees.push(scrutinee);
+    }
+
+    let mut alternatives = Vec::with_capacity(equations.len());
+    for equation in equations {
+        let mut patterns = patterns(context, &equation.binders)?;
+        while patterns.len() < arity {
+            patterns.push(context.pattern(PatternKind::Wildcard));
+        }
+        let expression = guarded_expression(context, &equation.guarded_expression)?;
+        alternatives.push(CaseAlternative { patterns: patterns.into(), expression });
+    }
+    let body = context.expression(ExpressionKind::Case {
+        scrutinees: scrutinees.into(),
+        alternatives: alternatives.into(),
+    });
+    Ok(context.abstraction(parameter_patterns, body))
+}
+
+fn guarded_expression(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    guarded: &checking_tree::GuardedExpression,
+) -> ConversionResult<ExpressionId> {
+    if let [alternative] = guarded.alternatives.as_ref()
+        && alternative.pattern_guards.is_empty()
+    {
+        return where_expression(context, &alternative.where_expression);
+    }
+
+    let alternatives =
+        guarded.alternatives.iter().map(|alternative| guarded_alternative(context, alternative));
+    let alternatives = alternatives.collect::<ConversionResult<Vec<_>>>()?;
+    Ok(context.expression(ExpressionKind::Guarded { alternatives: alternatives.into() }))
+}
+
+fn guarded_alternative(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    alternative: &checking_tree::GuardedAlternative,
+) -> ConversionResult<GuardedAlternative> {
+    let mut guards = Vec::new();
+    for guard in alternative.pattern_guards.iter() {
+        let guard = match guard {
+            checking_tree::PatternGuard::Boolean { expression } => {
+                Guard::Boolean(convert_expression(context, *expression)?)
+            }
+            checking_tree::PatternGuard::Pattern { binder, expression } => Guard::Pattern {
+                expression: convert_expression(context, *expression)?,
+                pattern: convert_pattern(context, *binder)?,
+            },
+        };
+        guards.push(guard);
+    }
+    let expression = where_expression(context, &alternative.where_expression)?;
+    Ok(GuardedAlternative { guards: guards.into(), expression })
+}
+
+fn where_expression(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    where_expression: &checking_tree::WhereExpression,
+) -> ConversionResult<ExpressionId> {
+    let expression = convert_expression(context, where_expression.expression)?;
+    let_bindings(context, &where_expression.bindings, expression)
+}
+
+fn let_bindings(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    bindings: &checking_tree::LetBindings,
+    mut body: ExpressionId,
+) -> ConversionResult<ExpressionId> {
+    let checked = Arc::clone(&context.checked);
+    for chunk in bindings.chunks.iter().rev() {
+        match chunk {
+            checking_tree::LetBindingChunk::Pattern { binder, where_expression: value, .. } => {
+                let value = where_expression(context, value)?;
+                let pattern = convert_pattern(context, *binder)?;
+                body = context.expression(ExpressionKind::LetPattern { pattern, value, body });
+            }
+            checking_tree::LetBindingChunk::PatternError { source, .. } => {
+                return Err(context.unsupported(UnsupportedState::PatternBindingError(*source)));
+            }
+            checking_tree::LetBindingChunk::Names { groups, .. } => {
+                for group in groups.iter().rev() {
+                    let mut converted = Vec::new();
+                    for &source in group.as_slice() {
+                        let Some(declaration_id) = checked.tree.lookup_let(source) else {
+                            return Err(context
+                                .unsupported(UnsupportedState::MissingLocalDeclaration(source)));
+                        };
+                        let declaration = &checked.tree[declaration_id];
+                        let parameter = context.local_parameter(source)?;
+                        let expression = value_declaration(context, &declaration.value)?;
+                        converted.push(Binding { parameter, expression });
+                    }
+                    body = context.expression(ExpressionKind::Let {
+                        recursive: group.is_recursive(),
+                        bindings: converted.into(),
+                        body,
+                    });
+                }
+            }
+        }
+    }
+    Ok(body)
+}
+
+fn convert_expression(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    expression_id: checking_tree::ExpressionId,
+) -> ConversionResult<ExpressionId> {
+    let checked = Arc::clone(&context.checked);
+    let expression = &checked.tree[expression_id];
+    let kind = match &expression.kind {
+        checking_tree::ExpressionKind::String { value, .. } => {
+            ExpressionKind::Literal { literal: Literal::String(value.clone()) }
+        }
+        checking_tree::ExpressionKind::Char { value } => {
+            ExpressionKind::Literal { literal: Literal::Char(*value) }
+        }
+        checking_tree::ExpressionKind::Boolean { value } => {
+            ExpressionKind::Literal { literal: Literal::Boolean(*value) }
+        }
+        checking_tree::ExpressionKind::Integer { value } => {
+            ExpressionKind::Literal { literal: Literal::Integer(*value) }
+        }
+        checking_tree::ExpressionKind::Number { value } => {
+            ExpressionKind::Literal { literal: Literal::Number(value.clone()) }
+        }
+        checking_tree::ExpressionKind::Array { elements } => {
+            let elements = expressions(context, elements)?;
+            ExpressionKind::Array { elements: elements.into() }
+        }
+        checking_tree::ExpressionKind::Record { fields } => {
+            let mut converted = Vec::new();
+            for field in fields.iter() {
+                let (label, expression) = match field {
+                    checking_tree::RecordExpressionField::Field { label, expression }
+                    | checking_tree::RecordExpressionField::Pun { label, expression, .. } => {
+                        (label, expression)
+                    }
+                };
+                let field = context.label_field(label.clone());
+                let expression = convert_expression(context, *expression)?;
+                converted.push(RecordField { field, expression });
+            }
+            ExpressionKind::Record { fields: converted.into() }
+        }
+        checking_tree::ExpressionKind::RecordAccess { record, labels } => {
+            let mut record = convert_expression(context, *record)?;
+            for label in labels.iter() {
+                let field = context.label_field(label.clone());
+                record = context.expression(ExpressionKind::Project { record, field });
+            }
+            return Ok(record);
+        }
+        checking_tree::ExpressionKind::RecordUpdate { record, updates } => {
+            let record = convert_expression(context, *record)?;
+            let updates = record_updates(context, updates)?;
+            ExpressionKind::RecordUpdate { record, updates: updates.into() }
+        }
+        checking_tree::ExpressionKind::Constructor { resolution } => {
+            ExpressionKind::Constructor { global: context.term_global(resolution.0, resolution.1)? }
+        }
+        checking_tree::ExpressionKind::Variable { resolution }
+        | checking_tree::ExpressionKind::RecordPun { resolution, .. } => {
+            return variable(context, *resolution);
+        }
+        checking_tree::ExpressionKind::Section { binder } => {
+            let parameter = context.checked_binder_parameter(*binder)?;
+            ExpressionKind::Local { parameter }
+        }
+        checking_tree::ExpressionKind::TermApplication { function, argument } => {
+            let function = convert_expression(context, *function)?;
+            let argument = convert_expression(context, *argument)?;
+            return Ok(context.application(function, [argument]));
+        }
+        checking_tree::ExpressionKind::EvidenceApplication { function, evidence, .. } => {
+            let evidence = evidence_variable(context, *evidence)?;
+            if let Some(resolution) = class_member_resolution(context, *function)? {
+                let field = context.member_field(resolution)?;
+                return Ok(context.expression(ExpressionKind::Project { record: evidence, field }));
+            }
+            let function = convert_expression(context, *function)?;
+            return Ok(context.application(function, [evidence]));
+        }
+        checking_tree::ExpressionKind::EvidenceAbstraction { binder, expression } => {
+            let parameter = context.evidence_parameter(*binder)?;
+            let body = convert_expression(context, *expression)?;
+            return Ok(context.parameter_abstraction([parameter], body));
+        }
+        checking_tree::ExpressionKind::Lambda { binders, expression } => {
+            let parameters = patterns(context, binders)?;
+            let body = convert_expression(context, *expression)?;
+            return Ok(context.abstraction(parameters, body));
+        }
+        checking_tree::ExpressionKind::IfThenElse { condition, then, else_ } => {
+            ExpressionKind::IfThenElse {
+                condition: convert_expression(context, *condition)?,
+                then: convert_expression(context, *then)?,
+                else_: convert_expression(context, *else_)?,
+            }
+        }
+        checking_tree::ExpressionKind::Case { scrutinees, alternatives } => {
+            let scrutinees = expressions(context, scrutinees)?;
+            let alternatives =
+                alternatives.iter().map(|alternative| case_alternative(context, alternative));
+            let alternatives = alternatives.collect::<ConversionResult<Vec<_>>>()?;
+            ExpressionKind::Case {
+                scrutinees: scrutinees.into(),
+                alternatives: alternatives.into(),
+            }
+        }
+        checking_tree::ExpressionKind::Let { bindings, expression } => {
+            let body = convert_expression(context, *expression)?;
+            return let_bindings(context, bindings, body);
+        }
+        checking_tree::ExpressionKind::Error => {
+            return Err(context.unsupported(UnsupportedState::ExpressionError(expression_id)));
+        }
+    };
+    Ok(context.expression(kind))
+}
+
+fn class_member_resolution(
+    context: &Context<'_, impl checking::ExternalQueries>,
+    expression_id: checking_tree::ExpressionId,
+) -> QueryResult<Option<(FileId, TermItemId)>> {
+    let expression = &context.checked.tree[expression_id];
+    let resolution = match expression.kind {
+        checking_tree::ExpressionKind::Variable { resolution }
+        | checking_tree::ExpressionKind::RecordPun { resolution, .. } => resolution,
+        _ => return Ok(None),
+    };
+    let checking_tree::VariableResolution::Source(resolution) = resolution else {
+        return Ok(None);
+    };
+    let lowering::TermVariableResolution::Reference(file_id, term_id) = resolution else {
+        return Ok(None);
+    };
+    let indexed = if file_id == context.file_id {
+        Arc::clone(&context.indexed)
+    } else {
+        context.queries.indexed(file_id)?
+    };
+    let is_class_member =
+        matches!(indexed.items[term_id].kind, IndexedTermItemKind::ClassMember { .. });
+    Ok(is_class_member.then_some((file_id, term_id)))
+}
+
+fn case_alternative(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    alternative: &checking_tree::CaseAlternative,
+) -> ConversionResult<CaseAlternative> {
+    let patterns = patterns(context, &alternative.binders)?;
+    let expression = guarded_expression(context, &alternative.guarded_expression)?;
+    Ok(CaseAlternative { patterns: patterns.into(), expression })
+}
+
+fn expressions(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    expressions: &[checking_tree::ExpressionId],
+) -> ConversionResult<Vec<ExpressionId>> {
+    let expressions = expressions.iter().map(|&expression| convert_expression(context, expression));
+    expressions.collect::<ConversionResult<Vec<_>>>()
+}
+
+fn record_updates(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    updates: &[checking_tree::RecordExpressionUpdate],
+) -> ConversionResult<Vec<RecordUpdate>> {
+    let mut converted = Vec::new();
+    for update in updates {
+        let update = match update {
+            checking_tree::RecordExpressionUpdate::Leaf { label, expression } => {
+                RecordUpdate::Leaf {
+                    field: context.label_field(label.clone()),
+                    expression: convert_expression(context, *expression)?,
+                }
+            }
+            checking_tree::RecordExpressionUpdate::Branch { label, updates } => {
+                let updates = record_updates(context, updates)?;
+                RecordUpdate::Branch {
+                    field: context.label_field(label.clone()),
+                    updates: updates.into(),
+                }
+            }
+            checking_tree::RecordExpressionUpdate::Error => {
+                return Err(context.unsupported(UnsupportedState::RecordUpdateError));
+            }
+        };
+        converted.push(update);
+    }
+    Ok(converted)
+}
+
+fn patterns(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    binders: &[checking_tree::BinderId],
+) -> ConversionResult<Vec<PatternId>> {
+    let patterns = binders.iter().map(|&binder| convert_pattern(context, binder));
+    patterns.collect::<ConversionResult<Vec<_>>>()
+}
+
+fn convert_pattern(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    binder_id: checking_tree::BinderId,
+) -> ConversionResult<PatternId> {
+    let checked = Arc::clone(&context.checked);
+    let binder = &checked.tree[binder_id];
+    let kind = match &binder.kind {
+        checking_tree::BinderKind::Typed { binder, .. } => {
+            return convert_pattern(context, *binder);
+        }
+        checking_tree::BinderKind::Integer { value } => {
+            PatternKind::Literal(Literal::Integer(*value))
+        }
+        checking_tree::BinderKind::Number { negative, value } => {
+            let value = if *negative { format_smolstr!("-{value}") } else { value.clone() };
+            PatternKind::Literal(Literal::Number(value))
+        }
+        checking_tree::BinderKind::Variable => {
+            PatternKind::Variable(context.checked_binder_parameter(binder_id)?)
+        }
+        checking_tree::BinderKind::Named { name, binder } => PatternKind::Named {
+            parameter: context.parameter(context.binding_source(binder_id), name.clone())?,
+            pattern: convert_pattern(context, *binder)?,
+        },
+        checking_tree::BinderKind::Wildcard => PatternKind::Wildcard,
+        checking_tree::BinderKind::String { value } => {
+            PatternKind::Literal(Literal::String(value.clone()))
+        }
+        checking_tree::BinderKind::Char { value } => PatternKind::Literal(Literal::Char(*value)),
+        checking_tree::BinderKind::Boolean { value } => {
+            PatternKind::Literal(Literal::Boolean(*value))
+        }
+        checking_tree::BinderKind::Array { elements } => {
+            PatternKind::Array(patterns(context, elements)?.into())
+        }
+        checking_tree::BinderKind::Record { fields } => {
+            let converted =
+                fields.iter().map(|field| record_pattern_field(context, binder_id, field));
+            let converted = converted.collect::<ConversionResult<Vec<_>>>()?;
+            PatternKind::Record(converted.into())
+        }
+        checking_tree::BinderKind::Constructor { resolution, arguments } => {
+            PatternKind::Constructor {
+                global: context.term_global(resolution.0, resolution.1)?,
+                arguments: patterns(context, arguments)?.into(),
+            }
+        }
+        checking_tree::BinderKind::Error => {
+            return Err(context.unsupported(UnsupportedState::BinderError(binder_id)));
+        }
+    };
+    Ok(context.pattern(kind))
+}
+
+fn record_pattern_field(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    binder_id: checking_tree::BinderId,
+    field: &checking_tree::RecordBinderField,
+) -> ConversionResult<RecordPatternField> {
+    let (label, pattern) = match field {
+        checking_tree::RecordBinderField::Field { label, binder } => {
+            (label.clone(), convert_pattern(context, *binder)?)
+        }
+        checking_tree::RecordBinderField::Pun { label } => {
+            let Some(source) = context.record_pun_source(binder_id, label) else {
+                return Err(context.unsupported(UnsupportedState::BinderError(binder_id)));
+            };
+            let parameter = context.record_pun_parameter(source, label.clone())?;
+            (label.clone(), context.pattern(PatternKind::Variable(parameter)))
+        }
+    };
+    Ok(RecordPatternField { field: context.label_field(label), pattern })
+}
+
+fn variable(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    resolution: checking_tree::VariableResolution,
+) -> ConversionResult<ExpressionId> {
+    match resolution {
+        checking_tree::VariableResolution::Generated(binder) => {
+            let parameter = context.checked_binder_parameter(binder)?;
+            Ok(context.expression(ExpressionKind::Local { parameter }))
+        }
+        checking_tree::VariableResolution::Source(resolution) => match resolution {
+            lowering::TermVariableResolution::Binder(binder) => {
+                let name = context.source_binder_name(binder);
+                let parameter = context.parameter(BindingSource::SourceBinder(binder), name)?;
+                Ok(context.expression(ExpressionKind::Local { parameter }))
+            }
+            lowering::TermVariableResolution::Let(source) => {
+                let parameter = context.local_parameter(source)?;
+                Ok(context.expression(ExpressionKind::Local { parameter }))
+            }
+            lowering::TermVariableResolution::RecordPun(source) => {
+                let name = context.record_pun_name(source);
+                let parameter = context.record_pun_parameter(source, name)?;
+                Ok(context.expression(ExpressionKind::Local { parameter }))
+            }
+            lowering::TermVariableResolution::Reference(file_id, term_id) => {
+                let global = context.term_global(file_id, term_id)?;
+                Ok(context.expression(ExpressionKind::Global { global }))
+            }
+        },
+    }
+}
+
+fn evidence_variable(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    variable: EvidenceVarId,
+) -> ConversionResult<ExpressionId> {
+    if !context.lowering_evidence.insert(variable) {
+        return Err(context.unsupported(UnsupportedState::CyclicEvidence(variable)));
+    }
+    let result = match context.checked.evidence[variable].state {
+        EvidenceState::Unsolved => {
+            Err(context.unsupported(UnsupportedState::UnsolvedEvidence(variable)))
+        }
+        EvidenceState::Solved(evidence) => convert_evidence(context, evidence),
+        EvidenceState::Error => Err(context.unsupported(UnsupportedState::EvidenceError(variable))),
+    };
+    context.lowering_evidence.remove(&variable);
+    result
+}
+
+fn convert_evidence(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    evidence_id: EvidenceId,
+) -> ConversionResult<ExpressionId> {
+    let checked = Arc::clone(&context.checked);
+    match &checked.evidence[evidence_id] {
+        Evidence::Variable(variable) => evidence_variable(context, *variable),
+        Evidence::Given(binder) => {
+            let parameter = context.evidence_parameter(*binder)?;
+            Ok(context.expression(ExpressionKind::Local { parameter }))
+        }
+        Evidence::Instance { origin, subgoals } => {
+            let global = context.instance_global(*origin)?;
+            let function = context.expression(ExpressionKind::Global { global });
+            let arguments = subgoals.iter().map(|&subgoal| evidence_variable(context, subgoal));
+            let arguments = arguments.collect::<ConversionResult<Vec<_>>>()?;
+            Ok(context.application(function, arguments))
+        }
+        Evidence::Superclass { parent, superclass } => {
+            let record = convert_evidence(context, *parent)?;
+            let field = context.superclass_field(*superclass);
+            Ok(context.expression(ExpressionKind::Project { record, field }))
+        }
+        Evidence::Trivial => Ok(context.expression(ExpressionKind::TrivialEvidence)),
+        Evidence::Synthesized(evidence) => {
+            let evidence = synthesized_evidence(context, evidence);
+            Ok(context.expression(ExpressionKind::SynthesizedEvidence { evidence }))
+        }
+    }
+}
+
+fn synthesized_evidence(
+    _context: &Context<'_, impl checking::ExternalQueries>,
+    evidence: &checking::evidence::SynthesizedEvidence,
+) -> SynthesizedEvidence {
+    match evidence {
+        checking::evidence::SynthesizedEvidence::IsSymbol(symbol) => {
+            SynthesizedEvidence::IsSymbol(symbol.clone())
+        }
+        checking::evidence::SynthesizedEvidence::Reflectable(reflectable) => {
+            let reflectable = match reflectable {
+                checking::evidence::ReflectableEvidence::Integer(value) => {
+                    ReflectableEvidence::Integer(*value)
+                }
+                checking::evidence::ReflectableEvidence::String(value) => {
+                    ReflectableEvidence::String(value.clone())
+                }
+                checking::evidence::ReflectableEvidence::Boolean(value) => {
+                    ReflectableEvidence::Boolean(*value)
+                }
+                checking::evidence::ReflectableEvidence::Ordering(ordering) => {
+                    let ordering = match ordering {
+                        checking::evidence::ReflectableOrdering::Less => ReflectableOrdering::Less,
+                        checking::evidence::ReflectableOrdering::Equal => {
+                            ReflectableOrdering::Equal
+                        }
+                        checking::evidence::ReflectableOrdering::Greater => {
+                            ReflectableOrdering::Greater
+                        }
+                    };
+                    ReflectableEvidence::Ordering(ordering)
+                }
+            };
+            SynthesizedEvidence::Reflectable(reflectable)
+        }
+    }
+}
+
+impl<'c, Q> Context<'c, Q>
+where
+    Q: checking::ExternalQueries,
+{
+    fn checked_binder_parameter(
+        &mut self,
+        binder_id: checking_tree::BinderId,
+    ) -> ConversionResult<Parameter> {
+        let source = self.binding_source(binder_id);
+        let name = self.checked_binder_name(binder_id);
+        self.parameter(source, name)
+    }
+
+    fn binding_source(&self, binder_id: checking_tree::BinderId) -> BindingSource {
+        match self.checked.tree[binder_id].source {
+            checking_tree::BinderSource::Binder(source) => BindingSource::SourceBinder(source),
+            _ => BindingSource::CheckedBinder(binder_id),
+        }
+    }
+
+    fn checked_binder_name(&self, binder_id: checking_tree::BinderId) -> SmolStr {
+        let binder = &self.checked.tree[binder_id];
+        match &binder.kind {
+            checking_tree::BinderKind::Named { name, .. } => name.clone(),
+            _ => match binder.source {
+                checking_tree::BinderSource::Binder(source) => self.source_binder_name(source),
+                checking_tree::BinderSource::Generated { name, .. } => {
+                    self.queries.lookup_smol_str(name)
+                }
+                checking_tree::BinderSource::Section(source) => {
+                    format_smolstr!("section{}", source.into_raw().get())
+                }
+                _ => format_smolstr!("local{}", binder_id.into_raw().into_u32()),
+            },
+        }
+    }
+
+    fn source_binder_name(&self, binder: lowering::BinderId) -> SmolStr {
+        match self.lowered.tree.get_binder_kind(binder) {
+            Some(lowering::BinderKind::Variable { variable: Some(name) }) => name.clone(),
+            Some(lowering::BinderKind::Named { named: Some(name), .. }) => name.clone(),
+            _ => format_smolstr!("binder{}", binder.into_raw().get()),
+        }
+    }
+
+    fn local_parameter(
+        &mut self,
+        source: lowering::LetBindingNameGroupId,
+    ) -> ConversionResult<Parameter> {
+        let group = self.lowered.tree.get_let_binding_group(source);
+        let name = group
+            .name
+            .clone()
+            .unwrap_or_else(|| format_smolstr!("binding{}", source.into_raw().into_u32()));
+        self.parameter(BindingSource::Let(source), name)
+    }
+
+    fn record_pun_parameter(
+        &mut self,
+        source: lowering::RecordPunId,
+        name: SmolStr,
+    ) -> ConversionResult<Parameter> {
+        self.parameter(BindingSource::RecordPun(source), name)
+    }
+
+    fn evidence_parameter(&mut self, binder: EvidenceBinderId) -> ConversionResult<Parameter> {
+        self.parameter(BindingSource::Evidence(binder), format_smolstr!("dictionary{}", binder.0))
+    }
+
+    fn parameter(&mut self, source: BindingSource, name: SmolStr) -> ConversionResult<Parameter> {
+        if let Some(parameter) = self.parameters.get(&source) {
+            return Ok(parameter.clone());
+        }
+        let parameter = self.fresh_parameter(name)?;
+        self.parameters.insert(source, parameter.clone());
+        Ok(parameter)
+    }
+
+    fn fresh_parameter(&mut self, name: SmolStr) -> ConversionResult<Parameter> {
+        let id = LocalId(self.next_local);
+        self.next_local = self
+            .next_local
+            .checked_add(1)
+            .ok_or_else(|| self.unsupported(UnsupportedState::LocalIdentityOverflow))?;
+        Ok(Parameter { id, name })
+    }
+
+    fn parameter_abstraction(
+        &mut self,
+        parameters: impl IntoIterator<Item = Parameter>,
+        body: ExpressionId,
+    ) -> ExpressionId {
+        let patterns =
+            parameters.into_iter().map(|parameter| self.pattern(PatternKind::Variable(parameter)));
+        let patterns = patterns.collect_vec();
+        self.abstraction(patterns, body)
+    }
+
+    fn abstraction(&mut self, parameters: Vec<PatternId>, body: ExpressionId) -> ExpressionId {
+        if parameters.is_empty() {
+            body
+        } else {
+            self.expression(ExpressionKind::Abstraction { parameters: parameters.into(), body })
+        }
+    }
+
+    fn application(
+        &mut self,
+        function: ExpressionId,
+        arguments: impl IntoIterator<Item = ExpressionId>,
+    ) -> ExpressionId {
+        let arguments = arguments.into_iter();
+        let arguments = arguments.collect_vec();
+        if arguments.is_empty() {
+            function
+        } else {
+            self.expression(ExpressionKind::Application { function, arguments: arguments.into() })
+        }
+    }
+
+    fn expression(&mut self, kind: ExpressionKind) -> ExpressionId {
+        self.storage.allocate_expression(Expression { kind })
+    }
+
+    fn pattern(&mut self, kind: PatternKind) -> PatternId {
+        self.storage.allocate_pattern(Pattern { kind })
+    }
+
+    fn label_field(&self, label: SmolStr) -> Field {
+        Field { identity: FieldIdentity::Label(label.clone()), name: label }
+    }
+
+    fn member_field(&self, resolution: (FileId, TermItemId)) -> QueryResult<Field> {
+        let global = self.term_global_readonly(resolution.0, resolution.1)?;
+        Ok(Field { identity: FieldIdentity::Member(resolution.0, resolution.1), name: global.name })
+    }
+
+    fn superclass_field(&self, superclass: checking::evidence::SuperclassId) -> Field {
+        let identity = SuperclassIdentity {
+            file_id: superclass.file_id,
+            class: superclass.type_id,
+            source: superclass.source_id,
+        };
+        let name = format_smolstr!("superclass{}", superclass.source_id.into_raw().get());
+        Field { identity: FieldIdentity::Superclass(identity), name }
+    }
+
+    fn term_global(&self, file_id: FileId, term_id: TermItemId) -> ConversionResult<Global> {
+        Ok(self.term_global_readonly(file_id, term_id)?)
+    }
+
+    fn term_global_readonly(&self, file_id: FileId, term_id: TermItemId) -> QueryResult<Global> {
+        let indexed = if file_id == self.file_id {
+            Arc::clone(&self.indexed)
+        } else {
+            self.queries.indexed(file_id)?
+        };
+        let name = if let Some(name) = &indexed.items[term_id].name {
+            name.clone()
+        } else {
+            self.term_fallback(term_id)
+        };
+        Ok(Global { id: GlobalId::Term(file_id, term_id), name })
+    }
+
+    fn instance_global(&self, origin: InstanceCandidateOrigin) -> ConversionResult<Global> {
+        let identity = match origin {
+            InstanceCandidateOrigin::Instance(file_id, id) => {
+                InstanceIdentity::Declared(file_id, id)
+            }
+            InstanceCandidateOrigin::Derive(file_id, id) => InstanceIdentity::Derived(file_id, id),
+        };
+        let name = self.instance_name(identity)?;
+        Ok(Global { id: GlobalId::Instance(identity), name })
+    }
+
+    fn instance_name(&self, identity: InstanceIdentity) -> QueryResult<SmolStr> {
+        let origin = match identity {
+            InstanceIdentity::Declared(file_id, id) => {
+                InstanceCandidateOrigin::Instance(file_id, id)
+            }
+            InstanceIdentity::Derived(file_id, id) => InstanceCandidateOrigin::Derive(file_id, id),
+        };
+        let pretty = checking::tree::pretty::Pretty::new(self.queries, &self.checked);
+        pretty.render_instance_name(self.file_id, origin)
+    }
+
+    fn record_pun_source(
+        &self,
+        binder_id: checking_tree::BinderId,
+        label: &str,
+    ) -> Option<lowering::RecordPunId> {
+        let checking_tree::BinderSource::Binder(source) = self.checked.tree[binder_id].source
+        else {
+            return None;
+        };
+        let lowering::BinderKind::Record { record } = self.lowered.tree.get_binder_kind(source)?
+        else {
+            return None;
+        };
+        record.iter().find_map(|field| {
+            let lowering::BinderRecordItem::RecordPun { id, name } = field else {
+                return None;
+            };
+            name.as_deref().filter(|name| *name == label).map(|_| *id)
+        })
+    }
+
+    fn record_pun_name(&self, source: lowering::RecordPunId) -> SmolStr {
+        self.lowered
+            .tree
+            .iter_binder()
+            .find_map(|(_, binder)| {
+                let lowering::BinderKind::Record { record } = binder else { return None };
+                record.iter().find_map(|field| {
+                    let lowering::BinderRecordItem::RecordPun { id, name } = field else {
+                        return None;
+                    };
+                    (*id == source).then(|| name.clone()).flatten()
+                })
+            })
+            .unwrap_or_else(|| format_smolstr!("pun{:?}", source))
+    }
+
+    fn term_fallback(&self, term_id: TermItemId) -> SmolStr {
+        format_smolstr!("term{}", term_id.into_raw().into_u32())
+    }
+
+    fn unsupported(&self, state: UnsupportedState) -> ConversionError {
+        ConversionError::Unsupported { file_id: self.file_id, state }
+    }
+}

--- a/compiler-backend/nbe/src/error.rs
+++ b/compiler-backend/nbe/src/error.rs
@@ -1,0 +1,46 @@
+use building_types::QueryError;
+use checking::evidence::EvidenceVarId;
+use checking::tree as checked_tree;
+use files::FileId;
+use indexing::TermItemId;
+use thiserror::Error;
+
+pub type ConversionResult<T> = Result<T, ConversionError>;
+
+#[derive(Debug, Error)]
+pub enum ConversionError {
+    #[error(transparent)]
+    Query(#[from] QueryError),
+    #[error("cannot convert checked module {file_id:?}: {state}")]
+    Unsupported { file_id: FileId, state: UnsupportedState },
+}
+
+#[derive(Debug, Error)]
+pub enum UnsupportedState {
+    #[error("checked expression {0:?} contains an error")]
+    ExpressionError(checked_tree::ExpressionId),
+    #[error("checked binder {0:?} contains an error")]
+    BinderError(checked_tree::BinderId),
+    #[error("record update contains an error")]
+    RecordUpdateError,
+    #[error("pattern let binding {0:?} contains an error")]
+    PatternBindingError(lowering::LetBindingId),
+    #[error("evidence variable {0:?} is unsolved")]
+    UnsolvedEvidence(EvidenceVarId),
+    #[error("evidence variable {0:?} contains an error")]
+    EvidenceError(EvidenceVarId),
+    #[error("evidence variable {0:?} is cyclic")]
+    CyclicEvidence(EvidenceVarId),
+    #[error("checked term declaration {0:?} is missing")]
+    MissingTermDeclaration(TermItemId),
+    #[error("checked instance declaration is missing")]
+    MissingInstanceDeclaration,
+    #[error("checked local declaration {0:?} is missing")]
+    MissingLocalDeclaration(lowering::LetBindingNameGroupId),
+    #[error("checked value declaration has no equations")]
+    MissingEquation,
+    #[error("instance prerequisite is not represented by given evidence")]
+    InvalidInstancePrerequisite,
+    #[error("local identity space is exhausted")]
+    LocalIdentityOverflow,
+}

--- a/compiler-backend/nbe/src/lib.rs
+++ b/compiler-backend/nbe/src/lib.rs
@@ -1,0 +1,9 @@
+//! Owned functional trees used as input to normalization by evaluation.
+
+pub mod convert;
+pub mod error;
+pub mod pretty;
+pub mod tree;
+
+pub use convert::convert_module;
+pub use error::{ConversionError, ConversionResult, UnsupportedState};

--- a/compiler-backend/nbe/src/pretty.rs
+++ b/compiler-backend/nbe/src/pretty.rs
@@ -211,8 +211,18 @@ impl<'a> Printer<'a, '_> {
     }
 
     fn pattern(&self, pattern_id: PatternId) -> Doc<'a> {
+        self.pattern_at(pattern_id, PatternPrecedence::Application)
+    }
+
+    fn pattern_at(&self, pattern_id: PatternId, required_precedence: PatternPrecedence) -> Doc<'a> {
         let pattern = &self.module.storage[pattern_id];
-        match &pattern.kind {
+        let precedence = match &pattern.kind {
+            PatternKind::Constructor { arguments, .. } if !arguments.is_empty() => {
+                PatternPrecedence::Application
+            }
+            _ => PatternPrecedence::Atom,
+        };
+        let document = match &pattern.kind {
             PatternKind::Variable(parameter) => self.parameter(parameter),
             PatternKind::Named { parameter, pattern } => {
                 let parameter = self.parameter(parameter);
@@ -234,11 +244,18 @@ impl<'a> Printer<'a, '_> {
                 self.braced(fields)
             }
             PatternKind::Constructor { global, arguments } => {
-                let arguments = arguments.iter().map(|argument| self.pattern(*argument));
+                let arguments = arguments
+                    .iter()
+                    .map(|argument| self.pattern_at(*argument, PatternPrecedence::Atom));
                 let arguments = arguments.map(|argument| self.arena.space().append(argument));
                 let arguments = self.arena.concat(arguments);
                 self.arena.text(global.name.to_string()).append(arguments)
             }
+        };
+        if precedence < required_precedence {
+            self.arena.text("(").append(document).append(")")
+        } else {
+            document
         }
     }
 
@@ -380,13 +397,14 @@ impl<'a> Printer<'a, '_> {
 
     fn field(&self, field: &Field) -> String {
         let name = field.name.as_str();
-        let is_valid_identifier = name.chars().enumerate().all(|(position, character)| {
-            if position == 0 {
-                character.is_ascii_lowercase() || character == '_'
-            } else {
-                character.is_ascii_alphanumeric() || character == '_' || character == '\''
-            }
-        });
+        let is_valid_identifier = !name.is_empty()
+            && name.chars().enumerate().all(|(position, character)| {
+                if position == 0 {
+                    character.is_ascii_lowercase() || character == '_'
+                } else {
+                    character.is_ascii_alphanumeric() || character == '_' || character == '\''
+                }
+            });
         if is_valid_identifier { name.to_string() } else { format!("{name:?}") }
     }
 
@@ -428,6 +446,12 @@ impl<'a> Printer<'a, '_> {
 enum ExpressionPrecedence {
     Abstraction,
     RecordUpdate,
+    Application,
+    Atom,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum PatternPrecedence {
     Application,
     Atom,
 }

--- a/compiler-backend/nbe/src/pretty.rs
+++ b/compiler-backend/nbe/src/pretty.rs
@@ -1,0 +1,433 @@
+//! Stable text rendering for functional-tree snapshots.
+
+use pretty::{Arena, DocAllocator, DocBuilder};
+
+use crate::tree::{
+    Declaration, DeclarationKind, EffectExpression, ExpressionId, ExpressionKind, Field, GlobalId,
+    Guard, Literal, Module, Parameter, PatternId, PatternKind, RecordUpdate, ReflectableEvidence,
+    ReflectableOrdering, SynthesizedEvidence,
+};
+
+type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
+
+const DEFAULT_WIDTH: usize = 100;
+
+pub fn render(module: &Module) -> String {
+    let arena = Arena::new();
+    let printer = Printer { arena: &arena, module };
+    let declarations =
+        module.declarations.iter().map(|declaration| printer.declaration(declaration));
+    let declaration_separator = arena.hardline().append(arena.hardline());
+    let document = arena.intersperse(declarations, declaration_separator);
+    let mut output = String::new();
+    document
+        .render_fmt(DEFAULT_WIDTH, &mut output)
+        .expect("critical failure: failed to render normalized functional tree");
+    output
+}
+
+struct Printer<'a, 'm> {
+    arena: &'a Arena<'a>,
+    module: &'m Module,
+}
+
+impl<'a> Printer<'a, '_> {
+    fn declaration(&self, declaration: &Declaration) -> Doc<'a> {
+        let name = &declaration.global.name;
+        match declaration.kind {
+            DeclarationKind::Foreign => self.arena.text(format!("foreign {name}")),
+            DeclarationKind::Value(expression) => {
+                let prefix = match declaration.global.id {
+                    GlobalId::Term(..) => "",
+                    GlobalId::Instance(..) => "instance ",
+                };
+                let recursion = declaration
+                    .recursive_group
+                    .map(|group| format!("recursive[{}] ", group.0))
+                    .unwrap_or_default();
+                let declaration = self.arena.text(format!("{prefix}{recursion}{name} ="));
+                let expression = self.expression(expression);
+                declaration.append(self.arena.space()).append(expression)
+            }
+        }
+    }
+
+    fn expression(&self, expression_id: ExpressionId) -> Doc<'a> {
+        self.expression_at(expression_id, ExpressionPrecedence::Abstraction)
+    }
+
+    fn expression_at(
+        &self,
+        expression_id: ExpressionId,
+        required_precedence: ExpressionPrecedence,
+    ) -> Doc<'a> {
+        let expression = &self.module.storage[expression_id];
+        let precedence = match expression.kind {
+            ExpressionKind::Abstraction { .. }
+            | ExpressionKind::IfThenElse { .. }
+            | ExpressionKind::Case { .. }
+            | ExpressionKind::Guarded { .. }
+            | ExpressionKind::Let { .. }
+            | ExpressionKind::LetPattern { .. } => ExpressionPrecedence::Abstraction,
+            ExpressionKind::Application { .. } | ExpressionKind::Effect { .. } => {
+                ExpressionPrecedence::Application
+            }
+            ExpressionKind::RecordUpdate { .. } => ExpressionPrecedence::RecordUpdate,
+            _ => ExpressionPrecedence::Atom,
+        };
+        let document = self.expression_unparenthesized(expression_id);
+        if precedence < required_precedence {
+            self.arena.text("(").append(document).append(")")
+        } else {
+            document
+        }
+    }
+
+    fn expression_unparenthesized(&self, expression_id: ExpressionId) -> Doc<'a> {
+        let expression = &self.module.storage[expression_id];
+        match &expression.kind {
+            ExpressionKind::Literal { literal } => self.literal(literal),
+            ExpressionKind::Array { elements } => {
+                let elements = elements.iter().map(|element| self.expression(*element));
+                self.delimited("[", elements, "]")
+            }
+            ExpressionKind::Record { fields } => {
+                let fields = fields.iter().map(|field| {
+                    let label = self.field(&field.field);
+                    let expression = self.expression(field.expression);
+                    let expression = self.arena.line().append(expression).nest(2);
+                    self.arena.text(format!("{label}:")).append(expression).group()
+                });
+                self.braced(fields)
+            }
+            ExpressionKind::RecordUpdate { record, updates } => {
+                let record = self.expression_at(*record, ExpressionPrecedence::Atom);
+                let updates = updates.iter().map(|update| self.record_update(update));
+                let updates = self.braced(updates);
+                record.append(self.arena.space()).append(updates)
+            }
+            ExpressionKind::Project { record, field } => {
+                let record = self.expression_at(*record, ExpressionPrecedence::Atom);
+                let field = self.field(field);
+                record.append(self.arena.text(format!(".{field}")))
+            }
+            ExpressionKind::Constructor { global } | ExpressionKind::Global { global } => {
+                self.arena.text(global.name.to_string())
+            }
+            ExpressionKind::Local { parameter } => self.parameter(parameter),
+            ExpressionKind::Abstraction { parameters, body } => {
+                let parameters = parameters.iter().map(|pattern| self.pattern(*pattern));
+                let parameters = self.arena.intersperse(parameters, self.arena.space());
+                let abstraction = self.arena.text("\\").append(parameters).append(" ->");
+                let body_document = self.expression(*body);
+                if self.expression_requires_body_break(*body) {
+                    let body = self.arena.hardline().append(body_document).nest(2);
+                    abstraction.append(body)
+                } else {
+                    let body = self.arena.line().append(body_document).nest(2);
+                    abstraction.append(body).group()
+                }
+            }
+            ExpressionKind::Application { function, arguments } => {
+                if let Some(application) = self.try_render_bind_application(*function, arguments) {
+                    application
+                } else {
+                    let function = self.expression_at(*function, ExpressionPrecedence::Application);
+                    let arguments = arguments
+                        .iter()
+                        .map(|argument| self.expression_at(*argument, ExpressionPrecedence::Atom));
+                    let arguments = self.arena.intersperse(arguments, self.arena.line());
+                    let arguments = self.arena.line().append(arguments).nest(2);
+                    function.append(arguments).group()
+                }
+            }
+            ExpressionKind::IfThenElse { condition, then, else_ } => {
+                let condition = self.expression(*condition);
+                let then = self.expression(*then);
+                let then = self.arena.line().append("then ").append(then).nest(2);
+                let else_ = self.expression(*else_);
+                let else_ = self.arena.line().append("else ").append(else_).nest(2);
+                self.arena.text("if ").append(condition).append(then).append(else_).group()
+            }
+            ExpressionKind::Case { scrutinees, alternatives } => {
+                let scrutinees = scrutinees.iter().map(|scrutinee| self.expression(*scrutinee));
+                let scrutinees = self.arena.intersperse(scrutinees, self.arena.text(", "));
+                let alternatives = alternatives.iter().map(|alternative| {
+                    let patterns =
+                        alternative.patterns.iter().map(|pattern| self.pattern(*pattern));
+                    let patterns = self.arena.intersperse(patterns, self.arena.text(", "));
+                    let expression = self.expression(alternative.expression);
+                    let expression = self.arena.hardline().append(expression).nest(2);
+                    patterns.append(" ->").append(expression)
+                });
+                let alternatives = self.arena.intersperse(alternatives, self.arena.hardline());
+                let alternatives = self.arena.hardline().append(alternatives).nest(2);
+                self.arena.text("case ").append(scrutinees).append(" of").append(alternatives)
+            }
+            ExpressionKind::Guarded { alternatives } => {
+                let alternatives = alternatives.iter().map(|alternative| {
+                    let guards = alternative.guards.iter().map(|guard| self.guard(guard));
+                    let guards = self.arena.intersperse(guards, self.arena.text(", "));
+                    let expression = self.expression(alternative.expression);
+                    let expression = self.arena.line().append(expression).nest(2);
+                    self.arena.text("| ").append(guards).append(" ->").append(expression).group()
+                });
+                self.arena.intersperse(alternatives, self.arena.hardline())
+            }
+            ExpressionKind::Let { recursive, bindings, body } => {
+                let bindings = bindings.iter().map(|binding| {
+                    let recursive = if *recursive { "rec " } else { "" };
+                    let parameter = self.parameter(&binding.parameter);
+                    let expression = self.expression(binding.expression);
+                    self.arena.text(recursive).append(parameter).append(" = ").append(expression)
+                });
+                let bindings = self.arena.intersperse(bindings, self.arena.hardline());
+                let bindings = self.arena.hardline().append(bindings).nest(2);
+                let body = self.expression(*body);
+                self.arena
+                    .text("let")
+                    .append(bindings)
+                    .append(self.arena.hardline())
+                    .append("in ")
+                    .append(body)
+            }
+            ExpressionKind::LetPattern { pattern, value, body } => {
+                let pattern = self.pattern(*pattern);
+                let value = self.expression(*value);
+                let binding = pattern.append(" = ").append(value);
+                let binding = self.arena.hardline().append(binding).nest(2);
+                let body = self.expression(*body);
+                self.arena
+                    .text("let")
+                    .append(binding)
+                    .append(self.arena.hardline())
+                    .append("in ")
+                    .append(body)
+            }
+            ExpressionKind::Effect { effect } => self.effect(effect),
+            ExpressionKind::SynthesizedEvidence { evidence } => self.synthesized_evidence(evidence),
+            ExpressionKind::TrivialEvidence => self.arena.text("<trivial evidence>"),
+        }
+    }
+
+    fn pattern(&self, pattern_id: PatternId) -> Doc<'a> {
+        let pattern = &self.module.storage[pattern_id];
+        match &pattern.kind {
+            PatternKind::Variable(parameter) => self.parameter(parameter),
+            PatternKind::Named { parameter, pattern } => {
+                let parameter = self.parameter(parameter);
+                let pattern = self.pattern(*pattern);
+                parameter.append("@(").append(pattern).append(")")
+            }
+            PatternKind::Wildcard => self.arena.text("_"),
+            PatternKind::Literal(literal) => self.literal(literal),
+            PatternKind::Array(elements) => {
+                let elements = elements.iter().map(|element| self.pattern(*element));
+                self.delimited("[", elements, "]")
+            }
+            PatternKind::Record(fields) => {
+                let fields = fields.iter().map(|field| {
+                    let label = self.field(&field.field);
+                    let pattern = self.pattern(field.pattern);
+                    self.arena.text(format!("{label}: ")).append(pattern)
+                });
+                self.braced(fields)
+            }
+            PatternKind::Constructor { global, arguments } => {
+                let arguments = arguments.iter().map(|argument| self.pattern(*argument));
+                let arguments = arguments.map(|argument| self.arena.space().append(argument));
+                let arguments = self.arena.concat(arguments);
+                self.arena.text(global.name.to_string()).append(arguments)
+            }
+        }
+    }
+
+    fn guard(&self, guard: &Guard) -> Doc<'a> {
+        match guard {
+            Guard::Boolean(expression) => self.expression(*expression),
+            Guard::Pattern { expression, pattern } => {
+                let pattern = self.pattern(*pattern);
+                let expression = self.expression(*expression);
+                pattern.append(" <- ").append(expression)
+            }
+        }
+    }
+
+    fn record_update(&self, update: &RecordUpdate) -> Doc<'a> {
+        match update {
+            RecordUpdate::Leaf { field, expression } => {
+                let field = self.field(field);
+                let expression = self.expression(*expression);
+                let expression = self.arena.line().append(expression).nest(2);
+                self.arena.text(format!("{field} =")).append(expression).group()
+            }
+            RecordUpdate::Branch { field, updates } => {
+                let field = self.field(field);
+                let updates = updates.iter().map(|update| self.record_update(update));
+                let updates = self.braced(updates);
+                self.arena.text(field).append(self.arena.space()).append(updates)
+            }
+        }
+    }
+
+    fn try_render_bind_application(
+        &self,
+        function: ExpressionId,
+        arguments: &[ExpressionId],
+    ) -> Option<Doc<'a>> {
+        let (function, mut all_arguments) = self.application_spine(function);
+        all_arguments.extend_from_slice(arguments);
+        let ExpressionKind::Global { global } = &self.module.storage[function].kind else {
+            return None;
+        };
+        if global.name != "bind" {
+            return None;
+        }
+        let (&continuation, arguments) = all_arguments.split_last()?;
+        let ExpressionKind::Abstraction { parameters, body } =
+            &self.module.storage[continuation].kind
+        else {
+            return None;
+        };
+        let arguments = arguments
+            .iter()
+            .map(|argument| self.expression_at(*argument, ExpressionPrecedence::Atom));
+        let arguments = arguments.map(|argument| self.arena.line().append(argument));
+        let arguments = self.arena.concat(arguments);
+        let function = self.expression_at(function, ExpressionPrecedence::Application);
+        let application = function.append(arguments);
+        let parameters = parameters.iter().map(|parameter| self.pattern(*parameter));
+        let parameters = self.arena.intersperse(parameters, self.arena.space());
+        let continuation = self.arena.text("\\").append(parameters).append(" ->");
+        let continuation = self.arena.line().append(continuation).nest(2);
+        let application = application.append(continuation).group();
+        let body = self.expression(*body);
+        let body = self.arena.hardline().append(body).nest(2);
+        Some(application.append(body))
+    }
+
+    fn application_spine(&self, expression: ExpressionId) -> (ExpressionId, Vec<ExpressionId>) {
+        let ExpressionKind::Application { function, arguments } =
+            &self.module.storage[expression].kind
+        else {
+            return (expression, Vec::new());
+        };
+        let (function, mut spine) = self.application_spine(*function);
+        spine.extend_from_slice(arguments);
+        (function, spine)
+    }
+
+    fn effect(&self, effect: &EffectExpression) -> Doc<'a> {
+        match effect {
+            EffectExpression::Pure(expression) => {
+                let expression = self.expression_at(*expression, ExpressionPrecedence::Atom);
+                self.arena.text("effect.pure ").append(expression)
+            }
+            EffectExpression::Bind { action, parameter, body } => {
+                let action = self.expression_at(*action, ExpressionPrecedence::Atom);
+                let parameter = self.parameter(parameter);
+                let body = self.expression(*body);
+                let continuation = self
+                    .arena
+                    .line()
+                    .append("\\")
+                    .append(parameter)
+                    .append(" -> ")
+                    .append(body)
+                    .nest(2);
+                self.arena.text("effect.bind ").append(action).append(continuation).group()
+            }
+        }
+    }
+
+    fn synthesized_evidence(&self, evidence: &SynthesizedEvidence) -> Doc<'a> {
+        let rendered = match evidence {
+            SynthesizedEvidence::IsSymbol(symbol) => format!("symbol {symbol:?}"),
+            SynthesizedEvidence::Reflectable(ReflectableEvidence::Integer(value)) => {
+                format!("reflectable {value}")
+            }
+            SynthesizedEvidence::Reflectable(ReflectableEvidence::String(value)) => {
+                format!("reflectable {value:?}")
+            }
+            SynthesizedEvidence::Reflectable(ReflectableEvidence::Boolean(value)) => {
+                format!("reflectable {value}")
+            }
+            SynthesizedEvidence::Reflectable(ReflectableEvidence::Ordering(ordering)) => {
+                match ordering {
+                    ReflectableOrdering::Less => "reflectable LT".into(),
+                    ReflectableOrdering::Equal => "reflectable EQ".into(),
+                    ReflectableOrdering::Greater => "reflectable GT".into(),
+                }
+            }
+        };
+        self.arena.text(rendered)
+    }
+
+    fn literal(&self, literal: &Literal) -> Doc<'a> {
+        let rendered = match literal {
+            Literal::String(value) => format!("{value:?}"),
+            Literal::Char(value) => format!("{value:?}"),
+            Literal::Boolean(value) => value.to_string(),
+            Literal::Integer(value) => value.to_string(),
+            Literal::Number(value) => value.to_string(),
+        };
+        self.arena.text(rendered)
+    }
+
+    fn parameter(&self, parameter: &Parameter) -> Doc<'a> {
+        self.arena.text(format!("{}%{}", parameter.name, parameter.id.0))
+    }
+
+    fn field(&self, field: &Field) -> String {
+        let name = field.name.as_str();
+        let is_valid_identifier = name.chars().enumerate().all(|(position, character)| {
+            if position == 0 {
+                character.is_ascii_lowercase() || character == '_'
+            } else {
+                character.is_ascii_alphanumeric() || character == '_' || character == '\''
+            }
+        });
+        if is_valid_identifier { name.to_string() } else { format!("{name:?}") }
+    }
+
+    fn expression_requires_body_break(&self, expression_id: ExpressionId) -> bool {
+        matches!(
+            self.module.storage[expression_id].kind,
+            ExpressionKind::IfThenElse { .. }
+                | ExpressionKind::Case { .. }
+                | ExpressionKind::Guarded { .. }
+                | ExpressionKind::Let { .. }
+                | ExpressionKind::LetPattern { .. }
+        )
+    }
+
+    fn delimited<I>(&self, open: &'static str, documents: I, close: &'static str) -> Doc<'a>
+    where
+        I: IntoIterator<Item = Doc<'a>>,
+    {
+        let separator = self.arena.text(",").append(self.arena.line());
+        let documents = self.arena.intersperse(documents, separator);
+        let documents = self.arena.softline_().append(documents).nest(2);
+        let closing_line = self.arena.softline_();
+        self.arena.text(open).append(documents).append(closing_line).append(close).group()
+    }
+
+    fn braced<I>(&self, documents: I) -> Doc<'a>
+    where
+        I: IntoIterator<Item = Doc<'a>>,
+    {
+        let separator = self.arena.text(",").append(self.arena.line());
+        let documents = self.arena.intersperse(documents, separator);
+        let documents = self.arena.line().append(documents).nest(2);
+        let closing_line = self.arena.line();
+        self.arena.text("{").append(documents).append(closing_line).append("}").group()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ExpressionPrecedence {
+    Abstraction,
+    RecordUpdate,
+    Application,
+    Atom,
+}

--- a/compiler-backend/nbe/src/pretty.rs
+++ b/compiler-backend/nbe/src/pretty.rs
@@ -69,9 +69,9 @@ impl<'a> Printer<'a, '_> {
             | ExpressionKind::Guarded { .. }
             | ExpressionKind::Let { .. }
             | ExpressionKind::LetPattern { .. } => ExpressionPrecedence::Abstraction,
-            ExpressionKind::Application { .. } | ExpressionKind::Effect { .. } => {
-                ExpressionPrecedence::Application
-            }
+            ExpressionKind::Application { .. }
+            | ExpressionKind::Effect { .. }
+            | ExpressionKind::SynthesizedEvidence { .. } => ExpressionPrecedence::Application,
             ExpressionKind::RecordUpdate { .. } => ExpressionPrecedence::RecordUpdate,
             _ => ExpressionPrecedence::Atom,
         };

--- a/compiler-backend/nbe/src/pretty.rs
+++ b/compiler-backend/nbe/src/pretty.rs
@@ -116,7 +116,9 @@ impl<'a> Printer<'a, '_> {
             }
             ExpressionKind::Local { parameter } => self.parameter(parameter),
             ExpressionKind::Abstraction { parameters, body } => {
-                let parameters = parameters.iter().map(|pattern| self.pattern(*pattern));
+                let parameters = parameters
+                    .iter()
+                    .map(|pattern| self.pattern_at(*pattern, PatternPrecedence::Atom));
                 let parameters = self.arena.intersperse(parameters, self.arena.space());
                 let abstraction = self.arena.text("\\").append(parameters).append(" ->");
                 let body_document = self.expression(*body);
@@ -129,17 +131,13 @@ impl<'a> Printer<'a, '_> {
                 }
             }
             ExpressionKind::Application { function, arguments } => {
-                if let Some(application) = self.try_render_bind_application(*function, arguments) {
-                    application
-                } else {
-                    let function = self.expression_at(*function, ExpressionPrecedence::Application);
-                    let arguments = arguments
-                        .iter()
-                        .map(|argument| self.expression_at(*argument, ExpressionPrecedence::Atom));
-                    let arguments = self.arena.intersperse(arguments, self.arena.line());
-                    let arguments = self.arena.line().append(arguments).nest(2);
-                    function.append(arguments).group()
-                }
+                let function = self.expression_at(*function, ExpressionPrecedence::Application);
+                let arguments = arguments
+                    .iter()
+                    .map(|argument| self.expression_at(*argument, ExpressionPrecedence::Atom));
+                let arguments = self.arena.intersperse(arguments, self.arena.line());
+                let arguments = self.arena.line().append(arguments).nest(2);
+                function.append(arguments).group()
             }
             ExpressionKind::IfThenElse { condition, then, else_ } => {
                 let condition = self.expression(*condition);
@@ -285,53 +283,6 @@ impl<'a> Printer<'a, '_> {
                 self.arena.text(field).append(self.arena.space()).append(updates)
             }
         }
-    }
-
-    fn try_render_bind_application(
-        &self,
-        function: ExpressionId,
-        arguments: &[ExpressionId],
-    ) -> Option<Doc<'a>> {
-        let (function, mut all_arguments) = self.application_spine(function);
-        all_arguments.extend_from_slice(arguments);
-        let ExpressionKind::Global { global } = &self.module.storage[function].kind else {
-            return None;
-        };
-        if global.name != "bind" {
-            return None;
-        }
-        let (&continuation, arguments) = all_arguments.split_last()?;
-        let ExpressionKind::Abstraction { parameters, body } =
-            &self.module.storage[continuation].kind
-        else {
-            return None;
-        };
-        let arguments = arguments
-            .iter()
-            .map(|argument| self.expression_at(*argument, ExpressionPrecedence::Atom));
-        let arguments = arguments.map(|argument| self.arena.line().append(argument));
-        let arguments = self.arena.concat(arguments);
-        let function = self.expression_at(function, ExpressionPrecedence::Application);
-        let application = function.append(arguments);
-        let parameters = parameters.iter().map(|parameter| self.pattern(*parameter));
-        let parameters = self.arena.intersperse(parameters, self.arena.space());
-        let continuation = self.arena.text("\\").append(parameters).append(" ->");
-        let continuation = self.arena.line().append(continuation).nest(2);
-        let application = application.append(continuation).group();
-        let body = self.expression(*body);
-        let body = self.arena.hardline().append(body).nest(2);
-        Some(application.append(body))
-    }
-
-    fn application_spine(&self, expression: ExpressionId) -> (ExpressionId, Vec<ExpressionId>) {
-        let ExpressionKind::Application { function, arguments } =
-            &self.module.storage[expression].kind
-        else {
-            return (expression, Vec::new());
-        };
-        let (function, mut spine) = self.application_spine(*function);
-        spine.extend_from_slice(arguments);
-        (function, spine)
     }
 
     fn effect(&self, effect: &EffectExpression) -> Doc<'a> {

--- a/compiler-backend/nbe/src/tree.rs
+++ b/compiler-backend/nbe/src/tree.rs
@@ -1,0 +1,244 @@
+//! Arena-allocated functional trees produced from checked modules.
+
+use std::ops::Index;
+use std::sync::Arc;
+
+use files::FileId;
+use indexing::{DeriveId, InstanceId, TermItemId, TypeItemId};
+use la_arena::{Arena, Idx};
+use lowering::TypeId as SourceTypeId;
+use smol_str::SmolStr;
+
+pub type ExpressionId = Idx<Expression>;
+pub type PatternId = Idx<Pattern>;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Module {
+    pub file_id: FileId,
+    pub declarations: Arc<[Declaration]>,
+    pub storage: Storage,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Storage {
+    expressions: Arena<Expression>,
+    patterns: Arena<Pattern>,
+}
+
+impl Storage {
+    pub fn allocate_expression(&mut self, expression: Expression) -> ExpressionId {
+        self.expressions.alloc(expression)
+    }
+
+    pub fn allocate_pattern(&mut self, pattern: Pattern) -> PatternId {
+        self.patterns.alloc(pattern)
+    }
+
+    pub fn expressions(&self) -> impl Iterator<Item = (ExpressionId, &Expression)> {
+        self.expressions.iter()
+    }
+
+    pub fn patterns(&self) -> impl Iterator<Item = (PatternId, &Pattern)> {
+        self.patterns.iter()
+    }
+}
+
+impl Index<ExpressionId> for Storage {
+    type Output = Expression;
+
+    fn index(&self, index: ExpressionId) -> &Expression {
+        &self.expressions[index]
+    }
+}
+
+impl Index<PatternId> for Storage {
+    type Output = Pattern;
+
+    fn index(&self, index: PatternId) -> &Pattern {
+        &self.patterns[index]
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Declaration {
+    pub global: Global,
+    pub recursive_group: Option<RecursiveGroupId>,
+    pub kind: DeclarationKind,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum DeclarationKind {
+    Value(ExpressionId),
+    Foreign,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Global {
+    pub id: GlobalId,
+    pub name: SmolStr,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GlobalId {
+    Term(FileId, TermItemId),
+    Instance(InstanceIdentity),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InstanceIdentity {
+    Declared(FileId, InstanceId),
+    Derived(FileId, DeriveId),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RecursiveGroupId(pub u32);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Parameter {
+    pub id: LocalId,
+    pub name: SmolStr,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LocalId(pub u32);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Field {
+    pub identity: FieldIdentity,
+    pub name: SmolStr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FieldIdentity {
+    Label(SmolStr),
+    Member(FileId, TermItemId),
+    Superclass(SuperclassIdentity),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SuperclassIdentity {
+    pub file_id: FileId,
+    pub class: TypeItemId,
+    pub source: SourceTypeId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Literal {
+    String(SmolStr),
+    Char(char),
+    Boolean(bool),
+    Integer(i32),
+    Number(SmolStr),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Expression {
+    pub kind: ExpressionKind,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ExpressionKind {
+    Literal { literal: Literal },
+    Array { elements: Arc<[ExpressionId]> },
+    Record { fields: Arc<[RecordField]> },
+    RecordUpdate { record: ExpressionId, updates: Arc<[RecordUpdate]> },
+    Project { record: ExpressionId, field: Field },
+    Constructor { global: Global },
+    Global { global: Global },
+    Local { parameter: Parameter },
+    Abstraction { parameters: Arc<[PatternId]>, body: ExpressionId },
+    Application { function: ExpressionId, arguments: Arc<[ExpressionId]> },
+    IfThenElse { condition: ExpressionId, then: ExpressionId, else_: ExpressionId },
+    Case { scrutinees: Arc<[ExpressionId]>, alternatives: Arc<[CaseAlternative]> },
+    Guarded { alternatives: Arc<[GuardedAlternative]> },
+    Let { recursive: bool, bindings: Arc<[Binding]>, body: ExpressionId },
+    LetPattern { pattern: PatternId, value: ExpressionId, body: ExpressionId },
+    Effect { effect: EffectExpression },
+    SynthesizedEvidence { evidence: SynthesizedEvidence },
+    TrivialEvidence,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum EffectExpression {
+    Pure(ExpressionId),
+    Bind { action: ExpressionId, parameter: Parameter, body: ExpressionId },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct RecordField {
+    pub field: Field,
+    pub expression: ExpressionId,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum RecordUpdate {
+    Leaf { field: Field, expression: ExpressionId },
+    Branch { field: Field, updates: Arc<[RecordUpdate]> },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Binding {
+    pub parameter: Parameter,
+    pub expression: ExpressionId,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct CaseAlternative {
+    pub patterns: Arc<[PatternId]>,
+    pub expression: ExpressionId,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct GuardedAlternative {
+    pub guards: Arc<[Guard]>,
+    pub expression: ExpressionId,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Guard {
+    Boolean(ExpressionId),
+    Pattern { expression: ExpressionId, pattern: PatternId },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Pattern {
+    pub kind: PatternKind,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum PatternKind {
+    Variable(Parameter),
+    Named { parameter: Parameter, pattern: PatternId },
+    Wildcard,
+    Literal(Literal),
+    Array(Arc<[PatternId]>),
+    Record(Arc<[RecordPatternField]>),
+    Constructor { global: Global, arguments: Arc<[PatternId]> },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct RecordPatternField {
+    pub field: Field,
+    pub pattern: PatternId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SynthesizedEvidence {
+    IsSymbol(SmolStr),
+    Reflectable(ReflectableEvidence),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReflectableEvidence {
+    Integer(i32),
+    String(SmolStr),
+    Boolean(bool),
+    Ordering(ReflectableOrdering),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReflectableOrdering {
+    Less,
+    Equal,
+    Greater,
+}

--- a/compiler-scripts/src/test_runner/category.rs
+++ b/compiler-scripts/src/test_runner/category.rs
@@ -30,6 +30,18 @@ impl TestCategory {
         format!("tests-integration/fixtures/{}", self.as_str())
     }
 
+    pub fn test_targets(&self) -> &'static [&'static str] {
+        match self {
+            TestCategory::Backend => &["backend", "nbe"],
+            TestCategory::Checking => &["checking"],
+            TestCategory::Semantic => &["semantic"],
+            TestCategory::Lowering => &["lowering"],
+            TestCategory::Resolving => &["resolving"],
+            TestCategory::Lsp => &["lsp"],
+            TestCategory::Docs => &["docs"],
+        }
+    }
+
     pub fn snapshot_path_fragments(&self) -> Vec<String> {
         vec![
             format!("tests-integration/fixtures/{}", self.as_str()),

--- a/compiler-scripts/src/test_runner/nextest.rs
+++ b/compiler-scripts/src/test_runner/nextest.rs
@@ -9,12 +9,11 @@ use crate::test_runner::cli::RunArgs;
 
 pub fn build_nextest_command(category: TestCategory, args: &RunArgs) -> Command {
     let mut cmd = Command::new("cargo");
-    cmd.arg("nextest")
-        .arg("run")
-        .arg("-p")
-        .arg("tests-integration")
-        .arg("--test")
-        .arg(category.as_str());
+    cmd.arg("nextest").arg("run").arg("-p").arg("tests-integration");
+
+    for target in category.test_targets() {
+        cmd.arg("--test").arg(target);
+    }
 
     for filter in &args.filters {
         cmd.arg(filter);
@@ -64,5 +63,65 @@ pub fn run_nextest(category: TestCategory, args: &RunArgs) -> anyhow::Result<boo
         }
 
         Ok(status.success())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use super::*;
+
+    fn args(filters: &[&str], verbose: bool) -> RunArgs {
+        RunArgs {
+            create: None,
+            delete: None,
+            confirm: false,
+            accept: false,
+            reject: false,
+            filters: filters.iter().map(|filter| (*filter).to_string()).collect(),
+            verbose,
+            diff: false,
+            count: 3,
+            exclude: Vec::new(),
+        }
+    }
+
+    fn command_arguments(command: &Command) -> Vec<&OsStr> {
+        command.get_args().collect()
+    }
+
+    #[test]
+    fn backend_runs_backend_and_nbe_reporters_with_filters() {
+        let command = build_nextest_command(TestCategory::Backend, &args(&["constructor"], false));
+        let arguments = command_arguments(&command);
+
+        assert_eq!(
+            arguments,
+            [
+                "nextest",
+                "run",
+                "-p",
+                "tests-integration",
+                "--test",
+                "backend",
+                "--test",
+                "nbe",
+                "constructor",
+                "--status-level=none",
+            ]
+        );
+    }
+
+    #[test]
+    fn other_categories_keep_their_single_reporter_and_verbose_options() {
+        let command = build_nextest_command(TestCategory::Checking, &args(&[], true));
+        let arguments = command_arguments(&command);
+
+        assert_eq!(
+            &arguments[..6],
+            ["nextest", "run", "-p", "tests-integration", "--test", "checking"]
+        );
+        assert!(arguments.contains(&OsStr::new("--status-level=fail")));
     }
 }

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -31,6 +31,7 @@ url = "2.5.8"
 
 [dev-dependencies]
 datatest-stable = "0.3"
+nbe = { version = "0.1.0", path = "../compiler-backend/nbe" }
 
 [[test]]
 name = "backend"
@@ -54,6 +55,10 @@ harness = false
 
 [[test]]
 name = "lsp"
+harness = false
+
+[[test]]
+name = "nbe"
 harness = false
 
 [[test]]

--- a/tests-integration/fixtures/backend/1787021280_literals_arrays_and_records/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021280_literals_arrays_and_records/Main.nbe.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+integer = 42
+
+number = 1.5
+
+character = 'a'
+
+string = "alexandrite"
+
+boolean = true
+
+array = [1, 2, 3]
+
+record = { integer: 42, nested: { value: "nested" } }
+
+projection = record.nested.value

--- a/tests-integration/fixtures/backend/1787021340_record_updates/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021340_record_updates/Main.nbe.snap
@@ -1,0 +1,7 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+model = { count: 0, nested: { enabled: true, label: "before" } }
+
+updated = model { count = 1, nested { enabled = false, label = "after" } }

--- a/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.nbe.snap
@@ -1,0 +1,38 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+integer = \argument0%0 ->
+  case argument0%0 of
+    0 ->
+      true
+    _ ->
+      false
+
+number = \argument0%1 ->
+  case argument0%1 of
+    1.5 ->
+      true
+    _ ->
+      false
+
+character = \argument0%2 ->
+  case argument0%2 of
+    'a' ->
+      true
+    _ ->
+      false
+
+string = \argument0%3 ->
+  case argument0%3 of
+    "alexandrite" ->
+      true
+    _ ->
+      false
+
+boolean = \argument0%4 ->
+  case argument0%4 of
+    true ->
+      true
+    false ->
+      false

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.nbe.snap
@@ -16,7 +16,7 @@ first = \argument0%0 ->
         _ ->
           Empty
 
-unwrap = \Identity value%4 -> value%4
+unwrap = \(Identity value%4) -> value%4
 
 nested = \argument0%5 ->
   case argument0%5 of
@@ -24,3 +24,7 @@ nested = \argument0%5 ->
       One value%6
     _ ->
       Empty
+
+bind = \value%8 continuation%7 -> continuation%7 value%8
+
+ordinaryBind = \identity%9 -> bind identity%9 (\(Identity value%10) -> value%10)

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.nbe.snap
@@ -1,5 +1,6 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 12
 expression: report
 ---
 first = \argument0%0 ->
@@ -16,3 +17,10 @@ first = \argument0%0 ->
           Empty
 
 unwrap = \Identity value%4 -> value%4
+
+nested = \argument0%5 ->
+  case argument0%5 of
+    Outer (One value%6) ->
+      One value%6
+    _ ->
+      Empty

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.nbe.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+first = \argument0%0 ->
+  case argument0%0 of
+    Empty ->
+      Empty
+    One value%1 ->
+      One value%1
+    whole%2@(Pair left%3 _) ->
+      case whole%2 of
+        Pair _ _ ->
+          One left%3
+        _ ->
+          Empty
+
+unwrap = \Identity value%4 -> value%4

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.purs
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.purs
@@ -19,3 +19,9 @@ unwrap (Identity value) = value
 nested :: forall a. Nested a -> Choice a
 nested (Outer (One value)) = One value
 nested _ = Empty
+
+bind :: forall a b. a -> (a -> b) -> b
+bind value continuation = continuation value
+
+ordinaryBind :: Identity Int -> Int
+ordinaryBind identity = bind identity (\(Identity value) -> value)

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.purs
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.purs
@@ -4,6 +4,8 @@ data Choice a = Empty | One a | Pair a a
 
 newtype Identity a = Identity a
 
+data Nested a = Outer (Choice a)
+
 first :: forall a. Choice a -> Choice a
 first Empty = Empty
 first (One value) = One value
@@ -13,3 +15,7 @@ first whole@(Pair left _) = case whole of
 
 unwrap :: forall a. Identity a -> a
 unwrap (Identity value) = value
+
+nested :: forall a. Nested a -> Choice a
+nested (Outer (One value)) = One value
+nested _ = Empty

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.snap
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.snap
@@ -8,13 +8,17 @@ Empty :: forall @a. Main.Choice a
 One :: forall @a. a -> Main.Choice a
 Pair :: forall @a. a -> a -> Main.Choice a
 Identity :: forall @a. a -> Main.Identity a
+Outer :: forall @a. Main.Choice a -> Main.Nested a
 first :: forall a. Main.Choice a -> Main.Choice a
 unwrap :: forall a. Main.Identity a -> a
+nested :: forall a. Main.Nested a -> Main.Choice a
 
 Types
 Choice :: Prim.Type -> Prim.Type
 Identity :: Prim.Type -> Prim.Type
+Nested :: Prim.Type -> Prim.Type
 
 Roles
 Choice = [Representational]
 Identity = [Representational]
+Nested = [Representational]

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.snap
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.snap
@@ -12,6 +12,8 @@ Outer :: forall @a. Main.Choice a -> Main.Nested a
 first :: forall a. Main.Choice a -> Main.Choice a
 unwrap :: forall a. Main.Identity a -> a
 nested :: forall a. Main.Nested a -> Main.Choice a
+bind :: forall a b. a -> (a -> b) -> b
+ordinaryBind :: Main.Identity Prim.Int -> Prim.Int
 
 Types
 Choice :: Prim.Type -> Prim.Type

--- a/tests-integration/fixtures/backend/1787021520_array_patterns/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021520_array_patterns/Main.nbe.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+describe = \argument0%0 ->
+  case argument0%0 of
+    [] ->
+      0
+    [value%1] ->
+      value%1
+    [first%2, second%3] ->
+      first%2
+    _ ->
+      3

--- a/tests-integration/fixtures/backend/1787021580_record_patterns/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021580_record_patterns/Main.nbe.snap
@@ -1,0 +1,5 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+select = \{ first: first%1, nested: { second: second%0 } } -> second%0

--- a/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/Main.nbe.snap
@@ -1,0 +1,12 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+choose = \first%0 second%1 ->
+  case first%0, second%1 of
+    true, true ->
+      2
+    true, false ->
+      1
+    false, _ ->
+      0

--- a/tests-integration/fixtures/backend/1787021700_guards/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021700_guards/Main.nbe.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+booleanGuard = \value%0 ->
+  | value%0 -> 1
+  | true -> 0
+
+patternGuard = \choice%1 ->
+  | One value%2 <- choice%1 -> value%2
+  | true -> 0

--- a/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.nbe.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+unwrap = \wrapped%1 ->
+  let
+    Identity value%0 = wrapped%1
+  in value%0
+
+select = \record%3 ->
+  let
+    { first: first%4, second: second%2 } = record%3
+  in second%2

--- a/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/Main.nbe.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+mutual = \condition%1 ->
+  let
+    rec second%2 = \argument0%3 ->
+      case argument0%3 of
+        true ->
+          2
+        false ->
+          first%0 true
+    rec first%0 = \argument0%4 ->
+      case argument0%4 of
+        true ->
+          1
+        false ->
+          second%2 true
+  in first%0 condition%1

--- a/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/Main.nbe.snap
@@ -1,0 +1,21 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+forward = later
+
+later = 42
+
+recursive[2] first = \argument0%0 ->
+  case argument0%0 of
+    true ->
+      1
+    false ->
+      second true
+
+recursive[2] second = \argument0%1 ->
+  case argument0%1 of
+    true ->
+      2
+    false ->
+      first true

--- a/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.nbe.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+foreign equalInt
+
+foreign lessThanInt
+
+instance equalInt1 = { equal: equalInt }
+
+instance orderedInt = { superclass17: equalInt1, lessThan: lessThanInt }
+
+genericEqual = \dictionary0%0 -> \left%1 right%2 -> dictionary0%0.equal left%1 right%2
+
+concreteEqual = equalInt1.equal 1 2
+
+concreteLessThan = orderedInt.lessThan 1 2
+
+superclassEqual = \dictionary1%3 ->
+  \left%4 right%5 -> dictionary1%3.superclass17.equal left%4 right%5

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.nbe.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+foreign firstAction
+
+foreign secondAction
+
+foreign independentAction
+
+sequential = bindEffect1.bind firstAction (\first%0 -> secondAction first%0)
+
+independent = applyEffect1.apply
+  (functorEffect.map (\first%1 second%2 -> { first: first%1, second: second%2 }) firstAction)
+  independentAction

--- a/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.nbe.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+foreign foreignValue
+
+foreign foreignFunction
+
+value = foreignFunction foreignValue

--- a/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.nbe.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+unbox = \Box value%0 -> value%0
+
+fromLibrary = unbox box
+
+directReference = libraryValue

--- a/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.nbe.snap
@@ -1,8 +1,9 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 12
 expression: report
 ---
-unbox = \Box value%0 -> value%0
+unbox = \(Box value%0) -> value%0
 
 fromLibrary = unbox box
 

--- a/tests-integration/fixtures/backend/1787022180_desugared_source_forms/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022180_desugared_source_forms/Main.nbe.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+add = \left%0 right%1 -> left%0
+
+identity = \value%2 -> value%2
+
+operatorApplication = add 1 2
+
+visibleTypeApplication = identity 42
+
+increment = \section60%3 -> add section60%3 1
+
+accessValue = \section79%4 -> section79%4.value

--- a/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/Main.nbe.snap
@@ -1,0 +1,21 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+apply = \function%0 value%1 -> function%0 value%1
+
+capture = \captured%2 -> \_ -> captured%2
+
+choose = \condition%3 left%4 right%5 ->
+  if condition%3 then left%4 else right%5
+
+partial = choose true 42
+
+literalCase = \value%6 ->
+  case value%6 of
+    0 ->
+      "zero"
+    _ ->
+      "other"
+
+higherOrder = apply (capture 42) 0

--- a/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.nbe.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+foreign addInt
+
+foreign multiplyInt
+
+constantAdd = addInt 20 22
+
+constantMultiply = multiplyInt 6 7
+
+overflowAdd = addInt 2147483647 1
+
+unknownAdd = addInt

--- a/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.nbe.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+foreign await
+
+arguments = await
+
+default = { "hyphen-label": arguments }
+
+readLabel = \record%0 -> record%0."hyphen-label"
+
+tagged = Tagged default

--- a/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.nbe.snap
@@ -1,5 +1,6 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 12
 expression: report
 ---
 foreign await
@@ -9,5 +10,9 @@ arguments = await
 default = { "hyphen-label": arguments }
 
 readLabel = \record%0 -> record%0."hyphen-label"
+
+emptyLabel = { "": arguments }
+
+readEmptyLabel = \record%1 -> record%1.""
 
 tagged = Tagged default

--- a/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.purs
+++ b/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.purs
@@ -11,6 +11,12 @@ default = { "hyphen-label": arguments }
 readLabel :: { "hyphen-label" :: Int } -> Int
 readLabel record = record."hyphen-label"
 
+emptyLabel :: { "" :: Int }
+emptyLabel = { "": arguments }
+
+readEmptyLabel :: { "" :: Int } -> Int
+readEmptyLabel record = record.""
+
 data Tagged = Tagged { "hyphen-label" :: Int }
 
 tagged :: Tagged

--- a/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.snap
+++ b/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.snap
@@ -8,6 +8,8 @@ await :: Prim.Int
 arguments :: Prim.Int
 default :: { hyphen-label :: Prim.Int }
 readLabel :: { hyphen-label :: Prim.Int } -> Prim.Int
+emptyLabel :: {  :: Prim.Int }
+readEmptyLabel :: {  :: Prim.Int } -> Prim.Int
 Tagged :: { hyphen-label :: Prim.Int } -> Main.Tagged
 tagged :: Main.Tagged
 

--- a/tests-integration/fixtures/backend/1787080920_derived_instance/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787080920_derived_instance/Main.nbe.snap
@@ -1,0 +1,17 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+instance eqBox = {
+  eq:
+    \left%0 right%1 ->
+      case left%0, right%1 of
+        Box, Box ->
+          true
+}
+
+equal = eqBox.eq Box Box
+
+instance showIdentity = \dictionary1%2 -> dictionary1%2
+
+rendered = (showIdentity showInt).show (Identity 42)

--- a/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.nbe.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+symbol = symbol "alexandrite".reflectSymbol Proxy
+
+reflectedString = reflectable "reflected".reflectType Proxy
+
+reflectedInteger = reflectable 42.reflectType Proxy
+
+reflectedTrue = reflectable true.reflectType Proxy
+
+reflectedFalse = reflectable false.reflectType Proxy
+
+reflectedLess = reflectable LT.reflectType Proxy
+
+reflectedEqual = reflectable EQ.reflectType Proxy
+
+reflectedGreater = reflectable GT.reflectType Proxy

--- a/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.nbe.snap
@@ -1,19 +1,20 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 12
 expression: report
 ---
-symbol = symbol "alexandrite".reflectSymbol Proxy
+symbol = (symbol "alexandrite").reflectSymbol Proxy
 
-reflectedString = reflectable "reflected".reflectType Proxy
+reflectedString = (reflectable "reflected").reflectType Proxy
 
-reflectedInteger = reflectable 42.reflectType Proxy
+reflectedInteger = (reflectable 42).reflectType Proxy
 
-reflectedTrue = reflectable true.reflectType Proxy
+reflectedTrue = (reflectable true).reflectType Proxy
 
-reflectedFalse = reflectable false.reflectType Proxy
+reflectedFalse = (reflectable false).reflectType Proxy
 
-reflectedLess = reflectable LT.reflectType Proxy
+reflectedLess = (reflectable LT).reflectType Proxy
 
-reflectedEqual = reflectable EQ.reflectType Proxy
+reflectedEqual = (reflectable EQ).reflectType Proxy
 
-reflectedGreater = reflectable GT.reflectType Proxy
+reflectedGreater = (reflectable GT).reflectType Proxy

--- a/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.nbe.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/tests/nbe.rs
+expression: report
+---
+sequence = \input%2 ->
+  let
+    first%1 = input%2
+  in let
+    second%0 = first%1
+  in second%0

--- a/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.nbe.snap
@@ -6,6 +6,6 @@ expression: report
 choose = \argument0%0 argument1%1 ->
   case argument0%0, argument1%1 of
     0, _ ->
-      \value%2 -> value%2
+      (\value%2 -> value%2) argument1%1
     left%3, _ ->
       left%3

--- a/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.nbe.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 12
+expression: report
+---
+choose = \argument0%0 argument1%1 ->
+  case argument0%0, argument1%1 of
+    0, _ ->
+      \value%2 -> value%2
+    left%3, _ ->
+      left%3

--- a/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.purs
+++ b/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.purs
@@ -1,0 +1,5 @@
+module Main where
+
+choose :: Int -> Int -> Int
+choose 0 = \value -> value
+choose left _ = left

--- a/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.snap
+++ b/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+choose :: Prim.Int -> Prim.Int -> Prim.Int
+
+Types

--- a/tests-integration/tests/nbe.rs
+++ b/tests-integration/tests/nbe.rs
@@ -1,0 +1,18 @@
+fn nbe(path: &std::path::Path) -> datatest_stable::Result<()> {
+    let folder = path.parent().ok_or("fixture path has no parent")?;
+    let (engine, _) = tests_integration::load_compiler(folder);
+    let id = engine.module_file("Main").ok_or("fixture has no Main module")?;
+    let module = nbe::convert_module(&engine, id)?;
+    let report = nbe::pretty::render(&module);
+
+    let snapshot_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(folder);
+    let mut settings = insta::Settings::clone_current();
+    settings.set_snapshot_path(snapshot_path);
+    settings.set_prepend_module_to_snapshot(false);
+    settings.bind(|| insta::assert_snapshot!("Main.nbe", report));
+    Ok(())
+}
+
+datatest_stable::harness! {
+    { test = nbe, root = "fixtures/backend", pattern = r".*/Main\.purs$" },
+}


### PR DESCRIPTION
## Summary

- introduce the arena-allocated functional backend tree in `crate:nbe`
- lower checked modules into explicit declarations, binders, expressions, evidence, recursive groups, and pattern alternatives
- represent deterministic conversion failures as typed module errors
- snapshot every shared backend fixture at the NbE boundary

This layer deliberately establishes the unoptimised functional representation only; evaluation, reification, and optimisation remain follow-up work.

## Stack

This is 2/7 in the backend stack, stacked on #343. The next layer is #345.

## Validation

```text
just format --check
just t backend
cargo nextest run -p tests-integration --test nbe --no-fail-fast
cargo check -p nbe --tests
cargo clippy -p nbe -p tests-integration --tests -- -D warnings
```

All 22 NbE integration fixtures pass.

Refs #330.

Amp-Thread-ID: https://ampcode.com/threads/T-01a015b1-dd0c-761d-9f62-5f25ca77586e

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
