### PR TITLE
[building] Cache NBE and SSA build queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,12 +269,14 @@ dependencies = [
  "lexing",
  "lock_api",
  "lowering",
+ "nbe",
  "parking_lot",
  "parsing",
  "prim-constants",
  "resolving",
  "rustc-hash",
  "smol_str",
+ "ssa",
  "stabilizing",
  "sugar",
  "thread_local",
@@ -2579,6 +2581,7 @@ dependencies = [
 name = "ssa"
 version = "0.1.0"
 dependencies = [
+ "building-types",
  "files",
  "indexing",
  "itertools 0.15.0",

--- a/compiler-backend/nbe/src/convert.rs
+++ b/compiler-backend/nbe/src/convert.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use building_types::QueryResult;
+use building_types::{QueryError, QueryResult};
 use checking::evidence::{
     Evidence, EvidenceBinderId, EvidenceId, EvidenceState, EvidenceVarId, InstanceCandidateOrigin,
 };
@@ -12,8 +12,9 @@ use indexing::{DeriveItemId, IndexedTermItemKind, InstanceItemId, OrderedTermIte
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smol_str::{SmolStr, format_smolstr};
+use thiserror::Error;
 
-use crate::error::{ConversionError, ConversionResult, UnsupportedState};
+use crate::error::{ModuleError, ModuleResult, UnsupportedState};
 use crate::tree::{
     Binding, CaseAlternative, Declaration, DeclarationKind, Expression, ExpressionId,
     ExpressionKind, Field, FieldIdentity, Global, GlobalId, Guard, GuardedAlternative,
@@ -21,6 +22,16 @@ use crate::tree::{
     RecordField, RecordPatternField, RecordUpdate, RecursiveGroupId, ReflectableEvidence,
     ReflectableOrdering, Storage, SuperclassIdentity, SynthesizedEvidence,
 };
+
+type ConversionResult<T> = Result<T, ConversionError>;
+
+#[derive(Debug, Error)]
+enum ConversionError {
+    #[error(transparent)]
+    Query(#[from] QueryError),
+    #[error(transparent)]
+    Module(#[from] ModuleError),
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum BindingSource {
@@ -32,6 +43,17 @@ enum BindingSource {
 }
 
 pub fn convert_module(
+    queries: &impl checking::ExternalQueries,
+    file_id: FileId,
+) -> QueryResult<ModuleResult<Module>> {
+    match convert_module_inner(queries, file_id) {
+        Ok(module) => Ok(Ok(module)),
+        Err(ConversionError::Query(error)) => Err(error),
+        Err(ConversionError::Module(error)) => Ok(Err(error)),
+    }
+}
+
+fn convert_module_inner(
     queries: &impl checking::ExternalQueries,
     file_id: FileId,
 ) -> ConversionResult<Module> {
@@ -1007,6 +1029,6 @@ where
     }
 
     fn unsupported(&self, state: UnsupportedState) -> ConversionError {
-        ConversionError::Unsupported { file_id: self.file_id, state }
+        crate::ModuleError::Unsupported { file_id: self.file_id, state }.into()
     }
 }

--- a/compiler-backend/nbe/src/error.rs
+++ b/compiler-backend/nbe/src/error.rs
@@ -1,21 +1,18 @@
-use building_types::QueryError;
 use checking::evidence::EvidenceVarId;
 use checking::tree as checked_tree;
 use files::FileId;
 use indexing::TermItemId;
 use thiserror::Error;
 
-pub type ConversionResult<T> = Result<T, ConversionError>;
+pub type ModuleResult<T> = Result<T, ModuleError>;
 
-#[derive(Debug, Error)]
-pub enum ConversionError {
-    #[error(transparent)]
-    Query(#[from] QueryError),
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ModuleError {
     #[error("cannot convert checked module {file_id:?}: {state}")]
     Unsupported { file_id: FileId, state: UnsupportedState },
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum UnsupportedState {
     #[error("checked expression {0:?} contains an error")]
     ExpressionError(checked_tree::ExpressionId),

--- a/compiler-backend/nbe/src/lib.rs
+++ b/compiler-backend/nbe/src/lib.rs
@@ -6,4 +6,13 @@ pub mod pretty;
 pub mod tree;
 
 pub use convert::convert_module;
-pub use error::{ConversionError, ConversionResult, UnsupportedState};
+pub use error::{ModuleError, ModuleResult, UnsupportedState};
+
+use std::sync::Arc;
+
+use building_types::QueryResult;
+use files::FileId;
+
+pub trait ExternalQueries {
+    fn nbe(&self, file_id: FileId) -> QueryResult<ModuleResult<Arc<tree::Module>>>;
+}

--- a/compiler-backend/ssa/Cargo.toml
+++ b/compiler-backend/ssa/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+building-types = { version = "0.1.0", path = "../../compiler-core/building-types" }
 files = { version = "0.1.0", path = "../../compiler-core/files" }
 indexing = { version = "0.1.0", path = "../../compiler-core/indexing" }
 itertools = "0.15.0"

--- a/compiler-backend/ssa/src/convert.rs
+++ b/compiler-backend/ssa/src/convert.rs
@@ -2,11 +2,13 @@
 
 use std::sync::Arc;
 
+use building_types::QueryResult;
+use files::FileId;
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smol_str::{SmolStr, format_smolstr};
 
-use crate::error::{ConversionError, ConversionResult, UnsupportedState};
+use crate::error::{ModuleError, ModuleResult, UnsupportedState};
 use crate::tree::{
     Block, BlockId, BlockTarget, CallingConvention, Declaration, DeclarationKind, Failure, Field,
     FieldIdentity, Function, FunctionId, Global, GlobalIdentity, InstanceIdentity, Instruction,
@@ -15,7 +17,20 @@ use crate::tree::{
     SuperclassIdentity, SynthesizedEvidence, Terminator, Value, ValueId,
 };
 
-pub fn convert_module(functional: &nbe::tree::Module) -> ConversionResult<Module> {
+type ConversionResult<T> = ModuleResult<T>;
+
+pub fn convert_module(
+    queries: &impl nbe::ExternalQueries,
+    file_id: FileId,
+) -> QueryResult<ModuleResult<Module>> {
+    let functional = match queries.nbe(file_id)? {
+        Ok(functional) => functional,
+        Err(error) => return Ok(Err(error.into())),
+    };
+    Ok(convert(&functional))
+}
+
+fn convert(functional: &nbe::tree::Module) -> ConversionResult<Module> {
     let mut state = State::default();
     let context = Context { functional };
     for declaration in functional.declarations.iter() {
@@ -1129,8 +1144,8 @@ impl State {
 }
 
 impl Context<'_> {
-    fn unsupported(&self, state: UnsupportedState) -> ConversionError {
-        ConversionError::Unsupported { file_id: self.functional.file_id, state }
+    fn unsupported(&self, state: UnsupportedState) -> ModuleError {
+        ModuleError::Unsupported { file_id: self.functional.file_id, state }
     }
 }
 

--- a/compiler-backend/ssa/src/error.rs
+++ b/compiler-backend/ssa/src/error.rs
@@ -1,15 +1,17 @@
 use files::FileId;
 use thiserror::Error;
 
-pub type ConversionResult<T> = Result<T, ConversionError>;
+pub type ModuleResult<T> = Result<T, ModuleError>;
 
-#[derive(Debug, Error)]
-pub enum ConversionError {
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ModuleError {
+    #[error(transparent)]
+    Functional(#[from] nbe::ModuleError),
     #[error("cannot convert functional module {file_id:?} to SSA: {state}")]
     Unsupported { file_id: FileId, state: UnsupportedState },
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum UnsupportedState {
     #[error("local {local_name} is not available in the current lexical scope")]
     MissingLocal { local_name: String },

--- a/compiler-backend/ssa/src/lib.rs
+++ b/compiler-backend/ssa/src/lib.rs
@@ -6,4 +6,4 @@ pub mod pretty;
 pub mod tree;
 
 pub use convert::convert_module;
-pub use error::{ConversionError, ConversionResult, UnsupportedState};
+pub use error::{ModuleError, ModuleResult, UnsupportedState};

--- a/compiler-core/building-types/src/lib.rs
+++ b/compiler-core/building-types/src/lib.rs
@@ -21,6 +21,8 @@ pub enum QueryKey {
     CheckedCore,
     Checked(FileId),
     Documented(FileId),
+    Nbe(FileId),
+    Ssa(FileId),
 }
 
 #[derive(Error, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/compiler-core/building/Cargo.toml
+++ b/compiler-core/building/Cargo.toml
@@ -13,6 +13,7 @@ interner = { version = "0.1.0", path = "../interner" }
 lexing = { version = "0.1.0", path = "../lexing" }
 lock_api = "0.4.14"
 lowering = { version = "0.1.0", path = "../lowering" }
+nbe = { version = "0.1.0", path = "../../compiler-backend/nbe" }
 parking_lot = "0.12.5"
 parsing = { version = "0.1.0", path = "../parsing" }
 prim-constants = { version = "0.1.0", path = "../prim-constants" }
@@ -21,6 +22,7 @@ rustc-hash = "2.1.3"
 stabilizing = { version = "0.1.0", path = "../stabilizing" }
 sugar = { version = "0.1.0", path = "../sugar" }
 smol_str = "0.3.2"
+ssa = { version = "0.1.0", path = "../../compiler-backend/ssa" }
 thread_local = "1.1.10"
 
 [dev-dependencies]

--- a/compiler-core/building/src/engine.rs
+++ b/compiler-core/building/src/engine.rs
@@ -133,6 +133,8 @@ struct DerivedStorage {
     checked_core: Shards<(), DerivedState<Arc<checking::context::CheckedCore>>>,
     checked: Shards<FileId, DerivedState<Arc<CheckedModule>>>,
     documented: Shards<FileId, DerivedState<Arc<DocumentedModule>>>,
+    nbe: Shards<FileId, DerivedState<nbe::ModuleResult<Arc<nbe::tree::Module>>>>,
+    ssa: Shards<FileId, DerivedState<ssa::ModuleResult<Arc<ssa::tree::Module>>>>,
 }
 
 #[derive(Default)]
@@ -482,7 +484,7 @@ impl QueryEngine {
 
         macro_rules! derived_changed {
             ($field:ident, $key:expr) => {{
-                self.$field(*$key)?;
+                let _ = self.$field(*$key)?;
                 let shard = self.derived.$field.shard($key).read();
                 if let Some(DerivedState::Computed { trace, .. }) = shard.get($key) {
                     latest = latest.max(trace.changed);
@@ -511,6 +513,8 @@ impl QueryEngine {
                 }
                 QueryKey::Checked(k) => derived_changed!(checked, k),
                 QueryKey::Documented(k) => derived_changed!(documented, k),
+                QueryKey::Nbe(k) => derived_changed!(nbe, k),
+                QueryKey::Ssa(k) => derived_changed!(ssa, k),
             }
         }
 
@@ -909,6 +913,30 @@ impl QueryEngine {
         )
     }
 
+    pub fn nbe(&self, id: FileId) -> QueryResult<nbe::ModuleResult<Arc<nbe::tree::Module>>> {
+        self.query(
+            QueryKey::Nbe(id),
+            id,
+            |derived| &derived.nbe,
+            |this| {
+                let converted = nbe::convert_module(this, id)?;
+                Ok(converted.map(Arc::new))
+            },
+        )
+    }
+
+    pub fn ssa(&self, id: FileId) -> QueryResult<ssa::ModuleResult<Arc<ssa::tree::Module>>> {
+        self.query(
+            QueryKey::Ssa(id),
+            id,
+            |derived| &derived.ssa,
+            |this| {
+                let converted = ssa::convert_module(this, id)?;
+                Ok(converted.map(Arc::new))
+            },
+        )
+    }
+
     pub fn documented(&self, id: FileId) -> QueryResult<Arc<DocumentedModule>> {
         self.query(
             QueryKey::Documented(id),
@@ -1002,6 +1030,12 @@ impl QueryProxy for QueryEngine {
 
     fn module_file(&self, name: &str) -> Option<FileId> {
         QueryEngine::module_file(self, name)
+    }
+}
+
+impl nbe::ExternalQueries for QueryEngine {
+    fn nbe(&self, file_id: FileId) -> QueryResult<nbe::ModuleResult<Arc<nbe::tree::Module>>> {
+        QueryEngine::nbe(self, file_id)
     }
 }
 
@@ -1341,6 +1375,85 @@ mod tests {
         let index_a = engine.indexed(id).unwrap();
         let index_b = engine.indexed(id).unwrap();
         assert!(Arc::ptr_eq(&index_a, &index_b));
+    }
+
+    #[test]
+    fn test_backend_queries_cache_and_invalidate() {
+        let mut engine = QueryEngine::default();
+        let mut files = Files::default();
+        prim::configure(&mut engine, &mut files);
+
+        let main = files.insert("Main.purs", "module Main where\n\nlife = 42");
+        engine.set_content(main, files.content(main));
+        engine.set_module_file("Main", main);
+
+        let nbe_initial = engine.nbe(main).unwrap().unwrap();
+        let ssa_initial = engine.ssa(main).unwrap().unwrap();
+        let nbe_repeated = engine.nbe(main).unwrap().unwrap();
+        let ssa_repeated = engine.ssa(main).unwrap().unwrap();
+        assert!(Arc::ptr_eq(&nbe_initial, &nbe_repeated));
+        assert!(Arc::ptr_eq(&ssa_initial, &ssa_repeated));
+
+        {
+            let shard = engine.derived.nbe.shard(&main).read();
+            let DerivedState::Computed { dependencies, .. } = shard.get(&main).unwrap() else {
+                unreachable!("invariant violated: expected computed query");
+            };
+            assert!(dependencies.contains(&QueryKey::Indexed(main)));
+            assert!(dependencies.contains(&QueryKey::Lowered(main)));
+            assert!(dependencies.contains(&QueryKey::Grouped(main)));
+            assert!(dependencies.contains(&QueryKey::Checked(main)));
+        }
+        {
+            let shard = engine.derived.ssa.shard(&main).read();
+            let DerivedState::Computed { dependencies, .. } = shard.get(&main).unwrap() else {
+                unreachable!("invariant violated: expected computed query");
+            };
+            assert_eq!(dependencies.as_ref(), &[QueryKey::Nbe(main)]);
+        }
+
+        let unrelated = files.insert("Unrelated.purs", "module Unrelated where\n\nvalue = 1");
+        engine.set_content(unrelated, files.content(unrelated));
+        engine.set_module_file("Unrelated", unrelated);
+
+        let ssa_after_unrelated = engine.ssa(main).unwrap().unwrap();
+        let nbe_after_unrelated = engine.nbe(main).unwrap().unwrap();
+        assert!(Arc::ptr_eq(&nbe_initial, &nbe_after_unrelated));
+        assert!(Arc::ptr_eq(&ssa_initial, &ssa_after_unrelated));
+
+        engine.set_content(main, "module Main where\n\nlife = 43");
+
+        let ssa_changed = engine.ssa(main).unwrap().unwrap();
+        let nbe_changed = engine.nbe(main).unwrap().unwrap();
+        assert!(!Arc::ptr_eq(&nbe_initial, &nbe_changed));
+        assert!(!Arc::ptr_eq(&ssa_initial, &ssa_changed));
+        assert_ne!(nbe_initial, nbe_changed);
+        assert_ne!(ssa_initial, ssa_changed);
+    }
+
+    #[test]
+    fn test_backend_queries_invalidate_conversion_errors() {
+        let mut engine = QueryEngine::default();
+        let mut files = Files::default();
+        prim::configure(&mut engine, &mut files);
+
+        let main = files.insert("Main.purs", "module Main where\n\nlife = unknown");
+        engine.set_content(main, files.content(main));
+        engine.set_module_file("Main", main);
+
+        let nbe_error = engine.nbe(main).unwrap().unwrap_err();
+        assert!(matches!(nbe_error, nbe::ModuleError::Unsupported { .. }));
+
+        let ssa_error = engine.ssa(main).unwrap().unwrap_err();
+        assert!(matches!(
+            ssa_error,
+            ssa::ModuleError::Functional(nbe::ModuleError::Unsupported { .. })
+        ));
+
+        engine.set_content(main, "module Main where\n\nlife = 42");
+
+        engine.nbe(main).unwrap().unwrap();
+        engine.ssa(main).unwrap().unwrap();
     }
 
     #[test]

--- a/tests-integration/src/fixtures.rs
+++ b/tests-integration/src/fixtures.rs
@@ -43,9 +43,10 @@ pub fn backend(path: &Path) -> FixtureResult {
     };
 
     let checking_report = crate::generated::basic::report_checked(&engine, id);
-    let functional = nbe::convert_module(&engine, id)?;
-    let control_flow = ssa::convert_module(&functional)?;
-    let ssa_report = ssa::pretty::render(&control_flow);
+    let ssa_report = match engine.ssa(id)? {
+        Ok(module) => ssa::pretty::render(&module),
+        Err(error) => error.to_string(),
+    };
     let ssa_snapshot = format!("{file}.ssa");
 
     let mut settings = insta::Settings::clone_current();

--- a/tests-integration/tests/nbe.rs
+++ b/tests-integration/tests/nbe.rs
@@ -2,8 +2,10 @@ fn nbe(path: &std::path::Path) -> datatest_stable::Result<()> {
     let folder = path.parent().ok_or("fixture path has no parent")?;
     let (engine, _) = tests_integration::load_compiler(folder);
     let id = engine.module_file("Main").ok_or("fixture has no Main module")?;
-    let module = nbe::convert_module(&engine, id)?;
-    let report = nbe::pretty::render(&module);
+    let report = match engine.nbe(id)? {
+        Ok(module) => nbe::pretty::render(&module),
+        Err(error) => error.to_string(),
+    };
 
     let snapshot_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(folder);
     let mut settings = insta::Settings::clone_current();


### PR DESCRIPTION
## Summary

- add cached `Nbe(FileId)` and `Ssa(FileId)` build queries
- have SSA conversion request NbE through external queries plus `FileId`, preserving the engine dependency graph
- keep cancellation and cycles as outer, uncached `QueryResult` errors
- keep deterministic conversion failures as inner, cacheable `ModuleResult` errors
- make integration reporters snapshot inner module errors while propagating outer query failures

The two commits intentionally separate the query/module error boundary from build-engine caching.

## Stack

This is 4/7 in the backend stack, stacked on #345. The next layer is #347.

## Validation

```text
just format --check
just t backend
cargo check -p building -p nbe -p ssa --tests
cargo clippy -p building --lib -- -D warnings
cargo clippy -p nbe -p ssa -p tests-integration --tests -- -D warnings
```

`cargo clippy -p building --tests -- -D warnings` remains blocked by three pre-existing `needless_borrows_for_generic_args` warnings for upstream `&compute` test calls; the affected library and all stack-owned crates are clean with warnings denied.

Closes #330.
Closes #339.

Amp-Thread-ID: https://ampcode.com/threads/T-01a017ed-f360-749b-afbf-be62c075c317

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
