### PR TITLE
[backend] Share repeated evidence construction

### DIFF
--- a/compiler-backend/nbe/src/convert.rs
+++ b/compiler-backend/nbe/src/convert.rs
@@ -79,8 +79,47 @@ struct Context<'c, Q> {
     parameters: FxHashMap<BindingSource, Parameter>,
     next_local: u32,
     lowering_evidence: FxHashSet<EvidenceVarId>,
+    evidence_scopes: Vec<EvidenceScope>,
 
     storage: Storage,
+}
+
+#[derive(Default)]
+struct EvidenceScope {
+    constructions: FxHashMap<EvidenceKey, EvidenceConstruction>,
+    bindings: Vec<EvidenceBinding>,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum EvidenceKey {
+    Given(EvidenceBinderId),
+    Instance { origin: InstanceCandidateOrigin, subgoals: Vec<EvidenceKey> },
+    Superclass { parent: Box<EvidenceKey>, superclass: checking::evidence::SuperclassId },
+    Opaque(EvidenceId),
+}
+
+impl EvidenceKey {
+    fn dependency_order(&self) -> usize {
+        match self {
+            EvidenceKey::Given(_) | EvidenceKey::Opaque(_) => 0,
+            EvidenceKey::Instance { subgoals, .. } => {
+                let orders = subgoals.iter().map(EvidenceKey::dependency_order);
+                orders.max().unwrap_or(0).saturating_add(1)
+            }
+            EvidenceKey::Superclass { parent, .. } => parent.dependency_order().saturating_add(1),
+        }
+    }
+}
+
+#[derive(Clone)]
+enum EvidenceConstruction {
+    Inline { expression: ExpressionId, name: SmolStr },
+    Shared(Parameter),
+}
+
+struct EvidenceBinding {
+    evidence: EvidenceKey,
+    binding: Binding,
 }
 
 impl<'c, Q> Context<'c, Q>
@@ -137,6 +176,7 @@ where
             parameters: FxHashMap::default(),
             next_local: 0,
             lowering_evidence: FxHashSet::default(),
+            evidence_scopes: Vec::new(),
 
             storage: Storage::default(),
         })
@@ -388,9 +428,9 @@ fn convert_instance_declaration(
     });
     let parameters = parameters.collect::<ConversionResult<Vec<_>>>()?;
 
-    let body = match &instance.implementation {
+    let body = context.evidence_scope(|context| match &instance.implementation {
         checking_tree::InstanceImplementation::Delegate { evidence, .. } => {
-            evidence_variable(context, *evidence)?
+            evidence_variable(context, *evidence)
         }
         checking_tree::InstanceImplementation::Members(members) => {
             let mut fields = Vec::new();
@@ -404,9 +444,9 @@ fn convert_instance_declaration(
                 let field = context.member_field(member.resolution)?;
                 fields.push(RecordField { field, expression });
             }
-            context.expression(ExpressionKind::Record { fields: fields.into() })
+            Ok(context.expression(ExpressionKind::Record { fields: fields.into() }))
         }
-    };
+    })?;
     let value = context.parameter_abstraction(parameters, body);
     let item_name = context.instance_name(identity)?;
     let global = Global { id: GlobalId::Instance(identity), item_name };
@@ -450,7 +490,8 @@ fn equations(
         return Err(context.unsupported(UnsupportedState::MissingEquation));
     };
     if equations.len() == 1 {
-        let body = guarded_expression(context, &first.guarded_expression)?;
+        let body = context
+            .evidence_scope(|context| guarded_expression(context, &first.guarded_expression))?;
         let patterns = patterns(context, &first.binders)?;
         return Ok(context.abstraction(patterns, body));
     }
@@ -466,22 +507,24 @@ fn equations(
         scrutinees.push(scrutinee);
     }
 
-    let mut alternatives = Vec::with_capacity(equations.len());
-    for equation in equations {
-        let mut patterns = patterns(context, &equation.binders)?;
-        let supplied = patterns.len();
-        while patterns.len() < arity {
-            patterns.push(context.pattern(PatternKind::Wildcard));
+    let body = context.evidence_scope(|context| {
+        let mut alternatives = Vec::with_capacity(equations.len());
+        for equation in equations {
+            let mut patterns = patterns(context, &equation.binders)?;
+            let supplied = patterns.len();
+            while patterns.len() < arity {
+                patterns.push(context.pattern(PatternKind::Wildcard));
+            }
+            let expression = guarded_expression(context, &equation.guarded_expression)?;
+            let remaining_arguments = scrutinees.iter().skip(supplied).copied();
+            let expression = context.application(expression, remaining_arguments);
+            alternatives.push(CaseAlternative { patterns: patterns.into(), expression });
         }
-        let expression = guarded_expression(context, &equation.guarded_expression)?;
-        let remaining_arguments = scrutinees.iter().skip(supplied).copied();
-        let expression = context.application(expression, remaining_arguments);
-        alternatives.push(CaseAlternative { patterns: patterns.into(), expression });
-    }
-    let body = context.expression(ExpressionKind::Case {
-        scrutinees: scrutinees.into(),
-        alternatives: alternatives.into(),
-    });
+        Ok(context.expression(ExpressionKind::Case {
+            scrutinees: scrutinees.into(),
+            alternatives: alternatives.into(),
+        }))
+    })?;
     Ok(context.abstraction(parameter_patterns, body))
 }
 
@@ -659,12 +702,14 @@ fn convert_expression(
         }
         checking_tree::ExpressionKind::EvidenceAbstraction { binder, expression } => {
             let parameter = context.evidence_parameter(*binder)?;
-            let body = convert_expression(context, *expression)?;
+            let body =
+                context.evidence_scope(|context| convert_expression(context, *expression))?;
             return Ok(context.parameter_abstraction([parameter], body));
         }
         checking_tree::ExpressionKind::Lambda { binders, expression } => {
             let parameters = patterns(context, binders)?;
-            let body = convert_expression(context, *expression)?;
+            let body =
+                context.evidence_scope(|context| convert_expression(context, *expression))?;
             return Ok(context.abstraction(parameters, body));
         }
         checking_tree::ExpressionKind::IfThenElse { condition, then, else_ } => {
@@ -918,11 +963,21 @@ fn convert_evidence(
             Ok(context.expression(ExpressionKind::Local { parameter }))
         }
         Evidence::Instance { origin, subgoals } => {
+            let evidence = context.evidence_key(evidence_id);
+            if let Some(expression) = context.shared_evidence(&evidence)? {
+                return Ok(expression);
+            }
             let global = context.instance_global(*origin)?;
+            let name = format_smolstr!("{}Dict", global.item_name);
             let function = context.expression(ExpressionKind::Global { global });
             let arguments = subgoals.iter().map(|&subgoal| evidence_variable(context, subgoal));
             let arguments = arguments.collect::<ConversionResult<Vec<_>>>()?;
-            Ok(context.application(function, arguments))
+            let construction = context.application(function, arguments);
+            if subgoals.is_empty() {
+                Ok(construction)
+            } else {
+                context.record_evidence(evidence, construction, name)
+            }
         }
         Evidence::Superclass { parent, superclass } => {
             let record = convert_evidence(context, *parent)?;
@@ -974,10 +1029,129 @@ fn synthesized_evidence(
     }
 }
 
+fn order_evidence_bindings(mut bindings: Vec<EvidenceBinding>) -> Vec<Binding> {
+    // Every prerequisite precedes the evidence that consumes it, so this order places inputs
+    // before the non-recursive bindings that reference them.
+    bindings.sort_by_key(|binding| binding.evidence.dependency_order());
+    let bindings = bindings.into_iter().map(|binding| binding.binding);
+    bindings.collect()
+}
+
 impl<'c, Q> Context<'c, Q>
 where
     Q: checking::ExternalQueries,
 {
+    fn evidence_scope(
+        &mut self,
+        convert: impl FnOnce(&mut Context<'c, Q>) -> ConversionResult<ExpressionId>,
+    ) -> ConversionResult<ExpressionId> {
+        self.evidence_scopes.push(EvidenceScope::default());
+        let result = convert(self);
+        let scope = self
+            .evidence_scopes
+            .pop()
+            .expect("invariant violated: evidence scope disappeared during conversion");
+        let body = result?;
+        if scope.bindings.is_empty() {
+            return Ok(body);
+        }
+        let bindings = order_evidence_bindings(scope.bindings);
+        Ok(self.expression(ExpressionKind::Let {
+            recursive: false,
+            bindings: bindings.into(),
+            body,
+        }))
+    }
+
+    fn shared_evidence(
+        &mut self,
+        evidence: &EvidenceKey,
+    ) -> ConversionResult<Option<ExpressionId>> {
+        let Some(scope) = self.evidence_scopes.last() else { return Ok(None) };
+        let Some(construction) = scope.constructions.get(evidence).cloned() else {
+            return Ok(None);
+        };
+        let parameter = match construction {
+            EvidenceConstruction::Shared(parameter) => parameter,
+            EvidenceConstruction::Inline { expression, name } => {
+                // The first occurrence stays inline until repetition justifies a binding. Replacing
+                // its arena node with a local updates that occurrence without a separate tree pass.
+                let parameter = self.fresh_parameter(name)?;
+                let local = ExpressionKind::Local { parameter: parameter.clone() };
+                let construction = self.storage.replace_expression_kind(expression, local);
+                let construction = self.expression(construction);
+                let scope = self
+                    .evidence_scopes
+                    .last_mut()
+                    .expect("invariant violated: evidence scope disappeared during conversion");
+                scope
+                    .constructions
+                    .insert(evidence.clone(), EvidenceConstruction::Shared(parameter.clone()));
+                scope.bindings.push(EvidenceBinding {
+                    evidence: evidence.clone(),
+                    binding: Binding { parameter: parameter.clone(), expression: construction },
+                });
+                parameter
+            }
+        };
+        Ok(Some(self.expression(ExpressionKind::Local { parameter })))
+    }
+
+    fn record_evidence(
+        &mut self,
+        evidence: EvidenceKey,
+        construction: ExpressionId,
+        name: SmolStr,
+    ) -> ConversionResult<ExpressionId> {
+        let Some(scope) = self.evidence_scopes.last_mut() else { return Ok(construction) };
+        scope
+            .constructions
+            .insert(evidence, EvidenceConstruction::Inline { expression: construction, name });
+        Ok(construction)
+    }
+
+    fn evidence_key(&self, evidence: EvidenceId) -> EvidenceKey {
+        self.evidence_key_inner(evidence, &mut FxHashSet::default())
+            .unwrap_or(EvidenceKey::Opaque(evidence))
+    }
+
+    fn evidence_key_inner(
+        &self,
+        evidence: EvidenceId,
+        visiting: &mut FxHashSet<EvidenceId>,
+    ) -> Option<EvidenceKey> {
+        if !visiting.insert(evidence) {
+            return None;
+        }
+        let key = match &self.checked.evidence[evidence] {
+            Evidence::Variable(variable) => {
+                let EvidenceState::Solved(evidence) = self.checked.evidence[*variable].state else {
+                    return None;
+                };
+                self.evidence_key_inner(evidence, visiting)?
+            }
+            Evidence::Given(binder) => EvidenceKey::Given(*binder),
+            Evidence::Instance { origin, subgoals } => {
+                let mut keys = Vec::with_capacity(subgoals.len());
+                for &subgoal in subgoals {
+                    let EvidenceState::Solved(evidence) = self.checked.evidence[subgoal].state
+                    else {
+                        return None;
+                    };
+                    keys.push(self.evidence_key_inner(evidence, visiting)?);
+                }
+                EvidenceKey::Instance { origin: *origin, subgoals: keys }
+            }
+            Evidence::Superclass { parent, superclass } => EvidenceKey::Superclass {
+                parent: Box::new(self.evidence_key_inner(*parent, visiting)?),
+                superclass: *superclass,
+            },
+            Evidence::Trivial | Evidence::Synthesized(_) => EvidenceKey::Opaque(evidence),
+        };
+        visiting.remove(&evidence);
+        Some(key)
+    }
+
     fn checked_binder_parameter(
         &mut self,
         binder_id: checking_tree::BinderId,

--- a/compiler-backend/nbe/src/tree.rs
+++ b/compiler-backend/nbe/src/tree.rs
@@ -61,6 +61,14 @@ impl Storage {
     pub fn patterns(&self) -> impl Iterator<Item = (PatternId, &Pattern)> {
         self.patterns.iter()
     }
+
+    pub(crate) fn replace_expression_kind(
+        &mut self,
+        expression: ExpressionId,
+        kind: ExpressionKind,
+    ) -> ExpressionKind {
+        std::mem::replace(&mut self.expressions[expression].kind, kind)
+    }
 }
 
 impl Index<ExpressionId> for Storage {

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Data.Eq.purs
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Data.Eq.purs
@@ -1,0 +1,19 @@
+module Data.Eq where
+
+class Eq a where
+  eq :: a -> a -> Boolean
+
+instance Eq Int where
+  eq _ _ = true
+
+instance Eq Boolean where
+  eq _ _ = true
+
+instance eqArray :: Eq a => Eq (Array a) where
+  eq _ _ = true
+
+class Eq a <= Ordered a where
+  lessThanOrEqual :: a -> a -> Boolean
+
+instance Ordered Int where
+  lessThanOrEqual _ _ = true

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.nbe.snap
@@ -11,79 +11,96 @@ expression: report
   if eqInt.eq left%3 right%4 then eqInt.eq right%4 left%3 else false
 
 @export compareArraysTwice = \left%5 right%6 ->
-  if (eqArray eqInt).eq left%5 right%6 then (eqArray eqInt).eq right%6 left%5 else false
+  let
+    eqArrayDict%7 = eqArray eqInt
+  in if eqArrayDict%7.eq left%5 right%6 then eqArrayDict%7.eq right%6 left%5 else false
 
-@export compareArraysOnce = \left%7 right%8 -> (eqArray eqInt).eq left%7 right%8
+@export compareArraysOnce = \left%8 right%9 -> (eqArray eqInt).eq left%8 right%9
 
-@export compareGenericArraysTwice = \dictionary1%9 ->
-  \left%10 right%11 ->
-    if (eqArray dictionary1%9).eq left%10 right%11
-      then (eqArray dictionary1%9).eq right%11 left%10
-      else false
+@export compareGenericArraysTwice = \dictionary1%10 ->
+  \left%11 right%12 ->
+    let
+      eqArrayDict%13 = eqArray dictionary1%10
+    in if eqArrayDict%13.eq left%11 right%12 then eqArrayDict%13.eq right%12 left%11 else false
 
-@export compareNestedArraysTwice = \left%14 right%15 nestedLeft%12 nestedRight%13 ->
-  if (eqArray (eqArray eqInt)).eq nestedLeft%12 nestedRight%13
-    then (eqArray (eqArray eqInt)).eq nestedRight%13 nestedLeft%12
-    else (eqArray eqInt).eq left%14 right%15
+@export compareNestedArraysTwice = \left%18 right%19 nestedLeft%14 nestedRight%15 ->
+  let
+    eqArrayDict%17 = eqArray eqInt
+    eqArrayDict%16 = eqArray eqArrayDict%17
+  in if eqArrayDict%16.eq nestedLeft%14 nestedRight%15
+    then eqArrayDict%16.eq nestedRight%15 nestedLeft%14
+    else eqArrayDict%17.eq left%18 right%19
 
-@export distinctGivens = \dictionary2%16 dictionary3%19 ->
-  \leftA%17 rightA%18 leftB%20 rightB%21 ->
-    if (eqArray dictionary2%16).eq leftA%17 rightA%18
-      then (eqArray dictionary2%16).eq rightA%18 leftA%17
-      else if (eqArray dictionary3%19).eq leftB%20 rightB%21
-        then (eqArray dictionary3%19).eq rightB%21 leftB%20
+@export distinctGivens = \dictionary2%20 dictionary3%24 ->
+  \leftA%21 rightA%22 leftB%25 rightB%26 ->
+    let
+      eqArrayDict%23 = eqArray dictionary2%20
+      eqArrayDict%27 = eqArray dictionary3%24
+    in if eqArrayDict%23.eq leftA%21 rightA%22
+      then eqArrayDict%23.eq rightA%22 leftA%21
+      else if eqArrayDict%27.eq leftB%25 rightB%26
+        then eqArrayDict%27.eq rightB%26 leftB%25
         else false
 
-@export distinctSubgoals = \leftInt%22 rightInt%23 leftBoolean%24 rightBoolean%25 ->
-  if (eqArray eqInt).eq leftInt%22 rightInt%23
-    then (eqArray eqInt).eq rightInt%23 leftInt%22
-    else if (eqArray eqBoolean).eq leftBoolean%24 rightBoolean%25
-      then (eqArray eqBoolean).eq rightBoolean%25 leftBoolean%24
-      else false
-
-@export compareArraysThrice = \left%26 right%27 ->
-  if (eqArray eqInt).eq left%26 right%27
-    then if (eqArray eqInt).eq right%27 left%26 then (eqArray eqInt).eq left%26 right%27 else false
-    else false
-
-@export compareNestedArraysWhole = \left%28 right%29 ->
-  if (eqArray (eqArray eqInt)).eq left%28 right%29
-    then (eqArray (eqArray eqInt)).eq right%29 left%28
-    else false
-
-@export compareSuperclassArraysTwice = \dictionary4%30 ->
-  \left%31 right%32 ->
-    if (eqArray dictionary4%30.superclass62).eq left%31 right%32
-      then (eqArray dictionary4%30.superclass62).eq right%32 left%31
-      else false
-
-@export compareSuperclassTwice = \dictionary5%33 ->
-  \left%34 right%35 ->
-    if dictionary5%33.superclass62.eq left%34 right%35
-      then dictionary5%33.superclass62.eq right%35 left%34
-      else false
-
-@export lambdaScope = \left%36 right%37 ->
-  if (eqArray eqInt).eq left%36 right%37
-    then (\lambdaLeft%38 lambdaRight%39 ->
-      if (eqArray eqInt).eq lambdaLeft%38 lambdaRight%39
-        then (eqArray eqInt).eq lambdaRight%39 lambdaLeft%38
-        else false)
-      left%36
-      right%37
-    else false
-
-@export whereIsolation = \left%41 right%42 ->
+@export distinctSubgoals = \leftInt%28 rightInt%29 leftBoolean%31 rightBoolean%32 ->
   let
-    helper%40 = \helperLeft%43 helperRight%44 -> (eqArray eqInt).eq helperLeft%43 helperRight%44
-  in if helper%40 left%41 right%42 then (eqArray eqInt).eq left%41 right%42 else false
+    eqArrayDict%30 = eqArray eqInt
+    eqArrayDict%33 = eqArray eqBoolean
+  in if eqArrayDict%30.eq leftInt%28 rightInt%29
+    then eqArrayDict%30.eq rightInt%29 leftInt%28
+    else if eqArrayDict%33.eq leftBoolean%31 rightBoolean%32
+      then eqArrayDict%33.eq rightBoolean%32 leftBoolean%31
+      else false
 
-@export equationScope = \argument0%45 argument1%46 argument2%47 ->
-  case argument0%45, argument1%46, argument2%47 of
-    true, left%48, right%49 ->
-      (eqArray eqInt).eq left%48 right%49
-    false, left%50, right%51 ->
-      (eqArray eqInt).eq right%51 left%50
+@export compareArraysThrice = \left%34 right%35 ->
+  let
+    eqArrayDict%36 = eqArray eqInt
+  in if eqArrayDict%36.eq left%34 right%35
+    then if eqArrayDict%36.eq right%35 left%34 then eqArrayDict%36.eq left%34 right%35 else false
+    else false
+
+@export compareNestedArraysWhole = \left%37 right%38 ->
+  let
+    eqArrayDict%39 = eqArray (eqArray eqInt)
+  in if eqArrayDict%39.eq left%37 right%38 then eqArrayDict%39.eq right%38 left%37 else false
+
+@export compareSuperclassArraysTwice = \dictionary4%40 ->
+  \left%41 right%42 ->
+    let
+      eqArrayDict%43 = eqArray dictionary4%40.superclass62
+    in if eqArrayDict%43.eq left%41 right%42 then eqArrayDict%43.eq right%42 left%41 else false
+
+@export compareSuperclassTwice = \dictionary5%44 ->
+  \left%45 right%46 ->
+    if dictionary5%44.superclass62.eq left%45 right%46
+      then dictionary5%44.superclass62.eq right%46 left%45
+      else false
+
+@export lambdaScope = \left%47 right%48 ->
+  if (eqArray eqInt).eq left%47 right%48
+    then (\lambdaLeft%49 lambdaRight%50 ->
+      let
+        eqArrayDict%51 = eqArray eqInt
+      in if eqArrayDict%51.eq lambdaLeft%49 lambdaRight%50
+        then eqArrayDict%51.eq lambdaRight%50 lambdaLeft%49
+        else false)
+      left%47
+      right%48
+    else false
+
+@export whereIsolation = \left%53 right%54 ->
+  let
+    helper%52 = \helperLeft%55 helperRight%56 -> (eqArray eqInt).eq helperLeft%55 helperRight%56
+  in if helper%52 left%53 right%54 then (eqArray eqInt).eq left%53 right%54 else false
+
+@export equationScope = \argument0%57 argument1%58 argument2%59 ->
+  let
+    eqArrayDict%64 = eqArray eqInt
+  in case argument0%57, argument1%58, argument2%59 of
+    true, left%60, right%61 ->
+      eqArrayDict%64.eq left%60 right%61
+    false, left%62, right%63 ->
+      eqArrayDict%64.eq right%63 left%62
 
 @export firstComparison = eqInt.eq 1 2
 

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.nbe.snap
@@ -1,0 +1,90 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export compareTwice = \dictionary0%0 ->
+  \left%1 right%2 ->
+    if dictionary0%0.eq left%1 right%2 then dictionary0%0.eq right%2 left%1 else false
+
+@export compareIntsTwice = \left%3 right%4 ->
+  if eqInt.eq left%3 right%4 then eqInt.eq right%4 left%3 else false
+
+@export compareArraysTwice = \left%5 right%6 ->
+  if (eqArray eqInt).eq left%5 right%6 then (eqArray eqInt).eq right%6 left%5 else false
+
+@export compareArraysOnce = \left%7 right%8 -> (eqArray eqInt).eq left%7 right%8
+
+@export compareGenericArraysTwice = \dictionary1%9 ->
+  \left%10 right%11 ->
+    if (eqArray dictionary1%9).eq left%10 right%11
+      then (eqArray dictionary1%9).eq right%11 left%10
+      else false
+
+@export compareNestedArraysTwice = \left%14 right%15 nestedLeft%12 nestedRight%13 ->
+  if (eqArray (eqArray eqInt)).eq nestedLeft%12 nestedRight%13
+    then (eqArray (eqArray eqInt)).eq nestedRight%13 nestedLeft%12
+    else (eqArray eqInt).eq left%14 right%15
+
+@export distinctGivens = \dictionary2%16 dictionary3%19 ->
+  \leftA%17 rightA%18 leftB%20 rightB%21 ->
+    if (eqArray dictionary2%16).eq leftA%17 rightA%18
+      then (eqArray dictionary2%16).eq rightA%18 leftA%17
+      else if (eqArray dictionary3%19).eq leftB%20 rightB%21
+        then (eqArray dictionary3%19).eq rightB%21 leftB%20
+        else false
+
+@export distinctSubgoals = \leftInt%22 rightInt%23 leftBoolean%24 rightBoolean%25 ->
+  if (eqArray eqInt).eq leftInt%22 rightInt%23
+    then (eqArray eqInt).eq rightInt%23 leftInt%22
+    else if (eqArray eqBoolean).eq leftBoolean%24 rightBoolean%25
+      then (eqArray eqBoolean).eq rightBoolean%25 leftBoolean%24
+      else false
+
+@export compareArraysThrice = \left%26 right%27 ->
+  if (eqArray eqInt).eq left%26 right%27
+    then if (eqArray eqInt).eq right%27 left%26 then (eqArray eqInt).eq left%26 right%27 else false
+    else false
+
+@export compareNestedArraysWhole = \left%28 right%29 ->
+  if (eqArray (eqArray eqInt)).eq left%28 right%29
+    then (eqArray (eqArray eqInt)).eq right%29 left%28
+    else false
+
+@export compareSuperclassArraysTwice = \dictionary4%30 ->
+  \left%31 right%32 ->
+    if (eqArray dictionary4%30.superclass62).eq left%31 right%32
+      then (eqArray dictionary4%30.superclass62).eq right%32 left%31
+      else false
+
+@export compareSuperclassTwice = \dictionary5%33 ->
+  \left%34 right%35 ->
+    if dictionary5%33.superclass62.eq left%34 right%35
+      then dictionary5%33.superclass62.eq right%35 left%34
+      else false
+
+@export lambdaScope = \left%36 right%37 ->
+  if (eqArray eqInt).eq left%36 right%37
+    then (\lambdaLeft%38 lambdaRight%39 ->
+      if (eqArray eqInt).eq lambdaLeft%38 lambdaRight%39
+        then (eqArray eqInt).eq lambdaRight%39 lambdaLeft%38
+        else false)
+      left%36
+      right%37
+    else false
+
+@export whereIsolation = \left%41 right%42 ->
+  let
+    helper%40 = \helperLeft%43 helperRight%44 -> (eqArray eqInt).eq helperLeft%43 helperRight%44
+  in if helper%40 left%41 right%42 then (eqArray eqInt).eq left%41 right%42 else false
+
+@export equationScope = \argument0%45 argument1%46 argument2%47 ->
+  case argument0%45, argument1%46, argument2%47 of
+    true, left%48, right%49 ->
+      (eqArray eqInt).eq left%48 right%49
+    false, left%50, right%51 ->
+      (eqArray eqInt).eq right%51 left%50
+
+@export firstComparison = eqInt.eq 1 2
+
+@export secondComparison = eqInt.eq 3 4

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.purs
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.purs
@@ -1,0 +1,111 @@
+module Main where
+
+import Data.Eq as Eq
+
+compareTwice :: forall a. Eq.Eq a => a -> a -> Boolean
+compareTwice left right =
+  if Eq.eq left right then Eq.eq right left else false
+
+compareIntsTwice :: Int -> Int -> Boolean
+compareIntsTwice left right =
+  if Eq.eq left right then Eq.eq right left else false
+
+compareArraysTwice :: Array Int -> Array Int -> Boolean
+compareArraysTwice left right =
+  if Eq.eq left right then Eq.eq right left else false
+
+compareArraysOnce :: Array Int -> Array Int -> Boolean
+compareArraysOnce left right = Eq.eq left right
+
+compareGenericArraysTwice :: forall a. Eq.Eq a => Array a -> Array a -> Boolean
+compareGenericArraysTwice left right =
+  if Eq.eq left right then Eq.eq right left else false
+
+compareNestedArraysTwice
+  :: Array Int
+  -> Array Int
+  -> Array (Array Int)
+  -> Array (Array Int)
+  -> Boolean
+compareNestedArraysTwice left right nestedLeft nestedRight =
+  if Eq.eq nestedLeft nestedRight then Eq.eq nestedRight nestedLeft else Eq.eq left right
+
+distinctGivens
+  :: forall a b
+   . Eq.Eq a
+  => Eq.Eq b
+  => Array a
+  -> Array a
+  -> Array b
+  -> Array b
+  -> Boolean
+distinctGivens leftA rightA leftB rightB =
+  if Eq.eq leftA rightA then Eq.eq rightA leftA
+  else if Eq.eq leftB rightB then Eq.eq rightB leftB
+  else false
+
+distinctSubgoals
+  :: Array Int
+  -> Array Int
+  -> Array Boolean
+  -> Array Boolean
+  -> Boolean
+distinctSubgoals leftInt rightInt leftBoolean rightBoolean =
+  if Eq.eq leftInt rightInt then Eq.eq rightInt leftInt
+  else if Eq.eq leftBoolean rightBoolean then Eq.eq rightBoolean leftBoolean
+  else false
+
+compareArraysThrice :: Array Int -> Array Int -> Boolean
+compareArraysThrice left right =
+  if Eq.eq left right
+  then if Eq.eq right left then Eq.eq left right else false
+  else false
+
+compareNestedArraysWhole
+  :: Array (Array Int)
+  -> Array (Array Int)
+  -> Boolean
+compareNestedArraysWhole left right =
+  if Eq.eq left right then Eq.eq right left else false
+
+compareSuperclassArraysTwice
+  :: forall a
+   . Eq.Ordered a
+  => Array a
+  -> Array a
+  -> Boolean
+compareSuperclassArraysTwice left right =
+  if Eq.eq left right then Eq.eq right left else false
+
+compareSuperclassTwice
+  :: forall a
+   . Eq.Ordered a
+  => a
+  -> a
+  -> Boolean
+compareSuperclassTwice left right =
+  if Eq.eq left right then Eq.eq right left else false
+
+lambdaScope :: Array Int -> Array Int -> Boolean
+lambdaScope left right =
+  if Eq.eq left right
+  then (\lambdaLeft lambdaRight ->
+    if Eq.eq lambdaLeft lambdaRight then Eq.eq lambdaRight lambdaLeft else false
+  ) left right
+  else false
+
+whereIsolation :: Array Int -> Array Int -> Boolean
+whereIsolation left right =
+  if helper left right then Eq.eq left right else false
+  where
+  helper helperLeft helperRight = Eq.eq helperLeft helperRight
+
+equationScope :: Boolean -> Array Int -> Array Int -> Boolean
+equationScope true left right = Eq.eq left right
+equationScope false left right = Eq.eq right left
+
+firstComparison :: Boolean
+firstComparison = Eq.eq 1 2
+
+secondComparison :: Boolean
+secondComparison = Eq.eq 3 4

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.snap
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.snap
@@ -1,0 +1,41 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 255
+expression: checking_report
+---
+Terms
+compareTwice :: forall a. Data.Eq.Eq a => a -> a -> Prim.Boolean
+compareIntsTwice :: Prim.Int -> Prim.Int -> Prim.Boolean
+compareArraysTwice :: Prim.Array Prim.Int -> Prim.Array Prim.Int -> Prim.Boolean
+compareArraysOnce :: Prim.Array Prim.Int -> Prim.Array Prim.Int -> Prim.Boolean
+compareGenericArraysTwice :: forall a. Data.Eq.Eq a => Prim.Array a -> Prim.Array a -> Prim.Boolean
+compareNestedArraysTwice ::
+  Prim.Array Prim.Int ->
+  Prim.Array Prim.Int ->
+  Prim.Array (Prim.Array Prim.Int) ->
+  Prim.Array (Prim.Array Prim.Int) ->
+  Prim.Boolean
+distinctGivens ::
+  forall a b.
+    Data.Eq.Eq a =>
+    Data.Eq.Eq b =>
+    Prim.Array a -> Prim.Array a -> Prim.Array b -> Prim.Array b -> Prim.Boolean
+distinctSubgoals ::
+  Prim.Array Prim.Int ->
+  Prim.Array Prim.Int ->
+  Prim.Array Prim.Boolean ->
+  Prim.Array Prim.Boolean ->
+  Prim.Boolean
+compareArraysThrice :: Prim.Array Prim.Int -> Prim.Array Prim.Int -> Prim.Boolean
+compareNestedArraysWhole ::
+  Prim.Array (Prim.Array Prim.Int) -> Prim.Array (Prim.Array Prim.Int) -> Prim.Boolean
+compareSuperclassArraysTwice ::
+  forall a. Data.Eq.Ordered a => Prim.Array a -> Prim.Array a -> Prim.Boolean
+compareSuperclassTwice :: forall a. Data.Eq.Ordered a => a -> a -> Prim.Boolean
+lambdaScope :: Prim.Array Prim.Int -> Prim.Array Prim.Int -> Prim.Boolean
+whereIsolation :: Prim.Array Prim.Int -> Prim.Array Prim.Int -> Prim.Boolean
+equationScope :: Prim.Boolean -> Prim.Array Prim.Int -> Prim.Array Prim.Int -> Prim.Boolean
+firstComparison :: Prim.Boolean
+secondComparison :: Prim.Boolean
+
+Types

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.ssa.snap
@@ -53,13 +53,10 @@ expression: ssa_report
     }
   }
   then() {
-    const eqArray$1 = global(eqArray);
-    const eqInt$1 = global(eqInt);
-    const call$3 = source.call(eqArray$1, eqInt$1);
-    const eq$1 = call$3.eq;
-    const call$4 = source.call(eq$1, right);
-    const call$5 = source.call(call$4, left);
-    if$join(call$5);
+    const eq$1 = call.eq;
+    const call$3 = source.call(eq$1, right);
+    const call$4 = source.call(call$3, left);
+    if$join(call$4);
   }
   else() {
     const literal = false;
@@ -92,10 +89,10 @@ expression: ssa_report
 @export function compareNestedArraysTwice(left, right, nestedLeft, nestedRight) {
   entry() {
     const eqArray = global(eqArray);
-    const eqArray$1 = global(eqArray);
     const eqInt = global(eqInt);
-    const call = source.call(eqArray$1, eqInt);
-    const call$1 = source.call(eqArray, call);
+    const call = source.call(eqArray, eqInt);
+    const eqArray$1 = global(eqArray);
+    const call$1 = source.call(eqArray$1, call);
     const eq = call$1.eq;
     const call$2 = source.call(eq, nestedLeft);
     const call$3 = source.call(call$2, nestedRight);
@@ -106,24 +103,16 @@ expression: ssa_report
     }
   }
   then() {
-    const eqArray$2 = global(eqArray);
-    const eqArray$3 = global(eqArray);
-    const eqInt$1 = global(eqInt);
-    const call$4 = source.call(eqArray$3, eqInt$1);
-    const call$5 = source.call(eqArray$2, call$4);
-    const eq$1 = call$5.eq;
-    const call$6 = source.call(eq$1, nestedRight);
-    const call$7 = source.call(call$6, nestedLeft);
-    if$join(call$7);
+    const eq$1 = call$1.eq;
+    const call$4 = source.call(eq$1, nestedRight);
+    const call$5 = source.call(call$4, nestedLeft);
+    if$join(call$5);
   }
   else() {
-    const eqArray$4 = global(eqArray);
-    const eqInt$2 = global(eqInt);
-    const call$8 = source.call(eqArray$4, eqInt$2);
-    const eq$2 = call$8.eq;
-    const call$9 = source.call(eq$2, left);
-    const call$10 = source.call(call$9, right);
-    if$join(call$10);
+    const eq$2 = call.eq;
+    const call$6 = source.call(eq$2, left);
+    const call$7 = source.call(call$6, right);
+    if$join(call$7);
   }
   if$join(result) {
     return result;
@@ -142,32 +131,29 @@ expression: ssa_report
     const eqArray = global(eqArray);
     const eqInt = global(eqInt);
     const call = source.call(eqArray, eqInt);
+    const eqArray$1 = global(eqArray);
+    const eqBoolean = global(eqBoolean);
+    const call$1 = source.call(eqArray$1, eqBoolean);
     const eq = call.eq;
-    const call$1 = source.call(eq, leftInt);
-    const call$2 = source.call(call$1, rightInt);
-    if (call$2) {
+    const call$2 = source.call(eq, leftInt);
+    const call$3 = source.call(call$2, rightInt);
+    if (call$3) {
       then();
     } else {
       else();
     }
   }
   then() {
-    const eqArray$1 = global(eqArray);
-    const eqInt$1 = global(eqInt);
-    const call$3 = source.call(eqArray$1, eqInt$1);
-    const eq$1 = call$3.eq;
+    const eq$1 = call.eq;
     const call$4 = source.call(eq$1, rightInt);
     const call$5 = source.call(call$4, leftInt);
     if$join(call$5);
   }
   else() {
-    const eqArray$2 = global(eqArray);
-    const eqBoolean = global(eqBoolean);
-    const call$6 = source.call(eqArray$2, eqBoolean);
-    const eq$2 = call$6.eq;
-    const call$7 = source.call(eq$2, leftBoolean);
-    const call$8 = source.call(call$7, rightBoolean);
-    if (call$8) {
+    const eq$2 = call$1.eq;
+    const call$6 = source.call(eq$2, leftBoolean);
+    const call$7 = source.call(call$6, rightBoolean);
+    if (call$7) {
       then$1();
     } else {
       else$1();
@@ -177,13 +163,10 @@ expression: ssa_report
     return result;
   }
   then$1() {
-    const eqArray$3 = global(eqArray);
-    const eqBoolean$1 = global(eqBoolean);
-    const call$9 = source.call(eqArray$3, eqBoolean$1);
-    const eq$3 = call$9.eq;
-    const call$10 = source.call(eq$3, rightBoolean);
-    const call$11 = source.call(call$10, leftBoolean);
-    if$join$1(call$11);
+    const eq$3 = call$1.eq;
+    const call$8 = source.call(eq$3, rightBoolean);
+    const call$9 = source.call(call$8, leftBoolean);
+    if$join$1(call$9);
   }
   else$1() {
     const literal = false;
@@ -209,13 +192,10 @@ expression: ssa_report
     }
   }
   then() {
-    const eqArray$1 = global(eqArray);
-    const eqInt$1 = global(eqInt);
-    const call$3 = source.call(eqArray$1, eqInt$1);
-    const eq$1 = call$3.eq;
-    const call$4 = source.call(eq$1, right);
-    const call$5 = source.call(call$4, left);
-    if (call$5) {
+    const eq$1 = call.eq;
+    const call$3 = source.call(eq$1, right);
+    const call$4 = source.call(call$3, left);
+    if (call$4) {
       then$1();
     } else {
       else$1();
@@ -229,13 +209,10 @@ expression: ssa_report
     return result;
   }
   then$1() {
-    const eqArray$2 = global(eqArray);
-    const eqInt$2 = global(eqInt);
-    const call$6 = source.call(eqArray$2, eqInt$2);
-    const eq$2 = call$6.eq;
-    const call$7 = source.call(eq$2, left);
-    const call$8 = source.call(call$7, right);
-    if$join$1(call$8);
+    const eq$2 = call.eq;
+    const call$5 = source.call(eq$2, left);
+    const call$6 = source.call(call$5, right);
+    if$join$1(call$6);
   }
   else$1() {
     const literal = false;
@@ -263,15 +240,10 @@ expression: ssa_report
     }
   }
   then() {
-    const eqArray$2 = global(eqArray);
-    const eqArray$3 = global(eqArray);
-    const eqInt$1 = global(eqInt);
-    const call$4 = source.call(eqArray$3, eqInt$1);
-    const call$5 = source.call(eqArray$2, call$4);
-    const eq$1 = call$5.eq;
-    const call$6 = source.call(eq$1, right);
-    const call$7 = source.call(call$6, left);
-    if$join(call$7);
+    const eq$1 = call$1.eq;
+    const call$4 = source.call(eq$1, right);
+    const call$5 = source.call(call$4, left);
+    if$join(call$5);
   }
   else() {
     const literal = false;
@@ -356,6 +328,9 @@ expression: ssa_report
 
 @export function equationScope(argument0, argument1, argument2) {
   entry() {
+    const eqArray = global(eqArray);
+    const eqInt = global(eqInt);
+    const call = source.call(eqArray, eqInt);
     case$0();
   }
   case$0() {
@@ -381,22 +356,16 @@ expression: ssa_report
     return result;
   }
   match$success() {
-    const eqArray = global(eqArray);
-    const eqInt = global(eqInt);
-    const call = source.call(eqArray, eqInt);
     const eq = call.eq;
     const call$1 = source.call(eq, argument1);
     const call$2 = source.call(call$1, argument2);
     case$join(call$2);
   }
   match$success$1() {
-    const eqArray$1 = global(eqArray);
-    const eqInt$1 = global(eqInt);
-    const call$3 = source.call(eqArray$1, eqInt$1);
-    const eq$1 = call$3.eq;
-    const call$4 = source.call(eq$1, argument2);
-    const call$5 = source.call(call$4, argument1);
-    case$join(call$5);
+    const eq$1 = call.eq;
+    const call$3 = source.call(eq$1, argument2);
+    const call$4 = source.call(call$3, argument1);
+    case$join(call$4);
   }
 }
 
@@ -464,12 +433,10 @@ closure compareGenericArraysTwice$closure[dictionary1](left, right) {
     }
   }
   then() {
-    const eqArray$1 = global(eqArray);
-    const call$3 = source.call(eqArray$1, dictionary1);
-    const eq$1 = call$3.eq;
-    const call$4 = source.call(eq$1, right);
-    const call$5 = source.call(call$4, left);
-    if$join(call$5);
+    const eq$1 = call.eq;
+    const call$3 = source.call(eq$1, right);
+    const call$4 = source.call(call$3, left);
+    if$join(call$4);
   }
   else() {
     const literal = false;
@@ -484,30 +451,28 @@ closure distinctGivens$closure[dictionary2, dictionary3](leftA, rightA, leftB, r
   entry() {
     const eqArray = global(eqArray);
     const call = source.call(eqArray, dictionary2);
+    const eqArray$1 = global(eqArray);
+    const call$1 = source.call(eqArray$1, dictionary3);
     const eq = call.eq;
-    const call$1 = source.call(eq, leftA);
-    const call$2 = source.call(call$1, rightA);
-    if (call$2) {
+    const call$2 = source.call(eq, leftA);
+    const call$3 = source.call(call$2, rightA);
+    if (call$3) {
       then();
     } else {
       else();
     }
   }
   then() {
-    const eqArray$1 = global(eqArray);
-    const call$3 = source.call(eqArray$1, dictionary2);
-    const eq$1 = call$3.eq;
+    const eq$1 = call.eq;
     const call$4 = source.call(eq$1, rightA);
     const call$5 = source.call(call$4, leftA);
     if$join(call$5);
   }
   else() {
-    const eqArray$2 = global(eqArray);
-    const call$6 = source.call(eqArray$2, dictionary3);
-    const eq$2 = call$6.eq;
-    const call$7 = source.call(eq$2, leftB);
-    const call$8 = source.call(call$7, rightB);
-    if (call$8) {
+    const eq$2 = call$1.eq;
+    const call$6 = source.call(eq$2, leftB);
+    const call$7 = source.call(call$6, rightB);
+    if (call$7) {
       then$1();
     } else {
       else$1();
@@ -517,12 +482,10 @@ closure distinctGivens$closure[dictionary2, dictionary3](leftA, rightA, leftB, r
     return result;
   }
   then$1() {
-    const eqArray$3 = global(eqArray);
-    const call$9 = source.call(eqArray$3, dictionary3);
-    const eq$3 = call$9.eq;
-    const call$10 = source.call(eq$3, rightB);
-    const call$11 = source.call(call$10, leftB);
-    if$join$1(call$11);
+    const eq$3 = call$1.eq;
+    const call$8 = source.call(eq$3, rightB);
+    const call$9 = source.call(call$8, leftB);
+    if$join$1(call$9);
   }
   else$1() {
     const literal = false;
@@ -548,13 +511,10 @@ closure compareSuperclassArraysTwice$closure[dictionary4](left, right) {
     }
   }
   then() {
-    const eqArray$1 = global(eqArray);
-    const superclass62$1 = dictionary4.superclass62;
-    const call$3 = source.call(eqArray$1, superclass62$1);
-    const eq$1 = call$3.eq;
-    const call$4 = source.call(eq$1, right);
-    const call$5 = source.call(call$4, left);
-    if$join(call$5);
+    const eq$1 = call.eq;
+    const call$3 = source.call(eq$1, right);
+    const call$4 = source.call(call$3, left);
+    if$join(call$4);
   }
   else() {
     const literal = false;
@@ -608,13 +568,10 @@ closure lambdaScope$closure[](lambdaLeft, lambdaRight) {
     }
   }
   then() {
-    const eqArray$1 = global(eqArray);
-    const eqInt$1 = global(eqInt);
-    const call$3 = source.call(eqArray$1, eqInt$1);
-    const eq$1 = call$3.eq;
-    const call$4 = source.call(eq$1, lambdaRight);
-    const call$5 = source.call(call$4, lambdaLeft);
-    if$join(call$5);
+    const eq$1 = call.eq;
+    const call$3 = source.call(eq$1, lambdaRight);
+    const call$4 = source.call(call$3, lambdaLeft);
+    if$join(call$4);
   }
   else() {
     const literal = false;

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.ssa.snap
@@ -1,0 +1,638 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 256
+expression: ssa_report
+---
+@export function compareTwice(dictionary0) {
+  entry() {
+    const closure = closure(compareTwice$closure, dictionary0);
+    return closure;
+  }
+}
+
+@export function compareIntsTwice(left, right) {
+  entry() {
+    const eqInt = global(eqInt);
+    const eq = eqInt.eq;
+    const call = source.call(eq, left);
+    const call$1 = source.call(call, right);
+    if (call$1) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const eqInt$1 = global(eqInt);
+    const eq$1 = eqInt$1.eq;
+    const call$2 = source.call(eq$1, right);
+    const call$3 = source.call(call$2, left);
+    if$join(call$3);
+  }
+  else() {
+    const literal = false;
+    if$join(literal);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+@export function compareArraysTwice(left, right) {
+  entry() {
+    const eqArray = global(eqArray);
+    const eqInt = global(eqInt);
+    const call = source.call(eqArray, eqInt);
+    const eq = call.eq;
+    const call$1 = source.call(eq, left);
+    const call$2 = source.call(call$1, right);
+    if (call$2) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const eqArray$1 = global(eqArray);
+    const eqInt$1 = global(eqInt);
+    const call$3 = source.call(eqArray$1, eqInt$1);
+    const eq$1 = call$3.eq;
+    const call$4 = source.call(eq$1, right);
+    const call$5 = source.call(call$4, left);
+    if$join(call$5);
+  }
+  else() {
+    const literal = false;
+    if$join(literal);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+@export function compareArraysOnce(left, right) {
+  entry() {
+    const eqArray = global(eqArray);
+    const eqInt = global(eqInt);
+    const call = source.call(eqArray, eqInt);
+    const eq = call.eq;
+    const call$1 = source.call(eq, left);
+    const call$2 = source.call(call$1, right);
+    return call$2;
+  }
+}
+
+@export function compareGenericArraysTwice(dictionary1) {
+  entry() {
+    const closure = closure(compareGenericArraysTwice$closure, dictionary1);
+    return closure;
+  }
+}
+
+@export function compareNestedArraysTwice(left, right, nestedLeft, nestedRight) {
+  entry() {
+    const eqArray = global(eqArray);
+    const eqArray$1 = global(eqArray);
+    const eqInt = global(eqInt);
+    const call = source.call(eqArray$1, eqInt);
+    const call$1 = source.call(eqArray, call);
+    const eq = call$1.eq;
+    const call$2 = source.call(eq, nestedLeft);
+    const call$3 = source.call(call$2, nestedRight);
+    if (call$3) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const eqArray$2 = global(eqArray);
+    const eqArray$3 = global(eqArray);
+    const eqInt$1 = global(eqInt);
+    const call$4 = source.call(eqArray$3, eqInt$1);
+    const call$5 = source.call(eqArray$2, call$4);
+    const eq$1 = call$5.eq;
+    const call$6 = source.call(eq$1, nestedRight);
+    const call$7 = source.call(call$6, nestedLeft);
+    if$join(call$7);
+  }
+  else() {
+    const eqArray$4 = global(eqArray);
+    const eqInt$2 = global(eqInt);
+    const call$8 = source.call(eqArray$4, eqInt$2);
+    const eq$2 = call$8.eq;
+    const call$9 = source.call(eq$2, left);
+    const call$10 = source.call(call$9, right);
+    if$join(call$10);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+@export function distinctGivens(dictionary2, dictionary3) {
+  entry() {
+    const closure = closure(distinctGivens$closure, dictionary2, dictionary3);
+    return closure;
+  }
+}
+
+@export function distinctSubgoals(leftInt, rightInt, leftBoolean, rightBoolean) {
+  entry() {
+    const eqArray = global(eqArray);
+    const eqInt = global(eqInt);
+    const call = source.call(eqArray, eqInt);
+    const eq = call.eq;
+    const call$1 = source.call(eq, leftInt);
+    const call$2 = source.call(call$1, rightInt);
+    if (call$2) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const eqArray$1 = global(eqArray);
+    const eqInt$1 = global(eqInt);
+    const call$3 = source.call(eqArray$1, eqInt$1);
+    const eq$1 = call$3.eq;
+    const call$4 = source.call(eq$1, rightInt);
+    const call$5 = source.call(call$4, leftInt);
+    if$join(call$5);
+  }
+  else() {
+    const eqArray$2 = global(eqArray);
+    const eqBoolean = global(eqBoolean);
+    const call$6 = source.call(eqArray$2, eqBoolean);
+    const eq$2 = call$6.eq;
+    const call$7 = source.call(eq$2, leftBoolean);
+    const call$8 = source.call(call$7, rightBoolean);
+    if (call$8) {
+      then$1();
+    } else {
+      else$1();
+    }
+  }
+  if$join(result) {
+    return result;
+  }
+  then$1() {
+    const eqArray$3 = global(eqArray);
+    const eqBoolean$1 = global(eqBoolean);
+    const call$9 = source.call(eqArray$3, eqBoolean$1);
+    const eq$3 = call$9.eq;
+    const call$10 = source.call(eq$3, rightBoolean);
+    const call$11 = source.call(call$10, leftBoolean);
+    if$join$1(call$11);
+  }
+  else$1() {
+    const literal = false;
+    if$join$1(literal);
+  }
+  if$join$1(result$1) {
+    if$join(result$1);
+  }
+}
+
+@export function compareArraysThrice(left, right) {
+  entry() {
+    const eqArray = global(eqArray);
+    const eqInt = global(eqInt);
+    const call = source.call(eqArray, eqInt);
+    const eq = call.eq;
+    const call$1 = source.call(eq, left);
+    const call$2 = source.call(call$1, right);
+    if (call$2) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const eqArray$1 = global(eqArray);
+    const eqInt$1 = global(eqInt);
+    const call$3 = source.call(eqArray$1, eqInt$1);
+    const eq$1 = call$3.eq;
+    const call$4 = source.call(eq$1, right);
+    const call$5 = source.call(call$4, left);
+    if (call$5) {
+      then$1();
+    } else {
+      else$1();
+    }
+  }
+  else() {
+    const literal$1 = false;
+    if$join(literal$1);
+  }
+  if$join(result) {
+    return result;
+  }
+  then$1() {
+    const eqArray$2 = global(eqArray);
+    const eqInt$2 = global(eqInt);
+    const call$6 = source.call(eqArray$2, eqInt$2);
+    const eq$2 = call$6.eq;
+    const call$7 = source.call(eq$2, left);
+    const call$8 = source.call(call$7, right);
+    if$join$1(call$8);
+  }
+  else$1() {
+    const literal = false;
+    if$join$1(literal);
+  }
+  if$join$1(result$1) {
+    if$join(result$1);
+  }
+}
+
+@export function compareNestedArraysWhole(left, right) {
+  entry() {
+    const eqArray = global(eqArray);
+    const eqArray$1 = global(eqArray);
+    const eqInt = global(eqInt);
+    const call = source.call(eqArray$1, eqInt);
+    const call$1 = source.call(eqArray, call);
+    const eq = call$1.eq;
+    const call$2 = source.call(eq, left);
+    const call$3 = source.call(call$2, right);
+    if (call$3) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const eqArray$2 = global(eqArray);
+    const eqArray$3 = global(eqArray);
+    const eqInt$1 = global(eqInt);
+    const call$4 = source.call(eqArray$3, eqInt$1);
+    const call$5 = source.call(eqArray$2, call$4);
+    const eq$1 = call$5.eq;
+    const call$6 = source.call(eq$1, right);
+    const call$7 = source.call(call$6, left);
+    if$join(call$7);
+  }
+  else() {
+    const literal = false;
+    if$join(literal);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+@export function compareSuperclassArraysTwice(dictionary4) {
+  entry() {
+    const closure = closure(compareSuperclassArraysTwice$closure, dictionary4);
+    return closure;
+  }
+}
+
+@export function compareSuperclassTwice(dictionary5) {
+  entry() {
+    const closure = closure(compareSuperclassTwice$closure, dictionary5);
+    return closure;
+  }
+}
+
+@export function lambdaScope(left, right) {
+  entry() {
+    const eqArray = global(eqArray);
+    const eqInt = global(eqInt);
+    const call = source.call(eqArray, eqInt);
+    const eq = call.eq;
+    const call$1 = source.call(eq, left);
+    const call$2 = source.call(call$1, right);
+    if (call$2) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const closure = closure(lambdaScope$closure);
+    const call$3 = source.call(closure, left);
+    const call$4 = source.call(call$3, right);
+    if$join(call$4);
+  }
+  else() {
+    const literal = false;
+    if$join(literal);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+@export function whereIsolation(left, right) {
+  entry() {
+    const closure = closure(whereIsolation$closure);
+    const call = source.call(closure, left);
+    const call$1 = source.call(call, right);
+    if (call$1) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const eqArray = global(eqArray);
+    const eqInt = global(eqInt);
+    const call$2 = source.call(eqArray, eqInt);
+    const eq = call$2.eq;
+    const call$3 = source.call(eq, left);
+    const call$4 = source.call(call$3, right);
+    if$join(call$4);
+  }
+  else() {
+    const literal = false;
+    if$join(literal);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+@export function equationScope(argument0, argument1, argument2) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(argument0, true);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const matches$1 = pattern.literal(argument0, false);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$failure();
+    }
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const eqArray = global(eqArray);
+    const eqInt = global(eqInt);
+    const call = source.call(eqArray, eqInt);
+    const eq = call.eq;
+    const call$1 = source.call(eq, argument1);
+    const call$2 = source.call(call$1, argument2);
+    case$join(call$2);
+  }
+  match$success$1() {
+    const eqArray$1 = global(eqArray);
+    const eqInt$1 = global(eqInt);
+    const call$3 = source.call(eqArray$1, eqInt$1);
+    const eq$1 = call$3.eq;
+    const call$4 = source.call(eq$1, argument2);
+    const call$5 = source.call(call$4, argument1);
+    case$join(call$5);
+  }
+}
+
+@export const firstComparison = initialize {
+  entry() {
+    const eqInt = global(eqInt);
+    const eq = eqInt.eq;
+    const literal = 1;
+    const call = source.call(eq, literal);
+    const literal$1 = 2;
+    const call$1 = source.call(call, literal$1);
+    return call$1;
+  }
+}
+
+@export const secondComparison = initialize {
+  entry() {
+    const eqInt = global(eqInt);
+    const eq = eqInt.eq;
+    const literal = 3;
+    const call = source.call(eq, literal);
+    const literal$1 = 4;
+    const call$1 = source.call(call, literal$1);
+    return call$1;
+  }
+}
+
+closure compareTwice$closure[dictionary0](left, right) {
+  entry() {
+    const eq = dictionary0.eq;
+    const call = source.call(eq, left);
+    const call$1 = source.call(call, right);
+    if (call$1) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const eq$1 = dictionary0.eq;
+    const call$2 = source.call(eq$1, right);
+    const call$3 = source.call(call$2, left);
+    if$join(call$3);
+  }
+  else() {
+    const literal = false;
+    if$join(literal);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+closure compareGenericArraysTwice$closure[dictionary1](left, right) {
+  entry() {
+    const eqArray = global(eqArray);
+    const call = source.call(eqArray, dictionary1);
+    const eq = call.eq;
+    const call$1 = source.call(eq, left);
+    const call$2 = source.call(call$1, right);
+    if (call$2) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const eqArray$1 = global(eqArray);
+    const call$3 = source.call(eqArray$1, dictionary1);
+    const eq$1 = call$3.eq;
+    const call$4 = source.call(eq$1, right);
+    const call$5 = source.call(call$4, left);
+    if$join(call$5);
+  }
+  else() {
+    const literal = false;
+    if$join(literal);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+closure distinctGivens$closure[dictionary2, dictionary3](leftA, rightA, leftB, rightB) {
+  entry() {
+    const eqArray = global(eqArray);
+    const call = source.call(eqArray, dictionary2);
+    const eq = call.eq;
+    const call$1 = source.call(eq, leftA);
+    const call$2 = source.call(call$1, rightA);
+    if (call$2) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const eqArray$1 = global(eqArray);
+    const call$3 = source.call(eqArray$1, dictionary2);
+    const eq$1 = call$3.eq;
+    const call$4 = source.call(eq$1, rightA);
+    const call$5 = source.call(call$4, leftA);
+    if$join(call$5);
+  }
+  else() {
+    const eqArray$2 = global(eqArray);
+    const call$6 = source.call(eqArray$2, dictionary3);
+    const eq$2 = call$6.eq;
+    const call$7 = source.call(eq$2, leftB);
+    const call$8 = source.call(call$7, rightB);
+    if (call$8) {
+      then$1();
+    } else {
+      else$1();
+    }
+  }
+  if$join(result) {
+    return result;
+  }
+  then$1() {
+    const eqArray$3 = global(eqArray);
+    const call$9 = source.call(eqArray$3, dictionary3);
+    const eq$3 = call$9.eq;
+    const call$10 = source.call(eq$3, rightB);
+    const call$11 = source.call(call$10, leftB);
+    if$join$1(call$11);
+  }
+  else$1() {
+    const literal = false;
+    if$join$1(literal);
+  }
+  if$join$1(result$1) {
+    if$join(result$1);
+  }
+}
+
+closure compareSuperclassArraysTwice$closure[dictionary4](left, right) {
+  entry() {
+    const eqArray = global(eqArray);
+    const superclass62 = dictionary4.superclass62;
+    const call = source.call(eqArray, superclass62);
+    const eq = call.eq;
+    const call$1 = source.call(eq, left);
+    const call$2 = source.call(call$1, right);
+    if (call$2) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const eqArray$1 = global(eqArray);
+    const superclass62$1 = dictionary4.superclass62;
+    const call$3 = source.call(eqArray$1, superclass62$1);
+    const eq$1 = call$3.eq;
+    const call$4 = source.call(eq$1, right);
+    const call$5 = source.call(call$4, left);
+    if$join(call$5);
+  }
+  else() {
+    const literal = false;
+    if$join(literal);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+closure compareSuperclassTwice$closure[dictionary5](left, right) {
+  entry() {
+    const superclass62 = dictionary5.superclass62;
+    const eq = superclass62.eq;
+    const call = source.call(eq, left);
+    const call$1 = source.call(call, right);
+    if (call$1) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const superclass62$1 = dictionary5.superclass62;
+    const eq$1 = superclass62$1.eq;
+    const call$2 = source.call(eq$1, right);
+    const call$3 = source.call(call$2, left);
+    if$join(call$3);
+  }
+  else() {
+    const literal = false;
+    if$join(literal);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+closure lambdaScope$closure[](lambdaLeft, lambdaRight) {
+  entry() {
+    const eqArray = global(eqArray);
+    const eqInt = global(eqInt);
+    const call = source.call(eqArray, eqInt);
+    const eq = call.eq;
+    const call$1 = source.call(eq, lambdaLeft);
+    const call$2 = source.call(call$1, lambdaRight);
+    if (call$2) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const eqArray$1 = global(eqArray);
+    const eqInt$1 = global(eqInt);
+    const call$3 = source.call(eqArray$1, eqInt$1);
+    const eq$1 = call$3.eq;
+    const call$4 = source.call(eq$1, lambdaRight);
+    const call$5 = source.call(call$4, lambdaLeft);
+    if$join(call$5);
+  }
+  else() {
+    const literal = false;
+    if$join(literal);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+closure whereIsolation$closure[](helperLeft, helperRight) {
+  entry() {
+    const eqArray = global(eqArray);
+    const eqInt = global(eqInt);
+    const call = source.call(eqArray, eqInt);
+    const eq = call.eq;
+    const call$1 = source.call(eq, helperLeft);
+    const call$2 = source.call(call$1, helperRight);
+    return call$2;
+  }
+}

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Data.Eq/index.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Data.Eq/index.js
@@ -1,0 +1,39 @@
+function eqInt$initialize$closure(argument0) {
+  return argument1 => {
+    const literal = true;
+    return literal;
+  };
+}
+
+function eqBoolean$initialize$closure(argument0) {
+  return argument1 => {
+    const literal = true;
+    return literal;
+  };
+}
+
+function eqArray$closure(argument0) {
+  return argument1 => {
+    const literal = true;
+    return literal;
+  };
+}
+
+function orderedInt$initialize$closure(argument0) {
+  return argument1 => {
+    const literal = true;
+    return literal;
+  };
+}
+
+export function eqArray(dictionary0) {
+  const closure = eqArray$closure;
+  const record = { eq: closure };
+  return record;
+}
+
+export const eqInt = { eq: eqInt$initialize$closure };
+
+export const eqBoolean = { eq: eqBoolean$initialize$closure };
+
+export const orderedInt = { superclass62: eqInt, lessThanOrEqual: orderedInt$initialize$closure };

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
@@ -1,0 +1,472 @@
+import * as Data_Eq from "../Data.Eq/index.js";
+
+function compareTwice$closure(dictionary0) {
+  return left => {
+    return right => {
+      const eq = dictionary0.eq;
+      const call = eq(left);
+      const call$1 = call(right);
+      if (call$1) {
+        const eq$1 = dictionary0.eq;
+        const call$2 = eq$1(right);
+        const call$3 = call$2(left);
+        return call$3;
+      } else {
+        const literal = false;
+        return literal;
+      }
+    };
+  };
+}
+
+function compareGenericArraysTwice$closure(dictionary1) {
+  return left => {
+    return right => {
+      const eqArray = Data_Eq.eqArray;
+      const call = eqArray(dictionary1);
+      const eq = call.eq;
+      const call$1 = eq(left);
+      const call$2 = call$1(right);
+      if (call$2) {
+        const eqArray$1 = Data_Eq.eqArray;
+        const call$3 = eqArray$1(dictionary1);
+        const eq$1 = call$3.eq;
+        const call$4 = eq$1(right);
+        const call$5 = call$4(left);
+        return call$5;
+      } else {
+        const literal = false;
+        return literal;
+      }
+    };
+  };
+}
+
+function distinctGivens$closure(dictionary2, dictionary3) {
+  return leftA => {
+    return rightA => {
+      return leftB => {
+        return rightB => {
+          function if$join$1(result$1) {
+            return result$1;
+          }
+
+          const eqArray = Data_Eq.eqArray;
+          const call = eqArray(dictionary2);
+          const eq = call.eq;
+          const call$1 = eq(leftA);
+          const call$2 = call$1(rightA);
+          if (call$2) {
+            const eqArray$1 = Data_Eq.eqArray;
+            const call$3 = eqArray$1(dictionary2);
+            const eq$1 = call$3.eq;
+            const call$4 = eq$1(rightA);
+            const call$5 = call$4(leftA);
+            return call$5;
+          } else {
+            const eqArray$2 = Data_Eq.eqArray;
+            const call$6 = eqArray$2(dictionary3);
+            const eq$2 = call$6.eq;
+            const call$7 = eq$2(leftB);
+            const call$8 = call$7(rightB);
+            if (call$8) {
+              const eqArray$3 = Data_Eq.eqArray;
+              const call$9 = eqArray$3(dictionary3);
+              const eq$3 = call$9.eq;
+              const call$10 = eq$3(rightB);
+              const call$11 = call$10(leftB);
+              return if$join$1(call$11);
+            } else {
+              const literal = false;
+              return if$join$1(literal);
+            }
+          }
+        };
+      };
+    };
+  };
+}
+
+function compareSuperclassArraysTwice$closure(dictionary4) {
+  return left => {
+    return right => {
+      const eqArray = Data_Eq.eqArray;
+      const superclass62 = dictionary4.superclass62;
+      const call = eqArray(superclass62);
+      const eq = call.eq;
+      const call$1 = eq(left);
+      const call$2 = call$1(right);
+      if (call$2) {
+        const eqArray$1 = Data_Eq.eqArray;
+        const superclass62$1 = dictionary4.superclass62;
+        const call$3 = eqArray$1(superclass62$1);
+        const eq$1 = call$3.eq;
+        const call$4 = eq$1(right);
+        const call$5 = call$4(left);
+        return call$5;
+      } else {
+        const literal = false;
+        return literal;
+      }
+    };
+  };
+}
+
+function compareSuperclassTwice$closure(dictionary5) {
+  return left => {
+    return right => {
+      const superclass62 = dictionary5.superclass62;
+      const eq = superclass62.eq;
+      const call = eq(left);
+      const call$1 = call(right);
+      if (call$1) {
+        const superclass62$1 = dictionary5.superclass62;
+        const eq$1 = superclass62$1.eq;
+        const call$2 = eq$1(right);
+        const call$3 = call$2(left);
+        return call$3;
+      } else {
+        const literal = false;
+        return literal;
+      }
+    };
+  };
+}
+
+function lambdaScope$closure(lambdaLeft) {
+  return lambdaRight => {
+    const eqArray = Data_Eq.eqArray;
+    const eqInt = Data_Eq.eqInt;
+    const call = eqArray(eqInt);
+    const eq = call.eq;
+    const call$1 = eq(lambdaLeft);
+    const call$2 = call$1(lambdaRight);
+    if (call$2) {
+      const eqArray$1 = Data_Eq.eqArray;
+      const eqInt$1 = Data_Eq.eqInt;
+      const call$3 = eqArray$1(eqInt$1);
+      const eq$1 = call$3.eq;
+      const call$4 = eq$1(lambdaRight);
+      const call$5 = call$4(lambdaLeft);
+      return call$5;
+    } else {
+      const literal = false;
+      return literal;
+    }
+  };
+}
+
+function whereIsolation$closure(helperLeft) {
+  return helperRight => {
+    const eqArray = Data_Eq.eqArray;
+    const eqInt = Data_Eq.eqInt;
+    const call = eqArray(eqInt);
+    const eq = call.eq;
+    const call$1 = eq(helperLeft);
+    const call$2 = call$1(helperRight);
+    return call$2;
+  };
+}
+
+export function compareTwice(dictionary0) {
+  const closure = compareTwice$closure(dictionary0);
+  return closure;
+}
+
+export function compareIntsTwice(left) {
+  return right => {
+    const eqInt = Data_Eq.eqInt;
+    const eq = eqInt.eq;
+    const call = eq(left);
+    const call$1 = call(right);
+    if (call$1) {
+      const eqInt$1 = Data_Eq.eqInt;
+      const eq$1 = eqInt$1.eq;
+      const call$2 = eq$1(right);
+      const call$3 = call$2(left);
+      return call$3;
+    } else {
+      const literal = false;
+      return literal;
+    }
+  };
+}
+
+export function compareArraysTwice(left) {
+  return right => {
+    const eqArray = Data_Eq.eqArray;
+    const eqInt = Data_Eq.eqInt;
+    const call = eqArray(eqInt);
+    const eq = call.eq;
+    const call$1 = eq(left);
+    const call$2 = call$1(right);
+    if (call$2) {
+      const eqArray$1 = Data_Eq.eqArray;
+      const eqInt$1 = Data_Eq.eqInt;
+      const call$3 = eqArray$1(eqInt$1);
+      const eq$1 = call$3.eq;
+      const call$4 = eq$1(right);
+      const call$5 = call$4(left);
+      return call$5;
+    } else {
+      const literal = false;
+      return literal;
+    }
+  };
+}
+
+export function compareArraysOnce(left) {
+  return right => {
+    const eqArray = Data_Eq.eqArray;
+    const eqInt = Data_Eq.eqInt;
+    const call = eqArray(eqInt);
+    const eq = call.eq;
+    const call$1 = eq(left);
+    const call$2 = call$1(right);
+    return call$2;
+  };
+}
+
+export function compareGenericArraysTwice(dictionary1) {
+  const closure = compareGenericArraysTwice$closure(dictionary1);
+  return closure;
+}
+
+export function compareNestedArraysTwice(left) {
+  return right => {
+    return nestedLeft => {
+      return nestedRight => {
+        const eqArray = Data_Eq.eqArray;
+        const eqArray$1 = Data_Eq.eqArray;
+        const eqInt = Data_Eq.eqInt;
+        const call = eqArray$1(eqInt);
+        const call$1 = eqArray(call);
+        const eq = call$1.eq;
+        const call$2 = eq(nestedLeft);
+        const call$3 = call$2(nestedRight);
+        if (call$3) {
+          const eqArray$2 = Data_Eq.eqArray;
+          const eqArray$3 = Data_Eq.eqArray;
+          const eqInt$1 = Data_Eq.eqInt;
+          const call$4 = eqArray$3(eqInt$1);
+          const call$5 = eqArray$2(call$4);
+          const eq$1 = call$5.eq;
+          const call$6 = eq$1(nestedRight);
+          const call$7 = call$6(nestedLeft);
+          return call$7;
+        } else {
+          const eqArray$4 = Data_Eq.eqArray;
+          const eqInt$2 = Data_Eq.eqInt;
+          const call$8 = eqArray$4(eqInt$2);
+          const eq$2 = call$8.eq;
+          const call$9 = eq$2(left);
+          const call$10 = call$9(right);
+          return call$10;
+        }
+      };
+    };
+  };
+}
+
+export function distinctGivens(dictionary2) {
+  return dictionary3 => {
+    const closure = distinctGivens$closure(dictionary2, dictionary3);
+    return closure;
+  };
+}
+
+export function distinctSubgoals(leftInt) {
+  return rightInt => {
+    return leftBoolean => {
+      return rightBoolean => {
+        function if$join$1(result$1) {
+          return result$1;
+        }
+
+        const eqArray = Data_Eq.eqArray;
+        const eqInt = Data_Eq.eqInt;
+        const call = eqArray(eqInt);
+        const eq = call.eq;
+        const call$1 = eq(leftInt);
+        const call$2 = call$1(rightInt);
+        if (call$2) {
+          const eqArray$1 = Data_Eq.eqArray;
+          const eqInt$1 = Data_Eq.eqInt;
+          const call$3 = eqArray$1(eqInt$1);
+          const eq$1 = call$3.eq;
+          const call$4 = eq$1(rightInt);
+          const call$5 = call$4(leftInt);
+          return call$5;
+        } else {
+          const eqArray$2 = Data_Eq.eqArray;
+          const eqBoolean = Data_Eq.eqBoolean;
+          const call$6 = eqArray$2(eqBoolean);
+          const eq$2 = call$6.eq;
+          const call$7 = eq$2(leftBoolean);
+          const call$8 = call$7(rightBoolean);
+          if (call$8) {
+            const eqArray$3 = Data_Eq.eqArray;
+            const eqBoolean$1 = Data_Eq.eqBoolean;
+            const call$9 = eqArray$3(eqBoolean$1);
+            const eq$3 = call$9.eq;
+            const call$10 = eq$3(rightBoolean);
+            const call$11 = call$10(leftBoolean);
+            return if$join$1(call$11);
+          } else {
+            const literal = false;
+            return if$join$1(literal);
+          }
+        }
+      };
+    };
+  };
+}
+
+export function compareArraysThrice(left) {
+  return right => {
+    function if$join$1(result$1) {
+      return result$1;
+    }
+
+    const eqArray = Data_Eq.eqArray;
+    const eqInt = Data_Eq.eqInt;
+    const call = eqArray(eqInt);
+    const eq = call.eq;
+    const call$1 = eq(left);
+    const call$2 = call$1(right);
+    if (call$2) {
+      const eqArray$1 = Data_Eq.eqArray;
+      const eqInt$1 = Data_Eq.eqInt;
+      const call$3 = eqArray$1(eqInt$1);
+      const eq$1 = call$3.eq;
+      const call$4 = eq$1(right);
+      const call$5 = call$4(left);
+      if (call$5) {
+        const eqArray$2 = Data_Eq.eqArray;
+        const eqInt$2 = Data_Eq.eqInt;
+        const call$6 = eqArray$2(eqInt$2);
+        const eq$2 = call$6.eq;
+        const call$7 = eq$2(left);
+        const call$8 = call$7(right);
+        return if$join$1(call$8);
+      } else {
+        const literal = false;
+        return if$join$1(literal);
+      }
+    } else {
+      const literal$1 = false;
+      return literal$1;
+    }
+  };
+}
+
+export function compareNestedArraysWhole(left) {
+  return right => {
+    const eqArray = Data_Eq.eqArray;
+    const eqArray$1 = Data_Eq.eqArray;
+    const eqInt = Data_Eq.eqInt;
+    const call = eqArray$1(eqInt);
+    const call$1 = eqArray(call);
+    const eq = call$1.eq;
+    const call$2 = eq(left);
+    const call$3 = call$2(right);
+    if (call$3) {
+      const eqArray$2 = Data_Eq.eqArray;
+      const eqArray$3 = Data_Eq.eqArray;
+      const eqInt$1 = Data_Eq.eqInt;
+      const call$4 = eqArray$3(eqInt$1);
+      const call$5 = eqArray$2(call$4);
+      const eq$1 = call$5.eq;
+      const call$6 = eq$1(right);
+      const call$7 = call$6(left);
+      return call$7;
+    } else {
+      const literal = false;
+      return literal;
+    }
+  };
+}
+
+export function compareSuperclassArraysTwice(dictionary4) {
+  const closure = compareSuperclassArraysTwice$closure(dictionary4);
+  return closure;
+}
+
+export function compareSuperclassTwice(dictionary5) {
+  const closure = compareSuperclassTwice$closure(dictionary5);
+  return closure;
+}
+
+export function lambdaScope(left) {
+  return right => {
+    const eqArray = Data_Eq.eqArray;
+    const eqInt = Data_Eq.eqInt;
+    const call = eqArray(eqInt);
+    const eq = call.eq;
+    const call$1 = eq(left);
+    const call$2 = call$1(right);
+    if (call$2) {
+      const closure = lambdaScope$closure;
+      const call$3 = closure(left);
+      const call$4 = call$3(right);
+      return call$4;
+    } else {
+      const literal = false;
+      return literal;
+    }
+  };
+}
+
+export function whereIsolation(left) {
+  return right => {
+    const closure = whereIsolation$closure;
+    const call = closure(left);
+    const call$1 = call(right);
+    if (call$1) {
+      const eqArray = Data_Eq.eqArray;
+      const eqInt = Data_Eq.eqInt;
+      const call$2 = eqArray(eqInt);
+      const eq = call$2.eq;
+      const call$3 = eq(left);
+      const call$4 = call$3(right);
+      return call$4;
+    } else {
+      const literal = false;
+      return literal;
+    }
+  };
+}
+
+export function equationScope(argument0) {
+  return argument1 => {
+    return argument2 => {
+      const matches = argument0 === true;
+      if (matches) {
+        const eqArray = Data_Eq.eqArray;
+        const eqInt = Data_Eq.eqInt;
+        const call = eqArray(eqInt);
+        const eq = call.eq;
+        const call$1 = eq(argument1);
+        const call$2 = call$1(argument2);
+        return call$2;
+      } else {
+        const matches$1 = argument0 === false;
+        if (matches$1) {
+          const eqArray$1 = Data_Eq.eqArray;
+          const eqInt$1 = Data_Eq.eqInt;
+          const call$3 = eqArray$1(eqInt$1);
+          const eq$1 = call$3.eq;
+          const call$4 = eq$1(argument2);
+          const call$5 = call$4(argument1);
+          return call$5;
+        } else {
+          throw new Error("Pattern match failure");
+        }
+      }
+    };
+  };
+}
+
+export const firstComparison = Data_Eq.eqInt.eq(1 | 0)(2 | 0);
+
+export const secondComparison = Data_Eq.eqInt.eq(3 | 0)(4 | 0);

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
@@ -28,12 +28,10 @@ function compareGenericArraysTwice$closure(dictionary1) {
       const call$1 = eq(left);
       const call$2 = call$1(right);
       if (call$2) {
-        const eqArray$1 = Data_Eq.eqArray;
-        const call$3 = eqArray$1(dictionary1);
-        const eq$1 = call$3.eq;
-        const call$4 = eq$1(right);
-        const call$5 = call$4(left);
-        return call$5;
+        const eq$1 = call.eq;
+        const call$3 = eq$1(right);
+        const call$4 = call$3(left);
+        return call$4;
       } else {
         const literal = false;
         return literal;
@@ -53,29 +51,25 @@ function distinctGivens$closure(dictionary2, dictionary3) {
 
           const eqArray = Data_Eq.eqArray;
           const call = eqArray(dictionary2);
+          const eqArray$1 = Data_Eq.eqArray;
+          const call$1 = eqArray$1(dictionary3);
           const eq = call.eq;
-          const call$1 = eq(leftA);
-          const call$2 = call$1(rightA);
-          if (call$2) {
-            const eqArray$1 = Data_Eq.eqArray;
-            const call$3 = eqArray$1(dictionary2);
-            const eq$1 = call$3.eq;
+          const call$2 = eq(leftA);
+          const call$3 = call$2(rightA);
+          if (call$3) {
+            const eq$1 = call.eq;
             const call$4 = eq$1(rightA);
             const call$5 = call$4(leftA);
             return call$5;
           } else {
-            const eqArray$2 = Data_Eq.eqArray;
-            const call$6 = eqArray$2(dictionary3);
-            const eq$2 = call$6.eq;
-            const call$7 = eq$2(leftB);
-            const call$8 = call$7(rightB);
-            if (call$8) {
-              const eqArray$3 = Data_Eq.eqArray;
-              const call$9 = eqArray$3(dictionary3);
-              const eq$3 = call$9.eq;
-              const call$10 = eq$3(rightB);
-              const call$11 = call$10(leftB);
-              return if$join$1(call$11);
+            const eq$2 = call$1.eq;
+            const call$6 = eq$2(leftB);
+            const call$7 = call$6(rightB);
+            if (call$7) {
+              const eq$3 = call$1.eq;
+              const call$8 = eq$3(rightB);
+              const call$9 = call$8(leftB);
+              return if$join$1(call$9);
             } else {
               const literal = false;
               return if$join$1(literal);
@@ -97,13 +91,10 @@ function compareSuperclassArraysTwice$closure(dictionary4) {
       const call$1 = eq(left);
       const call$2 = call$1(right);
       if (call$2) {
-        const eqArray$1 = Data_Eq.eqArray;
-        const superclass62$1 = dictionary4.superclass62;
-        const call$3 = eqArray$1(superclass62$1);
-        const eq$1 = call$3.eq;
-        const call$4 = eq$1(right);
-        const call$5 = call$4(left);
-        return call$5;
+        const eq$1 = call.eq;
+        const call$3 = eq$1(right);
+        const call$4 = call$3(left);
+        return call$4;
       } else {
         const literal = false;
         return literal;
@@ -142,13 +133,10 @@ function lambdaScope$closure(lambdaLeft) {
     const call$1 = eq(lambdaLeft);
     const call$2 = call$1(lambdaRight);
     if (call$2) {
-      const eqArray$1 = Data_Eq.eqArray;
-      const eqInt$1 = Data_Eq.eqInt;
-      const call$3 = eqArray$1(eqInt$1);
-      const eq$1 = call$3.eq;
-      const call$4 = eq$1(lambdaRight);
-      const call$5 = call$4(lambdaLeft);
-      return call$5;
+      const eq$1 = call.eq;
+      const call$3 = eq$1(lambdaRight);
+      const call$4 = call$3(lambdaLeft);
+      return call$4;
     } else {
       const literal = false;
       return literal;
@@ -201,13 +189,10 @@ export function compareArraysTwice(left) {
     const call$1 = eq(left);
     const call$2 = call$1(right);
     if (call$2) {
-      const eqArray$1 = Data_Eq.eqArray;
-      const eqInt$1 = Data_Eq.eqInt;
-      const call$3 = eqArray$1(eqInt$1);
-      const eq$1 = call$3.eq;
-      const call$4 = eq$1(right);
-      const call$5 = call$4(left);
-      return call$5;
+      const eq$1 = call.eq;
+      const call$3 = eq$1(right);
+      const call$4 = call$3(left);
+      return call$4;
     } else {
       const literal = false;
       return literal;
@@ -237,31 +222,23 @@ export function compareNestedArraysTwice(left) {
     return nestedLeft => {
       return nestedRight => {
         const eqArray = Data_Eq.eqArray;
-        const eqArray$1 = Data_Eq.eqArray;
         const eqInt = Data_Eq.eqInt;
-        const call = eqArray$1(eqInt);
-        const call$1 = eqArray(call);
+        const call = eqArray(eqInt);
+        const eqArray$1 = Data_Eq.eqArray;
+        const call$1 = eqArray$1(call);
         const eq = call$1.eq;
         const call$2 = eq(nestedLeft);
         const call$3 = call$2(nestedRight);
         if (call$3) {
-          const eqArray$2 = Data_Eq.eqArray;
-          const eqArray$3 = Data_Eq.eqArray;
-          const eqInt$1 = Data_Eq.eqInt;
-          const call$4 = eqArray$3(eqInt$1);
-          const call$5 = eqArray$2(call$4);
-          const eq$1 = call$5.eq;
-          const call$6 = eq$1(nestedRight);
-          const call$7 = call$6(nestedLeft);
-          return call$7;
+          const eq$1 = call$1.eq;
+          const call$4 = eq$1(nestedRight);
+          const call$5 = call$4(nestedLeft);
+          return call$5;
         } else {
-          const eqArray$4 = Data_Eq.eqArray;
-          const eqInt$2 = Data_Eq.eqInt;
-          const call$8 = eqArray$4(eqInt$2);
-          const eq$2 = call$8.eq;
-          const call$9 = eq$2(left);
-          const call$10 = call$9(right);
-          return call$10;
+          const eq$2 = call.eq;
+          const call$6 = eq$2(left);
+          const call$7 = call$6(right);
+          return call$7;
         }
       };
     };
@@ -286,32 +263,26 @@ export function distinctSubgoals(leftInt) {
         const eqArray = Data_Eq.eqArray;
         const eqInt = Data_Eq.eqInt;
         const call = eqArray(eqInt);
+        const eqArray$1 = Data_Eq.eqArray;
+        const eqBoolean = Data_Eq.eqBoolean;
+        const call$1 = eqArray$1(eqBoolean);
         const eq = call.eq;
-        const call$1 = eq(leftInt);
-        const call$2 = call$1(rightInt);
-        if (call$2) {
-          const eqArray$1 = Data_Eq.eqArray;
-          const eqInt$1 = Data_Eq.eqInt;
-          const call$3 = eqArray$1(eqInt$1);
-          const eq$1 = call$3.eq;
+        const call$2 = eq(leftInt);
+        const call$3 = call$2(rightInt);
+        if (call$3) {
+          const eq$1 = call.eq;
           const call$4 = eq$1(rightInt);
           const call$5 = call$4(leftInt);
           return call$5;
         } else {
-          const eqArray$2 = Data_Eq.eqArray;
-          const eqBoolean = Data_Eq.eqBoolean;
-          const call$6 = eqArray$2(eqBoolean);
-          const eq$2 = call$6.eq;
-          const call$7 = eq$2(leftBoolean);
-          const call$8 = call$7(rightBoolean);
-          if (call$8) {
-            const eqArray$3 = Data_Eq.eqArray;
-            const eqBoolean$1 = Data_Eq.eqBoolean;
-            const call$9 = eqArray$3(eqBoolean$1);
-            const eq$3 = call$9.eq;
-            const call$10 = eq$3(rightBoolean);
-            const call$11 = call$10(leftBoolean);
-            return if$join$1(call$11);
+          const eq$2 = call$1.eq;
+          const call$6 = eq$2(leftBoolean);
+          const call$7 = call$6(rightBoolean);
+          if (call$7) {
+            const eq$3 = call$1.eq;
+            const call$8 = eq$3(rightBoolean);
+            const call$9 = call$8(leftBoolean);
+            return if$join$1(call$9);
           } else {
             const literal = false;
             return if$join$1(literal);
@@ -335,20 +306,14 @@ export function compareArraysThrice(left) {
     const call$1 = eq(left);
     const call$2 = call$1(right);
     if (call$2) {
-      const eqArray$1 = Data_Eq.eqArray;
-      const eqInt$1 = Data_Eq.eqInt;
-      const call$3 = eqArray$1(eqInt$1);
-      const eq$1 = call$3.eq;
-      const call$4 = eq$1(right);
-      const call$5 = call$4(left);
-      if (call$5) {
-        const eqArray$2 = Data_Eq.eqArray;
-        const eqInt$2 = Data_Eq.eqInt;
-        const call$6 = eqArray$2(eqInt$2);
-        const eq$2 = call$6.eq;
-        const call$7 = eq$2(left);
-        const call$8 = call$7(right);
-        return if$join$1(call$8);
+      const eq$1 = call.eq;
+      const call$3 = eq$1(right);
+      const call$4 = call$3(left);
+      if (call$4) {
+        const eq$2 = call.eq;
+        const call$5 = eq$2(left);
+        const call$6 = call$5(right);
+        return if$join$1(call$6);
       } else {
         const literal = false;
         return if$join$1(literal);
@@ -371,15 +336,10 @@ export function compareNestedArraysWhole(left) {
     const call$2 = eq(left);
     const call$3 = call$2(right);
     if (call$3) {
-      const eqArray$2 = Data_Eq.eqArray;
-      const eqArray$3 = Data_Eq.eqArray;
-      const eqInt$1 = Data_Eq.eqInt;
-      const call$4 = eqArray$3(eqInt$1);
-      const call$5 = eqArray$2(call$4);
-      const eq$1 = call$5.eq;
-      const call$6 = eq$1(right);
-      const call$7 = call$6(left);
-      return call$7;
+      const eq$1 = call$1.eq;
+      const call$4 = eq$1(right);
+      const call$5 = call$4(left);
+      return call$5;
     } else {
       const literal = false;
       return literal;
@@ -440,11 +400,11 @@ export function whereIsolation(left) {
 export function equationScope(argument0) {
   return argument1 => {
     return argument2 => {
+      const eqArray = Data_Eq.eqArray;
+      const eqInt = Data_Eq.eqInt;
+      const call = eqArray(eqInt);
       const matches = argument0 === true;
       if (matches) {
-        const eqArray = Data_Eq.eqArray;
-        const eqInt = Data_Eq.eqInt;
-        const call = eqArray(eqInt);
         const eq = call.eq;
         const call$1 = eq(argument1);
         const call$2 = call$1(argument2);
@@ -452,13 +412,10 @@ export function equationScope(argument0) {
       } else {
         const matches$1 = argument0 === false;
         if (matches$1) {
-          const eqArray$1 = Data_Eq.eqArray;
-          const eqInt$1 = Data_Eq.eqInt;
-          const call$3 = eqArray$1(eqInt$1);
-          const eq$1 = call$3.eq;
-          const call$4 = eq$1(argument2);
-          const call$5 = call$4(argument1);
-          return call$5;
+          const eq$1 = call.eq;
+          const call$3 = eq$1(argument2);
+          const call$4 = call$3(argument1);
+          return call$4;
         } else {
           throw new Error("Pattern match failure");
         }


### PR DESCRIPTION
## Summary

- share structurally equivalent instance evidence applications within definition-local NBE scopes
- keep nullary and single-use evidence inline while ordering shared prerequisite dictionaries before their consumers
- add backend regression coverage for concrete, generic, nested, superclass, lambda, local-definition, and multi-equation evidence construction

## Testing

- `cargo check -p nbe --tests`
- `just t backend`
- `git diff --check`
