### PR TITLE
[tests] Execute Effect operations in backend fixtures

### DIFF
--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.js
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.js
@@ -1,0 +1,19 @@
+const trace = [];
+
+export const resetTrace = () => {
+  trace.length = 0;
+};
+export const readTrace = () => trace.slice();
+
+export const firstAction = () => {
+  trace.push("first");
+  return 20;
+};
+export const secondAction = value => () => {
+  trace.push("second");
+  return `value:${value}`;
+};
+export const independentAction = () => {
+  trace.push("independent");
+  return true;
+};

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.nbe.snap
@@ -1,6 +1,5 @@
 ---
 source: tests-integration/tests/nbe.rs
-assertion_line: 14
 expression: report
 ---
 @export foreign firstAction
@@ -14,3 +13,5 @@ expression: report
 @export independent = applyEffect1.apply
   (functorEffect.map (\first%1 second%2 -> { first: first%1, second: second%2 }) firstAction)
   independentAction
+
+@export pureValue = applicativeEffect.pure 42

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.purs
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.purs
@@ -20,3 +20,6 @@ independent = ado
   first <- firstAction
   second <- independentAction
   in { first, second }
+
+pureValue :: Effect Int
+pureValue = pure 42

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.snap
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.snap
@@ -1,7 +1,7 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+assertion_line: 232
+expression: checking_report
 ---
 Terms
 firstAction :: Effect.Effect Prim.Int
@@ -9,5 +9,6 @@ secondAction :: Prim.Int -> Effect.Effect Prim.String
 independentAction :: Effect.Effect Prim.Boolean
 sequential :: Effect.Effect Prim.String
 independent :: Effect.Effect { first :: Prim.Int, second :: Prim.Boolean }
+pureValue :: Effect.Effect Prim.Int
 
 Types

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.ssa.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 142
+assertion_line: 233
 expression: ssa_report
 ---
 @export foreign const firstAction;
@@ -35,6 +35,16 @@ expression: ssa_report
     const independentAction = global(independentAction);
     const call$3 = source.call(call$2, independentAction);
     return call$3;
+  }
+}
+
+@export const pureValue = initialize {
+  entry() {
+    const applicativeEffect = global(applicativeEffect);
+    const pure = applicativeEffect.pure;
+    const literal = 42;
+    const call = source.call(pure, literal);
+    return call;
   }
 }
 

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Effect/foreign.js
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Effect/foreign.js
@@ -1,0 +1,4 @@
+export const mapEffect = transform => action => () => transform(action());
+export const applyEffect = functionAction => valueAction => () => functionAction()(valueAction());
+export const pureEffect = value => () => value;
+export const bindEffect = action => continuation => () => continuation(action())();

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Main/foreign.js
@@ -1,0 +1,19 @@
+const trace = [];
+
+export const resetTrace = () => {
+  trace.length = 0;
+};
+export const readTrace = () => trace.slice();
+
+export const firstAction = () => {
+  trace.push("first");
+  return 20;
+};
+export const secondAction = value => () => {
+  trace.push("second");
+  return `value:${value}`;
+};
+export const independentAction = () => {
+  trace.push("independent");
+  return true;
+};

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Main/index.js
@@ -23,3 +23,5 @@ export const sequential = Effect.bindEffect1.bind(firstAction)(sequential$initia
 export const independent = Effect.applyEffect1.apply(
   Effect.functorEffect.map(independent$initialize$closure)(firstAction)
 )(independentAction);
+
+export const pureValue = Effect.applicativeEffect.pure(42 | 0);

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/package.json
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/verify.mjs
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/verify.mjs
@@ -1,0 +1,33 @@
+import * as Main from "./output/Main/index.js";
+import { readTrace, resetTrace } from "./output/Main/foreign.js";
+
+resetTrace();
+const sequential = Main.sequential();
+const sequentialTrace = readTrace();
+resetTrace();
+const independent = Main.independent();
+const independentTrace = readTrace();
+resetTrace();
+const pure = Main.pureValue();
+const actual = {
+  sequential,
+  sequentialTrace,
+  independent,
+  independentTrace,
+  pure,
+  pureTrace: readTrace(),
+};
+const expected = {
+  sequential: "value:20",
+  sequentialTrace: ["first", "second"],
+  independent: { first: 20, second: true },
+  independentTrace: ["first", "independent"],
+  pure: 42,
+  pureTrace: [],
+};
+
+if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+  throw new Error(
+    `unexpected effects\nactual: ${JSON.stringify(actual)}\nexpected: ${JSON.stringify(expected)}`,
+  );
+}

--- a/tests-integration/fixtures/checking/prelude/Effect.js
+++ b/tests-integration/fixtures/checking/prelude/Effect.js
@@ -1,0 +1,4 @@
+export const mapEffect = transform => action => () => transform(action());
+export const applyEffect = functionAction => valueAction => () => functionAction()(valueAction());
+export const pureEffect = value => () => value;
+export const bindEffect = action => continuation => () => continuation(action())();


### PR DESCRIPTION
## Summary

- complete the shared test prelude's Effect foreign implementation
- execute generated `pure`, `bind`, `map`, `apply`, `do`, and `ado` programs with Node
- assert result values, left-to-right action order, and exactly-once execution
- keep the fixture's foreign implementation and verification script beside its generated `output/` tree

This adds executable semantic coverage; it does not claim to implement NbE Effect normalisation.

## Stack

This is 7/7 in the backend stack, stacked on #348.

## Validation

```text
just format --check
just t backend
just t checking
just t semantic
cargo check -p tests-integration --tests
cargo clippy -p javascript -p tests-integration --tests -- -D warnings
cargo nextest run -p tests-integration --no-fail-fast
cargo check --workspace --all-targets
```

All 793 integration tests pass.

Refs #334.
Refs #341.

Amp-Thread-ID: https://ampcode.com/threads/T-01a017ed-f360-749b-afbf-be62c075c317

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
