### PR TITLE
[backend] Add SSA control-flow backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,6 +2576,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssa"
+version = "0.1.0"
+dependencies = [
+ "files",
+ "indexing",
+ "itertools 0.15.0",
+ "la-arena",
+ "lowering",
+ "nbe",
+ "pretty",
+ "rustc-hash",
+ "smol_str",
+ "thiserror",
+]
+
+[[package]]
 name = "stabilizing"
 version = "0.1.0"
 dependencies = [
@@ -2824,6 +2840,7 @@ dependencies = [
  "prim-constants",
  "serde_json",
  "similar 3.1.2",
+ "ssa",
  "stabilizing",
  "sugar",
  "syntax",

--- a/compiler-backend/ssa/Cargo.toml
+++ b/compiler-backend/ssa/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ssa"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+files = { version = "0.1.0", path = "../../compiler-core/files" }
+indexing = { version = "0.1.0", path = "../../compiler-core/indexing" }
+itertools = "0.15.0"
+la-arena = "0.3.1"
+lowering = { version = "0.1.0", path = "../../compiler-core/lowering" }
+nbe = { version = "0.1.0", path = "../nbe" }
+pretty = "0.12"
+rustc-hash = "2.1.3"
+smol_str = "0.3.5"
+thiserror = "2.0.20"

--- a/compiler-backend/ssa/src/convert.rs
+++ b/compiler-backend/ssa/src/convert.rs
@@ -1,0 +1,1151 @@
+//! Conversion from owned functional trees into A-normal control-flow graphs.
+
+use std::sync::Arc;
+
+use itertools::Itertools;
+use rustc_hash::{FxHashMap, FxHashSet};
+use smol_str::{SmolStr, format_smolstr};
+
+use crate::error::{ConversionError, ConversionResult, UnsupportedState};
+use crate::tree::{
+    Block, BlockId, BlockTarget, CallingConvention, Declaration, DeclarationKind, Failure, Field,
+    FieldIdentity, Function, FunctionId, Global, GlobalIdentity, InstanceIdentity, Instruction,
+    InstructionValue, Literal, Module, PatternTest, Projection, RecordField, RecordUpdate,
+    RecursiveClosure, RecursiveGroupId, ReflectableEvidence, ReflectableOrdering, Storage,
+    SuperclassIdentity, SynthesizedEvidence, Terminator, Value, ValueId,
+};
+
+pub fn convert_module(functional: &nbe::tree::Module) -> ConversionResult<Module> {
+    let mut state = State::default();
+    let context = Context { functional };
+    for declaration in functional.declarations.iter() {
+        convert_declaration(&mut state, &context, declaration)?;
+    }
+    Ok(Module {
+        file_id: functional.file_id,
+        declarations: state.output.declarations.into(),
+        storage: state.output.storage,
+    })
+}
+
+struct Context<'m> {
+    functional: &'m nbe::tree::Module,
+}
+
+struct Traversal {
+    function_name: SmolStr,
+    current_block: Option<BlockId>,
+    blocks: Vec<BlockId>,
+    scope: FxHashMap<nbe::tree::LocalId, ValueId>,
+    value_names: FxHashMap<SmolStr, u32>,
+    block_names: FxHashMap<SmolStr, u32>,
+    unterminated: FxHashSet<BlockId>,
+}
+
+impl Traversal {
+    fn new(function_name: SmolStr) -> Traversal {
+        Traversal {
+            function_name,
+            current_block: None,
+            blocks: vec![],
+            scope: FxHashMap::default(),
+            value_names: FxHashMap::default(),
+            block_names: FxHashMap::default(),
+            unterminated: FxHashSet::default(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct PersistedOutput {
+    declarations: Vec<Declaration>,
+    storage: Storage,
+    function_names: FxHashMap<SmolStr, u32>,
+}
+
+#[derive(Default)]
+struct State {
+    traversal: Option<Traversal>,
+    output: PersistedOutput,
+}
+
+#[derive(Clone)]
+enum FunctionParameter {
+    Pattern { pattern: nbe::tree::PatternId },
+    Local { parameter: nbe::tree::Parameter },
+}
+
+struct BuiltFunction {
+    function: FunctionId,
+    captures: Arc<[ValueId]>,
+}
+
+fn convert_declaration(
+    state: &mut State,
+    context: &Context<'_>,
+    declaration: &nbe::tree::Declaration,
+) -> ConversionResult<()> {
+    let global = convert_global(&declaration.global);
+    let recursive_group =
+        declaration.recursive_group.map(|group| RecursiveGroupId { index: group.0 });
+    let kind = match declaration.kind {
+        nbe::tree::DeclarationKind::Value(expression) => {
+            let expression = &context.functional.storage[expression];
+            if let nbe::tree::ExpressionKind::Abstraction { parameters, body } = &expression.kind {
+                let parameters =
+                    parameters.iter().map(|&pattern| FunctionParameter::Pattern { pattern });
+                let parameters = parameters.collect_vec();
+                let built = build_function(
+                    state,
+                    context,
+                    global.name.clone(),
+                    CallingConvention::Source,
+                    parameters,
+                    *body,
+                )?;
+                DeclarationKind::Function { function: built.function }
+            } else {
+                let name = format_smolstr!("{}$initialize", global.name);
+                let built = build_function(
+                    state,
+                    context,
+                    name,
+                    CallingConvention::Initializer,
+                    vec![],
+                    expression_id(declaration),
+                )?;
+                DeclarationKind::Value { initializer: built.function }
+            }
+        }
+        nbe::tree::DeclarationKind::Foreign => DeclarationKind::Foreign,
+    };
+    state.output.declarations.push(Declaration { global, recursive_group, kind });
+    Ok(())
+}
+
+fn expression_id(declaration: &nbe::tree::Declaration) -> nbe::tree::ExpressionId {
+    let nbe::tree::DeclarationKind::Value(expression) = declaration.kind else {
+        unreachable!("invariant violated: requested expression from foreign declaration")
+    };
+    expression
+}
+
+fn build_function(
+    state: &mut State,
+    context: &Context<'_>,
+    preferred_name: SmolStr,
+    calling_convention: CallingConvention,
+    parameters: Vec<FunctionParameter>,
+    body: nbe::tree::ExpressionId,
+) -> ConversionResult<BuiltFunction> {
+    let function_name = state.fresh_function_name(preferred_name);
+    let free_parameters = free_parameters(context, &parameters, body);
+    let capture_sources =
+        free_parameters.iter().map(|parameter| state.lookup_local(context, parameter));
+    let capture_sources = capture_sources.collect::<ConversionResult<Vec<_>>>()?;
+
+    let parent = state.traversal.take();
+    state.traversal = Some(Traversal::new(function_name.clone()));
+    let result = build_function_body(state, context, &free_parameters, &parameters, body);
+    let traversal =
+        state.traversal.take().expect("invariant violated: function traversal is missing");
+    state.traversal = parent;
+
+    let (captures, formal_parameters, entry) = result?;
+    if !traversal.unterminated.is_empty() {
+        return Err(context.unsupported(UnsupportedState::UnterminatedBlock {
+            function_name: traversal.function_name.to_string(),
+        }));
+    }
+    let function = Function {
+        name: function_name,
+        calling_convention,
+        captures: captures.into(),
+        parameters: formal_parameters.into(),
+        entry,
+        blocks: traversal.blocks.into(),
+    };
+    let function = state.output.storage.allocate_function(function);
+    Ok(BuiltFunction { function, captures: capture_sources.into() })
+}
+
+fn build_function_body(
+    state: &mut State,
+    context: &Context<'_>,
+    free_parameters: &[nbe::tree::Parameter],
+    parameters: &[FunctionParameter],
+    body: nbe::tree::ExpressionId,
+) -> ConversionResult<(Vec<ValueId>, Vec<ValueId>, BlockId)> {
+    let entry = state.create_block("entry", vec![]);
+    state.switch_to(entry);
+
+    let mut captures = vec![];
+    for parameter in free_parameters {
+        let value = state.fresh_value(parameter.name.clone());
+        state.bind_local(parameter, value);
+        captures.push(value);
+    }
+
+    let mut formal_parameters = vec![];
+    for (position, parameter) in parameters.iter().enumerate() {
+        let name = function_parameter_name(context, parameter, position);
+        formal_parameters.push(state.fresh_value(name));
+    }
+
+    let has_refutable_parameter = parameters.iter().any(|parameter| match parameter {
+        FunctionParameter::Pattern { pattern } => pattern_is_refutable(context, *pattern),
+        FunctionParameter::Local { .. } => false,
+    });
+    let failure = has_refutable_parameter.then(|| state.create_block("parameter$failure", vec![]));
+    for (parameter, value) in parameters.iter().zip(formal_parameters.iter().copied()) {
+        match parameter {
+            FunctionParameter::Pattern { pattern } => {
+                compile_pattern(state, context, *pattern, value, failure)?;
+            }
+            FunctionParameter::Local { parameter } => state.bind_local(parameter, value),
+        }
+    }
+
+    let result = lower_expression(state, context, body)?;
+    state.terminate(Terminator::Return { value: result });
+    if let Some(failure) = failure {
+        state.switch_to(failure);
+        state.terminate(Terminator::Fail { failure: Failure::PatternMatch });
+    }
+    Ok((captures, formal_parameters, entry))
+}
+
+fn lower_expression(
+    state: &mut State,
+    context: &Context<'_>,
+    expression_id: nbe::tree::ExpressionId,
+) -> ConversionResult<ValueId> {
+    let expression = &context.functional.storage[expression_id];
+    match &expression.kind {
+        nbe::tree::ExpressionKind::Literal { literal } => {
+            let literal = convert_literal(literal);
+            Ok(state.emit("literal", InstructionValue::Literal { literal }))
+        }
+        nbe::tree::ExpressionKind::Array { elements } => {
+            let elements = lower_expressions(state, context, elements)?;
+            Ok(state.emit("array", InstructionValue::Array { elements: elements.into() }))
+        }
+        nbe::tree::ExpressionKind::Record { fields } => {
+            let mut converted = vec![];
+            for field in fields.iter() {
+                let value = lower_expression(state, context, field.expression)?;
+                converted.push(RecordField { field: convert_field(&field.field), value });
+            }
+            Ok(state.emit("record", InstructionValue::Record { fields: converted.into() }))
+        }
+        nbe::tree::ExpressionKind::RecordUpdate { record, updates } => {
+            let record = lower_expression(state, context, *record)?;
+            let updates = lower_record_updates(state, context, updates)?;
+            let value = InstructionValue::RecordUpdate { record, updates: updates.into() };
+            Ok(state.emit("updated", value))
+        }
+        nbe::tree::ExpressionKind::Project { record, field } => {
+            let record = lower_expression(state, context, *record)?;
+            let field = convert_field(field);
+            let name = field.name.clone();
+            Ok(state.emit(name, InstructionValue::Project { record, field }))
+        }
+        nbe::tree::ExpressionKind::Constructor { global } => {
+            let global = convert_global(global);
+            let name = global.name.clone();
+            Ok(state.emit(name, InstructionValue::Constructor { global }))
+        }
+        nbe::tree::ExpressionKind::Global { global } => {
+            let global = convert_global(global);
+            let name = global.name.clone();
+            Ok(state.emit(name, InstructionValue::Global { global }))
+        }
+        nbe::tree::ExpressionKind::Local { parameter } => state.lookup_local(context, parameter),
+        nbe::tree::ExpressionKind::Abstraction { parameters, body } => {
+            let parameters =
+                parameters.iter().map(|&pattern| FunctionParameter::Pattern { pattern });
+            let parameters = parameters.collect_vec();
+            let preferred_name = format_smolstr!("{}$closure", state.function_name());
+            let built = build_function(
+                state,
+                context,
+                preferred_name,
+                CallingConvention::Source,
+                parameters,
+                *body,
+            )?;
+            let value =
+                InstructionValue::Closure { function: built.function, captures: built.captures };
+            Ok(state.emit("closure", value))
+        }
+        nbe::tree::ExpressionKind::Application { function, arguments } => {
+            let function = lower_expression(state, context, *function)?;
+            let arguments = lower_expressions(state, context, arguments)?;
+            let value = InstructionValue::Call {
+                calling_convention: CallingConvention::Source,
+                function,
+                arguments: arguments.into(),
+            };
+            Ok(state.emit("call", value))
+        }
+        nbe::tree::ExpressionKind::IfThenElse { condition, then, else_ } => {
+            lower_if_then_else(state, context, *condition, *then, *else_)
+        }
+        nbe::tree::ExpressionKind::Case { scrutinees, alternatives } => {
+            lower_case(state, context, scrutinees, alternatives)
+        }
+        nbe::tree::ExpressionKind::Guarded { alternatives } => {
+            lower_guarded(state, context, alternatives)
+        }
+        nbe::tree::ExpressionKind::Let { recursive, bindings, body } => {
+            lower_let(state, context, *recursive, bindings, *body)
+        }
+        nbe::tree::ExpressionKind::LetPattern { pattern, value, body } => {
+            lower_pattern_let(state, context, *pattern, *value, *body)
+        }
+        nbe::tree::ExpressionKind::Effect { effect } => lower_effect(state, context, effect),
+        nbe::tree::ExpressionKind::SynthesizedEvidence { evidence } => {
+            let evidence = convert_synthesized_evidence(evidence);
+            Ok(state.emit("evidence", InstructionValue::SynthesizedEvidence { evidence }))
+        }
+        nbe::tree::ExpressionKind::TrivialEvidence => {
+            Ok(state.emit("evidence", InstructionValue::TrivialEvidence))
+        }
+    }
+}
+
+fn lower_expressions(
+    state: &mut State,
+    context: &Context<'_>,
+    expressions: &[nbe::tree::ExpressionId],
+) -> ConversionResult<Vec<ValueId>> {
+    let values = expressions.iter().map(|&expression| lower_expression(state, context, expression));
+    values.collect::<ConversionResult<Vec<_>>>()
+}
+
+fn lower_record_updates(
+    state: &mut State,
+    context: &Context<'_>,
+    updates: &[nbe::tree::RecordUpdate],
+) -> ConversionResult<Vec<RecordUpdate>> {
+    let mut converted = vec![];
+    for update in updates {
+        let update = match update {
+            nbe::tree::RecordUpdate::Leaf { field, expression } => {
+                let value = lower_expression(state, context, *expression)?;
+                RecordUpdate::Leaf { field: convert_field(field), value }
+            }
+            nbe::tree::RecordUpdate::Branch { field, updates } => {
+                let updates = lower_record_updates(state, context, updates)?;
+                RecordUpdate::Branch { field: convert_field(field), updates: updates.into() }
+            }
+        };
+        converted.push(update);
+    }
+    Ok(converted)
+}
+
+fn lower_if_then_else(
+    state: &mut State,
+    context: &Context<'_>,
+    condition: nbe::tree::ExpressionId,
+    then: nbe::tree::ExpressionId,
+    else_: nbe::tree::ExpressionId,
+) -> ConversionResult<ValueId> {
+    let condition = lower_expression(state, context, condition)?;
+    let outer_scope = state.scope().clone();
+    let then_block = state.create_block("then", vec![]);
+    let else_block = state.create_block("else", vec![]);
+    let result = state.fresh_value("result".into());
+    let join = state.create_block("if$join", vec![result]);
+    let then_target = state.target(then_block, vec![]);
+    let else_target = state.target(else_block, vec![]);
+    state.terminate(Terminator::Branch { condition, then_target, else_target });
+
+    state.switch_to(then_block);
+    state.set_scope(outer_scope.clone());
+    let then = lower_expression(state, context, then)?;
+    let target = state.target(join, vec![then]);
+    state.terminate(Terminator::Jump { target });
+
+    state.switch_to(else_block);
+    state.set_scope(outer_scope.clone());
+    let else_ = lower_expression(state, context, else_)?;
+    let target = state.target(join, vec![else_]);
+    state.terminate(Terminator::Jump { target });
+
+    state.switch_to(join);
+    state.set_scope(outer_scope);
+    Ok(result)
+}
+
+fn lower_case(
+    state: &mut State,
+    context: &Context<'_>,
+    scrutinees: &[nbe::tree::ExpressionId],
+    alternatives: &[nbe::tree::CaseAlternative],
+) -> ConversionResult<ValueId> {
+    if alternatives.is_empty() {
+        return Err(context.unsupported(UnsupportedState::MissingCaseAlternative));
+    }
+    let scrutinees = lower_expressions(state, context, scrutinees)?;
+    let outer_scope = state.scope().clone();
+    let alternative_blocks = (0..alternatives.len())
+        .map(|position| state.create_block(format_smolstr!("case${position}"), vec![]));
+    let alternative_blocks = alternative_blocks.collect_vec();
+    let first_alternative = alternative_blocks
+        .first()
+        .copied()
+        .expect("invariant violated: case expression has no alternative block");
+    let failure = state.create_block("case$failure", vec![]);
+    let result = state.fresh_value("result".into());
+    let join = state.create_block("case$join", vec![result]);
+    let target = state.target(first_alternative, vec![]);
+    state.terminate(Terminator::Jump { target });
+
+    let mut blocks = alternative_blocks.iter().copied().peekable();
+    for alternative in alternatives {
+        if alternative.patterns.len() != scrutinees.len() {
+            return Err(context.unsupported(UnsupportedState::CaseArity {
+                patterns: alternative.patterns.len(),
+                scrutinees: scrutinees.len(),
+            }));
+        }
+        let block = blocks.next().expect("invariant violated: case alternative has no basic block");
+        let next = blocks.peek().copied().unwrap_or(failure);
+        state.switch_to(block);
+        state.set_scope(outer_scope.clone());
+        for (&pattern, value) in alternative.patterns.iter().zip(scrutinees.iter().copied()) {
+            compile_pattern(state, context, pattern, value, Some(next))?;
+        }
+        let value = lower_expression(state, context, alternative.expression)?;
+        let target = state.target(join, vec![value]);
+        state.terminate(Terminator::Jump { target });
+    }
+
+    state.switch_to(failure);
+    state.terminate(Terminator::Fail { failure: Failure::PatternMatch });
+    state.switch_to(join);
+    state.set_scope(outer_scope);
+    Ok(result)
+}
+
+fn lower_guarded(
+    state: &mut State,
+    context: &Context<'_>,
+    alternatives: &[nbe::tree::GuardedAlternative],
+) -> ConversionResult<ValueId> {
+    if alternatives.is_empty() {
+        return Err(context.unsupported(UnsupportedState::MissingGuardedAlternative));
+    }
+    let outer_scope = state.scope().clone();
+    let alternative_blocks = (0..alternatives.len())
+        .map(|position| state.create_block(format_smolstr!("guard${position}"), vec![]));
+    let alternative_blocks = alternative_blocks.collect_vec();
+    let first_alternative = alternative_blocks
+        .first()
+        .copied()
+        .expect("invariant violated: guarded expression has no alternative block");
+    let failure = state.create_block("guard$failure", vec![]);
+    let result = state.fresh_value("result".into());
+    let join = state.create_block("guard$join", vec![result]);
+    let target = state.target(first_alternative, vec![]);
+    state.terminate(Terminator::Jump { target });
+
+    let mut blocks = alternative_blocks.iter().copied().peekable();
+    for alternative in alternatives {
+        let block =
+            blocks.next().expect("invariant violated: guarded alternative has no basic block");
+        let next = blocks.peek().copied().unwrap_or(failure);
+        state.switch_to(block);
+        state.set_scope(outer_scope.clone());
+        for guard in alternative.guards.iter() {
+            match guard {
+                nbe::tree::Guard::Boolean(expression) => {
+                    let condition = lower_expression(state, context, *expression)?;
+                    let success = state.create_block("guard$success", vec![]);
+                    let then_target = state.target(success, vec![]);
+                    let else_target = state.target(next, vec![]);
+                    state.terminate(Terminator::Branch { condition, then_target, else_target });
+                    state.switch_to(success);
+                }
+                nbe::tree::Guard::Pattern { expression, pattern } => {
+                    let value = lower_expression(state, context, *expression)?;
+                    compile_pattern(state, context, *pattern, value, Some(next))?;
+                }
+            }
+        }
+        let value = lower_expression(state, context, alternative.expression)?;
+        let target = state.target(join, vec![value]);
+        state.terminate(Terminator::Jump { target });
+    }
+
+    state.switch_to(failure);
+    state.terminate(Terminator::Fail { failure: Failure::PatternMatch });
+    state.switch_to(join);
+    state.set_scope(outer_scope);
+    Ok(result)
+}
+
+fn lower_let(
+    state: &mut State,
+    context: &Context<'_>,
+    recursive: bool,
+    bindings: &[nbe::tree::Binding],
+    body: nbe::tree::ExpressionId,
+) -> ConversionResult<ValueId> {
+    let outer_scope = state.scope().clone();
+    if recursive {
+        lower_recursive_bindings(state, context, bindings)?;
+    } else {
+        for binding in bindings {
+            let value = lower_expression(state, context, binding.expression)?;
+            state.bind_local(&binding.parameter, value);
+        }
+    }
+    let result = lower_expression(state, context, body);
+    state.set_scope(outer_scope);
+    result
+}
+
+fn lower_recursive_bindings(
+    state: &mut State,
+    context: &Context<'_>,
+    bindings: &[nbe::tree::Binding],
+) -> ConversionResult<()> {
+    let mut results = vec![];
+    for binding in bindings {
+        let result = state.fresh_value(binding.parameter.name.clone());
+        state.bind_local(&binding.parameter, result);
+        results.push(result);
+    }
+
+    let mut closures = vec![];
+    for (binding, result) in bindings.iter().zip(results) {
+        let expression = &context.functional.storage[binding.expression];
+        let nbe::tree::ExpressionKind::Abstraction { parameters, body } = &expression.kind else {
+            return Err(context.unsupported(UnsupportedState::RecursiveValue {
+                local_name: binding.parameter.name.to_string(),
+            }));
+        };
+        let parameters = parameters.iter().map(|&pattern| FunctionParameter::Pattern { pattern });
+        let parameters = parameters.collect_vec();
+        let preferred_name = format_smolstr!("{}$function", binding.parameter.name);
+        let built = build_function(
+            state,
+            context,
+            preferred_name,
+            CallingConvention::Source,
+            parameters,
+            *body,
+        )?;
+        closures.push(RecursiveClosure {
+            result,
+            function: built.function,
+            captures: built.captures,
+        });
+    }
+    state.append(Instruction::RecursiveClosures { bindings: closures.into() });
+    Ok(())
+}
+
+fn lower_pattern_let(
+    state: &mut State,
+    context: &Context<'_>,
+    pattern: nbe::tree::PatternId,
+    value: nbe::tree::ExpressionId,
+    body: nbe::tree::ExpressionId,
+) -> ConversionResult<ValueId> {
+    let value = lower_expression(state, context, value)?;
+    let outer_scope = state.scope().clone();
+    let failure =
+        pattern_is_refutable(context, pattern).then(|| state.create_block("let$failure", vec![]));
+    compile_pattern(state, context, pattern, value, failure)?;
+    let result = lower_expression(state, context, body)?;
+    let continuation = state.current_block();
+    if let Some(failure) = failure {
+        state.switch_to(failure);
+        state.terminate(Terminator::Fail { failure: Failure::PatternMatch });
+        state.switch_to(continuation);
+    }
+    state.set_scope(outer_scope);
+    Ok(result)
+}
+
+fn lower_effect(
+    state: &mut State,
+    context: &Context<'_>,
+    effect: &nbe::tree::EffectExpression,
+) -> ConversionResult<ValueId> {
+    match effect {
+        nbe::tree::EffectExpression::Pure(expression) => {
+            let value = lower_expression(state, context, *expression)?;
+            Ok(state.emit("effect", InstructionValue::EffectPure { value }))
+        }
+        nbe::tree::EffectExpression::Bind { action, parameter, body } => {
+            let action = lower_expression(state, context, *action)?;
+            let parameters = vec![FunctionParameter::Local { parameter: parameter.clone() }];
+            let preferred_name = format_smolstr!("{}$effect", state.function_name());
+            let built = build_function(
+                state,
+                context,
+                preferred_name,
+                CallingConvention::Effect,
+                parameters,
+                *body,
+            )?;
+            let continuation =
+                InstructionValue::Closure { function: built.function, captures: built.captures };
+            let continuation = state.emit("continuation", continuation);
+            let value = InstructionValue::EffectBind { action, continuation };
+            Ok(state.emit("effect", value))
+        }
+    }
+}
+
+fn compile_pattern(
+    state: &mut State,
+    context: &Context<'_>,
+    pattern_id: nbe::tree::PatternId,
+    value: ValueId,
+    failure: Option<BlockId>,
+) -> ConversionResult<()> {
+    let pattern = &context.functional.storage[pattern_id];
+    match &pattern.kind {
+        nbe::tree::PatternKind::Variable(parameter) => state.bind_local(parameter, value),
+        nbe::tree::PatternKind::Named { parameter, pattern } => {
+            state.bind_local(parameter, value);
+            compile_pattern(state, context, *pattern, value, failure)?;
+        }
+        nbe::tree::PatternKind::Literal(literal) => {
+            let test = PatternTest::Literal { literal: convert_literal(literal) };
+            compile_refutable_test(state, value, test, failure)?;
+        }
+        nbe::tree::PatternKind::Array(elements) => {
+            let test = PatternTest::ArrayLength { length: elements.len() };
+            compile_refutable_test(state, value, test, failure)?;
+            for (index, &element) in elements.iter().enumerate() {
+                let name = pattern_value_name(context, element, "element");
+                let projection = Projection::ArrayElement { index };
+                let element_value =
+                    state.emit(name, InstructionValue::Extract { value, projection });
+                compile_pattern(state, context, element, element_value, failure)?;
+            }
+        }
+        nbe::tree::PatternKind::Record(fields) => {
+            for field in fields.iter() {
+                let pattern = field.pattern;
+                let name = pattern_value_name(context, pattern, &field.field.name);
+                let field = convert_field(&field.field);
+                let field_value =
+                    state.emit(name, InstructionValue::Project { record: value, field });
+                compile_pattern(state, context, pattern, field_value, failure)?;
+            }
+        }
+        nbe::tree::PatternKind::Constructor { global, arguments } => {
+            let global = convert_global(global);
+            let test = PatternTest::Constructor { global: global.clone() };
+            compile_refutable_test(state, value, test, failure)?;
+            for (index, &argument) in arguments.iter().enumerate() {
+                let name = pattern_value_name(context, argument, "argument");
+                let projection =
+                    Projection::ConstructorArgument { constructor: global.clone(), index };
+                let argument_value =
+                    state.emit(name, InstructionValue::Extract { value, projection });
+                compile_pattern(state, context, argument, argument_value, failure)?;
+            }
+        }
+        nbe::tree::PatternKind::Wildcard => {}
+    }
+    Ok(())
+}
+
+fn compile_refutable_test(
+    state: &mut State,
+    value: ValueId,
+    test: PatternTest,
+    failure: Option<BlockId>,
+) -> ConversionResult<()> {
+    let Some(failure) = failure else {
+        unreachable!("invariant violated: refutable pattern has no failure block")
+    };
+    let condition = state.emit("matches", InstructionValue::Test { value, test });
+    let success = state.create_block("match$success", vec![]);
+    let then_target = state.target(success, vec![]);
+    let else_target = state.target(failure, vec![]);
+    state.terminate(Terminator::Branch { condition, then_target, else_target });
+    state.switch_to(success);
+    Ok(())
+}
+
+fn pattern_is_refutable(context: &Context<'_>, pattern_id: nbe::tree::PatternId) -> bool {
+    let pattern = &context.functional.storage[pattern_id];
+    match &pattern.kind {
+        nbe::tree::PatternKind::Variable(_) | nbe::tree::PatternKind::Wildcard => false,
+        nbe::tree::PatternKind::Named { pattern, .. } => pattern_is_refutable(context, *pattern),
+        nbe::tree::PatternKind::Record(fields) => {
+            fields.iter().any(|field| pattern_is_refutable(context, field.pattern))
+        }
+        nbe::tree::PatternKind::Literal(_)
+        | nbe::tree::PatternKind::Array(_)
+        | nbe::tree::PatternKind::Constructor { .. } => true,
+    }
+}
+
+fn function_parameter_name(
+    context: &Context<'_>,
+    parameter: &FunctionParameter,
+    position: usize,
+) -> SmolStr {
+    match parameter {
+        FunctionParameter::Pattern { pattern } => {
+            pattern_value_name(context, *pattern, &format!("argument{position}"))
+        }
+        FunctionParameter::Local { parameter } => parameter.name.clone(),
+    }
+}
+
+fn pattern_value_name(
+    context: &Context<'_>,
+    pattern_id: nbe::tree::PatternId,
+    fallback: &str,
+) -> SmolStr {
+    let pattern = &context.functional.storage[pattern_id];
+    match &pattern.kind {
+        nbe::tree::PatternKind::Variable(parameter)
+        | nbe::tree::PatternKind::Named { parameter, .. } => parameter.name.clone(),
+        _ => SmolStr::new(fallback),
+    }
+}
+
+fn free_parameters(
+    context: &Context<'_>,
+    parameters: &[FunctionParameter],
+    body: nbe::tree::ExpressionId,
+) -> Vec<nbe::tree::Parameter> {
+    let mut bound = FxHashSet::default();
+    for parameter in parameters {
+        match parameter {
+            FunctionParameter::Pattern { pattern } => {
+                collect_pattern_bindings(context, *pattern, &mut bound);
+            }
+            FunctionParameter::Local { parameter } => {
+                bound.insert(parameter.id);
+            }
+        }
+    }
+    let mut free = FreeParameters::default();
+    collect_free_expression(context, body, &bound, &mut free);
+    free.parameters
+}
+
+#[derive(Default)]
+struct FreeParameters {
+    seen: FxHashSet<nbe::tree::LocalId>,
+    parameters: Vec<nbe::tree::Parameter>,
+}
+
+impl FreeParameters {
+    fn insert(&mut self, parameter: &nbe::tree::Parameter) {
+        if self.seen.insert(parameter.id) {
+            self.parameters.push(parameter.clone());
+        }
+    }
+}
+
+fn collect_free_expression(
+    context: &Context<'_>,
+    expression_id: nbe::tree::ExpressionId,
+    bound: &FxHashSet<nbe::tree::LocalId>,
+    free: &mut FreeParameters,
+) {
+    let expression = &context.functional.storage[expression_id];
+    match &expression.kind {
+        nbe::tree::ExpressionKind::Array { elements } => {
+            for &element in elements.iter() {
+                collect_free_expression(context, element, bound, free);
+            }
+        }
+        nbe::tree::ExpressionKind::Record { fields } => {
+            for field in fields.iter() {
+                collect_free_expression(context, field.expression, bound, free);
+            }
+        }
+        nbe::tree::ExpressionKind::RecordUpdate { record, updates } => {
+            collect_free_expression(context, *record, bound, free);
+            collect_free_record_updates(context, updates, bound, free);
+        }
+        nbe::tree::ExpressionKind::Project { record, .. } => {
+            collect_free_expression(context, *record, bound, free);
+        }
+        nbe::tree::ExpressionKind::Local { parameter } => {
+            if !bound.contains(&parameter.id) {
+                free.insert(parameter);
+            }
+        }
+        nbe::tree::ExpressionKind::Abstraction { parameters, body } => {
+            let mut nested_bound = bound.clone();
+            for &pattern in parameters.iter() {
+                collect_pattern_bindings(context, pattern, &mut nested_bound);
+            }
+            collect_free_expression(context, *body, &nested_bound, free);
+        }
+        nbe::tree::ExpressionKind::Application { function, arguments } => {
+            collect_free_expression(context, *function, bound, free);
+            for &argument in arguments.iter() {
+                collect_free_expression(context, argument, bound, free);
+            }
+        }
+        nbe::tree::ExpressionKind::IfThenElse { condition, then, else_ } => {
+            collect_free_expression(context, *condition, bound, free);
+            collect_free_expression(context, *then, bound, free);
+            collect_free_expression(context, *else_, bound, free);
+        }
+        nbe::tree::ExpressionKind::Case { scrutinees, alternatives } => {
+            for &scrutinee in scrutinees.iter() {
+                collect_free_expression(context, scrutinee, bound, free);
+            }
+            for alternative in alternatives.iter() {
+                let mut alternative_bound = bound.clone();
+                for &pattern in alternative.patterns.iter() {
+                    collect_pattern_bindings(context, pattern, &mut alternative_bound);
+                }
+                collect_free_expression(context, alternative.expression, &alternative_bound, free);
+            }
+        }
+        nbe::tree::ExpressionKind::Guarded { alternatives } => {
+            for alternative in alternatives.iter() {
+                let mut alternative_bound = bound.clone();
+                for guard in alternative.guards.iter() {
+                    match guard {
+                        nbe::tree::Guard::Boolean(expression) => {
+                            collect_free_expression(context, *expression, &alternative_bound, free);
+                        }
+                        nbe::tree::Guard::Pattern { expression, pattern } => {
+                            collect_free_expression(context, *expression, &alternative_bound, free);
+                            collect_pattern_bindings(context, *pattern, &mut alternative_bound);
+                        }
+                    }
+                }
+                collect_free_expression(context, alternative.expression, &alternative_bound, free);
+            }
+        }
+        nbe::tree::ExpressionKind::Let { recursive, bindings, body } => {
+            collect_free_let(context, *recursive, bindings, *body, bound, free);
+        }
+        nbe::tree::ExpressionKind::LetPattern { pattern, value, body } => {
+            collect_free_expression(context, *value, bound, free);
+            let mut body_bound = bound.clone();
+            collect_pattern_bindings(context, *pattern, &mut body_bound);
+            collect_free_expression(context, *body, &body_bound, free);
+        }
+        nbe::tree::ExpressionKind::Effect { effect } => match effect {
+            nbe::tree::EffectExpression::Pure(expression) => {
+                collect_free_expression(context, *expression, bound, free);
+            }
+            nbe::tree::EffectExpression::Bind { action, parameter, body } => {
+                collect_free_expression(context, *action, bound, free);
+                let mut body_bound = bound.clone();
+                body_bound.insert(parameter.id);
+                collect_free_expression(context, *body, &body_bound, free);
+            }
+        },
+        nbe::tree::ExpressionKind::Literal { .. }
+        | nbe::tree::ExpressionKind::Constructor { .. }
+        | nbe::tree::ExpressionKind::Global { .. }
+        | nbe::tree::ExpressionKind::SynthesizedEvidence { .. }
+        | nbe::tree::ExpressionKind::TrivialEvidence => {}
+    }
+}
+
+fn collect_free_let(
+    context: &Context<'_>,
+    recursive: bool,
+    bindings: &[nbe::tree::Binding],
+    body: nbe::tree::ExpressionId,
+    bound: &FxHashSet<nbe::tree::LocalId>,
+    free: &mut FreeParameters,
+) {
+    let mut body_bound = bound.clone();
+    if recursive {
+        for binding in bindings {
+            body_bound.insert(binding.parameter.id);
+        }
+        for binding in bindings {
+            collect_free_expression(context, binding.expression, &body_bound, free);
+        }
+    } else {
+        for binding in bindings {
+            collect_free_expression(context, binding.expression, &body_bound, free);
+            body_bound.insert(binding.parameter.id);
+        }
+    }
+    collect_free_expression(context, body, &body_bound, free);
+}
+
+fn collect_free_record_updates(
+    context: &Context<'_>,
+    updates: &[nbe::tree::RecordUpdate],
+    bound: &FxHashSet<nbe::tree::LocalId>,
+    free: &mut FreeParameters,
+) {
+    for update in updates {
+        match update {
+            nbe::tree::RecordUpdate::Leaf { expression, .. } => {
+                collect_free_expression(context, *expression, bound, free);
+            }
+            nbe::tree::RecordUpdate::Branch { updates, .. } => {
+                collect_free_record_updates(context, updates, bound, free);
+            }
+        }
+    }
+}
+
+fn collect_pattern_bindings(
+    context: &Context<'_>,
+    pattern_id: nbe::tree::PatternId,
+    bound: &mut FxHashSet<nbe::tree::LocalId>,
+) {
+    let pattern = &context.functional.storage[pattern_id];
+    match &pattern.kind {
+        nbe::tree::PatternKind::Variable(parameter) => {
+            bound.insert(parameter.id);
+        }
+        nbe::tree::PatternKind::Named { parameter, pattern } => {
+            bound.insert(parameter.id);
+            collect_pattern_bindings(context, *pattern, bound);
+        }
+        nbe::tree::PatternKind::Array(elements) => {
+            for &element in elements.iter() {
+                collect_pattern_bindings(context, element, bound);
+            }
+        }
+        nbe::tree::PatternKind::Record(fields) => {
+            for field in fields.iter() {
+                collect_pattern_bindings(context, field.pattern, bound);
+            }
+        }
+        nbe::tree::PatternKind::Constructor { arguments, .. } => {
+            for &argument in arguments.iter() {
+                collect_pattern_bindings(context, argument, bound);
+            }
+        }
+        nbe::tree::PatternKind::Wildcard | nbe::tree::PatternKind::Literal(_) => {}
+    }
+}
+
+fn convert_global(global: &nbe::tree::Global) -> Global {
+    let identity = match global.id {
+        nbe::tree::GlobalId::Term(file_id, term_id) => GlobalIdentity::Term { file_id, term_id },
+        nbe::tree::GlobalId::Instance(identity) => {
+            GlobalIdentity::Instance { identity: convert_instance_identity(identity) }
+        }
+    };
+    Global { identity, name: global.name.clone() }
+}
+
+fn convert_instance_identity(identity: nbe::tree::InstanceIdentity) -> InstanceIdentity {
+    match identity {
+        nbe::tree::InstanceIdentity::Declared(file_id, instance_id) => {
+            InstanceIdentity::Declared { file_id, instance_id }
+        }
+        nbe::tree::InstanceIdentity::Derived(file_id, derive_id) => {
+            InstanceIdentity::Derived { file_id, derive_id }
+        }
+    }
+}
+
+fn convert_field(field: &nbe::tree::Field) -> Field {
+    let identity = match &field.identity {
+        nbe::tree::FieldIdentity::Label(label) => FieldIdentity::Label { label: label.clone() },
+        nbe::tree::FieldIdentity::Member(file_id, term_id) => {
+            FieldIdentity::Member { file_id: *file_id, term_id: *term_id }
+        }
+        nbe::tree::FieldIdentity::Superclass(identity) => {
+            let identity = SuperclassIdentity {
+                file_id: identity.file_id,
+                class: identity.class,
+                source: identity.source,
+            };
+            FieldIdentity::Superclass { identity }
+        }
+    };
+    Field { identity, name: field.name.clone() }
+}
+
+fn convert_literal(literal: &nbe::tree::Literal) -> Literal {
+    match literal {
+        nbe::tree::Literal::String(value) => Literal::String { value: value.clone() },
+        nbe::tree::Literal::Char(value) => Literal::Char { value: *value },
+        nbe::tree::Literal::Boolean(value) => Literal::Boolean { value: *value },
+        nbe::tree::Literal::Integer(value) => Literal::Integer { value: *value },
+        nbe::tree::Literal::Number(value) => Literal::Number { value: value.clone() },
+    }
+}
+
+fn convert_synthesized_evidence(evidence: &nbe::tree::SynthesizedEvidence) -> SynthesizedEvidence {
+    match evidence {
+        nbe::tree::SynthesizedEvidence::IsSymbol(symbol) => {
+            SynthesizedEvidence::IsSymbol { symbol: symbol.clone() }
+        }
+        nbe::tree::SynthesizedEvidence::Reflectable(evidence) => {
+            let evidence = match evidence {
+                nbe::tree::ReflectableEvidence::Integer(value) => {
+                    ReflectableEvidence::Integer { value: *value }
+                }
+                nbe::tree::ReflectableEvidence::String(value) => {
+                    ReflectableEvidence::String { value: value.clone() }
+                }
+                nbe::tree::ReflectableEvidence::Boolean(value) => {
+                    ReflectableEvidence::Boolean { value: *value }
+                }
+                nbe::tree::ReflectableEvidence::Ordering(ordering) => {
+                    let ordering = match ordering {
+                        nbe::tree::ReflectableOrdering::Less => ReflectableOrdering::Less,
+                        nbe::tree::ReflectableOrdering::Equal => ReflectableOrdering::Equal,
+                        nbe::tree::ReflectableOrdering::Greater => ReflectableOrdering::Greater,
+                    };
+                    ReflectableEvidence::Ordering { ordering }
+                }
+            };
+            SynthesizedEvidence::Reflectable { evidence }
+        }
+    }
+}
+
+impl State {
+    fn traversal(&self) -> &Traversal {
+        self.traversal.as_ref().expect("invariant violated: no active function traversal")
+    }
+
+    fn traversal_mut(&mut self) -> &mut Traversal {
+        self.traversal.as_mut().expect("invariant violated: no active function traversal")
+    }
+
+    fn function_name(&self) -> &str {
+        &self.traversal().function_name
+    }
+
+    fn fresh_function_name(&mut self, preferred: SmolStr) -> SmolStr {
+        let preferred = normalize_local_name(preferred);
+        deconflict(&mut self.output.function_names, preferred)
+    }
+
+    fn fresh_value(&mut self, preferred: SmolStr) -> ValueId {
+        let preferred = normalize_local_name(preferred);
+        let name = deconflict(&mut self.traversal_mut().value_names, preferred);
+        self.output.storage.allocate_value(Value { name })
+    }
+
+    fn create_block(&mut self, preferred: impl Into<SmolStr>, parameters: Vec<ValueId>) -> BlockId {
+        let preferred = normalize_local_name(preferred.into());
+        let name = deconflict(&mut self.traversal_mut().block_names, preferred);
+        let block = Block {
+            name,
+            parameters: parameters.into(),
+            instructions: vec![],
+            terminator: Terminator::Unreachable,
+        };
+        let block = self.output.storage.allocate_block(block);
+        let traversal = self.traversal_mut();
+        traversal.blocks.push(block);
+        traversal.unterminated.insert(block);
+        block
+    }
+
+    fn current_block(&self) -> BlockId {
+        self.traversal().current_block.expect("invariant violated: no active basic block")
+    }
+
+    fn switch_to(&mut self, block: BlockId) {
+        self.traversal_mut().current_block = Some(block);
+    }
+
+    fn append(&mut self, instruction: Instruction) {
+        let block = self.current_block();
+        assert!(
+            self.traversal().unterminated.contains(&block),
+            "invariant violated: appending to a terminated basic block"
+        );
+        self.output.storage.append_instruction(block, instruction);
+    }
+
+    fn emit(&mut self, preferred: impl Into<SmolStr>, value: InstructionValue) -> ValueId {
+        let result = self.fresh_value(preferred.into());
+        self.append(Instruction::Assign { result, value });
+        result
+    }
+
+    fn terminate(&mut self, terminator: Terminator) {
+        let block = self.current_block();
+        let removed = self.traversal_mut().unterminated.remove(&block);
+        assert!(removed, "invariant violated: basic block terminated more than once");
+        self.output.storage.set_terminator(block, terminator);
+    }
+
+    fn target(&self, block: BlockId, arguments: Vec<ValueId>) -> BlockTarget {
+        BlockTarget { block, arguments: arguments.into() }
+    }
+
+    fn scope(&self) -> &FxHashMap<nbe::tree::LocalId, ValueId> {
+        &self.traversal().scope
+    }
+
+    fn set_scope(&mut self, scope: FxHashMap<nbe::tree::LocalId, ValueId>) {
+        self.traversal_mut().scope = scope;
+    }
+
+    fn bind_local(&mut self, parameter: &nbe::tree::Parameter, value: ValueId) {
+        self.traversal_mut().scope.insert(parameter.id, value);
+    }
+
+    fn lookup_local(
+        &self,
+        context: &Context<'_>,
+        parameter: &nbe::tree::Parameter,
+    ) -> ConversionResult<ValueId> {
+        let Some(traversal) = &self.traversal else {
+            return Err(context.unsupported(UnsupportedState::MissingLocal {
+                local_name: parameter.name.to_string(),
+            }));
+        };
+        traversal.scope.get(&parameter.id).copied().ok_or_else(|| {
+            context.unsupported(UnsupportedState::MissingLocal {
+                local_name: parameter.name.to_string(),
+            })
+        })
+    }
+}
+
+impl Context<'_> {
+    fn unsupported(&self, state: UnsupportedState) -> ConversionError {
+        ConversionError::Unsupported { file_id: self.functional.file_id, state }
+    }
+}
+
+fn normalize_local_name(preferred: SmolStr) -> SmolStr {
+    let mut normalized = String::new();
+    for (position, character) in preferred.chars().enumerate() {
+        let valid_initial = character.is_ascii_alphabetic() || character == '_' || character == '$';
+        let valid_subsequent = valid_initial || character.is_ascii_digit();
+        if position == 0 && !valid_initial {
+            normalized.push_str("value_");
+        }
+        if valid_subsequent {
+            normalized.push(character);
+        } else {
+            normalized.push('_');
+        }
+    }
+    if normalized.is_empty() {
+        normalized.push_str("value");
+    }
+    SmolStr::new(normalized)
+}
+
+fn deconflict(names: &mut FxHashMap<SmolStr, u32>, preferred: SmolStr) -> SmolStr {
+    let next = names.entry(preferred.clone()).or_default();
+    let name = if *next == 0 { preferred } else { format_smolstr!("{preferred}${next}") };
+    *next += 1;
+    name
+}

--- a/compiler-backend/ssa/src/convert.rs
+++ b/compiler-backend/ssa/src/convert.rs
@@ -295,7 +295,7 @@ fn lower_expression(
             lower_case(state, context, scrutinees, alternatives)
         }
         nbe::tree::ExpressionKind::Guarded { alternatives } => {
-            lower_guarded(state, context, alternatives)
+            lower_guarded(state, context, alternatives, None)
         }
         nbe::tree::ExpressionKind::Let { recursive, bindings, body } => {
             lower_let(state, context, *recursive, bindings, *body)
@@ -418,7 +418,13 @@ fn lower_case(
         for (&pattern, value) in alternative.patterns.iter().zip(scrutinees.iter().copied()) {
             compile_pattern(state, context, pattern, value, Some(next))?;
         }
-        let value = lower_expression(state, context, alternative.expression)?;
+        let expression = &context.functional.storage[alternative.expression];
+        let value = match &expression.kind {
+            nbe::tree::ExpressionKind::Guarded { alternatives } => {
+                lower_guarded(state, context, alternatives, Some(next))?
+            }
+            _ => lower_expression(state, context, alternative.expression)?,
+        };
         let target = state.target(join, vec![value]);
         state.terminate(Terminator::Jump { target });
     }
@@ -434,6 +440,7 @@ fn lower_guarded(
     state: &mut State,
     context: &Context<'_>,
     alternatives: &[nbe::tree::GuardedAlternative],
+    failure: Option<BlockId>,
 ) -> ConversionResult<ValueId> {
     if alternatives.is_empty() {
         return Err(context.unsupported(UnsupportedState::MissingGuardedAlternative));
@@ -446,7 +453,9 @@ fn lower_guarded(
         .first()
         .copied()
         .expect("invariant violated: guarded expression has no alternative block");
-    let failure = state.create_block("guard$failure", vec![]);
+    let local_failure = failure.is_none().then(|| state.create_block("guard$failure", vec![]));
+    let failure =
+        failure.or(local_failure).expect("invariant violated: guard has no failure block");
     let result = state.fresh_value("result".into());
     let join = state.create_block("guard$join", vec![result]);
     let target = state.target(first_alternative, vec![]);
@@ -480,8 +489,10 @@ fn lower_guarded(
         state.terminate(Terminator::Jump { target });
     }
 
-    state.switch_to(failure);
-    state.terminate(Terminator::Fail { failure: Failure::PatternMatch });
+    if let Some(local_failure) = local_failure {
+        state.switch_to(local_failure);
+        state.terminate(Terminator::Fail { failure: Failure::PatternMatch });
+    }
     state.switch_to(join);
     state.set_scope(outer_scope);
     Ok(result)

--- a/compiler-backend/ssa/src/error.rs
+++ b/compiler-backend/ssa/src/error.rs
@@ -1,0 +1,26 @@
+use files::FileId;
+use thiserror::Error;
+
+pub type ConversionResult<T> = Result<T, ConversionError>;
+
+#[derive(Debug, Error)]
+pub enum ConversionError {
+    #[error("cannot convert functional module {file_id:?} to SSA: {state}")]
+    Unsupported { file_id: FileId, state: UnsupportedState },
+}
+
+#[derive(Debug, Error)]
+pub enum UnsupportedState {
+    #[error("local {local_name} is not available in the current lexical scope")]
+    MissingLocal { local_name: String },
+    #[error("recursive local {local_name} is not a function")]
+    RecursiveValue { local_name: String },
+    #[error("case expression has no alternatives")]
+    MissingCaseAlternative,
+    #[error("guarded expression has no alternatives")]
+    MissingGuardedAlternative,
+    #[error("case alternative has {patterns} patterns for {scrutinees} scrutinees")]
+    CaseArity { patterns: usize, scrutinees: usize },
+    #[error("function {function_name} contains an unterminated basic block")]
+    UnterminatedBlock { function_name: String },
+}

--- a/compiler-backend/ssa/src/lib.rs
+++ b/compiler-backend/ssa/src/lib.rs
@@ -1,0 +1,9 @@
+//! Owned static single-assignment control-flow graphs lowered from functional trees.
+
+pub mod convert;
+pub mod error;
+pub mod pretty;
+pub mod tree;
+
+pub use convert::convert_module;
+pub use error::{ConversionError, ConversionResult, UnsupportedState};

--- a/compiler-backend/ssa/src/pretty.rs
+++ b/compiler-backend/ssa/src/pretty.rs
@@ -1,0 +1,432 @@
+//! Stable JS-like control-flow rendering for SSA snapshots.
+
+use itertools::Itertools;
+use pretty::{Arena, DocAllocator, DocBuilder};
+use rustc_hash::FxHashSet;
+
+use crate::tree::{
+    Block, BlockTarget, CallingConvention, Declaration, DeclarationKind, Failure, Field, Function,
+    Global, Instruction, InstructionValue, Literal, Module, PatternTest, Projection, RecordUpdate,
+    RecursiveClosure, ReflectableEvidence, ReflectableOrdering, SynthesizedEvidence, Terminator,
+    ValueId,
+};
+
+type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
+
+const DEFAULT_WIDTH: usize = 100;
+
+pub fn render(module: &Module) -> String {
+    let arena = Arena::new();
+    let printer = Printer { arena: &arena, module };
+    let root_functions =
+        module.declarations.iter().filter_map(|declaration| match declaration.kind {
+            DeclarationKind::Function { function } => Some(function),
+            DeclarationKind::Value { initializer } => Some(initializer),
+            DeclarationKind::Foreign => None,
+        });
+    let root_functions = root_functions.collect::<FxHashSet<_>>();
+
+    let declarations =
+        module.declarations.iter().map(|declaration| printer.declaration(declaration));
+    let nested_functions = module
+        .storage
+        .functions()
+        .filter(|(function, _)| !root_functions.contains(function))
+        .map(|(_, function)| printer.nested_function(function));
+    let documents = declarations.chain(nested_functions);
+    let separator = arena.hardline().append(arena.hardline());
+    let document = arena.intersperse(documents, separator);
+
+    let mut output = String::new();
+    document
+        .render_fmt(DEFAULT_WIDTH, &mut output)
+        .expect("critical failure: failed to render SSA control-flow graph");
+    output
+}
+
+struct Printer<'a, 'm> {
+    arena: &'a Arena<'a>,
+    module: &'m Module,
+}
+
+impl<'a> Printer<'a, '_> {
+    fn declaration(&self, declaration: &Declaration) -> Doc<'a> {
+        let recursion = declaration
+            .recursive_group
+            .map(|group| format!("recursive[{}] ", group.index))
+            .unwrap_or_default();
+        match declaration.kind {
+            DeclarationKind::Function { function } => {
+                let function = &self.module.storage[function];
+                let parameters = self.values(&function.parameters);
+                let header = self
+                    .arena
+                    .text(format!("{recursion}function {}", declaration.global.name))
+                    .append(self.parenthesized(parameters));
+                self.function_body(header, function)
+            }
+            DeclarationKind::Value { initializer } => {
+                let function = &self.module.storage[initializer];
+                let header = self
+                    .arena
+                    .text(format!("{recursion}const {} = initialize", declaration.global.name));
+                self.function_body(header, function)
+            }
+            DeclarationKind::Foreign => {
+                self.arena.text(format!("{recursion}foreign const {};", declaration.global.name))
+            }
+        }
+    }
+
+    fn nested_function(&self, function: &Function) -> Doc<'a> {
+        let convention = match function.calling_convention {
+            CallingConvention::Initializer => "initializer",
+            CallingConvention::Source => "closure",
+            CallingConvention::Effect => "effect closure",
+        };
+        let captures = self.values(&function.captures);
+        let captures = self.bracketed(captures);
+        let parameters = self.values(&function.parameters);
+        let parameters = self.parenthesized(parameters);
+        let header = self
+            .arena
+            .text(format!("{convention} {}", function.name))
+            .append(captures)
+            .append(parameters);
+        self.function_body(header, function)
+    }
+
+    fn function_body(&self, header: Doc<'a>, function: &Function) -> Doc<'a> {
+        let blocks = function.blocks.iter().map(|block| self.block(&self.module.storage[*block]));
+        let blocks = self.arena.intersperse(blocks, self.arena.hardline());
+        let blocks = self.arena.hardline().append(blocks).nest(2);
+        header.append(" {").append(blocks).append(self.arena.hardline()).append("}")
+    }
+
+    fn block(&self, block: &Block) -> Doc<'a> {
+        let parameters = self.values(&block.parameters);
+        let header = self.arena.text(block.name.to_string()).append(self.parenthesized(parameters));
+        let instructions =
+            block.instructions.iter().map(|instruction| self.instruction(instruction));
+        let instructions = instructions.chain(std::iter::once(self.terminator(&block.terminator)));
+        let instructions = self.arena.intersperse(instructions, self.arena.hardline());
+        let instructions = self.arena.hardline().append(instructions).nest(2);
+        header.append(" {").append(instructions).append(self.arena.hardline()).append("}")
+    }
+
+    fn instruction(&self, instruction: &Instruction) -> Doc<'a> {
+        match instruction {
+            Instruction::Assign { result, value } => {
+                let result = self.value(*result);
+                let value = self.instruction_value(value);
+                self.arena.text("const ").append(result).append(" = ").append(value).append(";")
+            }
+            Instruction::RecursiveClosures { bindings } => {
+                let results = bindings.iter().map(|binding| self.value(binding.result));
+                let results = self.bracketed(results);
+                let bindings = bindings.iter().map(|binding| self.recursive_closure(binding));
+                let bindings = self.braced(bindings);
+                self.arena
+                    .text("const ")
+                    .append(results)
+                    .append(" = closures.recursive(")
+                    .append(bindings)
+                    .append(");")
+            }
+        }
+    }
+
+    fn recursive_closure(&self, closure: &RecursiveClosure) -> Doc<'a> {
+        let name = self.value(closure.result);
+        let function = &self.module.storage[closure.function];
+        let captures = closure.captures.iter().map(|capture| self.value(*capture));
+        let captures = self.arguments(captures);
+        name.append(": closure(")
+            .append(self.arena.text(function.name.to_string()))
+            .append(captures)
+            .append(")")
+    }
+
+    fn instruction_value(&self, value: &InstructionValue) -> Doc<'a> {
+        match value {
+            InstructionValue::Literal { literal } => self.literal(literal),
+            InstructionValue::Array { elements } => {
+                let elements = elements.iter().map(|element| self.value(*element));
+                self.bracketed(elements)
+            }
+            InstructionValue::Record { fields } => {
+                let fields = fields.iter().map(|field| {
+                    let field_name = self.field(&field.field);
+                    let value = self.value(field.value);
+                    self.arena.text(format!("{field_name}: ")).append(value)
+                });
+                self.braced(fields)
+            }
+            InstructionValue::RecordUpdate { record, updates } => {
+                let record = self.value(*record);
+                let updates = updates.iter().map(|update| self.record_update(update));
+                let updates = self.braced(updates);
+                self.arena
+                    .text("record.update(")
+                    .append(record)
+                    .append(", ")
+                    .append(updates)
+                    .append(")")
+            }
+            InstructionValue::Project { record, field } => {
+                let record = self.value(*record);
+                self.project_field(record, field)
+            }
+            InstructionValue::Constructor { global } => {
+                self.arena.text("constructor(").append(self.global(global)).append(")")
+            }
+            InstructionValue::Global { global } => {
+                self.arena.text("global(").append(self.global(global)).append(")")
+            }
+            InstructionValue::Closure { function, captures } => {
+                let function = &self.module.storage[*function];
+                let captures = captures.iter().map(|capture| self.value(*capture));
+                let captures = self.arguments(captures);
+                self.arena
+                    .text("closure(")
+                    .append(self.arena.text(function.name.to_string()))
+                    .append(captures)
+                    .append(")")
+            }
+            InstructionValue::Call { calling_convention, function, arguments } => {
+                let convention = match calling_convention {
+                    CallingConvention::Initializer => "initializer.call",
+                    CallingConvention::Source => "source.call",
+                    CallingConvention::Effect => "effect.call",
+                };
+                let function = self.value(*function);
+                let arguments = arguments.iter().map(|argument| self.value(*argument));
+                let arguments = self.arguments(arguments);
+                self.arena
+                    .text(format!("{convention}("))
+                    .append(function)
+                    .append(arguments)
+                    .append(")")
+            }
+            InstructionValue::Test { value, test } => self.pattern_test(*value, test),
+            InstructionValue::Extract { value, projection } => self.projection(*value, projection),
+            InstructionValue::EffectPure { value } => {
+                self.arena.text("effect.pure(").append(self.value(*value)).append(")")
+            }
+            InstructionValue::EffectBind { action, continuation } => self
+                .arena
+                .text("effect.bind(")
+                .append(self.value(*action))
+                .append(", ")
+                .append(self.value(*continuation))
+                .append(")"),
+            InstructionValue::SynthesizedEvidence { evidence } => {
+                self.synthesized_evidence(evidence)
+            }
+            InstructionValue::TrivialEvidence => self.arena.text("evidence.trivial"),
+        }
+    }
+
+    fn pattern_test(&self, value: ValueId, test: &PatternTest) -> Doc<'a> {
+        let value = self.value(value);
+        match test {
+            PatternTest::Literal { literal } => self
+                .arena
+                .text("pattern.literal(")
+                .append(value)
+                .append(", ")
+                .append(self.literal(literal))
+                .append(")"),
+            PatternTest::ArrayLength { length } => {
+                self.arena.text("pattern.array(").append(value).append(format!(", {length})"))
+            }
+            PatternTest::Constructor { global } => self
+                .arena
+                .text("pattern.constructor(")
+                .append(value)
+                .append(", ")
+                .append(self.global(global))
+                .append(")"),
+        }
+    }
+
+    fn projection(&self, value: ValueId, projection: &Projection) -> Doc<'a> {
+        let value = self.value(value);
+        match projection {
+            Projection::ArrayElement { index } => value.append(format!("[{index}]")),
+            Projection::ConstructorArgument { constructor, index } => self
+                .arena
+                .text("pattern.argument(")
+                .append(value)
+                .append(", ")
+                .append(self.global(constructor))
+                .append(format!(", {index})")),
+        }
+    }
+
+    fn record_update(&self, update: &RecordUpdate) -> Doc<'a> {
+        match update {
+            RecordUpdate::Leaf { field, value } => {
+                let field = self.field(field);
+                self.arena.text(format!("{field}: ")).append(self.value(*value))
+            }
+            RecordUpdate::Branch { field, updates } => {
+                let field = self.field(field);
+                let updates = updates.iter().map(|update| self.record_update(update));
+                self.arena.text(format!("{field}: ")).append(self.braced(updates))
+            }
+        }
+    }
+
+    fn terminator(&self, terminator: &Terminator) -> Doc<'a> {
+        match terminator {
+            Terminator::Return { value } => {
+                self.arena.text("return ").append(self.value(*value)).append(";")
+            }
+            Terminator::Jump { target } => self.block_target(target),
+            Terminator::Branch { condition, then_target, else_target } => {
+                let then_target = self.block_target(then_target);
+                let then_target = self.arena.hardline().append(then_target).nest(2);
+                let else_target = self.block_target(else_target);
+                let else_target = self.arena.hardline().append(else_target).nest(2);
+                self.arena
+                    .text("if (")
+                    .append(self.value(*condition))
+                    .append(") {")
+                    .append(then_target)
+                    .append(self.arena.hardline())
+                    .append("} else {")
+                    .append(else_target)
+                    .append(self.arena.hardline())
+                    .append("}")
+            }
+            Terminator::Fail { failure } => match failure {
+                Failure::PatternMatch => self.arena.text("throw patternMatchFailure();"),
+            },
+            Terminator::Unreachable => self.arena.text("throw unreachable();"),
+        }
+    }
+
+    fn block_target(&self, target: &BlockTarget) -> Doc<'a> {
+        let block = &self.module.storage[target.block];
+        let arguments = target.arguments.iter().map(|argument| self.value(*argument));
+        self.arena.text(block.name.to_string()).append(self.parenthesized(arguments)).append(";")
+    }
+
+    fn synthesized_evidence(&self, evidence: &SynthesizedEvidence) -> Doc<'a> {
+        match evidence {
+            SynthesizedEvidence::IsSymbol { symbol } => {
+                self.arena.text(format!("evidence.symbol({symbol:?})"))
+            }
+            SynthesizedEvidence::Reflectable { evidence } => {
+                let evidence = match evidence {
+                    ReflectableEvidence::Integer { value } => value.to_string(),
+                    ReflectableEvidence::String { value } => format!("{value:?}"),
+                    ReflectableEvidence::Boolean { value } => value.to_string(),
+                    ReflectableEvidence::Ordering { ordering } => match ordering {
+                        ReflectableOrdering::Less => "LT".into(),
+                        ReflectableOrdering::Equal => "EQ".into(),
+                        ReflectableOrdering::Greater => "GT".into(),
+                    },
+                };
+                self.arena.text(format!("evidence.reflectable({evidence})"))
+            }
+        }
+    }
+
+    fn literal(&self, literal: &Literal) -> Doc<'a> {
+        let literal = match literal {
+            Literal::String { value } => format!("{value:?}"),
+            Literal::Char { value } => format!("{value:?}"),
+            Literal::Boolean { value } => value.to_string(),
+            Literal::Integer { value } => value.to_string(),
+            Literal::Number { value } => value.to_string(),
+        };
+        self.arena.text(literal)
+    }
+
+    fn values(&self, values: &[ValueId]) -> Vec<Doc<'a>> {
+        let values = values.iter().map(|value| self.value(*value));
+        values.collect_vec()
+    }
+
+    fn value(&self, value: ValueId) -> Doc<'a> {
+        self.arena.text(self.module.storage[value].name.to_string())
+    }
+
+    fn global(&self, global: &Global) -> Doc<'a> {
+        self.arena.text(global.name.to_string())
+    }
+
+    fn field(&self, field: &Field) -> String {
+        let name = field.name.as_str();
+        let is_valid_identifier = field_is_valid_identifier(name);
+        if is_valid_identifier { name.to_string() } else { format!("{name:?}") }
+    }
+
+    fn project_field(&self, record: Doc<'a>, field: &Field) -> Doc<'a> {
+        let name = field.name.as_str();
+        if field_is_valid_identifier(name) {
+            record.append(self.arena.text(format!(".{name}")))
+        } else {
+            record.append(self.arena.text(format!("[{name:?}]")))
+        }
+    }
+
+    fn arguments<I>(&self, arguments: I) -> Doc<'a>
+    where
+        I: IntoIterator<Item = Doc<'a>>,
+    {
+        let arguments = arguments
+            .into_iter()
+            .map(|argument| self.arena.text(",").append(self.arena.line()).append(argument));
+        self.arena.concat(arguments).group()
+    }
+
+    fn parenthesized<I>(&self, documents: I) -> Doc<'a>
+    where
+        I: IntoIterator<Item = Doc<'a>>,
+    {
+        self.delimited("(", documents, ")")
+    }
+
+    fn bracketed<I>(&self, documents: I) -> Doc<'a>
+    where
+        I: IntoIterator<Item = Doc<'a>>,
+    {
+        self.delimited("[", documents, "]")
+    }
+
+    fn braced<I>(&self, documents: I) -> Doc<'a>
+    where
+        I: IntoIterator<Item = Doc<'a>>,
+    {
+        let separator = self.arena.text(",").append(self.arena.line());
+        let documents = self.arena.intersperse(documents, separator);
+        let documents = self.arena.line().append(documents).nest(2);
+        let closing_line = self.arena.line();
+        self.arena.text("{").append(documents).append(closing_line).append("}").group()
+    }
+
+    fn delimited<I>(&self, open: &'static str, documents: I, close: &'static str) -> Doc<'a>
+    where
+        I: IntoIterator<Item = Doc<'a>>,
+    {
+        let separator = self.arena.text(",").append(self.arena.line());
+        let documents = self.arena.intersperse(documents, separator);
+        let documents = self.arena.softline_().append(documents).nest(2);
+        let closing_line = self.arena.softline_();
+        self.arena.text(open).append(documents).append(closing_line).append(close).group()
+    }
+}
+
+fn field_is_valid_identifier(name: &str) -> bool {
+    let mut characters = name.chars();
+    let Some(initial) = characters.next() else {
+        return false;
+    };
+    let valid_initial = initial.is_ascii_alphabetic() || initial == '_' || initial == '$';
+    let valid_subsequent = characters
+        .all(|character| character.is_ascii_alphanumeric() || character == '_' || character == '$');
+    valid_initial && valid_subsequent
+}

--- a/compiler-backend/ssa/src/tree.rs
+++ b/compiler-backend/ssa/src/tree.rs
@@ -1,0 +1,280 @@
+//! Arena-allocated A-normal instructions and control-flow graphs.
+
+use std::ops::Index;
+use std::sync::Arc;
+
+use files::FileId;
+use indexing::{DeriveId, InstanceId, TermItemId, TypeItemId};
+use la_arena::{Arena, Idx};
+use lowering::TypeId as SourceTypeId;
+use smol_str::SmolStr;
+
+pub type FunctionId = Idx<Function>;
+pub type BlockId = Idx<Block>;
+pub type ValueId = Idx<Value>;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Module {
+    pub file_id: FileId,
+    pub declarations: Arc<[Declaration]>,
+    pub storage: Storage,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Storage {
+    functions: Arena<Function>,
+    blocks: Arena<Block>,
+    values: Arena<Value>,
+}
+
+impl Storage {
+    pub fn allocate_function(&mut self, function: Function) -> FunctionId {
+        self.functions.alloc(function)
+    }
+
+    pub fn allocate_block(&mut self, block: Block) -> BlockId {
+        self.blocks.alloc(block)
+    }
+
+    pub fn allocate_value(&mut self, value: Value) -> ValueId {
+        self.values.alloc(value)
+    }
+
+    pub fn functions(&self) -> impl Iterator<Item = (FunctionId, &Function)> {
+        self.functions.iter()
+    }
+
+    pub fn blocks(&self) -> impl Iterator<Item = (BlockId, &Block)> {
+        self.blocks.iter()
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = (ValueId, &Value)> {
+        self.values.iter()
+    }
+
+    pub(crate) fn append_instruction(&mut self, block: BlockId, instruction: Instruction) {
+        self.blocks[block].instructions.push(instruction);
+    }
+
+    pub(crate) fn set_terminator(&mut self, block: BlockId, terminator: Terminator) {
+        self.blocks[block].terminator = terminator;
+    }
+}
+
+impl Index<FunctionId> for Storage {
+    type Output = Function;
+
+    fn index(&self, index: FunctionId) -> &Function {
+        &self.functions[index]
+    }
+}
+
+impl Index<BlockId> for Storage {
+    type Output = Block;
+
+    fn index(&self, index: BlockId) -> &Block {
+        &self.blocks[index]
+    }
+}
+
+impl Index<ValueId> for Storage {
+    type Output = Value;
+
+    fn index(&self, index: ValueId) -> &Value {
+        &self.values[index]
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Declaration {
+    pub global: Global,
+    pub recursive_group: Option<RecursiveGroupId>,
+    pub kind: DeclarationKind,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum DeclarationKind {
+    Function { function: FunctionId },
+    Value { initializer: FunctionId },
+    Foreign,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Global {
+    pub identity: GlobalIdentity,
+    pub name: SmolStr,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GlobalIdentity {
+    Term { file_id: FileId, term_id: TermItemId },
+    Instance { identity: InstanceIdentity },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InstanceIdentity {
+    Declared { file_id: FileId, instance_id: InstanceId },
+    Derived { file_id: FileId, derive_id: DeriveId },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RecursiveGroupId {
+    pub index: u32,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Function {
+    pub name: SmolStr,
+    pub calling_convention: CallingConvention,
+    pub captures: Arc<[ValueId]>,
+    pub parameters: Arc<[ValueId]>,
+    pub entry: BlockId,
+    pub blocks: Arc<[BlockId]>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallingConvention {
+    Initializer,
+    Source,
+    Effect,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Block {
+    pub name: SmolStr,
+    pub parameters: Arc<[ValueId]>,
+    pub instructions: Vec<Instruction>,
+    pub terminator: Terminator,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Value {
+    pub name: SmolStr,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Instruction {
+    Assign { result: ValueId, value: InstructionValue },
+    RecursiveClosures { bindings: Arc<[RecursiveClosure]> },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct RecursiveClosure {
+    pub result: ValueId,
+    pub function: FunctionId,
+    pub captures: Arc<[ValueId]>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum InstructionValue {
+    Literal { literal: Literal },
+    Array { elements: Arc<[ValueId]> },
+    Record { fields: Arc<[RecordField]> },
+    RecordUpdate { record: ValueId, updates: Arc<[RecordUpdate]> },
+    Project { record: ValueId, field: Field },
+    Constructor { global: Global },
+    Global { global: Global },
+    Closure { function: FunctionId, captures: Arc<[ValueId]> },
+    Call { calling_convention: CallingConvention, function: ValueId, arguments: Arc<[ValueId]> },
+    Test { value: ValueId, test: PatternTest },
+    Extract { value: ValueId, projection: Projection },
+    EffectPure { value: ValueId },
+    EffectBind { action: ValueId, continuation: ValueId },
+    SynthesizedEvidence { evidence: SynthesizedEvidence },
+    TrivialEvidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Literal {
+    String { value: SmolStr },
+    Char { value: char },
+    Boolean { value: bool },
+    Integer { value: i32 },
+    Number { value: SmolStr },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Field {
+    pub identity: FieldIdentity,
+    pub name: SmolStr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FieldIdentity {
+    Label { label: SmolStr },
+    Member { file_id: FileId, term_id: TermItemId },
+    Superclass { identity: SuperclassIdentity },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SuperclassIdentity {
+    pub file_id: FileId,
+    pub class: TypeItemId,
+    pub source: SourceTypeId,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct RecordField {
+    pub field: Field,
+    pub value: ValueId,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum RecordUpdate {
+    Leaf { field: Field, value: ValueId },
+    Branch { field: Field, updates: Arc<[RecordUpdate]> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PatternTest {
+    Literal { literal: Literal },
+    ArrayLength { length: usize },
+    Constructor { global: Global },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Projection {
+    ArrayElement { index: usize },
+    ConstructorArgument { constructor: Global, index: usize },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Terminator {
+    Return { value: ValueId },
+    Jump { target: BlockTarget },
+    Branch { condition: ValueId, then_target: BlockTarget, else_target: BlockTarget },
+    Fail { failure: Failure },
+    Unreachable,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct BlockTarget {
+    pub block: BlockId,
+    pub arguments: Arc<[ValueId]>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Failure {
+    PatternMatch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SynthesizedEvidence {
+    IsSymbol { symbol: SmolStr },
+    Reflectable { evidence: ReflectableEvidence },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReflectableEvidence {
+    Integer { value: i32 },
+    String { value: SmolStr },
+    Boolean { value: bool },
+    Ordering { ordering: ReflectableOrdering },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReflectableOrdering {
+    Less,
+    Equal,
+    Greater,
+}

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -19,9 +19,11 @@ insta = "1.48.0"
 line-index = "0.1.2"
 lowering = { version = "0.1.0", path = "../compiler-core/lowering" }
 lsp-types.workspace = true
+nbe = { version = "0.1.0", path = "../compiler-backend/nbe" }
 prim-constants = { version = "0.1.0", path = "../compiler-core/prim-constants" }
 serde_json = "1.0"
 similar = "3"
+ssa = { version = "0.1.0", path = "../compiler-backend/ssa" }
 stabilizing = { version = "0.1.0", path = "../compiler-core/stabilizing" }
 sugar = { version = "0.1.0", path = "../compiler-core/sugar" }
 syntax = { version = "0.1.0", path = "../compiler-core/syntax" }
@@ -31,7 +33,6 @@ url = "2.5.8"
 
 [dev-dependencies]
 datatest-stable = "0.3"
-nbe = { version = "0.1.0", path = "../compiler-backend/nbe" }
 
 [[test]]
 name = "backend"

--- a/tests-integration/fixtures/backend/1787021280_literals_arrays_and_records/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021280_literals_arrays_and_records/Main.ssa.snap
@@ -1,0 +1,68 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+const integer = initialize {
+  entry() {
+    const literal = 42;
+    return literal;
+  }
+}
+
+const number = initialize {
+  entry() {
+    const literal = 1.5;
+    return literal;
+  }
+}
+
+const character = initialize {
+  entry() {
+    const literal = 'a';
+    return literal;
+  }
+}
+
+const string = initialize {
+  entry() {
+    const literal = "alexandrite";
+    return literal;
+  }
+}
+
+const boolean = initialize {
+  entry() {
+    const literal = true;
+    return literal;
+  }
+}
+
+const array = initialize {
+  entry() {
+    const literal = 1;
+    const literal$1 = 2;
+    const literal$2 = 3;
+    const array = [literal, literal$1, literal$2];
+    return array;
+  }
+}
+
+const record = initialize {
+  entry() {
+    const literal = 42;
+    const literal$1 = "nested";
+    const record = { value: literal$1 };
+    const record$1 = { integer: literal, nested: record };
+    return record$1;
+  }
+}
+
+const projection = initialize {
+  entry() {
+    const record = global(record);
+    const nested = record.nested;
+    const value = nested.value;
+    return value;
+  }
+}

--- a/tests-integration/fixtures/backend/1787021340_record_updates/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021340_record_updates/Main.ssa.snap
@@ -1,0 +1,29 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+const model = initialize {
+  entry() {
+    const literal = 0;
+    const literal$1 = true;
+    const literal$2 = "before";
+    const record = { enabled: literal$1, label: literal$2 };
+    const record$1 = { count: literal, nested: record };
+    return record$1;
+  }
+}
+
+const updated = initialize {
+  entry() {
+    const model = global(model);
+    const literal = 1;
+    const literal$1 = false;
+    const literal$2 = "after";
+    const updated = record.update(model, {
+      count: literal,
+      nested: { enabled: literal$1, label: literal$2 }
+    });
+    return updated;
+  }
+}

--- a/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.ssa.snap
@@ -1,0 +1,152 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+function integer(argument0) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(argument0, 0);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const literal$1 = false;
+    case$join(literal$1);
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const literal = true;
+    case$join(literal);
+  }
+}
+
+function number(argument0) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(argument0, 1.5);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const literal$1 = false;
+    case$join(literal$1);
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const literal = true;
+    case$join(literal);
+  }
+}
+
+function character(argument0) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(argument0, 'a');
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const literal$1 = false;
+    case$join(literal$1);
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const literal = true;
+    case$join(literal);
+  }
+}
+
+function string(argument0) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(argument0, "alexandrite");
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const literal$1 = false;
+    case$join(literal$1);
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const literal = true;
+    case$join(literal);
+  }
+}
+
+function boolean(argument0) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(argument0, true);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const matches$1 = pattern.literal(argument0, false);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$failure();
+    }
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const literal = true;
+    case$join(literal);
+  }
+  match$success$1() {
+    const literal$1 = false;
+    case$join(literal$1);
+  }
+}

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.ssa.snap
@@ -1,0 +1,172 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+function first(argument0) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.constructor(argument0, Empty);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const matches$1 = pattern.constructor(argument0, One);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$2();
+    }
+  }
+  case$2() {
+    const matches$2 = pattern.constructor(argument0, Pair);
+    if (matches$2) {
+      match$success$2();
+    } else {
+      case$failure();
+    }
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const Empty = constructor(Empty);
+    case$join(Empty);
+  }
+  match$success$1() {
+    const value = pattern.argument(argument0, One, 0);
+    const One = constructor(One);
+    const call = source.call(One, value);
+    case$join(call);
+  }
+  match$success$2() {
+    const left = pattern.argument(argument0, Pair, 0);
+    const argument = pattern.argument(argument0, Pair, 1);
+    case$0$1();
+  }
+  case$0$1() {
+    const matches$3 = pattern.constructor(argument0, Pair);
+    if (matches$3) {
+      match$success$3();
+    } else {
+      case$1$1();
+    }
+  }
+  case$1$1() {
+    const Empty$1 = constructor(Empty);
+    case$join$1(Empty$1);
+  }
+  case$failure$1() {
+    throw patternMatchFailure();
+  }
+  case$join$1(result$1) {
+    case$join(result$1);
+  }
+  match$success$3() {
+    const argument$1 = pattern.argument(argument0, Pair, 0);
+    const argument$2 = pattern.argument(argument0, Pair, 1);
+    const One$1 = constructor(One);
+    const call$1 = source.call(One$1, left);
+    case$join$1(call$1);
+  }
+}
+
+function unwrap(argument0) {
+  entry() {
+    const matches = pattern.constructor(argument0, Identity);
+    if (matches) {
+      match$success();
+    } else {
+      parameter$failure();
+    }
+  }
+  parameter$failure() {
+    throw patternMatchFailure();
+  }
+  match$success() {
+    const value = pattern.argument(argument0, Identity, 0);
+    return value;
+  }
+}
+
+function nested(argument0) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.constructor(argument0, Outer);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const Empty = constructor(Empty);
+    case$join(Empty);
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const argument = pattern.argument(argument0, Outer, 0);
+    const matches$1 = pattern.constructor(argument, One);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$1();
+    }
+  }
+  match$success$1() {
+    const value = pattern.argument(argument, One, 0);
+    const One = constructor(One);
+    const call = source.call(One, value);
+    case$join(call);
+  }
+}
+
+function bind(value, continuation) {
+  entry() {
+    const call = source.call(continuation, value);
+    return call;
+  }
+}
+
+function ordinaryBind(identity) {
+  entry() {
+    const bind = global(bind);
+    const call = source.call(bind, identity);
+    const closure = closure(ordinaryBind$closure);
+    const call$1 = source.call(call, closure);
+    return call$1;
+  }
+}
+
+closure ordinaryBind$closure[](argument0) {
+  entry() {
+    const matches = pattern.constructor(argument0, Identity);
+    if (matches) {
+      match$success();
+    } else {
+      parameter$failure();
+    }
+  }
+  parameter$failure() {
+    throw patternMatchFailure();
+  }
+  match$success() {
+    const value = pattern.argument(argument0, Identity, 0);
+    return value;
+  }
+}

--- a/tests-integration/fixtures/backend/1787021520_array_patterns/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021520_array_patterns/Main.ssa.snap
@@ -1,0 +1,57 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+function describe(argument0) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.array(argument0, 0);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const matches$1 = pattern.array(argument0, 1);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$2();
+    }
+  }
+  case$2() {
+    const matches$2 = pattern.array(argument0, 2);
+    if (matches$2) {
+      match$success$2();
+    } else {
+      case$3();
+    }
+  }
+  case$3() {
+    const literal$1 = 3;
+    case$join(literal$1);
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const literal = 0;
+    case$join(literal);
+  }
+  match$success$1() {
+    const value = argument0[0];
+    case$join(value);
+  }
+  match$success$2() {
+    const first = argument0[0];
+    const second = argument0[1];
+    case$join(first);
+  }
+}

--- a/tests-integration/fixtures/backend/1787021580_record_patterns/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021580_record_patterns/Main.ssa.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+function select(argument0) {
+  entry() {
+    const first = argument0.first;
+    const nested = argument0.nested;
+    const second = nested.second;
+    return second;
+  }
+}

--- a/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/Main.ssa.snap
@@ -1,0 +1,68 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+function choose(first, second) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(first, true);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const matches$2 = pattern.literal(first, true);
+    if (matches$2) {
+      match$success$2();
+    } else {
+      case$2();
+    }
+  }
+  case$2() {
+    const matches$4 = pattern.literal(first, false);
+    if (matches$4) {
+      match$success$4();
+    } else {
+      case$failure();
+    }
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const matches$1 = pattern.literal(second, true);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$1();
+    }
+  }
+  match$success$1() {
+    const literal = 2;
+    case$join(literal);
+  }
+  match$success$2() {
+    const matches$3 = pattern.literal(second, false);
+    if (matches$3) {
+      match$success$3();
+    } else {
+      case$2();
+    }
+  }
+  match$success$3() {
+    const literal$1 = 1;
+    case$join(literal$1);
+  }
+  match$success$4() {
+    const literal$2 = 0;
+    case$join(literal$2);
+  }
+}

--- a/tests-integration/fixtures/backend/1787021700_guards/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021700_guards/Main.nbe.snap
@@ -9,3 +9,29 @@ booleanGuard = \value%0 ->
 patternGuard = \choice%1 ->
   | One value%2 <- choice%1 -> value%2
   | true -> 0
+
+caseBooleanGuard = \value%3 ->
+  case value%3 of
+    _ ->
+      | false -> 1
+    _ ->
+      2
+
+casePatternGuard = \choice%4 ->
+  case choice%4 of
+    _ ->
+      | One value%5 <- choice%4 -> value%5
+    _ ->
+      0
+
+nestedCaseGuard = \value%6 ->
+  case value%6 of
+    true ->
+      | true ->
+        case value%6 of
+          _ ->
+            | false -> 1
+          _ ->
+            2
+    _ ->
+      3

--- a/tests-integration/fixtures/backend/1787021700_guards/Main.purs
+++ b/tests-integration/fixtures/backend/1787021700_guards/Main.purs
@@ -11,3 +11,20 @@ patternGuard :: Choice Int -> Int
 patternGuard choice
   | One value <- choice = value
   | true = 0
+
+caseBooleanGuard :: Boolean -> Int
+caseBooleanGuard value = case value of
+  _ | false -> 1
+  _ -> 2
+
+casePatternGuard :: Choice Int -> Int
+casePatternGuard choice = case choice of
+  _ | One value <- choice -> value
+  _ -> 0
+
+nestedCaseGuard :: Boolean -> Int
+nestedCaseGuard value = case value of
+  true | true -> case value of
+    _ | false -> 1
+    _ -> 2
+  _ -> 3

--- a/tests-integration/fixtures/backend/1787021700_guards/Main.snap
+++ b/tests-integration/fixtures/backend/1787021700_guards/Main.snap
@@ -1,13 +1,16 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+assertion_line: 55
+expression: checking_report
 ---
 Terms
 Empty :: forall @a. Main.Choice a
 One :: forall @a. a -> Main.Choice a
 booleanGuard :: Prim.Boolean -> Prim.Int
 patternGuard :: Main.Choice Prim.Int -> Prim.Int
+caseBooleanGuard :: Prim.Boolean -> Prim.Int
+casePatternGuard :: Main.Choice Prim.Int -> Prim.Int
+nestedCaseGuard :: Prim.Boolean -> Prim.Int
 
 Types
 Choice :: Prim.Type -> Prim.Type

--- a/tests-integration/fixtures/backend/1787021700_guards/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021700_guards/Main.ssa.snap
@@ -1,0 +1,75 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+function booleanGuard(value) {
+  entry() {
+    guard$0();
+  }
+  guard$0() {
+    if (value) {
+      guard$success();
+    } else {
+      guard$1();
+    }
+  }
+  guard$1() {
+    const literal$1 = true;
+    if (literal$1) {
+      guard$success$1();
+    } else {
+      guard$failure();
+    }
+  }
+  guard$failure() {
+    throw patternMatchFailure();
+  }
+  guard$join(result) {
+    return result;
+  }
+  guard$success() {
+    const literal = 1;
+    guard$join(literal);
+  }
+  guard$success$1() {
+    const literal$2 = 0;
+    guard$join(literal$2);
+  }
+}
+
+function patternGuard(choice) {
+  entry() {
+    guard$0();
+  }
+  guard$0() {
+    const matches = pattern.constructor(choice, One);
+    if (matches) {
+      match$success();
+    } else {
+      guard$1();
+    }
+  }
+  guard$1() {
+    const literal = true;
+    if (literal) {
+      guard$success();
+    } else {
+      guard$failure();
+    }
+  }
+  guard$failure() {
+    throw patternMatchFailure();
+  }
+  guard$join(result) {
+    return result;
+  }
+  match$success() {
+    const value = pattern.argument(choice, One, 0);
+    guard$join(value);
+  }
+  guard$success() {
+    const literal$1 = 0;
+    guard$join(literal$1);
+  }
+}

--- a/tests-integration/fixtures/backend/1787021700_guards/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021700_guards/Main.ssa.snap
@@ -73,3 +73,140 @@ function patternGuard(choice) {
     guard$join(literal$1);
   }
 }
+
+function caseBooleanGuard(value) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    guard$0();
+  }
+  case$1() {
+    const literal$2 = 2;
+    case$join(literal$2);
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  guard$0() {
+    const literal = false;
+    if (literal) {
+      guard$success();
+    } else {
+      case$1();
+    }
+  }
+  guard$join(result$1) {
+    case$join(result$1);
+  }
+  guard$success() {
+    const literal$1 = 1;
+    guard$join(literal$1);
+  }
+}
+
+function casePatternGuard(choice) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    guard$0();
+  }
+  case$1() {
+    const literal = 0;
+    case$join(literal);
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  guard$0() {
+    const matches = pattern.constructor(choice, One);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  guard$join(result$1) {
+    case$join(result$1);
+  }
+  match$success() {
+    const value = pattern.argument(choice, One, 0);
+    guard$join(value);
+  }
+}
+
+function nestedCaseGuard(value) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(value, true);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const literal$4 = 3;
+    case$join(literal$4);
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    guard$0();
+  }
+  guard$0() {
+    const literal = true;
+    if (literal) {
+      guard$success();
+    } else {
+      case$1();
+    }
+  }
+  guard$join(result$1) {
+    case$join(result$1);
+  }
+  guard$success() {
+    case$0$1();
+  }
+  case$0$1() {
+    guard$0$1();
+  }
+  case$1$1() {
+    const literal$3 = 2;
+    case$join$1(literal$3);
+  }
+  case$failure$1() {
+    throw patternMatchFailure();
+  }
+  case$join$1(result$2) {
+    guard$join(result$2);
+  }
+  guard$0$1() {
+    const literal$1 = false;
+    if (literal$1) {
+      guard$success$1();
+    } else {
+      case$1$1();
+    }
+  }
+  guard$join$1(result$3) {
+    case$join$1(result$3);
+  }
+  guard$success$1() {
+    const literal$2 = 1;
+    guard$join$1(literal$2);
+  }
+}

--- a/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.ssa.snap
@@ -1,0 +1,30 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+function unwrap(wrapped) {
+  entry() {
+    const matches = pattern.constructor(wrapped, Identity);
+    if (matches) {
+      match$success();
+    } else {
+      let$failure();
+    }
+  }
+  let$failure() {
+    throw patternMatchFailure();
+  }
+  match$success() {
+    const value = pattern.argument(wrapped, Identity, 0);
+    return value;
+  }
+}
+
+function select(record) {
+  entry() {
+    const first = record.first;
+    const second = record.second;
+    return second;
+  }
+}

--- a/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/Main.ssa.snap
@@ -1,0 +1,89 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+function mutual(condition) {
+  entry() {
+    const [second, first] = closures.recursive({
+      second: closure(second$function, first),
+      first: closure(first$function, second)
+    });
+    const call = source.call(first, condition);
+    return call;
+  }
+}
+
+closure second$function[first](argument0) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(argument0, true);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const matches$1 = pattern.literal(argument0, false);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$failure();
+    }
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const literal = 2;
+    case$join(literal);
+  }
+  match$success$1() {
+    const literal$1 = true;
+    const call = source.call(first, literal$1);
+    case$join(call);
+  }
+}
+
+closure first$function[second](argument0) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(argument0, true);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const matches$1 = pattern.literal(argument0, false);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$failure();
+    }
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const literal = 1;
+    case$join(literal);
+  }
+  match$success$1() {
+    const literal$1 = true;
+    const call = source.call(second, literal$1);
+    case$join(call);
+  }
+}

--- a/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/Main.ssa.snap
@@ -1,0 +1,94 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+const forward = initialize {
+  entry() {
+    const later = global(later);
+    return later;
+  }
+}
+
+const later = initialize {
+  entry() {
+    const literal = 42;
+    return literal;
+  }
+}
+
+recursive[2] function first(argument0) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(argument0, true);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const matches$1 = pattern.literal(argument0, false);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$failure();
+    }
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const literal = 1;
+    case$join(literal);
+  }
+  match$success$1() {
+    const second = global(second);
+    const literal$1 = true;
+    const call = source.call(second, literal$1);
+    case$join(call);
+  }
+}
+
+recursive[2] function second(argument0) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(argument0, true);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const matches$1 = pattern.literal(argument0, false);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$failure();
+    }
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const literal = 2;
+    case$join(literal);
+  }
+  match$success$1() {
+    const first = global(first);
+    const literal$1 = true;
+    const call = source.call(first, literal$1);
+    case$join(call);
+  }
+}

--- a/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.ssa.snap
@@ -1,0 +1,82 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+foreign const equalInt;
+
+foreign const lessThanInt;
+
+const equalInt1 = initialize {
+  entry() {
+    const equalInt = global(equalInt);
+    const record = { equal: equalInt };
+    return record;
+  }
+}
+
+const orderedInt = initialize {
+  entry() {
+    const equalInt1 = global(equalInt1);
+    const lessThanInt = global(lessThanInt);
+    const record = { superclass17: equalInt1, lessThan: lessThanInt };
+    return record;
+  }
+}
+
+function genericEqual(dictionary0) {
+  entry() {
+    const closure = closure(genericEqual$closure, dictionary0);
+    return closure;
+  }
+}
+
+const concreteEqual = initialize {
+  entry() {
+    const equalInt1 = global(equalInt1);
+    const equal = equalInt1.equal;
+    const literal = 1;
+    const call = source.call(equal, literal);
+    const literal$1 = 2;
+    const call$1 = source.call(call, literal$1);
+    return call$1;
+  }
+}
+
+const concreteLessThan = initialize {
+  entry() {
+    const orderedInt = global(orderedInt);
+    const lessThan = orderedInt.lessThan;
+    const literal = 1;
+    const call = source.call(lessThan, literal);
+    const literal$1 = 2;
+    const call$1 = source.call(call, literal$1);
+    return call$1;
+  }
+}
+
+function superclassEqual(dictionary1) {
+  entry() {
+    const closure = closure(superclassEqual$closure, dictionary1);
+    return closure;
+  }
+}
+
+closure genericEqual$closure[dictionary0](left, right) {
+  entry() {
+    const equal = dictionary0.equal;
+    const call = source.call(equal, left);
+    const call$1 = source.call(call, right);
+    return call$1;
+  }
+}
+
+closure superclassEqual$closure[dictionary1](left, right) {
+  entry() {
+    const superclass17 = dictionary1.superclass17;
+    const equal = superclass17.equal;
+    const call = source.call(equal, left);
+    const call$1 = source.call(call, right);
+    return call$1;
+  }
+}

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.ssa.snap
@@ -1,0 +1,54 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+foreign const firstAction;
+
+foreign const secondAction;
+
+foreign const independentAction;
+
+const sequential = initialize {
+  entry() {
+    const bindEffect1 = global(bindEffect1);
+    const bind = bindEffect1.bind;
+    const firstAction = global(firstAction);
+    const call = source.call(bind, firstAction);
+    const closure = closure(sequential$initialize$closure);
+    const call$1 = source.call(call, closure);
+    return call$1;
+  }
+}
+
+const independent = initialize {
+  entry() {
+    const applyEffect1 = global(applyEffect1);
+    const apply = applyEffect1.apply;
+    const functorEffect = global(functorEffect);
+    const map = functorEffect.map;
+    const closure = closure(independent$initialize$closure);
+    const call = source.call(map, closure);
+    const firstAction = global(firstAction);
+    const call$1 = source.call(call, firstAction);
+    const call$2 = source.call(apply, call$1);
+    const independentAction = global(independentAction);
+    const call$3 = source.call(call$2, independentAction);
+    return call$3;
+  }
+}
+
+closure sequential$initialize$closure[](first) {
+  entry() {
+    const secondAction = global(secondAction);
+    const call = source.call(secondAction, first);
+    return call;
+  }
+}
+
+closure independent$initialize$closure[](first, second) {
+  entry() {
+    const record = { first: first, second: second };
+    return record;
+  }
+}

--- a/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.ssa.snap
@@ -1,0 +1,17 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+foreign const foreignValue;
+
+foreign const foreignFunction;
+
+const value = initialize {
+  entry() {
+    const foreignFunction = global(foreignFunction);
+    const foreignValue = global(foreignValue);
+    const call = source.call(foreignFunction, foreignValue);
+    return call;
+  }
+}

--- a/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.ssa.snap
@@ -1,0 +1,38 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+function unbox(argument0) {
+  entry() {
+    const matches = pattern.constructor(argument0, Box);
+    if (matches) {
+      match$success();
+    } else {
+      parameter$failure();
+    }
+  }
+  parameter$failure() {
+    throw patternMatchFailure();
+  }
+  match$success() {
+    const value = pattern.argument(argument0, Box, 0);
+    return value;
+  }
+}
+
+const fromLibrary = initialize {
+  entry() {
+    const unbox = global(unbox);
+    const box = global(box);
+    const call = source.call(unbox, box);
+    return call;
+  }
+}
+
+const directReference = initialize {
+  entry() {
+    const libraryValue = global(libraryValue);
+    return libraryValue;
+  }
+}

--- a/tests-integration/fixtures/backend/1787022180_desugared_source_forms/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787022180_desugared_source_forms/Main.ssa.snap
@@ -1,0 +1,53 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+function add(left, right) {
+  entry() {
+    return left;
+  }
+}
+
+function identity(value) {
+  entry() {
+    return value;
+  }
+}
+
+const operatorApplication = initialize {
+  entry() {
+    const add = global(add);
+    const literal = 1;
+    const call = source.call(add, literal);
+    const literal$1 = 2;
+    const call$1 = source.call(call, literal$1);
+    return call$1;
+  }
+}
+
+const visibleTypeApplication = initialize {
+  entry() {
+    const identity = global(identity);
+    const literal = 42;
+    const call = source.call(identity, literal);
+    return call;
+  }
+}
+
+function increment(section60) {
+  entry() {
+    const add = global(add);
+    const call = source.call(add, section60);
+    const literal = 1;
+    const call$1 = source.call(call, literal);
+    return call$1;
+  }
+}
+
+function accessValue(section79) {
+  entry() {
+    const value = section79.value;
+    return value;
+  }
+}

--- a/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/Main.ssa.snap
@@ -1,0 +1,95 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+function apply(function, value) {
+  entry() {
+    const call = source.call(function, value);
+    return call;
+  }
+}
+
+function capture(captured) {
+  entry() {
+    const closure = closure(capture$closure, captured);
+    return closure;
+  }
+}
+
+function choose(condition, left, right) {
+  entry() {
+    if (condition) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    if$join(left);
+  }
+  else() {
+    if$join(right);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+const partial = initialize {
+  entry() {
+    const choose = global(choose);
+    const literal = true;
+    const call = source.call(choose, literal);
+    const literal$1 = 42;
+    const call$1 = source.call(call, literal$1);
+    return call$1;
+  }
+}
+
+function literalCase(value) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(value, 0);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const literal$1 = "other";
+    case$join(literal$1);
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const literal = "zero";
+    case$join(literal);
+  }
+}
+
+const higherOrder = initialize {
+  entry() {
+    const apply = global(apply);
+    const capture = global(capture);
+    const literal = 42;
+    const call = source.call(capture, literal);
+    const call$1 = source.call(apply, call);
+    const literal$1 = 0;
+    const call$2 = source.call(call$1, literal$1);
+    return call$2;
+  }
+}
+
+closure capture$closure[captured](argument0) {
+  entry() {
+    return captured;
+  }
+}

--- a/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.ssa.snap
@@ -1,0 +1,48 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+foreign const addInt;
+
+foreign const multiplyInt;
+
+const constantAdd = initialize {
+  entry() {
+    const addInt = global(addInt);
+    const literal = 20;
+    const call = source.call(addInt, literal);
+    const literal$1 = 22;
+    const call$1 = source.call(call, literal$1);
+    return call$1;
+  }
+}
+
+const constantMultiply = initialize {
+  entry() {
+    const multiplyInt = global(multiplyInt);
+    const literal = 6;
+    const call = source.call(multiplyInt, literal);
+    const literal$1 = 7;
+    const call$1 = source.call(call, literal$1);
+    return call$1;
+  }
+}
+
+const overflowAdd = initialize {
+  entry() {
+    const addInt = global(addInt);
+    const literal = 2147483647;
+    const call = source.call(addInt, literal);
+    const literal$1 = 1;
+    const call$1 = source.call(call, literal$1);
+    return call$1;
+  }
+}
+
+const unknownAdd = initialize {
+  entry() {
+    const addInt = global(addInt);
+    return addInt;
+  }
+}

--- a/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.ssa.snap
@@ -1,0 +1,52 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+foreign const await;
+
+const arguments = initialize {
+  entry() {
+    const await = global(await);
+    return await;
+  }
+}
+
+const default = initialize {
+  entry() {
+    const arguments = global(arguments);
+    const record = { "hyphen-label": arguments };
+    return record;
+  }
+}
+
+function readLabel(record) {
+  entry() {
+    const hyphen_label = record["hyphen-label"];
+    return hyphen_label;
+  }
+}
+
+const emptyLabel = initialize {
+  entry() {
+    const arguments = global(arguments);
+    const record = { "": arguments };
+    return record;
+  }
+}
+
+function readEmptyLabel(record) {
+  entry() {
+    const value = record[""];
+    return value;
+  }
+}
+
+const tagged = initialize {
+  entry() {
+    const Tagged = constructor(Tagged);
+    const default = global(default);
+    const call = source.call(Tagged, default);
+    return call;
+  }
+}

--- a/tests-integration/fixtures/backend/1787080920_derived_instance/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787080920_derived_instance/Main.ssa.snap
@@ -1,0 +1,76 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+const eqBox = initialize {
+  entry() {
+    const closure = closure(eqBox$initialize$closure);
+    const record = { eq: closure };
+    return record;
+  }
+}
+
+const equal = initialize {
+  entry() {
+    const eqBox = global(eqBox);
+    const eq = eqBox.eq;
+    const Box = constructor(Box);
+    const call = source.call(eq, Box);
+    const Box$1 = constructor(Box);
+    const call$1 = source.call(call, Box$1);
+    return call$1;
+  }
+}
+
+function showIdentity(dictionary1) {
+  entry() {
+    return dictionary1;
+  }
+}
+
+const rendered = initialize {
+  entry() {
+    const showIdentity = global(showIdentity);
+    const showInt = global(showInt);
+    const call = source.call(showIdentity, showInt);
+    const show = call.show;
+    const Identity = constructor(Identity);
+    const literal = 42;
+    const call$1 = source.call(Identity, literal);
+    const call$2 = source.call(show, call$1);
+    return call$2;
+  }
+}
+
+closure eqBox$initialize$closure[](left, right) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.constructor(left, Box);
+    if (matches) {
+      match$success();
+    } else {
+      case$failure();
+    }
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const matches$1 = pattern.constructor(right, Box);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$failure();
+    }
+  }
+  match$success$1() {
+    const literal = true;
+    case$join(literal);
+  }
+}

--- a/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.ssa.snap
@@ -1,0 +1,84 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+const symbol = initialize {
+  entry() {
+    const evidence = evidence.symbol("alexandrite");
+    const reflectSymbol = evidence.reflectSymbol;
+    const Proxy = constructor(Proxy);
+    const call = source.call(reflectSymbol, Proxy);
+    return call;
+  }
+}
+
+const reflectedString = initialize {
+  entry() {
+    const evidence = evidence.reflectable("reflected");
+    const reflectType = evidence.reflectType;
+    const Proxy = constructor(Proxy);
+    const call = source.call(reflectType, Proxy);
+    return call;
+  }
+}
+
+const reflectedInteger = initialize {
+  entry() {
+    const evidence = evidence.reflectable(42);
+    const reflectType = evidence.reflectType;
+    const Proxy = constructor(Proxy);
+    const call = source.call(reflectType, Proxy);
+    return call;
+  }
+}
+
+const reflectedTrue = initialize {
+  entry() {
+    const evidence = evidence.reflectable(true);
+    const reflectType = evidence.reflectType;
+    const Proxy = constructor(Proxy);
+    const call = source.call(reflectType, Proxy);
+    return call;
+  }
+}
+
+const reflectedFalse = initialize {
+  entry() {
+    const evidence = evidence.reflectable(false);
+    const reflectType = evidence.reflectType;
+    const Proxy = constructor(Proxy);
+    const call = source.call(reflectType, Proxy);
+    return call;
+  }
+}
+
+const reflectedLess = initialize {
+  entry() {
+    const evidence = evidence.reflectable(LT);
+    const reflectType = evidence.reflectType;
+    const Proxy = constructor(Proxy);
+    const call = source.call(reflectType, Proxy);
+    return call;
+  }
+}
+
+const reflectedEqual = initialize {
+  entry() {
+    const evidence = evidence.reflectable(EQ);
+    const reflectType = evidence.reflectType;
+    const Proxy = constructor(Proxy);
+    const call = source.call(reflectType, Proxy);
+    return call;
+  }
+}
+
+const reflectedGreater = initialize {
+  entry() {
+    const evidence = evidence.reflectable(GT);
+    const reflectType = evidence.reflectType;
+    const Proxy = constructor(Proxy);
+    const call = source.call(reflectType, Proxy);
+    return call;
+  }
+}

--- a/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.ssa.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+function sequence(input) {
+  entry() {
+    return input;
+  }
+}

--- a/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.ssa.snap
@@ -1,0 +1,38 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 56
+expression: ssa_report
+---
+function choose(argument0, argument1) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(argument0, 0);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    case$join(argument0);
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const closure = closure(choose$closure);
+    const call = source.call(closure, argument1);
+    case$join(call);
+  }
+}
+
+closure choose$closure[](value) {
+  entry() {
+    return value;
+  }
+}

--- a/tests-integration/src/fixtures.rs
+++ b/tests-integration/src/fixtures.rs
@@ -42,12 +42,19 @@ pub fn backend(path: &Path) -> FixtureResult {
         return Err(missing_module(path, &file).into());
     };
 
-    let report = crate::generated::basic::report_checked(&engine, id);
+    let checking_report = crate::generated::basic::report_checked(&engine, id);
+    let functional = nbe::convert_module(&engine, id)?;
+    let control_flow = ssa::convert_module(&functional)?;
+    let ssa_report = ssa::pretty::render(&control_flow);
+    let ssa_snapshot = format!("{file}.ssa");
 
     let mut settings = insta::Settings::clone_current();
     settings.set_snapshot_path(snapshot_path(folder));
     settings.set_prepend_module_to_snapshot(false);
-    settings.bind(|| insta::assert_snapshot!(file, report));
+    settings.bind(|| {
+        insta::assert_snapshot!(file, checking_report);
+        insta::assert_snapshot!(ssa_snapshot, ssa_report);
+    });
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- introduce the arena-allocated A-normal SSA tree downstream of `crate:nbe`
- preserve evaluation order with explicit instructions, blocks, block parameters, and terminators
- represent ordinary, effect, and initializer calling conventions explicitly
- discover closure captures and represent recursive closure groups without turning source recursion into CFG dispatch
- lower pattern matching and joins into reviewable SSA snapshots across the shared corpus

This layer defines and lowers the baseline SSA representation without adding optimisation passes.

## Stack

This is 3/7 in the backend stack, stacked on #344. The next layer is #346.

## Validation

```text
just format --check
just t backend
cargo check -p ssa --tests
cargo nextest run -p ssa --no-fail-fast --no-tests=pass
cargo clippy -p nbe -p ssa -p tests-integration --tests -- -D warnings
```

Refs #339.

Amp-Thread-ID: https://ampcode.com/threads/T-01a01626-c86f-77d5-8dda-c81d960c3cff

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
