### PR TITLE
[backend] Expose NBE and SSA module surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,6 +1637,7 @@ dependencies = [
  "la-arena",
  "lowering",
  "pretty",
+ "resolving",
  "rustc-hash",
  "smol_str",
  "thiserror",

--- a/compiler-backend/nbe/Cargo.toml
+++ b/compiler-backend/nbe/Cargo.toml
@@ -12,6 +12,7 @@ itertools = "0.15.0"
 la-arena = "0.3.1"
 lowering = { version = "0.1.0", path = "../../compiler-core/lowering" }
 pretty = "0.12"
+resolving = { version = "0.1.0", path = "../../compiler-core/resolving" }
 rustc-hash = "2.1.3"
 smol_str = "0.3.5"
 thiserror = "2.0.20"

--- a/compiler-backend/nbe/src/convert.rs
+++ b/compiler-backend/nbe/src/convert.rs
@@ -8,7 +8,10 @@ use checking::evidence::{
 };
 use checking::tree as checking_tree;
 use files::FileId;
-use indexing::{DeriveItemId, IndexedTermItemKind, InstanceItemId, OrderedTermItemId, TermItemId};
+use indexing::{
+    DeriveItemId, IndexedTermItemKind, IndexedTypeItemKind, InstanceItemId, OrderedTermItemId,
+    TermItemId,
+};
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smol_str::{SmolStr, format_smolstr};
@@ -18,9 +21,10 @@ use crate::error::{ModuleError, ModuleResult, UnsupportedState};
 use crate::tree::{
     Binding, CaseAlternative, Declaration, DeclarationKind, Expression, ExpressionId,
     ExpressionKind, Field, FieldIdentity, Global, GlobalId, Guard, GuardedAlternative,
-    InstanceIdentity, Literal, LocalId, Module, Parameter, Pattern, PatternId, PatternKind,
-    RecordField, RecordPatternField, RecordUpdate, RecursiveGroupId, ReflectableEvidence,
-    ReflectableOrdering, Storage, SuperclassIdentity, SynthesizedEvidence,
+    IndirectModuleExports, InstanceIdentity, Literal, LocalId, Module, ModuleDependency,
+    ModuleSurface, Parameter, Pattern, PatternId, PatternKind, RecordField, RecordPatternField,
+    RecordUpdate, RecursiveGroupId, ReflectableEvidence, ReflectableOrdering, Storage,
+    SuperclassIdentity, SynthesizedEvidence,
 };
 
 type ConversionResult<T> = Result<T, ConversionError>;
@@ -64,11 +68,13 @@ fn convert_module_inner(
 struct Context<'c, Q> {
     queries: &'c Q,
     file_id: FileId,
+    module_name: SmolStr,
     indexed: Arc<indexing::IndexedModule>,
     lowered: Arc<lowering::LoweredModule>,
     checked: Arc<checking::CheckedModule>,
     recursive_groups: FxHashMap<TermItemId, RecursiveGroupId>,
     record_pun_names: FxHashMap<lowering::RecordPunId, SmolStr>,
+    dependencies: FxHashMap<FileId, SmolStr>,
 
     parameters: FxHashMap<BindingSource, Parameter>,
     next_local: u32,
@@ -82,6 +88,11 @@ where
     Q: checking::ExternalQueries,
 {
     fn new(queries: &'c Q, file_id: FileId) -> ConversionResult<Context<'c, Q>> {
+        let content = queries.content(file_id);
+        let (parsed, _) = queries.parsed(file_id)?;
+        let module_name = parsed
+            .module_name(&content)
+            .expect("invariant violated: checked module has no source module name");
         let indexed = queries.indexed(file_id)?;
         let lowered = queries.lowered(file_id)?;
         let grouped = queries.grouped(file_id)?;
@@ -115,11 +126,13 @@ where
         Ok(Context {
             queries,
             file_id,
+            module_name,
             indexed,
             lowered,
             checked,
             recursive_groups,
             record_pun_names,
+            dependencies: FxHashMap::default(),
 
             parameters: FxHashMap::default(),
             next_local: 0,
@@ -131,12 +144,16 @@ where
 }
 
 fn convert(mut context: Context<'_, impl checking::ExternalQueries>) -> ConversionResult<Module> {
+    let exported = context.queries.exported(context.file_id)?;
+    let RuntimeExports { local, surface } = runtime_exports(&mut context, &exported)?;
     let ordered_terms = context.indexed.items.ordered_terms().iter().copied();
     let ordered_terms = ordered_terms.collect_vec();
     let mut declarations = Vec::new();
     for item_id in ordered_terms {
         let declaration = match item_id {
-            OrderedTermItemId::Term(term_id) => term_declaration(&mut context, term_id)?,
+            OrderedTermItemId::Term(term_id) => {
+                term_declaration(&mut context, term_id, local.contains(&term_id))?
+            }
             OrderedTermItemId::Instance(instance_id) => {
                 Some(instance_declaration(&mut context, instance_id)?)
             }
@@ -146,50 +163,184 @@ fn convert(mut context: Context<'_, impl checking::ExternalQueries>) -> Conversi
         };
         declarations.extend(declaration);
     }
+    validate_runtime_exports(&context, &declarations, &surface)?;
+
+    let dependencies = context.dependencies.iter().map(|(&file_id, module_name)| {
+        ModuleDependency { file_id, module_name: SmolStr::clone(module_name) }
+    });
+    let mut dependencies = dependencies.collect_vec();
+    dependencies.sort_by(|left, right| {
+        left.module_name.cmp(&right.module_name).then_with(|| {
+            left.file_id.into_raw().into_u32().cmp(&right.file_id.into_raw().into_u32())
+        })
+    });
 
     Ok(Module {
         file_id: context.file_id,
+        name: context.module_name,
+        dependencies: dependencies.into(),
+        surface,
         declarations: declarations.into(),
         storage: context.storage,
     })
 }
 
+struct RuntimeExports {
+    local: FxHashSet<TermItemId>,
+    surface: ModuleSurface,
+}
+
+fn runtime_exports(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    exports: &resolving::ExportedModule,
+) -> ConversionResult<RuntimeExports> {
+    let mut local = FxHashSet::default();
+    for &term_id in exports.local.iter() {
+        let Some(global) = local_runtime_export(context, term_id)? else {
+            continue;
+        };
+        let GlobalId::Term(file_id, term_id) = global.id else {
+            unreachable!("invariant violated: resolved term export became an instance")
+        };
+        if file_id == context.file_id {
+            local.insert(term_id);
+        }
+    }
+
+    let mut indirect = Vec::new();
+    for exports in exports.indirect.iter() {
+        let mut globals = Vec::new();
+        for &term_id in exports.terms.iter() {
+            if let Some(global) = runtime_term_global(context, exports.file_id, term_id)? {
+                globals.push(global);
+            }
+        }
+        globals.sort_by(|left, right| left.item_name.cmp(&right.item_name));
+        if !globals.is_empty() {
+            indirect
+                .push(IndirectModuleExports { file_id: exports.file_id, globals: globals.into() });
+        }
+    }
+    indirect.sort_by(|left, right| {
+        context.dependencies[&left.file_id].cmp(&context.dependencies[&right.file_id]).then_with(
+            || left.file_id.into_raw().into_u32().cmp(&right.file_id.into_raw().into_u32()),
+        )
+    });
+
+    let surface = ModuleSurface { indirect: indirect.into() };
+    Ok(RuntimeExports { local, surface })
+}
+
+fn local_runtime_export(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    term_id: TermItemId,
+) -> ConversionResult<Option<Global>> {
+    let indexed = Arc::clone(&context.indexed);
+    if !matches!(indexed.items[term_id].kind, IndexedTermItemKind::Operator { .. }) {
+        return runtime_term_global(context, context.file_id, term_id);
+    }
+
+    let resolution = context.lowered.tree.get_term_item_kind(term_id).and_then(|kind| match kind {
+        lowering::TermItemKind::Operator { resolution, .. } => *resolution,
+        _ => None,
+    });
+    let Some((file_id, term_id)) = resolution else {
+        let state = UnsupportedState::MissingRuntimeExportOperatorResolution { term_id };
+        return Err(context.unsupported(state));
+    };
+    if file_id != context.file_id {
+        return Ok(None);
+    }
+    runtime_term_global(context, file_id, term_id)
+}
+
+fn runtime_term_global(
+    context: &mut Context<'_, impl checking::ExternalQueries>,
+    file_id: FileId,
+    term_id: TermItemId,
+) -> ConversionResult<Option<Global>> {
+    let indexed = context.indexed_module(file_id)?;
+    match &indexed.items[term_id].kind {
+        IndexedTermItemKind::Value { .. } | IndexedTermItemKind::Foreign { .. } => {
+            Ok(Some(context.term_global(file_id, term_id)?))
+        }
+        IndexedTermItemKind::Constructor { .. } => {
+            if context.constructor_is_newtype(file_id, term_id)? {
+                Ok(None)
+            } else {
+                Ok(Some(context.term_global(file_id, term_id)?))
+            }
+        }
+        IndexedTermItemKind::ClassMember { .. } | IndexedTermItemKind::Operator { .. } => Ok(None),
+    }
+}
+
+fn validate_runtime_exports(
+    context: &Context<'_, impl checking::ExternalQueries>,
+    declarations: &[Declaration],
+    surface: &ModuleSurface,
+) -> ConversionResult<()> {
+    let local = declarations.iter().filter(|declaration| declaration.exported);
+    let local = local.map(|declaration| &declaration.global);
+    let indirect = surface.indirect.iter().flat_map(|exports| exports.globals.iter());
+    let globals = local.chain(indirect);
+    let mut names = FxHashMap::default();
+    for global in globals {
+        if let Some(existing) = names.insert(SmolStr::clone(&global.item_name), global.id)
+            && existing != global.id
+        {
+            let state = UnsupportedState::ConflictingRuntimeExport {
+                name: global.item_name.to_string(),
+                existing,
+                duplicate: global.id,
+            };
+            return Err(context.unsupported(state));
+        }
+    }
+    Ok(())
+}
+
 fn term_declaration(
     context: &mut Context<'_, impl checking::ExternalQueries>,
     term_id: TermItemId,
+    exported: bool,
 ) -> ConversionResult<Option<Declaration>> {
     let indexed_module = Arc::clone(&context.indexed);
     let checked = Arc::clone(&context.checked);
     let indexed = &indexed_module.items[term_id];
-    match indexed.kind {
-        IndexedTermItemKind::Constructor { .. }
-        | IndexedTermItemKind::ClassMember { .. }
-        | IndexedTermItemKind::Operator { .. } => Ok(None),
-        IndexedTermItemKind::Foreign { .. } | IndexedTermItemKind::Value { .. } => {
-            let declaration_id = checked.tree.lookup_term(term_id).ok_or_else(|| {
-                context.unsupported(UnsupportedState::MissingTermDeclaration(term_id))
-            })?;
-            let declaration = &checked.tree[declaration_id];
-            let name = if let Some(name) = &indexed.name {
-                name.clone()
-            } else {
-                context.term_fallback(term_id)
-            };
-            let global = Global { id: GlobalId::Term(context.file_id, term_id), name };
-            let recursive_group = context.recursive_groups.get(&term_id).copied();
-            let kind = match &declaration.kind {
-                checking_tree::TermDeclarationKind::Value(value) => {
-                    DeclarationKind::Value(value_declaration(context, value)?)
-                }
-                checking_tree::TermDeclarationKind::Foreign => DeclarationKind::Foreign,
-                checking_tree::TermDeclarationKind::Constructor(_) => return Ok(None),
-                checking_tree::TermDeclarationKind::Instance(_) => {
-                    unreachable!("invariant violated: instance stored as a term declaration")
-                }
-            };
-            Ok(Some(Declaration { global, recursive_group, kind }))
-        }
+    if matches!(
+        indexed.kind,
+        IndexedTermItemKind::ClassMember { .. } | IndexedTermItemKind::Operator { .. }
+    ) {
+        return Ok(None);
     }
+    let declaration_id = checked
+        .tree
+        .lookup_term(term_id)
+        .ok_or_else(|| context.unsupported(UnsupportedState::MissingTermDeclaration(term_id)))?;
+    let declaration = &checked.tree[declaration_id];
+    let item_name = match &indexed.name {
+        Some(name) => SmolStr::clone(name),
+        None => context.term_fallback(term_id),
+    };
+    let global = Global { id: GlobalId::Term(context.file_id, term_id), item_name };
+    let recursive_group = context.recursive_groups.get(&term_id).copied();
+    let kind = match &declaration.kind {
+        checking_tree::TermDeclarationKind::Value(value) => {
+            DeclarationKind::Value(value_declaration(context, value)?)
+        }
+        checking_tree::TermDeclarationKind::Foreign => DeclarationKind::Foreign,
+        checking_tree::TermDeclarationKind::Constructor(constructor) => {
+            if context.constructor_is_newtype(context.file_id, term_id)? {
+                return Ok(None);
+            }
+            DeclarationKind::Constructor { arity: constructor.arguments.len() }
+        }
+        checking_tree::TermDeclarationKind::Instance(_) => {
+            unreachable!("invariant violated: instance stored as a term declaration")
+        }
+    };
+    Ok(Some(Declaration { global, exported, recursive_group, kind }))
 }
 
 fn instance_declaration(
@@ -257,10 +408,10 @@ fn convert_instance_declaration(
         }
     };
     let value = context.parameter_abstraction(parameters, body);
-    let name = context.instance_name(identity)?;
-    let global = Global { id: GlobalId::Instance(identity), name };
+    let item_name = context.instance_name(identity)?;
+    let global = Global { id: GlobalId::Instance(identity), item_name };
     let kind = DeclarationKind::Value(value);
-    Ok(Declaration { global, recursive_group: None, kind })
+    Ok(Declaration { global, exported: true, recursive_group: None, kind })
 }
 
 fn member_declaration(
@@ -475,7 +626,14 @@ fn convert_expression(
             ExpressionKind::RecordUpdate { record, updates: updates.into() }
         }
         checking_tree::ExpressionKind::Constructor { resolution } => {
-            ExpressionKind::Constructor { global: context.term_global(resolution.0, resolution.1)? }
+            let &(file_id, term_id) = resolution;
+            if context.constructor_is_newtype(file_id, term_id)? {
+                let parameter = context.fresh_parameter("value".into())?;
+                let body =
+                    context.expression(ExpressionKind::Local { parameter: parameter.clone() });
+                return Ok(context.parameter_abstraction([parameter], body));
+            }
+            ExpressionKind::Constructor { global: context.term_global(file_id, term_id)? }
         }
         checking_tree::ExpressionKind::Variable { resolution }
         | checking_tree::ExpressionKind::RecordPun { resolution, .. } => {
@@ -659,8 +817,15 @@ fn convert_pattern(
             PatternKind::Record(converted.into())
         }
         checking_tree::BinderKind::Constructor { resolution, arguments } => {
+            let &(file_id, term_id) = resolution;
+            if context.constructor_is_newtype(file_id, term_id)? {
+                let [argument] = arguments.as_ref() else {
+                    return Err(context.unsupported(UnsupportedState::BinderError(binder_id)));
+                };
+                return convert_pattern(context, *argument);
+            }
             PatternKind::Constructor {
-                global: context.term_global(resolution.0, resolution.1)?,
+                global: context.term_global(file_id, term_id)?,
                 arguments: patterns(context, arguments)?.into(),
             }
         }
@@ -938,12 +1103,16 @@ where
     }
 
     fn label_field(&self, label: SmolStr) -> Field {
-        Field { identity: FieldIdentity::Label(label.clone()), name: label }
+        Field { identity: FieldIdentity::Label(SmolStr::clone(&label)), name: label }
     }
 
-    fn member_field(&self, resolution: (FileId, TermItemId)) -> QueryResult<Field> {
-        let global = self.term_global_readonly(resolution.0, resolution.1)?;
-        Ok(Field { identity: FieldIdentity::Member(resolution.0, resolution.1), name: global.name })
+    fn member_field(&self, (file_id, term_id): (FileId, TermItemId)) -> QueryResult<Field> {
+        let indexed = self.indexed_module(file_id)?;
+        let name = match &indexed.items[term_id].name {
+            Some(name) => SmolStr::clone(name),
+            None => self.term_fallback(term_id),
+        };
+        Ok(Field { identity: FieldIdentity::Member(file_id, term_id), name })
     }
 
     fn superclass_field(&self, superclass: checking::evidence::SuperclassId) -> Field {
@@ -956,33 +1125,69 @@ where
         Field { identity: FieldIdentity::Superclass(identity), name }
     }
 
-    fn term_global(&self, file_id: FileId, term_id: TermItemId) -> ConversionResult<Global> {
-        Ok(self.term_global_readonly(file_id, term_id)?)
+    fn source_module_name(&self, file_id: FileId) -> QueryResult<SmolStr> {
+        if file_id == self.file_id {
+            return Ok(SmolStr::clone(&self.module_name));
+        }
+        let content = self.queries.content(file_id);
+        let (parsed, _) = self.queries.parsed(file_id)?;
+        let name = parsed
+            .module_name(&content)
+            .expect("invariant violated: referenced checked module has no source module name");
+        Ok(name)
     }
 
-    fn term_global_readonly(&self, file_id: FileId, term_id: TermItemId) -> QueryResult<Global> {
-        let indexed = if file_id == self.file_id {
-            Arc::clone(&self.indexed)
+    fn indexed_module(&self, file_id: FileId) -> QueryResult<Arc<indexing::IndexedModule>> {
+        if file_id == self.file_id {
+            Ok(Arc::clone(&self.indexed))
         } else {
-            self.queries.indexed(file_id)?
-        };
-        let name = if let Some(name) = &indexed.items[term_id].name {
-            name.clone()
+            self.queries.indexed(file_id)
+        }
+    }
+
+    fn term_global(&mut self, file_id: FileId, term_id: TermItemId) -> ConversionResult<Global> {
+        let indexed = self.indexed_module(file_id)?;
+        let item_name = if let Some(name) = &indexed.items[term_id].name {
+            SmolStr::clone(name)
         } else {
             self.term_fallback(term_id)
         };
-        Ok(Global { id: GlobalId::Term(file_id, term_id), name })
+        self.register_dependency(file_id)?;
+        Ok(Global { id: GlobalId::Term(file_id, term_id), item_name })
     }
 
-    fn instance_global(&self, origin: InstanceCandidateOrigin) -> ConversionResult<Global> {
+    fn constructor_is_newtype(&self, file_id: FileId, term_id: TermItemId) -> QueryResult<bool> {
+        let indexed = self.indexed_module(file_id)?;
+        let Some(type_id) = indexed.constructor_type(term_id) else {
+            return Ok(false);
+        };
+        Ok(matches!(indexed.items[type_id].kind, IndexedTypeItemKind::Newtype { .. }))
+    }
+
+    fn instance_global(&mut self, origin: InstanceCandidateOrigin) -> ConversionResult<Global> {
         let identity = match origin {
             InstanceCandidateOrigin::Instance(file_id, id) => {
                 InstanceIdentity::Declared(file_id, id)
             }
             InstanceCandidateOrigin::Derive(file_id, id) => InstanceIdentity::Derived(file_id, id),
         };
-        let name = self.instance_name(identity)?;
-        Ok(Global { id: GlobalId::Instance(identity), name })
+        let item_name = self.instance_name(identity)?;
+        let file_id = match identity {
+            InstanceIdentity::Declared(file_id, _) | InstanceIdentity::Derived(file_id, _) => {
+                file_id
+            }
+        };
+        self.register_dependency(file_id)?;
+        Ok(Global { id: GlobalId::Instance(identity), item_name })
+    }
+
+    fn register_dependency(&mut self, file_id: FileId) -> QueryResult<()> {
+        if file_id == self.file_id || self.dependencies.contains_key(&file_id) {
+            return Ok(());
+        }
+        let module_name = self.source_module_name(file_id)?;
+        self.dependencies.insert(file_id, module_name);
+        Ok(())
     }
 
     fn instance_name(&self, identity: InstanceIdentity) -> QueryResult<SmolStr> {

--- a/compiler-backend/nbe/src/error.rs
+++ b/compiler-backend/nbe/src/error.rs
@@ -4,6 +4,8 @@ use files::FileId;
 use indexing::TermItemId;
 use thiserror::Error;
 
+use crate::tree::GlobalId;
+
 pub type ModuleResult<T> = Result<T, ModuleError>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -36,6 +38,12 @@ pub enum UnsupportedState {
     MissingLocalDeclaration(lowering::LetBindingNameGroupId),
     #[error("checked value declaration has no equations")]
     MissingEquation,
+    #[error(
+        "runtime export name {name:?} refers to conflicting globals {existing:?} and {duplicate:?}"
+    )]
+    ConflictingRuntimeExport { name: String, existing: GlobalId, duplicate: GlobalId },
+    #[error("exported operator {term_id:?} has no runtime resolution")]
+    MissingRuntimeExportOperatorResolution { term_id: TermItemId },
     #[error("instance prerequisite is not represented by given evidence")]
     InvalidInstancePrerequisite,
     #[error("local identity space is exhausted")]

--- a/compiler-backend/nbe/src/pretty.rs
+++ b/compiler-backend/nbe/src/pretty.rs
@@ -4,8 +4,8 @@ use pretty::{Arena, DocAllocator, DocBuilder};
 
 use crate::tree::{
     Declaration, DeclarationKind, EffectExpression, ExpressionId, ExpressionKind, Field, GlobalId,
-    Guard, Literal, Module, Parameter, PatternId, PatternKind, RecordUpdate, ReflectableEvidence,
-    ReflectableOrdering, SynthesizedEvidence,
+    Guard, IndirectModuleExports, Literal, Module, Parameter, PatternId, PatternKind, RecordUpdate,
+    ReflectableEvidence, ReflectableOrdering, SynthesizedEvidence,
 };
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
@@ -15,10 +15,12 @@ const DEFAULT_WIDTH: usize = 100;
 pub fn render(module: &Module) -> String {
     let arena = Arena::new();
     let printer = Printer { arena: &arena, module };
+    let indirect = module.surface.indirect.iter().map(|exports| printer.indirect_exports(exports));
     let declarations =
         module.declarations.iter().map(|declaration| printer.declaration(declaration));
+    let documents = indirect.chain(declarations);
     let declaration_separator = arena.hardline().append(arena.hardline());
-    let document = arena.intersperse(declarations, declaration_separator);
+    let document = arena.intersperse(documents, declaration_separator);
     let mut output = String::new();
     document
         .render_fmt(DEFAULT_WIDTH, &mut output)
@@ -32,10 +34,30 @@ struct Printer<'a, 'm> {
 }
 
 impl<'a> Printer<'a, '_> {
+    fn indirect_exports(&self, exports: &IndirectModuleExports) -> Doc<'a> {
+        let dependency = self
+            .module
+            .dependencies
+            .iter()
+            .find(|dependency| dependency.file_id == exports.file_id)
+            .expect("invariant violated: indirect exports have no module dependency");
+        let globals =
+            exports.globals.iter().map(|global| self.arena.text(global.item_name.to_string()));
+        let globals = self.arena.intersperse(globals, ", ");
+        self.arena
+            .text(format!("@export {} {{ ", dependency.module_name))
+            .append(globals)
+            .append(" }")
+    }
+
     fn declaration(&self, declaration: &Declaration) -> Doc<'a> {
-        let name = &declaration.global.name;
+        let name = &declaration.global.item_name;
+        let export = if declaration.exported { "@export " } else { "" };
         match declaration.kind {
-            DeclarationKind::Foreign => self.arena.text(format!("foreign {name}")),
+            DeclarationKind::Foreign => self.arena.text(format!("{export}foreign {name}")),
+            DeclarationKind::Constructor { arity } => {
+                self.arena.text(format!("{export}constructor {name}/{arity}"))
+            }
             DeclarationKind::Value(expression) => {
                 let prefix = match declaration.global.id {
                     GlobalId::Term(..) => "",
@@ -45,7 +67,7 @@ impl<'a> Printer<'a, '_> {
                     .recursive_group
                     .map(|group| format!("recursive[{}] ", group.0))
                     .unwrap_or_default();
-                let declaration = self.arena.text(format!("{prefix}{recursion}{name} ="));
+                let declaration = self.arena.text(format!("{export}{prefix}{recursion}{name} ="));
                 let expression = self.expression(expression);
                 declaration.append(self.arena.space()).append(expression)
             }
@@ -112,7 +134,7 @@ impl<'a> Printer<'a, '_> {
                 record.append(self.arena.text(format!(".{field}")))
             }
             ExpressionKind::Constructor { global } | ExpressionKind::Global { global } => {
-                self.arena.text(global.name.to_string())
+                self.arena.text(global.item_name.to_string())
             }
             ExpressionKind::Local { parameter } => self.parameter(parameter),
             ExpressionKind::Abstraction { parameters, body } => {
@@ -247,7 +269,7 @@ impl<'a> Printer<'a, '_> {
                     .map(|argument| self.pattern_at(*argument, PatternPrecedence::Atom));
                 let arguments = arguments.map(|argument| self.arena.space().append(argument));
                 let arguments = self.arena.concat(arguments);
-                self.arena.text(global.name.to_string()).append(arguments)
+                self.arena.text(global.item_name.to_string()).append(arguments)
             }
         };
         if precedence < required_precedence {

--- a/compiler-backend/nbe/src/tree.rs
+++ b/compiler-backend/nbe/src/tree.rs
@@ -15,8 +15,28 @@ pub type PatternId = Idx<Pattern>;
 #[derive(Debug, PartialEq, Eq)]
 pub struct Module {
     pub file_id: FileId,
+    pub name: SmolStr,
+    pub dependencies: Arc<[ModuleDependency]>,
+    pub surface: ModuleSurface,
     pub declarations: Arc<[Declaration]>,
     pub storage: Storage,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ModuleSurface {
+    pub indirect: Arc<[IndirectModuleExports]>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct IndirectModuleExports {
+    pub file_id: FileId,
+    pub globals: Arc<[Global]>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ModuleDependency {
+    pub file_id: FileId,
+    pub module_name: SmolStr,
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -62,6 +82,7 @@ impl Index<PatternId> for Storage {
 #[derive(Debug, PartialEq, Eq)]
 pub struct Declaration {
     pub global: Global,
+    pub exported: bool,
     pub recursive_group: Option<RecursiveGroupId>,
     pub kind: DeclarationKind,
 }
@@ -69,13 +90,14 @@ pub struct Declaration {
 #[derive(Debug, PartialEq, Eq)]
 pub enum DeclarationKind {
     Value(ExpressionId),
+    Constructor { arity: usize },
     Foreign,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Global {
     pub id: GlobalId,
-    pub name: SmolStr,
+    pub item_name: SmolStr,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/compiler-backend/ssa/src/convert.rs
+++ b/compiler-backend/ssa/src/convert.rs
@@ -11,10 +11,11 @@ use smol_str::{SmolStr, format_smolstr};
 use crate::error::{ModuleError, ModuleResult, UnsupportedState};
 use crate::tree::{
     Block, BlockId, BlockTarget, CallingConvention, Declaration, DeclarationKind, Failure, Field,
-    FieldIdentity, Function, FunctionId, Global, GlobalIdentity, InstanceIdentity, Instruction,
-    InstructionValue, Literal, Module, PatternTest, Projection, RecordField, RecordUpdate,
-    RecursiveClosure, RecursiveGroupId, ReflectableEvidence, ReflectableOrdering, Storage,
-    SuperclassIdentity, SynthesizedEvidence, Terminator, Value, ValueId,
+    FieldIdentity, Function, FunctionId, Global, GlobalIdentity, IndirectModuleExports,
+    InstanceIdentity, Instruction, InstructionValue, Literal, Module, ModuleDependency,
+    ModuleSurface, PatternTest, Projection, RecordField, RecordUpdate, RecursiveClosure,
+    RecursiveGroupId, ReflectableEvidence, ReflectableOrdering, Storage, SuperclassIdentity,
+    SynthesizedEvidence, Terminator, Value, ValueId,
 };
 
 type ConversionResult<T> = ModuleResult<T>;
@@ -36,8 +37,22 @@ fn convert(functional: &nbe::tree::Module) -> ConversionResult<Module> {
     for declaration in functional.declarations.iter() {
         convert_declaration(&mut state, &context, declaration)?;
     }
+    let dependencies = functional.dependencies.iter().map(|dependency| ModuleDependency {
+        file_id: dependency.file_id,
+        module_name: SmolStr::clone(&dependency.module_name),
+    });
+    let dependencies = dependencies.collect_vec();
+    let indirect = functional.surface.indirect.iter().map(|exports| {
+        let globals = exports.globals.iter().map(convert_global);
+        let globals = globals.collect_vec();
+        IndirectModuleExports { file_id: exports.file_id, globals: globals.into() }
+    });
+    let indirect = indirect.collect_vec();
     Ok(Module {
         file_id: functional.file_id,
+        name: SmolStr::clone(&functional.name),
+        dependencies: dependencies.into(),
+        surface: ModuleSurface { indirect: indirect.into() },
         declarations: state.output.declarations.into(),
         storage: state.output.storage,
     })
@@ -113,14 +128,14 @@ fn convert_declaration(
                 let built = build_function(
                     state,
                     context,
-                    global.name.clone(),
+                    SmolStr::clone(&global.item_name),
                     CallingConvention::Source,
                     parameters,
                     *body,
                 )?;
                 DeclarationKind::Function { function: built.function }
             } else {
-                let name = format_smolstr!("{}$initialize", global.name);
+                let name = format_smolstr!("{}$initialize", global.item_name);
                 let built = build_function(
                     state,
                     context,
@@ -132,9 +147,15 @@ fn convert_declaration(
                 DeclarationKind::Value { initializer: built.function }
             }
         }
+        nbe::tree::DeclarationKind::Constructor { arity } => DeclarationKind::Constructor { arity },
         nbe::tree::DeclarationKind::Foreign => DeclarationKind::Foreign,
     };
-    state.output.declarations.push(Declaration { global, recursive_group, kind });
+    state.output.declarations.push(Declaration {
+        global,
+        exported: declaration.exported,
+        recursive_group,
+        kind,
+    });
     Ok(())
 }
 
@@ -267,12 +288,12 @@ fn lower_expression(
         }
         nbe::tree::ExpressionKind::Constructor { global } => {
             let global = convert_global(global);
-            let name = global.name.clone();
+            let name = SmolStr::clone(&global.item_name);
             Ok(state.emit(name, InstructionValue::Constructor { global }))
         }
         nbe::tree::ExpressionKind::Global { global } => {
             let global = convert_global(global);
-            let name = global.name.clone();
+            let name = SmolStr::clone(&global.item_name);
             Ok(state.emit(name, InstructionValue::Global { global }))
         }
         nbe::tree::ExpressionKind::Local { parameter } => state.lookup_local(context, parameter),
@@ -967,7 +988,7 @@ fn convert_global(global: &nbe::tree::Global) -> Global {
             GlobalIdentity::Instance { identity: convert_instance_identity(identity) }
         }
     };
-    Global { identity, name: global.name.clone() }
+    Global { identity, item_name: SmolStr::clone(&global.item_name) }
 }
 
 fn convert_instance_identity(identity: nbe::tree::InstanceIdentity) -> InstanceIdentity {

--- a/compiler-backend/ssa/src/pretty.rs
+++ b/compiler-backend/ssa/src/pretty.rs
@@ -6,9 +6,9 @@ use rustc_hash::FxHashSet;
 
 use crate::tree::{
     Block, BlockTarget, CallingConvention, Declaration, DeclarationKind, Failure, Field, Function,
-    Global, Instruction, InstructionValue, Literal, Module, PatternTest, Projection, RecordUpdate,
-    RecursiveClosure, ReflectableEvidence, ReflectableOrdering, SynthesizedEvidence, Terminator,
-    ValueId,
+    Global, GlobalIdentity, IndirectModuleExports, Instruction, InstructionValue, Literal, Module,
+    PatternTest, Projection, RecordUpdate, RecursiveClosure, ReflectableEvidence,
+    ReflectableOrdering, SynthesizedEvidence, Terminator, ValueId,
 };
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
@@ -22,7 +22,7 @@ pub fn render(module: &Module) -> String {
         module.declarations.iter().filter_map(|declaration| match declaration.kind {
             DeclarationKind::Function { function } => Some(function),
             DeclarationKind::Value { initializer } => Some(initializer),
-            DeclarationKind::Foreign => None,
+            DeclarationKind::Constructor { .. } | DeclarationKind::Foreign => None,
         });
     let root_functions = root_functions.collect::<FxHashSet<_>>();
 
@@ -33,7 +33,8 @@ pub fn render(module: &Module) -> String {
         .functions()
         .filter(|(function, _)| !root_functions.contains(function))
         .map(|(_, function)| printer.nested_function(function));
-    let documents = declarations.chain(nested_functions);
+    let indirect = module.surface.indirect.iter().map(|exports| printer.indirect_exports(exports));
+    let documents = indirect.chain(declarations).chain(nested_functions);
     let separator = arena.hardline().append(arena.hardline());
     let document = arena.intersperse(documents, separator);
 
@@ -50,7 +51,29 @@ struct Printer<'a, 'm> {
 }
 
 impl<'a> Printer<'a, '_> {
+    fn indirect_exports(&self, exports: &IndirectModuleExports) -> Doc<'a> {
+        let dependency = self
+            .module
+            .dependencies
+            .iter()
+            .find(|dependency| dependency.file_id == exports.file_id)
+            .expect("invariant violated: indirect exports have no module dependency");
+        let globals =
+            exports.globals.iter().map(|global| self.arena.text(global.item_name.to_string()));
+        let globals = self.arena.intersperse(globals, ", ");
+        self.arena
+            .text(format!("@export {} {{ ", dependency.module_name))
+            .append(globals)
+            .append(" }")
+    }
+
     fn declaration(&self, declaration: &Declaration) -> Doc<'a> {
+        let export = if declaration.exported { "@export " } else { "" };
+        let instance = if matches!(declaration.global.identity, GlobalIdentity::Instance { .. }) {
+            "instance "
+        } else {
+            ""
+        };
         let recursion = declaration
             .recursive_group
             .map(|group| format!("recursive[{}] ", group.index))
@@ -61,20 +84,29 @@ impl<'a> Printer<'a, '_> {
                 let parameters = self.values(&function.parameters);
                 let header = self
                     .arena
-                    .text(format!("{recursion}function {}", declaration.global.name))
+                    .text(format!(
+                        "{export}{instance}{recursion}function {}",
+                        declaration.global.item_name
+                    ))
                     .append(self.parenthesized(parameters));
                 self.function_body(header, function)
             }
             DeclarationKind::Value { initializer } => {
                 let function = &self.module.storage[initializer];
-                let header = self
-                    .arena
-                    .text(format!("{recursion}const {} = initialize", declaration.global.name));
+                let header = self.arena.text(format!(
+                    "{export}{instance}{recursion}const {} = initialize",
+                    declaration.global.item_name
+                ));
                 self.function_body(header, function)
             }
-            DeclarationKind::Foreign => {
-                self.arena.text(format!("{recursion}foreign const {};", declaration.global.name))
-            }
+            DeclarationKind::Constructor { arity } => self.arena.text(format!(
+                "{export}{instance}{recursion}constructor {}/{arity};",
+                declaration.global.item_name
+            )),
+            DeclarationKind::Foreign => self.arena.text(format!(
+                "{export}{instance}{recursion}foreign const {};",
+                declaration.global.item_name
+            )),
         }
     }
 
@@ -355,7 +387,7 @@ impl<'a> Printer<'a, '_> {
     }
 
     fn global(&self, global: &Global) -> Doc<'a> {
-        self.arena.text(global.name.to_string())
+        self.arena.text(global.item_name.to_string())
     }
 
     fn field(&self, field: &Field) -> String {

--- a/compiler-backend/ssa/src/tree.rs
+++ b/compiler-backend/ssa/src/tree.rs
@@ -16,8 +16,28 @@ pub type ValueId = Idx<Value>;
 #[derive(Debug, PartialEq, Eq)]
 pub struct Module {
     pub file_id: FileId,
+    pub name: SmolStr,
+    pub dependencies: Arc<[ModuleDependency]>,
+    pub surface: ModuleSurface,
     pub declarations: Arc<[Declaration]>,
     pub storage: Storage,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ModuleSurface {
+    pub indirect: Arc<[IndirectModuleExports]>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct IndirectModuleExports {
+    pub file_id: FileId,
+    pub globals: Arc<[Global]>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ModuleDependency {
+    pub file_id: FileId,
+    pub module_name: SmolStr,
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -88,6 +108,7 @@ impl Index<ValueId> for Storage {
 #[derive(Debug, PartialEq, Eq)]
 pub struct Declaration {
     pub global: Global,
+    pub exported: bool,
     pub recursive_group: Option<RecursiveGroupId>,
     pub kind: DeclarationKind,
 }
@@ -96,13 +117,14 @@ pub struct Declaration {
 pub enum DeclarationKind {
     Function { function: FunctionId },
     Value { initializer: FunctionId },
+    Constructor { arity: usize },
     Foreign,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Global {
     pub identity: GlobalIdentity,
-    pub name: SmolStr,
+    pub item_name: SmolStr,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/compiler-core/building-types/src/lib.rs
+++ b/compiler-core/building-types/src/lib.rs
@@ -16,6 +16,7 @@ pub enum QueryKey {
     Lowered(FileId),
     Grouped(FileId),
     Resolved(FileId),
+    Exported(FileId),
     Bracketed(FileId),
     Sectioned(FileId),
     CheckedCore,
@@ -42,6 +43,7 @@ pub trait QueryProxy {
     type Lowered;
     type Grouped;
     type Resolved;
+    type Exported;
     type Bracketed;
     type Sectioned;
     type Checked;
@@ -60,6 +62,8 @@ pub trait QueryProxy {
     fn grouped(&self, id: FileId) -> QueryResult<Self::Grouped>;
 
     fn resolved(&self, id: FileId) -> QueryResult<Self::Resolved>;
+
+    fn exported(&self, id: FileId) -> QueryResult<Self::Exported>;
 
     fn bracketed(&self, id: FileId) -> QueryResult<Self::Bracketed>;
 

--- a/compiler-core/building/src/engine.rs
+++ b/compiler-core/building/src/engine.rs
@@ -44,7 +44,7 @@ use lowering::{GroupedModule, LoweredModule};
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use parsing::FullParsedModule;
 use promise::{Future, Promise};
-use resolving::ResolvedModule;
+use resolving::{ExportedModule, ResolvedModule};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use stabilizing::StabilizedModule;
 use thread_local::ThreadLocal;
@@ -128,6 +128,7 @@ struct DerivedStorage {
     lowered: Shards<FileId, DerivedState<Arc<LoweredModule>>>,
     grouped: Shards<FileId, DerivedState<Arc<GroupedModule>>>,
     resolved: Shards<FileId, DerivedState<Arc<ResolvedModule>>>,
+    exported: Shards<FileId, DerivedState<Arc<ExportedModule>>>,
     bracketed: Shards<FileId, DerivedState<Arc<sugar::Bracketed>>>,
     sectioned: Shards<FileId, DerivedState<Arc<sugar::Sectioned>>>,
     checked_core: Shards<(), DerivedState<Arc<checking::context::CheckedCore>>>,
@@ -502,6 +503,7 @@ impl QueryEngine {
                 QueryKey::Lowered(k) => derived_changed!(lowered, k),
                 QueryKey::Grouped(k) => derived_changed!(grouped, k),
                 QueryKey::Resolved(k) => derived_changed!(resolved, k),
+                QueryKey::Exported(k) => derived_changed!(exported, k),
                 QueryKey::Bracketed(k) => derived_changed!(bracketed, k),
                 QueryKey::Sectioned(k) => derived_changed!(sectioned, k),
                 QueryKey::CheckedCore => {
@@ -863,6 +865,19 @@ impl QueryEngine {
         )
     }
 
+    pub fn exported(&self, id: FileId) -> QueryResult<Arc<ExportedModule>> {
+        self.query(
+            QueryKey::Exported(id),
+            id,
+            |derived| &derived.exported,
+            |this| {
+                let resolved = this.resolved(id)?;
+                let exported = resolving::export_module(&resolved);
+                Ok(Arc::new(exported))
+            },
+        )
+    }
+
     pub fn bracketed(&self, id: FileId) -> QueryResult<Arc<sugar::Bracketed>> {
         self.query(
             QueryKey::Bracketed(id),
@@ -972,6 +987,8 @@ impl QueryProxy for QueryEngine {
 
     type Resolved = Arc<ResolvedModule>;
 
+    type Exported = Arc<ExportedModule>;
+
     type Bracketed = Arc<sugar::Bracketed>;
 
     type Sectioned = Arc<sugar::Sectioned>;
@@ -1006,6 +1023,10 @@ impl QueryProxy for QueryEngine {
 
     fn resolved(&self, id: FileId) -> QueryResult<Self::Resolved> {
         QueryEngine::resolved(self, id)
+    }
+
+    fn exported(&self, id: FileId) -> QueryResult<Self::Exported> {
+        QueryEngine::exported(self, id)
     }
 
     fn bracketed(&self, id: FileId) -> QueryResult<Self::Bracketed> {
@@ -1399,6 +1420,7 @@ mod tests {
             let DerivedState::Computed { dependencies, .. } = shard.get(&main).unwrap() else {
                 unreachable!("invariant violated: expected computed query");
             };
+            assert!(dependencies.contains(&QueryKey::Exported(main)));
             assert!(dependencies.contains(&QueryKey::Indexed(main)));
             assert!(dependencies.contains(&QueryKey::Lowered(main)));
             assert!(dependencies.contains(&QueryKey::Grouped(main)));
@@ -2077,6 +2099,31 @@ mod tests {
         let groups_a = engine.grouped(id).unwrap();
         let groups_b = engine.grouped(id).unwrap();
         assert!(Arc::ptr_eq(&groups_a, &groups_b));
+    }
+
+    #[test]
+    fn test_exported_identity() {
+        let mut engine = QueryEngine::default();
+        let mut files = Files::default();
+        prim::configure(&mut engine, &mut files);
+
+        let id = files.insert("./src/Main.purs", "module Main (x) where\n\nx = 1\ny = 2");
+        let content = files.content(id);
+        engine.set_content(id, content);
+
+        let exported_a = engine.exported(id).unwrap();
+        let exported_b = engine.exported(id).unwrap();
+        assert!(Arc::ptr_eq(&exported_a, &exported_b));
+        let indexed = engine.indexed(id).unwrap();
+        let x = indexed.names.terms.lookup("x").unwrap();
+        assert_eq!(exported_a.local.as_ref(), &[x]);
+        assert!(exported_a.indirect.is_empty());
+
+        let shard = engine.derived.exported.shard(&id).read();
+        let DerivedState::Computed { dependencies, .. } = shard.get(&id).unwrap() else {
+            unreachable!("invariant violated: expected computed query");
+        };
+        assert_eq!(dependencies.as_ref(), &[QueryKey::Resolved(id)]);
     }
 
     #[test]

--- a/compiler-core/checking/src/lib.rs
+++ b/compiler-core/checking/src/lib.rs
@@ -39,6 +39,7 @@ pub trait ExternalQueries:
         Lowered = Arc<lowering::LoweredModule>,
         Grouped = Arc<lowering::GroupedModule>,
         Resolved = Arc<ResolvedModule>,
+        Exported = Arc<resolving::ExportedModule>,
         Bracketed = Arc<sugar::Bracketed>,
         Sectioned = Arc<sugar::Sectioned>,
         Checked = Arc<CheckedModule>,

--- a/compiler-core/resolving/src/lib.rs
+++ b/compiler-core/resolving/src/lib.rs
@@ -313,6 +313,41 @@ pub enum ExportSource {
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
+pub struct ExportedModule {
+    pub local: Arc<[TermItemId]>,
+    pub indirect: Arc<[IndirectExports]>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct IndirectExports {
+    pub file_id: FileId,
+    pub terms: Arc<[TermItemId]>,
+}
+
+pub fn export_module(module: &ResolvedModule) -> ExportedModule {
+    let mut local = Vec::new();
+    let mut indirect = FxHashMap::<FileId, Vec<TermItemId>>::default();
+    for &(file_id, term_id, source) in module.exports.terms.values() {
+        match source {
+            ExportSource::Local => local.push(term_id),
+            ExportSource::Import(_) => indirect.entry(file_id).or_default().push(term_id),
+        }
+    }
+
+    local.sort_by_key(|term_id| term_id.into_raw().into_u32());
+    local.dedup();
+    let indirect = indirect.into_iter().map(|(file_id, mut terms)| {
+        terms.sort_by_key(|term_id| term_id.into_raw().into_u32());
+        terms.dedup();
+        IndirectExports { file_id, terms: terms.into() }
+    });
+    let mut indirect = indirect.collect::<Vec<_>>();
+    indirect.sort_by_key(|exports| exports.file_id.into_raw().into_u32());
+
+    ExportedModule { local: local.into(), indirect: indirect.into() }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct ResolvedExports {
     terms: FxHashMap<SmolStr, (FileId, TermItemId, ExportSource)>,
     types: FxHashMap<SmolStr, (FileId, TypeItemId, ExportSource)>,

--- a/docs/src/wasm/src/engine.rs
+++ b/docs/src/wasm/src/engine.rs
@@ -11,7 +11,7 @@ use indexing::IndexedModule;
 use lowering::{GroupedModule, LoweredModule};
 use parsing::FullParsedModule;
 use prim_constants::MODULE_MAP;
-use resolving::ResolvedModule;
+use resolving::{ExportedModule, ResolvedModule};
 use rustc_hash::FxHashMap;
 use stabilizing::StabilizedModule;
 use url::Url;
@@ -30,6 +30,7 @@ struct DerivedStorage {
     lowered: FxHashMap<FileId, Arc<LoweredModule>>,
     grouped: FxHashMap<FileId, Arc<GroupedModule>>,
     resolved: FxHashMap<FileId, Arc<ResolvedModule>>,
+    exported: FxHashMap<FileId, Arc<ExportedModule>>,
     bracketed: FxHashMap<FileId, Arc<sugar::Bracketed>>,
     sectioned: FxHashMap<FileId, Arc<sugar::Sectioned>>,
     checked: FxHashMap<FileId, Arc<checking::CheckedModule>>,
@@ -120,6 +121,7 @@ impl WasmQueryEngine {
             derived.lowered.remove(&id);
             derived.grouped.remove(&id);
             derived.resolved.remove(&id);
+            derived.exported.remove(&id);
             derived.bracketed.remove(&id);
             derived.sectioned.remove(&id);
             derived.checked.remove(&id);
@@ -133,6 +135,7 @@ impl WasmQueryEngine {
             derived.lowered.remove(&user_id);
             derived.grouped.remove(&user_id);
             derived.resolved.remove(&user_id);
+            derived.exported.remove(&user_id);
             derived.bracketed.remove(&user_id);
             derived.sectioned.remove(&user_id);
             derived.checked.remove(&user_id);
@@ -151,6 +154,7 @@ impl WasmQueryEngine {
             derived.lowered.remove(&existing_id);
             derived.grouped.remove(&existing_id);
             derived.resolved.remove(&existing_id);
+            derived.exported.remove(&existing_id);
             derived.bracketed.remove(&existing_id);
             derived.sectioned.remove(&existing_id);
             derived.checked.remove(&existing_id);
@@ -208,6 +212,7 @@ impl QueryProxy for WasmQueryEngine {
     type Lowered = Arc<LoweredModule>;
     type Grouped = Arc<GroupedModule>;
     type Resolved = Arc<ResolvedModule>;
+    type Exported = Arc<ExportedModule>;
     type Bracketed = Arc<sugar::Bracketed>;
     type Sectioned = Arc<sugar::Sectioned>;
     type Checked = Arc<checking::CheckedModule>;
@@ -309,6 +314,18 @@ impl QueryProxy for WasmQueryEngine {
 
         self.derived.borrow_mut().resolved.insert(id, resolved.clone());
         Ok(resolved)
+    }
+
+    fn exported(&self, id: FileId) -> QueryResult<Self::Exported> {
+        if let Some(cached) = self.derived.borrow().exported.get(&id) {
+            return Ok(Arc::clone(cached));
+        }
+
+        let resolved = self.resolved(id)?;
+        let exported = Arc::new(resolving::export_module(&resolved));
+
+        self.derived.borrow_mut().exported.insert(id, Arc::clone(&exported));
+        Ok(exported)
     }
 
     fn bracketed(&self, id: FileId) -> QueryResult<Self::Bracketed> {
@@ -427,3 +444,23 @@ impl checking::ExternalQueries for WasmQueryEngine {
 
 impl resolving::ExternalQueries for WasmQueryEngine {}
 impl sugar::ExternalQueries for WasmQueryEngine {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replacing_user_source_invalidates_exported_module() {
+        let mut engine = WasmQueryEngine::new();
+        let id = engine.set_user_source("module Main (x) where\n\nx = 1\ny = 2");
+
+        let exported = engine.exported(id).unwrap();
+        assert_eq!(exported.local.len(), 1);
+
+        let replacement_id = engine.set_user_source("module Main (x, y) where\n\nx = 1\ny = 2");
+        assert_eq!(replacement_id, id);
+
+        let exported = engine.exported(replacement_id).unwrap();
+        assert_eq!(exported.local.len(), 2);
+    }
+}

--- a/tests-integration/fixtures/backend/1787021280_literals_arrays_and_records/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021280_literals_arrays_and_records/Main.nbe.snap
@@ -1,19 +1,20 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-integer = 42
+@export integer = 42
 
-number = 1.5
+@export number = 1.5
 
-character = 'a'
+@export character = 'a'
 
-string = "alexandrite"
+@export string = "alexandrite"
 
-boolean = true
+@export boolean = true
 
-array = [1, 2, 3]
+@export array = [1, 2, 3]
 
-record = { integer: 42, nested: { value: "nested" } }
+@export record = { integer: 42, nested: { value: "nested" } }
 
-projection = record.nested.value
+@export projection = record.nested.value

--- a/tests-integration/fixtures/backend/1787021280_literals_arrays_and_records/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021280_literals_arrays_and_records/Main.ssa.snap
@@ -1,44 +1,44 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-const integer = initialize {
+@export const integer = initialize {
   entry() {
     const literal = 42;
     return literal;
   }
 }
 
-const number = initialize {
+@export const number = initialize {
   entry() {
     const literal = 1.5;
     return literal;
   }
 }
 
-const character = initialize {
+@export const character = initialize {
   entry() {
     const literal = 'a';
     return literal;
   }
 }
 
-const string = initialize {
+@export const string = initialize {
   entry() {
     const literal = "alexandrite";
     return literal;
   }
 }
 
-const boolean = initialize {
+@export const boolean = initialize {
   entry() {
     const literal = true;
     return literal;
   }
 }
 
-const array = initialize {
+@export const array = initialize {
   entry() {
     const literal = 1;
     const literal$1 = 2;
@@ -48,7 +48,7 @@ const array = initialize {
   }
 }
 
-const record = initialize {
+@export const record = initialize {
   entry() {
     const literal = 42;
     const literal$1 = "nested";
@@ -58,7 +58,7 @@ const record = initialize {
   }
 }
 
-const projection = initialize {
+@export const projection = initialize {
   entry() {
     const record = global(record);
     const nested = record.nested;

--- a/tests-integration/fixtures/backend/1787021340_record_updates/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021340_record_updates/Main.nbe.snap
@@ -1,7 +1,8 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-model = { count: 0, nested: { enabled: true, label: "before" } }
+@export model = { count: 0, nested: { enabled: true, label: "before" } }
 
-updated = model { count = 1, nested { enabled = false, label = "after" } }
+@export updated = model { count = 1, nested { enabled = false, label = "after" } }

--- a/tests-integration/fixtures/backend/1787021340_record_updates/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021340_record_updates/Main.ssa.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-const model = initialize {
+@export const model = initialize {
   entry() {
     const literal = 0;
     const literal$1 = true;
@@ -14,7 +14,7 @@ const model = initialize {
   }
 }
 
-const updated = initialize {
+@export const updated = initialize {
   entry() {
     const model = global(model);
     const literal = 1;

--- a/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.nbe.snap
@@ -1,36 +1,37 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-integer = \argument0%0 ->
+@export integer = \argument0%0 ->
   case argument0%0 of
     0 ->
       true
     _ ->
       false
 
-number = \argument0%1 ->
+@export number = \argument0%1 ->
   case argument0%1 of
     1.5 ->
       true
     _ ->
       false
 
-character = \argument0%2 ->
+@export character = \argument0%2 ->
   case argument0%2 of
     'a' ->
       true
     _ ->
       false
 
-string = \argument0%3 ->
+@export string = \argument0%3 ->
   case argument0%3 of
     "alexandrite" ->
       true
     _ ->
       false
 
-boolean = \argument0%4 ->
+@export boolean = \argument0%4 ->
   case argument0%4 of
     true ->
       true

--- a/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.ssa.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-function integer(argument0) {
+@export function integer(argument0) {
   entry() {
     case$0();
   }
@@ -31,7 +31,7 @@ function integer(argument0) {
   }
 }
 
-function number(argument0) {
+@export function number(argument0) {
   entry() {
     case$0();
   }
@@ -59,7 +59,7 @@ function number(argument0) {
   }
 }
 
-function character(argument0) {
+@export function character(argument0) {
   entry() {
     case$0();
   }
@@ -87,7 +87,7 @@ function character(argument0) {
   }
 }
 
-function string(argument0) {
+@export function string(argument0) {
   entry() {
     case$0();
   }
@@ -115,7 +115,7 @@ function string(argument0) {
   }
 }
 
-function boolean(argument0) {
+@export function boolean(argument0) {
   entry() {
     case$0();
   }

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.nbe.snap
@@ -1,9 +1,17 @@
 ---
 source: tests-integration/tests/nbe.rs
-assertion_line: 12
+assertion_line: 14
 expression: report
 ---
-first = \argument0%0 ->
+@export constructor Empty/0
+
+@export constructor One/1
+
+@export constructor Pair/2
+
+@export constructor Outer/1
+
+@export first = \argument0%0 ->
   case argument0%0 of
     Empty ->
       Empty
@@ -16,15 +24,15 @@ first = \argument0%0 ->
         _ ->
           Empty
 
-unwrap = \(Identity value%4) -> value%4
+@export unwrap = \value%4 -> value%4
 
-nested = \argument0%5 ->
+@export nested = \argument0%5 ->
   case argument0%5 of
     Outer (One value%6) ->
       One value%6
     _ ->
       Empty
 
-bind = \value%8 continuation%7 -> continuation%7 value%8
+@export bind = \value%8 continuation%7 -> continuation%7 value%8
 
-ordinaryBind = \identity%9 -> bind identity%9 (\(Identity value%10) -> value%10)
+@export ordinaryBind = \identity%9 -> bind identity%9 (\value%10 -> value%10)

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.ssa.snap
@@ -1,9 +1,17 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-function first(argument0) {
+@export constructor Empty/0;
+
+@export constructor One/1;
+
+@export constructor Pair/2;
+
+@export constructor Outer/1;
+
+@export function first(argument0) {
   entry() {
     case$0();
   }
@@ -79,25 +87,13 @@ function first(argument0) {
   }
 }
 
-function unwrap(argument0) {
+@export function unwrap(value) {
   entry() {
-    const matches = pattern.constructor(argument0, Identity);
-    if (matches) {
-      match$success();
-    } else {
-      parameter$failure();
-    }
-  }
-  parameter$failure() {
-    throw patternMatchFailure();
-  }
-  match$success() {
-    const value = pattern.argument(argument0, Identity, 0);
     return value;
   }
 }
 
-function nested(argument0) {
+@export function nested(argument0) {
   entry() {
     case$0();
   }
@@ -136,14 +132,14 @@ function nested(argument0) {
   }
 }
 
-function bind(value, continuation) {
+@export function bind(value, continuation) {
   entry() {
     const call = source.call(continuation, value);
     return call;
   }
 }
 
-function ordinaryBind(identity) {
+@export function ordinaryBind(identity) {
   entry() {
     const bind = global(bind);
     const call = source.call(bind, identity);
@@ -153,20 +149,8 @@ function ordinaryBind(identity) {
   }
 }
 
-closure ordinaryBind$closure[](argument0) {
+closure ordinaryBind$closure[](value) {
   entry() {
-    const matches = pattern.constructor(argument0, Identity);
-    if (matches) {
-      match$success();
-    } else {
-      parameter$failure();
-    }
-  }
-  parameter$failure() {
-    throw patternMatchFailure();
-  }
-  match$success() {
-    const value = pattern.argument(argument0, Identity, 0);
     return value;
   }
 }

--- a/tests-integration/fixtures/backend/1787021520_array_patterns/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021520_array_patterns/Main.nbe.snap
@@ -1,8 +1,9 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-describe = \argument0%0 ->
+@export describe = \argument0%0 ->
   case argument0%0 of
     [] ->
       0

--- a/tests-integration/fixtures/backend/1787021520_array_patterns/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021520_array_patterns/Main.ssa.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-function describe(argument0) {
+@export function describe(argument0) {
   entry() {
     case$0();
   }

--- a/tests-integration/fixtures/backend/1787021580_record_patterns/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021580_record_patterns/Main.nbe.snap
@@ -1,5 +1,6 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-select = \{ first: first%1, nested: { second: second%0 } } -> second%0
+@export select = \{ first: first%1, nested: { second: second%0 } } -> second%0

--- a/tests-integration/fixtures/backend/1787021580_record_patterns/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021580_record_patterns/Main.ssa.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-function select(argument0) {
+@export function select(argument0) {
   entry() {
     const first = argument0.first;
     const nested = argument0.nested;

--- a/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/Main.nbe.snap
@@ -1,8 +1,9 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-choose = \first%0 second%1 ->
+@export choose = \first%0 second%1 ->
   case first%0, second%1 of
     true, true ->
       2

--- a/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/Main.ssa.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-function choose(first, second) {
+@export function choose(first, second) {
   entry() {
     case$0();
   }

--- a/tests-integration/fixtures/backend/1787021700_guards/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021700_guards/Main.nbe.snap
@@ -1,30 +1,35 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-booleanGuard = \value%0 ->
+@export constructor Empty/0
+
+@export constructor One/1
+
+@export booleanGuard = \value%0 ->
   | value%0 -> 1
   | true -> 0
 
-patternGuard = \choice%1 ->
+@export patternGuard = \choice%1 ->
   | One value%2 <- choice%1 -> value%2
   | true -> 0
 
-caseBooleanGuard = \value%3 ->
+@export caseBooleanGuard = \value%3 ->
   case value%3 of
     _ ->
       | false -> 1
     _ ->
       2
 
-casePatternGuard = \choice%4 ->
+@export casePatternGuard = \choice%4 ->
   case choice%4 of
     _ ->
       | One value%5 <- choice%4 -> value%5
     _ ->
       0
 
-nestedCaseGuard = \value%6 ->
+@export nestedCaseGuard = \value%6 ->
   case value%6 of
     true ->
       | true ->

--- a/tests-integration/fixtures/backend/1787021700_guards/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021700_guards/Main.ssa.snap
@@ -1,9 +1,13 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-function booleanGuard(value) {
+@export constructor Empty/0;
+
+@export constructor One/1;
+
+@export function booleanGuard(value) {
   entry() {
     guard$0();
   }
@@ -38,7 +42,7 @@ function booleanGuard(value) {
   }
 }
 
-function patternGuard(choice) {
+@export function patternGuard(choice) {
   entry() {
     guard$0();
   }
@@ -74,7 +78,7 @@ function patternGuard(choice) {
   }
 }
 
-function caseBooleanGuard(value) {
+@export function caseBooleanGuard(value) {
   entry() {
     case$0();
   }
@@ -108,7 +112,7 @@ function caseBooleanGuard(value) {
   }
 }
 
-function casePatternGuard(choice) {
+@export function casePatternGuard(choice) {
   entry() {
     case$0();
   }
@@ -142,7 +146,7 @@ function casePatternGuard(choice) {
   }
 }
 
-function nestedCaseGuard(value) {
+@export function nestedCaseGuard(value) {
   entry() {
     case$0();
   }

--- a/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.nbe.snap
@@ -1,13 +1,14 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-unwrap = \wrapped%1 ->
+@export unwrap = \wrapped%1 ->
   let
-    Identity value%0 = wrapped%1
+    value%0 = wrapped%1
   in value%0
 
-select = \record%3 ->
+@export select = \record%3 ->
   let
     { first: first%4, second: second%2 } = record%3
   in second%2

--- a/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.ssa.snap
@@ -1,27 +1,15 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-function unwrap(wrapped) {
+@export function unwrap(wrapped) {
   entry() {
-    const matches = pattern.constructor(wrapped, Identity);
-    if (matches) {
-      match$success();
-    } else {
-      let$failure();
-    }
-  }
-  let$failure() {
-    throw patternMatchFailure();
-  }
-  match$success() {
-    const value = pattern.argument(wrapped, Identity, 0);
-    return value;
+    return wrapped;
   }
 }
 
-function select(record) {
+@export function select(record) {
   entry() {
     const first = record.first;
     const second = record.second;

--- a/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/Main.nbe.snap
@@ -1,8 +1,9 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-mutual = \condition%1 ->
+@export mutual = \condition%1 ->
   let
     rec second%2 = \argument0%3 ->
       case argument0%3 of

--- a/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/Main.ssa.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-function mutual(condition) {
+@export function mutual(condition) {
   entry() {
     const [second, first] = closures.recursive({
       second: closure(second$function, first),

--- a/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/Main.nbe.snap
@@ -1,19 +1,20 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-forward = later
+@export forward = later
 
-later = 42
+@export later = 42
 
-recursive[2] first = \argument0%0 ->
+@export recursive[2] first = \argument0%0 ->
   case argument0%0 of
     true ->
       1
     false ->
       second true
 
-recursive[2] second = \argument0%1 ->
+@export recursive[2] second = \argument0%1 ->
   case argument0%1 of
     true ->
       2

--- a/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/Main.ssa.snap
@@ -1,23 +1,23 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-const forward = initialize {
+@export const forward = initialize {
   entry() {
     const later = global(later);
     return later;
   }
 }
 
-const later = initialize {
+@export const later = initialize {
   entry() {
     const literal = 42;
     return literal;
   }
 }
 
-recursive[2] function first(argument0) {
+@export recursive[2] function first(argument0) {
   entry() {
     case$0();
   }
@@ -55,7 +55,7 @@ recursive[2] function first(argument0) {
   }
 }
 
-recursive[2] function second(argument0) {
+@export recursive[2] function second(argument0) {
   entry() {
     case$0();
   }

--- a/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.nbe.snap
@@ -1,20 +1,21 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-foreign equalInt
+@export foreign equalInt
 
-foreign lessThanInt
+@export foreign lessThanInt
 
-instance equalInt1 = { equal: equalInt }
+@export instance equalInt1 = { equal: equalInt }
 
-instance orderedInt = { superclass17: equalInt1, lessThan: lessThanInt }
+@export instance orderedInt = { superclass17: equalInt1, lessThan: lessThanInt }
 
-genericEqual = \dictionary0%0 -> \left%1 right%2 -> dictionary0%0.equal left%1 right%2
+@export genericEqual = \dictionary0%0 -> \left%1 right%2 -> dictionary0%0.equal left%1 right%2
 
-concreteEqual = equalInt1.equal 1 2
+@export concreteEqual = equalInt1.equal 1 2
 
-concreteLessThan = orderedInt.lessThan 1 2
+@export concreteLessThan = orderedInt.lessThan 1 2
 
-superclassEqual = \dictionary1%3 ->
+@export superclassEqual = \dictionary1%3 ->
   \left%4 right%5 -> dictionary1%3.superclass17.equal left%4 right%5

--- a/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.ssa.snap
@@ -1,13 +1,13 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-foreign const equalInt;
+@export foreign const equalInt;
 
-foreign const lessThanInt;
+@export foreign const lessThanInt;
 
-const equalInt1 = initialize {
+@export instance const equalInt1 = initialize {
   entry() {
     const equalInt = global(equalInt);
     const record = { equal: equalInt };
@@ -15,7 +15,7 @@ const equalInt1 = initialize {
   }
 }
 
-const orderedInt = initialize {
+@export instance const orderedInt = initialize {
   entry() {
     const equalInt1 = global(equalInt1);
     const lessThanInt = global(lessThanInt);
@@ -24,14 +24,14 @@ const orderedInt = initialize {
   }
 }
 
-function genericEqual(dictionary0) {
+@export function genericEqual(dictionary0) {
   entry() {
     const closure = closure(genericEqual$closure, dictionary0);
     return closure;
   }
 }
 
-const concreteEqual = initialize {
+@export const concreteEqual = initialize {
   entry() {
     const equalInt1 = global(equalInt1);
     const equal = equalInt1.equal;
@@ -43,7 +43,7 @@ const concreteEqual = initialize {
   }
 }
 
-const concreteLessThan = initialize {
+@export const concreteLessThan = initialize {
   entry() {
     const orderedInt = global(orderedInt);
     const lessThan = orderedInt.lessThan;
@@ -55,7 +55,7 @@ const concreteLessThan = initialize {
   }
 }
 
-function superclassEqual(dictionary1) {
+@export function superclassEqual(dictionary1) {
   entry() {
     const closure = closure(superclassEqual$closure, dictionary1);
     return closure;

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.nbe.snap
@@ -1,15 +1,16 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-foreign firstAction
+@export foreign firstAction
 
-foreign secondAction
+@export foreign secondAction
 
-foreign independentAction
+@export foreign independentAction
 
-sequential = bindEffect1.bind firstAction (\first%0 -> secondAction first%0)
+@export sequential = bindEffect1.bind firstAction (\first%0 -> secondAction first%0)
 
-independent = applyEffect1.apply
+@export independent = applyEffect1.apply
   (functorEffect.map (\first%1 second%2 -> { first: first%1, second: second%2 }) firstAction)
   independentAction

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.ssa.snap
@@ -1,15 +1,15 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-foreign const firstAction;
+@export foreign const firstAction;
 
-foreign const secondAction;
+@export foreign const secondAction;
 
-foreign const independentAction;
+@export foreign const independentAction;
 
-const sequential = initialize {
+@export const sequential = initialize {
   entry() {
     const bindEffect1 = global(bindEffect1);
     const bind = bindEffect1.bind;
@@ -21,7 +21,7 @@ const sequential = initialize {
   }
 }
 
-const independent = initialize {
+@export const independent = initialize {
   entry() {
     const applyEffect1 = global(applyEffect1);
     const apply = applyEffect1.apply;

--- a/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.nbe.snap
@@ -1,9 +1,10 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-foreign foreignValue
+@export foreign foreignValue
 
-foreign foreignFunction
+@export foreign foreignFunction
 
-value = foreignFunction foreignValue
+@export value = foreignFunction foreignValue

--- a/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.ssa.snap
@@ -1,13 +1,13 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-foreign const foreignValue;
+@export foreign const foreignValue;
 
-foreign const foreignFunction;
+@export foreign const foreignFunction;
 
-const value = initialize {
+@export const value = initialize {
   entry() {
     const foreignFunction = global(foreignFunction);
     const foreignValue = global(foreignValue);

--- a/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.nbe.snap
@@ -1,10 +1,10 @@
 ---
 source: tests-integration/tests/nbe.rs
-assertion_line: 12
+assertion_line: 14
 expression: report
 ---
-unbox = \(Box value%0) -> value%0
+@export unbox = \(Box value%0) -> value%0
 
-fromLibrary = unbox box
+@export fromLibrary = unbox box
 
-directReference = libraryValue
+@export directReference = libraryValue

--- a/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.ssa.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-function unbox(argument0) {
+@export function unbox(argument0) {
   entry() {
     const matches = pattern.constructor(argument0, Box);
     if (matches) {
@@ -21,7 +21,7 @@ function unbox(argument0) {
   }
 }
 
-const fromLibrary = initialize {
+@export const fromLibrary = initialize {
   entry() {
     const unbox = global(unbox);
     const box = global(box);
@@ -30,7 +30,7 @@ const fromLibrary = initialize {
   }
 }
 
-const directReference = initialize {
+@export const directReference = initialize {
   entry() {
     const libraryValue = global(libraryValue);
     return libraryValue;

--- a/tests-integration/fixtures/backend/1787022180_desugared_source_forms/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022180_desugared_source_forms/Main.nbe.snap
@@ -1,15 +1,16 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-add = \left%0 right%1 -> left%0
+@export add = \left%0 right%1 -> left%0
 
-identity = \value%2 -> value%2
+@export identity = \value%2 -> value%2
 
-operatorApplication = add 1 2
+@export operatorApplication = add 1 2
 
-visibleTypeApplication = identity 42
+@export visibleTypeApplication = identity 42
 
-increment = \section60%3 -> add section60%3 1
+@export increment = \section60%3 -> add section60%3 1
 
-accessValue = \section79%4 -> section79%4.value
+@export accessValue = \section79%4 -> section79%4.value

--- a/tests-integration/fixtures/backend/1787022180_desugared_source_forms/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787022180_desugared_source_forms/Main.ssa.snap
@@ -1,21 +1,21 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-function add(left, right) {
+@export function add(left, right) {
   entry() {
     return left;
   }
 }
 
-function identity(value) {
+@export function identity(value) {
   entry() {
     return value;
   }
 }
 
-const operatorApplication = initialize {
+@export const operatorApplication = initialize {
   entry() {
     const add = global(add);
     const literal = 1;
@@ -26,7 +26,7 @@ const operatorApplication = initialize {
   }
 }
 
-const visibleTypeApplication = initialize {
+@export const visibleTypeApplication = initialize {
   entry() {
     const identity = global(identity);
     const literal = 42;
@@ -35,7 +35,7 @@ const visibleTypeApplication = initialize {
   }
 }
 
-function increment(section60) {
+@export function increment(section60) {
   entry() {
     const add = global(add);
     const call = source.call(add, section60);
@@ -45,7 +45,7 @@ function increment(section60) {
   }
 }
 
-function accessValue(section79) {
+@export function accessValue(section79) {
   entry() {
     const value = section79.value;
     return value;

--- a/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/Main.nbe.snap
@@ -1,21 +1,22 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-apply = \function%0 value%1 -> function%0 value%1
+@export apply = \function%0 value%1 -> function%0 value%1
 
-capture = \captured%2 -> \_ -> captured%2
+@export capture = \captured%2 -> \_ -> captured%2
 
-choose = \condition%3 left%4 right%5 ->
+@export choose = \condition%3 left%4 right%5 ->
   if condition%3 then left%4 else right%5
 
-partial = choose true 42
+@export partial = choose true 42
 
-literalCase = \value%6 ->
+@export literalCase = \value%6 ->
   case value%6 of
     0 ->
       "zero"
     _ ->
       "other"
 
-higherOrder = apply (capture 42) 0
+@export higherOrder = apply (capture 42) 0

--- a/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/Main.ssa.snap
@@ -1,23 +1,23 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-function apply(function, value) {
+@export function apply(function, value) {
   entry() {
     const call = source.call(function, value);
     return call;
   }
 }
 
-function capture(captured) {
+@export function capture(captured) {
   entry() {
     const closure = closure(capture$closure, captured);
     return closure;
   }
 }
 
-function choose(condition, left, right) {
+@export function choose(condition, left, right) {
   entry() {
     if (condition) {
       then();
@@ -36,7 +36,7 @@ function choose(condition, left, right) {
   }
 }
 
-const partial = initialize {
+@export const partial = initialize {
   entry() {
     const choose = global(choose);
     const literal = true;
@@ -47,7 +47,7 @@ const partial = initialize {
   }
 }
 
-function literalCase(value) {
+@export function literalCase(value) {
   entry() {
     case$0();
   }
@@ -75,7 +75,7 @@ function literalCase(value) {
   }
 }
 
-const higherOrder = initialize {
+@export const higherOrder = initialize {
   entry() {
     const apply = global(apply);
     const capture = global(capture);

--- a/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.nbe.snap
@@ -1,15 +1,16 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-foreign addInt
+@export foreign addInt
 
-foreign multiplyInt
+@export foreign multiplyInt
 
-constantAdd = addInt 20 22
+@export constantAdd = addInt 20 22
 
-constantMultiply = multiplyInt 6 7
+@export constantMultiply = multiplyInt 6 7
 
-overflowAdd = addInt 2147483647 1
+@export overflowAdd = addInt 2147483647 1
 
-unknownAdd = addInt
+@export unknownAdd = addInt

--- a/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.ssa.snap
@@ -1,13 +1,13 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-foreign const addInt;
+@export foreign const addInt;
 
-foreign const multiplyInt;
+@export foreign const multiplyInt;
 
-const constantAdd = initialize {
+@export const constantAdd = initialize {
   entry() {
     const addInt = global(addInt);
     const literal = 20;
@@ -18,7 +18,7 @@ const constantAdd = initialize {
   }
 }
 
-const constantMultiply = initialize {
+@export const constantMultiply = initialize {
   entry() {
     const multiplyInt = global(multiplyInt);
     const literal = 6;
@@ -29,7 +29,7 @@ const constantMultiply = initialize {
   }
 }
 
-const overflowAdd = initialize {
+@export const overflowAdd = initialize {
   entry() {
     const addInt = global(addInt);
     const literal = 2147483647;
@@ -40,7 +40,7 @@ const overflowAdd = initialize {
   }
 }
 
-const unknownAdd = initialize {
+@export const unknownAdd = initialize {
   entry() {
     const addInt = global(addInt);
     return addInt;

--- a/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.nbe.snap
@@ -1,18 +1,20 @@
 ---
 source: tests-integration/tests/nbe.rs
-assertion_line: 12
+assertion_line: 14
 expression: report
 ---
-foreign await
+@export foreign await
 
-arguments = await
+@export arguments = await
 
-default = { "hyphen-label": arguments }
+@export default = { "hyphen-label": arguments }
 
-readLabel = \record%0 -> record%0."hyphen-label"
+@export readLabel = \record%0 -> record%0."hyphen-label"
 
-emptyLabel = { "": arguments }
+@export emptyLabel = { "": arguments }
 
-readEmptyLabel = \record%1 -> record%1.""
+@export readEmptyLabel = \record%1 -> record%1.""
 
-tagged = Tagged default
+@export constructor Tagged/1
+
+@export tagged = Tagged default

--- a/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.ssa.snap
@@ -1,18 +1,18 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-foreign const await;
+@export foreign const await;
 
-const arguments = initialize {
+@export const arguments = initialize {
   entry() {
     const await = global(await);
     return await;
   }
 }
 
-const default = initialize {
+@export const default = initialize {
   entry() {
     const arguments = global(arguments);
     const record = { "hyphen-label": arguments };
@@ -20,14 +20,14 @@ const default = initialize {
   }
 }
 
-function readLabel(record) {
+@export function readLabel(record) {
   entry() {
     const hyphen_label = record["hyphen-label"];
     return hyphen_label;
   }
 }
 
-const emptyLabel = initialize {
+@export const emptyLabel = initialize {
   entry() {
     const arguments = global(arguments);
     const record = { "": arguments };
@@ -35,14 +35,16 @@ const emptyLabel = initialize {
   }
 }
 
-function readEmptyLabel(record) {
+@export function readEmptyLabel(record) {
   entry() {
     const value = record[""];
     return value;
   }
 }
 
-const tagged = initialize {
+@export constructor Tagged/1;
+
+@export const tagged = initialize {
   entry() {
     const Tagged = constructor(Tagged);
     const default = global(default);

--- a/tests-integration/fixtures/backend/1787080920_derived_instance/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787080920_derived_instance/Main.nbe.snap
@@ -1,8 +1,11 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-instance eqBox = {
+@export constructor Box/0
+
+@export instance eqBox = {
   eq:
     \left%0 right%1 ->
       case left%0, right%1 of
@@ -10,8 +13,8 @@ instance eqBox = {
           true
 }
 
-equal = eqBox.eq Box Box
+@export equal = eqBox.eq Box Box
 
-instance showIdentity = \dictionary1%2 -> dictionary1%2
+@export instance showIdentity = \dictionary1%2 -> dictionary1%2
 
-rendered = (showIdentity showInt).show (Identity 42)
+@export rendered = (showIdentity showInt).show ((\value%3 -> value%3) 42)

--- a/tests-integration/fixtures/backend/1787080920_derived_instance/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787080920_derived_instance/Main.ssa.snap
@@ -1,9 +1,11 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-const eqBox = initialize {
+@export constructor Box/0;
+
+@export instance const eqBox = initialize {
   entry() {
     const closure = closure(eqBox$initialize$closure);
     const record = { eq: closure };
@@ -11,7 +13,7 @@ const eqBox = initialize {
   }
 }
 
-const equal = initialize {
+@export const equal = initialize {
   entry() {
     const eqBox = global(eqBox);
     const eq = eqBox.eq;
@@ -23,21 +25,21 @@ const equal = initialize {
   }
 }
 
-function showIdentity(dictionary1) {
+@export instance function showIdentity(dictionary1) {
   entry() {
     return dictionary1;
   }
 }
 
-const rendered = initialize {
+@export const rendered = initialize {
   entry() {
     const showIdentity = global(showIdentity);
     const showInt = global(showInt);
     const call = source.call(showIdentity, showInt);
     const show = call.show;
-    const Identity = constructor(Identity);
+    const closure = closure(rendered$initialize$closure);
     const literal = 42;
-    const call$1 = source.call(Identity, literal);
+    const call$1 = source.call(closure, literal);
     const call$2 = source.call(show, call$1);
     return call$2;
   }
@@ -72,5 +74,11 @@ closure eqBox$initialize$closure[](left, right) {
   match$success$1() {
     const literal = true;
     case$join(literal);
+  }
+}
+
+closure rendered$initialize$closure[](value) {
+  entry() {
+    return value;
   }
 }

--- a/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.nbe.snap
@@ -1,20 +1,20 @@
 ---
 source: tests-integration/tests/nbe.rs
-assertion_line: 12
+assertion_line: 14
 expression: report
 ---
-symbol = (symbol "alexandrite").reflectSymbol Proxy
+@export symbol = (symbol "alexandrite").reflectSymbol Proxy
 
-reflectedString = (reflectable "reflected").reflectType Proxy
+@export reflectedString = (reflectable "reflected").reflectType Proxy
 
-reflectedInteger = (reflectable 42).reflectType Proxy
+@export reflectedInteger = (reflectable 42).reflectType Proxy
 
-reflectedTrue = (reflectable true).reflectType Proxy
+@export reflectedTrue = (reflectable true).reflectType Proxy
 
-reflectedFalse = (reflectable false).reflectType Proxy
+@export reflectedFalse = (reflectable false).reflectType Proxy
 
-reflectedLess = (reflectable LT).reflectType Proxy
+@export reflectedLess = (reflectable LT).reflectType Proxy
 
-reflectedEqual = (reflectable EQ).reflectType Proxy
+@export reflectedEqual = (reflectable EQ).reflectType Proxy
 
-reflectedGreater = (reflectable GT).reflectType Proxy
+@export reflectedGreater = (reflectable GT).reflectType Proxy

--- a/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.ssa.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-const symbol = initialize {
+@export const symbol = initialize {
   entry() {
     const evidence = evidence.symbol("alexandrite");
     const reflectSymbol = evidence.reflectSymbol;
@@ -13,7 +13,7 @@ const symbol = initialize {
   }
 }
 
-const reflectedString = initialize {
+@export const reflectedString = initialize {
   entry() {
     const evidence = evidence.reflectable("reflected");
     const reflectType = evidence.reflectType;
@@ -23,7 +23,7 @@ const reflectedString = initialize {
   }
 }
 
-const reflectedInteger = initialize {
+@export const reflectedInteger = initialize {
   entry() {
     const evidence = evidence.reflectable(42);
     const reflectType = evidence.reflectType;
@@ -33,7 +33,7 @@ const reflectedInteger = initialize {
   }
 }
 
-const reflectedTrue = initialize {
+@export const reflectedTrue = initialize {
   entry() {
     const evidence = evidence.reflectable(true);
     const reflectType = evidence.reflectType;
@@ -43,7 +43,7 @@ const reflectedTrue = initialize {
   }
 }
 
-const reflectedFalse = initialize {
+@export const reflectedFalse = initialize {
   entry() {
     const evidence = evidence.reflectable(false);
     const reflectType = evidence.reflectType;
@@ -53,7 +53,7 @@ const reflectedFalse = initialize {
   }
 }
 
-const reflectedLess = initialize {
+@export const reflectedLess = initialize {
   entry() {
     const evidence = evidence.reflectable(LT);
     const reflectType = evidence.reflectType;
@@ -63,7 +63,7 @@ const reflectedLess = initialize {
   }
 }
 
-const reflectedEqual = initialize {
+@export const reflectedEqual = initialize {
   entry() {
     const evidence = evidence.reflectable(EQ);
     const reflectType = evidence.reflectType;
@@ -73,7 +73,7 @@ const reflectedEqual = initialize {
   }
 }
 
-const reflectedGreater = initialize {
+@export const reflectedGreater = initialize {
   entry() {
     const evidence = evidence.reflectable(GT);
     const reflectType = evidence.reflectType;

--- a/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.nbe.snap
@@ -1,8 +1,9 @@
 ---
 source: tests-integration/tests/nbe.rs
+assertion_line: 14
 expression: report
 ---
-sequence = \input%2 ->
+@export sequence = \input%2 ->
   let
     first%1 = input%2
   in let

--- a/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.ssa.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-function sequence(input) {
+@export function sequence(input) {
   entry() {
     return input;
   }

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/Direct.purs
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/Direct.purs
@@ -1,0 +1,17 @@
+module Direct (module Origin, module Again, append) where
+
+import Origin as Again
+import Origin
+  ( Option(Just)
+  , Wrapped(..)
+  , await
+  , class Measure
+  , foreignValue
+  , measure
+  , type (:*:)
+  , visible
+  , (<>)
+  ) as Origin
+
+append :: Int
+append = 99

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/Main.nbe.snap
@@ -1,0 +1,24 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export Direct { append }
+
+@export Origin { Just, await, foreignValue, visible }
+
+@export Transitive { marker }
+
+@export constructorValue = Just 42
+
+@export operatorValue = append (visible 23) 9
+
+@export localCollision = append
+
+@export foreignResult = foreignValue
+
+@export hostileResult = await
+
+@export measured = measureInt.measure 41
+
+@export transitiveMarker = marker

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/Main.purs
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/Main.purs
@@ -1,0 +1,44 @@
+module Main
+  ( module Transitive
+  , constructorValue
+  , operatorValue
+  , localCollision
+  , foreignResult
+  , hostileResult
+  , measured
+  , transitiveMarker
+  ) where
+
+import Origin ()
+import Transitive
+  ( Option(Just)
+  , append
+  , await
+  , class Measure
+  , foreignValue
+  , marker
+  , measure
+  , visible
+  , (<>)
+  )
+
+constructorValue :: Option
+constructorValue = Just 42
+
+operatorValue :: Int
+operatorValue = visible 23 <> 9
+
+localCollision :: Int
+localCollision = append
+
+foreignResult :: Int
+foreignResult = foreignValue
+
+hostileResult :: Int
+hostileResult = await
+
+measured :: Int
+measured = measure 41
+
+transitiveMarker :: Int
+transitiveMarker = marker

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/Main.snap
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 141
+expression: checking_report
+---
+Terms
+constructorValue :: Origin.Option
+operatorValue :: Prim.Int
+localCollision :: Prim.Int
+foreignResult :: Prim.Int
+hostileResult :: Prim.Int
+measured :: Prim.Int
+transitiveMarker :: Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/Main.ssa.snap
@@ -1,0 +1,70 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 57
+expression: ssa_report
+---
+@export Direct { append }
+
+@export Origin { Just, await, foreignValue, visible }
+
+@export Transitive { marker }
+
+@export const constructorValue = initialize {
+  entry() {
+    const Just = constructor(Just);
+    const literal = 42;
+    const call = source.call(Just, literal);
+    return call;
+  }
+}
+
+@export const operatorValue = initialize {
+  entry() {
+    const append = global(append);
+    const visible = global(visible);
+    const literal = 23;
+    const call = source.call(visible, literal);
+    const call$1 = source.call(append, call);
+    const literal$1 = 9;
+    const call$2 = source.call(call$1, literal$1);
+    return call$2;
+  }
+}
+
+@export const localCollision = initialize {
+  entry() {
+    const append = global(append);
+    return append;
+  }
+}
+
+@export const foreignResult = initialize {
+  entry() {
+    const foreignValue = global(foreignValue);
+    return foreignValue;
+  }
+}
+
+@export const hostileResult = initialize {
+  entry() {
+    const await = global(await);
+    return await;
+  }
+}
+
+@export const measured = initialize {
+  entry() {
+    const measureInt = global(measureInt);
+    const measure = measureInt.measure;
+    const literal = 41;
+    const call = source.call(measure, literal);
+    return call;
+  }
+}
+
+@export const transitiveMarker = initialize {
+  entry() {
+    const marker = global(marker);
+    return marker;
+  }
+}

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/Origin.js
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/Origin.js
@@ -1,0 +1,1 @@
+export const foreignValue = 7;

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/Origin.purs
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/Origin.purs
@@ -1,0 +1,44 @@
+module Origin
+  ( Option(Just)
+  , Wrapped(..)
+  , await
+  , class Measure
+  , foreignValue
+  , type (:*:)
+  , visible
+  , (<>)
+  ) where
+
+import Data.Eq (class Eq)
+
+foreign import foreignValue :: Int
+
+visible :: Int -> Int
+visible value = value
+
+hidden :: Int
+hidden = 13
+
+await :: Int
+await = 17
+
+data Option = Just Int | Nothing
+
+derive instance Eq Option
+
+newtype Wrapped = Wrapped Int
+
+append :: Int -> Int -> Int
+append left _ = left
+
+infixr 5 append as <>
+
+type Product left right = left
+
+infixr 6 type Product as :*:
+
+class Measure a where
+  measure :: a -> Int
+
+instance measureInt :: Measure Int where
+  measure value = value

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/Transitive.purs
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/Transitive.purs
@@ -1,0 +1,6 @@
+module Transitive (module Direct, marker) where
+
+import Direct as Direct
+
+marker :: Int
+marker = 1

--- a/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.nbe.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/tests/nbe.rs
-assertion_line: 12
+assertion_line: 14
 expression: report
 ---
-choose = \argument0%0 argument1%1 ->
+@export choose = \argument0%0 argument1%1 ->
   case argument0%0, argument1%1 of
     0, _ ->
       (\value%2 -> value%2) argument1%1

--- a/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.ssa.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 56
+assertion_line: 57
 expression: ssa_report
 ---
-function choose(argument0, argument1) {
+@export function choose(argument0, argument1) {
   entry() {
     case$0();
   }


### PR DESCRIPTION
## Summary

- expose a cached resolving query for runtime-exported terms
- mark ABI-visible local declarations directly in NbE and preserve the marker in SSA
- represent indirect module exports as grouped module surfaces rather than source-level operator names or per-item re-export machinery
- cover direct, transitive, constructor, class-member, operator-alias, and foreign re-export boundaries in the shared corpus

The exported surface is derived from indexing/resolving identity, while generated JavaScript can later choose target-safe names for that ABI.

## Stack

This is 5/7 in the backend stack, stacked on #346. The next layer is #348.

## Validation

```text
just format --check
just t backend
just t resolving
just t checking
cargo check -p resolving -p building -p nbe -p ssa -p tests-integration --tests
cargo clippy -p building --lib -- -D warnings
cargo clippy -p resolving -p nbe -p ssa -p tests-integration --tests -- -D warnings
```

Refs #338.

Amp-Thread-ID: https://ampcode.com/threads/T-01a017ed-f360-749b-afbf-be62c075c317

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
