### PR TITLE
[backend] Nest JavaScript closure implementations

### DIFF
--- a/compiler-backend/javascript/src/convert/generator.rs
+++ b/compiler-backend/javascript/src/convert/generator.rs
@@ -10,8 +10,8 @@ use itertools::Itertools;
 use pretty::Arena as DocumentArena;
 use rustc_hash::{FxHashMap, FxHashSet};
 use ssa::tree::{
-    CallingConvention, Declaration, DeclarationKind, Function, FunctionId, Global, GlobalIdentity,
-    Instruction, Terminator, ValueId,
+    CallingConvention, Declaration, DeclarationKind, Function, Global, GlobalIdentity, Instruction,
+    Terminator, ValueId,
 };
 
 use crate::error::{ModuleError, ModuleResult, UnsupportedState};
@@ -31,9 +31,7 @@ pub(super) struct Generator<'m> {
     module: &'m ssa::tree::Module,
     global_names: FxHashMap<GlobalIdentity, String>,
     external_module_namespaces: FxHashMap<FileId, String>,
-    function_names: FxHashMap<FunctionId, String>,
     external_references: Vec<&'m Global>,
-    root_functions: FxHashSet<FunctionId>,
     foreign_namespace: Option<String>,
     reserved_module_names: FxHashSet<String>,
 }
@@ -42,22 +40,10 @@ impl<'m> Generator<'m> {
     pub(super) fn new(module: &'m ssa::tree::Module) -> Generator<'m> {
         let mut allocator = NameAllocator::default();
         let mut global_names = FxHashMap::default();
-        let mut function_names = FxHashMap::default();
-        let mut root_functions = FxHashSet::default();
 
         for declaration in module.declarations.iter() {
             let name = allocator.allocate(&declaration.global.item_name);
             global_names.insert(declaration.global.identity, name.clone());
-            match declaration.kind {
-                DeclarationKind::Function { function } => {
-                    function_names.insert(function, name);
-                    root_functions.insert(function);
-                }
-                DeclarationKind::Value { initializer } => {
-                    root_functions.insert(initializer);
-                }
-                DeclarationKind::Constructor { .. } | DeclarationKind::Foreign => {}
-            }
         }
 
         let external_references = collect_module_references(module);
@@ -74,14 +60,6 @@ impl<'m> Generator<'m> {
                 .or_insert_with(|| allocator.allocate(&dependency.module_name.replace('.', "_")));
         }
 
-        for (function_id, function) in module.storage.functions() {
-            if root_functions.contains(&function_id) {
-                continue;
-            }
-            let name = allocator.allocate(&function.name);
-            function_names.insert(function_id, name);
-        }
-
         let has_foreign = module
             .declarations
             .iter()
@@ -94,9 +72,7 @@ impl<'m> Generator<'m> {
             module,
             global_names,
             external_module_namespaces,
-            function_names,
             external_references,
-            root_functions,
             foreign_namespace,
             reserved_module_names,
         }
@@ -108,7 +84,6 @@ impl<'m> Generator<'m> {
         let mut writer = Writer::new(&documents);
         self.render_imports(&mut tree, &mut writer);
         self.render_constructors(&mut tree, &mut writer);
-        self.render_nested_functions(&mut tree, &mut writer)?;
         self.render_source_functions(&mut tree, &mut writer)?;
         self.render_foreign_declarations(&mut tree, &mut writer);
         self.render_value_declarations(&mut tree, &mut writer)?;
@@ -164,22 +139,6 @@ impl<'m> Generator<'m> {
         if rendered {
             writer.blank();
         }
-    }
-
-    fn render_nested_functions(
-        &self,
-        tree: &mut Tree,
-        writer: &mut Writer<'_>,
-    ) -> ModuleResult<()> {
-        for (function_id, function) in self.module.storage.functions() {
-            if self.root_functions.contains(&function_id) {
-                continue;
-            }
-            let name = self.function_name(function_id);
-            self.render_function(tree, writer, name, function, false)?;
-            writer.blank();
-        }
-        Ok(())
     }
 
     fn render_source_functions(
@@ -414,13 +373,6 @@ impl<'m> Generator<'m> {
             let namespace = tree.identifier(namespace);
             tree.member(namespace, global.item_name.as_str())
         }
-    }
-
-    fn function_name(&self, function: FunctionId) -> &str {
-        self.function_names
-            .get(&function)
-            .map(String::as_str)
-            .expect("invariant violated: JavaScript function has no allocated name")
     }
 
     fn unsupported(&self, state: UnsupportedState) -> ModuleError {

--- a/compiler-backend/javascript/src/convert/generator/analysis.rs
+++ b/compiler-backend/javascript/src/convert/generator/analysis.rs
@@ -16,6 +16,7 @@ use crate::tree::{ExpressionId, Tree};
 
 pub(super) struct FunctionContext {
     pub(super) names: FxHashMap<ValueId, String>,
+    closure_names: FxHashMap<FunctionId, String>,
     block_names: FxHashMap<BlockId, String>,
     inlineable_values: FxHashMap<BlockId, FxHashSet<ValueId>>,
     pub(super) dispatch_block: String,
@@ -24,6 +25,8 @@ pub(super) struct FunctionContext {
 
 pub(super) trait ValueExpressionContext {
     fn expression(&self, tree: &mut Tree, value: ValueId) -> ExpressionId;
+
+    fn closure(&self, function: FunctionId) -> &str;
 }
 
 pub(super) struct InlineExpressionContext {
@@ -48,6 +51,10 @@ impl ValueExpressionContext for InlineExpressionContext {
             .borrow_mut()
             .remove(&value)
             .expect("invariant violated: inline JavaScript expression has no SSA operand")
+    }
+
+    fn closure(&self, _function: FunctionId) -> &str {
+        panic!("invariant violated: inline JavaScript expression contains a closure")
     }
 }
 
@@ -77,6 +84,10 @@ impl ValueExpressionContext for BlockExpressionContext<'_> {
             .remove(&value)
             .unwrap_or_else(|| self.function.expression(tree, value))
     }
+
+    fn closure(&self, function: FunctionId) -> &str {
+        self.function.closure(function)
+    }
 }
 
 impl FunctionContext {
@@ -89,6 +100,13 @@ impl FunctionContext {
                 .entry(value)
                 .or_insert_with(|| allocator.allocate(&generator.module.storage[value].name));
         }
+        let mut closure_names = FxHashMap::default();
+        for function_id in direct_closures(generator.module, function) {
+            let function_name = &generator.module.storage[function_id].name;
+            let preferred_name = locally_scoped_function_name(function_name);
+            let name = allocator.allocate(preferred_name);
+            closure_names.insert(function_id, name);
+        }
         let mut block_names = FxHashMap::default();
         for block in function.blocks.iter().copied() {
             let name = allocator.allocate(&generator.module.storage[block].name);
@@ -99,6 +117,7 @@ impl FunctionContext {
         let dispatch_arguments = allocator.allocate("$arguments");
         FunctionContext {
             names,
+            closure_names,
             block_names,
             inlineable_values,
             dispatch_block,
@@ -118,6 +137,13 @@ impl FunctionContext {
             .get(&block)
             .map(String::as_str)
             .expect("invariant violated: JavaScript SSA block has no allocated name")
+    }
+
+    pub(super) fn closure(&self, function: FunctionId) -> &str {
+        self.closure_names
+            .get(&function)
+            .map(String::as_str)
+            .expect("invariant violated: JavaScript closure function has no allocated name")
     }
 
     pub(super) fn inlineable_values(&self, block: BlockId) -> &FxHashSet<ValueId> {
@@ -140,9 +166,42 @@ impl FunctionContext {
     }
 }
 
+fn direct_closures(module: &ssa::tree::Module, function: &Function) -> Vec<FunctionId> {
+    let mut closures = vec![];
+    for block in function.blocks.iter().copied() {
+        for instruction in &module.storage[block].instructions {
+            match instruction {
+                Instruction::Assign {
+                    value: InstructionValue::Closure { function, .. }, ..
+                } => closures.push(*function),
+                Instruction::RecursiveClosures { bindings } => {
+                    closures.extend(bindings.iter().map(|binding| binding.function));
+                }
+                Instruction::Assign { .. } => {}
+            }
+        }
+    }
+    closures
+}
+
+fn locally_scoped_function_name(name: &str) -> &str {
+    let Some((preferred, suffix)) = name.rsplit_once('$') else {
+        return name;
+    };
+    if !suffix.is_empty() && suffix.chars().all(|character| character.is_ascii_digit()) {
+        preferred
+    } else {
+        name
+    }
+}
+
 impl ValueExpressionContext for FunctionContext {
     fn expression(&self, tree: &mut Tree, value: ValueId) -> ExpressionId {
         tree.identifier(self.value(value))
+    }
+
+    fn closure(&self, function: FunctionId) -> &str {
+        FunctionContext::closure(self, function)
     }
 }
 
@@ -785,6 +844,7 @@ pub(super) fn initializer_value_is_inlineable(value: &InstructionValue) -> bool 
     !matches!(
         value,
         InstructionValue::RecordUpdate { .. }
+            | InstructionValue::Closure { .. }
             | InstructionValue::Test { .. }
             | InstructionValue::EffectPure { .. }
             | InstructionValue::EffectBind { .. }

--- a/compiler-backend/javascript/src/convert/generator/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/render.rs
@@ -147,6 +147,7 @@ impl Generator<'_> {
             if let Instruction::Assign { result, value } = instruction
                 && inlineable.contains(result)
             {
+                self.render_closure_function(output.tree, output.writer, value, context)?;
                 let expression = self.instruction_expression(output.tree, value, &expressions)?;
                 expressions.insert(*result, expression);
             } else {
@@ -379,6 +380,7 @@ impl Generator<'_> {
     ) -> ModuleResult<()> {
         match instruction {
             Instruction::Assign { result, value } => {
+                self.render_closure_function(tree, writer, value, context)?;
                 let expression = self.instruction_expression(tree, value, expressions)?;
                 let binding = if declare { "const " } else { "" };
                 writer.expression_line(
@@ -389,6 +391,11 @@ impl Generator<'_> {
                 );
             }
             Instruction::RecursiveClosures { bindings } => {
+                for binding in bindings.iter() {
+                    let name = context.closure(binding.function);
+                    let function = &self.module.storage[binding.function];
+                    self.render_function(tree, writer, name, function, false)?;
+                }
                 for binding in bindings.iter() {
                     let expression = self.recursive_closure_expression(tree, binding, context);
                     let declaration = if declare { "const " } else { "" };
@@ -402,6 +409,21 @@ impl Generator<'_> {
             }
         }
         Ok(())
+    }
+
+    fn render_closure_function(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        value: &InstructionValue,
+        context: &FunctionContext,
+    ) -> ModuleResult<()> {
+        let InstructionValue::Closure { function, .. } = value else {
+            return Ok(());
+        };
+        let name = context.closure(*function);
+        let function = &self.module.storage[*function];
+        self.render_function(tree, writer, name, function, false)
     }
 
     pub(super) fn instruction_expression(
@@ -438,7 +460,7 @@ impl Generator<'_> {
             InstructionValue::Constructor { global } => Ok(self.global_expression(tree, global)),
             InstructionValue::Global { global } => Ok(self.global_expression(tree, global)),
             InstructionValue::Closure { function, captures } => {
-                let name = tree.identifier(self.function_name(*function));
+                let name = tree.identifier(context.closure(*function));
                 if captures.is_empty() {
                     Ok(name)
                 } else {
@@ -498,7 +520,7 @@ impl Generator<'_> {
         let parameter = allocator.allocate(&self.module.storage[*parameter].name);
         let captures = closure.captures.iter().map(|capture| context.expression(tree, *capture));
         let captures = captures.collect_vec();
-        let function = tree.identifier(self.function_name(closure.function));
+        let function = tree.identifier(context.closure(closure.function));
         // Defer capture evaluation until every binding in the recursive group has been initialized.
         let function = tree.call(function, captures);
         let argument = tree.identifier(&parameter);

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/output/Main/index.js
@@ -3,10 +3,6 @@ export const One = $value0 => ["One", $value0];
 export const Pair = $value0 => $value1 => ["Pair", $value0, $value1];
 export const Outer = $value0 => ["Outer", $value0];
 
-function ordinaryBind$closure(value) {
-  return value;
-}
-
 export function first(argument0) {
   function case$join$1(result$1) {
     return result$1;
@@ -63,5 +59,8 @@ export function bind(value) {
 }
 
 export function ordinaryBind(identity) {
+  function ordinaryBind$closure(value) {
+    return value;
+  }
   return bind(identity)(ordinaryBind$closure);
 }

--- a/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/output/Main/index.js
@@ -1,60 +1,30 @@
-function second$function(first) {
-  return argument0 => {
-    if (argument0 === true) {
-      return 2 | 0;
-    } else {
-      if (argument0 === false) {
-        return first(true);
-      } else {
-        throw new Error("Pattern match failure");
-      }
-    }
-  };
-}
-
-function first$function(second) {
-  return argument0 => {
-    if (argument0 === true) {
-      return 1 | 0;
-    } else {
-      if (argument0 === false) {
-        return second(true);
-      } else {
-        throw new Error("Pattern match failure");
-      }
-    }
-  };
-}
-
-function second$function$1(captured, first) {
-  return argument0 => {
-    if (argument0 === true) {
-      return captured;
-    } else {
-      if (argument0 === false) {
-        return first(true);
-      } else {
-        throw new Error("Pattern match failure");
-      }
-    }
-  };
-}
-
-function first$function$1(captured, second) {
-  return argument0 => {
-    if (argument0 === true) {
-      return captured;
-    } else {
-      if (argument0 === false) {
-        return second(true);
-      } else {
-        throw new Error("Pattern match failure");
-      }
-    }
-  };
-}
-
 export function mutual(condition) {
+  function second$function(first) {
+    return argument0 => {
+      if (argument0 === true) {
+        return 2 | 0;
+      } else {
+        if (argument0 === false) {
+          return first(true);
+        } else {
+          throw new Error("Pattern match failure");
+        }
+      }
+    };
+  }
+  function first$function(second) {
+    return argument0 => {
+      if (argument0 === true) {
+        return 1 | 0;
+      } else {
+        if (argument0 === false) {
+          return second(true);
+        } else {
+          throw new Error("Pattern match failure");
+        }
+      }
+    };
+  }
   const second = argument0 => second$function(first)(argument0);
   const first = argument0 => first$function(second)(argument0);
   return first(condition);
@@ -62,8 +32,34 @@ export function mutual(condition) {
 
 export function capturedMutual(captured) {
   return condition => {
-    const second = argument0 => second$function$1(captured, first)(argument0);
-    const first = argument0 => first$function$1(captured, second)(argument0);
+    function second$function(captured, first) {
+      return argument0 => {
+        if (argument0 === true) {
+          return captured;
+        } else {
+          if (argument0 === false) {
+            return first(true);
+          } else {
+            throw new Error("Pattern match failure");
+          }
+        }
+      };
+    }
+    function first$function(captured, second) {
+      return argument0 => {
+        if (argument0 === true) {
+          return captured;
+        } else {
+          if (argument0 === false) {
+            return second(true);
+          } else {
+            throw new Error("Pattern match failure");
+          }
+        }
+      };
+    }
+    const second = argument0 => second$function(captured, first)(argument0);
+    const first = argument0 => first$function(captured, second)(argument0);
     return first(condition);
   };
 }

--- a/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/output/Main/index.js
@@ -1,19 +1,3 @@
-function recursiveValue$initialize$closure(value) {
-  if (value) {
-    return 3 | 0;
-  } else {
-    return recursivePeer.run(true);
-  }
-}
-
-function recursivePeer$initialize$closure(value) {
-  if (value) {
-    return 4 | 0;
-  } else {
-    return recursiveValue.run(true);
-  }
-}
-
 export function first(argument0) {
   if (argument0 === true) {
     return 1 | 0;
@@ -42,6 +26,24 @@ export const later = 42 | 0;
 
 export const forward = later;
 
-export const recursiveValue = { run: recursiveValue$initialize$closure };
+export const recursiveValue = (() => {
+  function recursiveValue$initialize$closure(value) {
+    if (value) {
+      return 3 | 0;
+    } else {
+      return recursivePeer.run(true);
+    }
+  }
+  return { run: recursiveValue$initialize$closure };
+})();
 
-export const recursivePeer = { run: recursivePeer$initialize$closure };
+export const recursivePeer = (() => {
+  function recursivePeer$initialize$closure(value) {
+    if (value) {
+      return 4 | 0;
+    } else {
+      return recursiveValue.run(true);
+    }
+  }
+  return { run: recursivePeer$initialize$closure };
+})();

--- a/tests-integration/fixtures/backend/1787021940_type_class_evidence/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021940_type_class_evidence/output/Main/index.js
@@ -1,26 +1,24 @@
 import * as $foreign from "./foreign.js";
 
-function genericEqual$closure(dictionary0) {
-  return left => {
-    return right => {
-      return dictionary0.equal(left)(right);
-    };
-  };
-}
-
-function superclassEqual$closure(dictionary1) {
-  return left => {
-    return right => {
-      return dictionary1.superclass17.equal(left)(right);
-    };
-  };
-}
-
 export function genericEqual(dictionary0) {
+  function genericEqual$closure(dictionary0) {
+    return left => {
+      return right => {
+        return dictionary0.equal(left)(right);
+      };
+    };
+  }
   return genericEqual$closure(dictionary0);
 }
 
 export function superclassEqual(dictionary1) {
+  function superclassEqual$closure(dictionary1) {
+    return left => {
+      return right => {
+        return dictionary1.superclass17.equal(left)(right);
+      };
+    };
+  }
   return superclassEqual$closure(dictionary1);
 }
 

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Main/index.js
@@ -1,24 +1,26 @@
 import * as Effect from "../Effect/index.js";
 import * as $foreign from "./foreign.js";
 
-function sequential$initialize$closure(first) {
-  return secondAction(first);
-}
-
-function independent$initialize$closure(first) {
-  return second => {
-    return { first: first, second: second };
-  };
-}
-
 export const firstAction = $foreign["firstAction"];
 export const secondAction = $foreign["secondAction"];
 export const independentAction = $foreign["independentAction"];
 
-export const sequential = Effect.bindEffect1.bind(firstAction)(sequential$initialize$closure);
+export const sequential = (() => {
+  function sequential$initialize$closure(first) {
+    return secondAction(first);
+  }
+  return Effect.bindEffect1.bind(firstAction)(sequential$initialize$closure);
+})();
 
-export const independent = Effect.applyEffect1.apply(
-  Effect.functorEffect.map(independent$initialize$closure)(firstAction)
-)(independentAction);
+export const independent = (() => {
+  function independent$initialize$closure(first) {
+    return second => {
+      return { first: first, second: second };
+    };
+  }
+  return Effect.applyEffect1.apply(
+    Effect.functorEffect.map(independent$initialize$closure)(firstAction)
+  )(independentAction);
+})();
 
 export const pureValue = Effect.applicativeEffect.pure(42 | 0);

--- a/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/output/Main/index.js
@@ -1,9 +1,3 @@
-function capture$closure(captured) {
-  return argument0 => {
-    return captured;
-  };
-}
-
 export function apply($function) {
   return value => {
     return $function(value);
@@ -11,6 +5,11 @@ export function apply($function) {
 }
 
 export function capture(captured) {
+  function capture$closure(captured) {
+    return argument0 => {
+      return captured;
+    };
+  }
   return capture$closure(captured);
 }
 

--- a/tests-integration/fixtures/backend/1787080920_derived_instance/output/Data.Show/index.js
+++ b/tests-integration/fixtures/backend/1787080920_derived_instance/output/Data.Show/index.js
@@ -1,13 +1,13 @@
-function showInt$initialize$closure(argument0) {
-  return "";
-}
-
-function showArray$closure(argument0) {
-  return "";
-}
-
 export function showArray(dictionary0) {
+  function showArray$closure(argument0) {
+    return "";
+  }
   return { show: showArray$closure };
 }
 
-export const showInt = { show: showInt$initialize$closure };
+export const showInt = (() => {
+  function showInt$initialize$closure(argument0) {
+    return "";
+  }
+  return { show: showInt$initialize$closure };
+})();

--- a/tests-integration/fixtures/backend/1787080920_derived_instance/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787080920_derived_instance/output/Main/index.js
@@ -2,30 +2,32 @@ import * as Data_Show from "../Data.Show/index.js";
 
 export const Box = ["Box"];
 
-function eqBox$initialize$closure(left) {
-  return right => {
-    if (Array.isArray(left) && left[0] === "Box") {
-      if (Array.isArray(right) && right[0] === "Box") {
-        return true;
-      } else {
-        throw new Error("Pattern match failure");
-      }
-    } else {
-      throw new Error("Pattern match failure");
-    }
-  };
-}
-
-function rendered$initialize$closure(value) {
-  return value;
-}
-
 export function showIdentity(dictionary1) {
   return dictionary1;
 }
 
-export const eqBox = { eq: eqBox$initialize$closure };
+export const eqBox = (() => {
+  function eqBox$initialize$closure(left) {
+    return right => {
+      if (Array.isArray(left) && left[0] === "Box") {
+        if (Array.isArray(right) && right[0] === "Box") {
+          return true;
+        } else {
+          throw new Error("Pattern match failure");
+        }
+      } else {
+        throw new Error("Pattern match failure");
+      }
+    };
+  }
+  return { eq: eqBox$initialize$closure };
+})();
 
 export const equal = eqBox.eq(Box)(Box);
 
-export const rendered = (showIdentity(Data_Show.showInt)).show(rendered$initialize$closure(42 | 0));
+export const rendered = (() => {
+  function rendered$initialize$closure(value) {
+    return value;
+  }
+  return (showIdentity(Data_Show.showInt)).show(rendered$initialize$closure(42 | 0));
+})();

--- a/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
@@ -4,46 +4,6 @@ import * as $foreign from "./foreign.js";
 export const None = ["None"];
 export const Pair = $value0 => $value1 => ["Pair", $value0, $value1];
 
-function capture$closure(captured) {
-  return argument0 => {
-    return captured;
-  };
-}
-
-function addCaptured$closure(amount) {
-  return value => {
-    return addInt(amount)(value);
-  };
-}
-
-function localSecond$function(captured, localFirst) {
-  return argument0 => {
-    if (argument0 === true) {
-      return captured;
-    } else {
-      if (argument0 === false) {
-        return localFirst(true);
-      } else {
-        throw new Error("Pattern match failure");
-      }
-    }
-  };
-}
-
-function localFirst$function(captured, localSecond) {
-  return argument0 => {
-    if (argument0 === true) {
-      return captured;
-    } else {
-      if (argument0 === false) {
-        return localSecond(true);
-      } else {
-        throw new Error("Pattern match failure");
-      }
-    }
-  };
-}
-
 export function readHostile(value) {
   return value["hostile-field"];
 }
@@ -53,6 +13,11 @@ export function readProto(value) {
 }
 
 export function capture(captured) {
+  function capture$closure(captured) {
+    return argument0 => {
+      return captured;
+    };
+  }
   return capture$closure(captured);
 }
 
@@ -63,6 +28,11 @@ export function apply($function) {
 }
 
 export function addCaptured(amount) {
+  function addCaptured$closure(amount) {
+    return value => {
+      return addInt(amount)(value);
+    };
+  }
   return addCaptured$closure(amount);
 }
 
@@ -111,6 +81,32 @@ export function isOdd(value) {
 
 export function capturedMutual(captured) {
   return condition => {
+    function localSecond$function(captured, localFirst) {
+      return argument0 => {
+        if (argument0 === true) {
+          return captured;
+        } else {
+          if (argument0 === false) {
+            return localFirst(true);
+          } else {
+            throw new Error("Pattern match failure");
+          }
+        }
+      };
+    }
+    function localFirst$function(captured, localSecond) {
+      return argument0 => {
+        if (argument0 === true) {
+          return captured;
+        } else {
+          if (argument0 === false) {
+            return localSecond(true);
+          } else {
+            throw new Error("Pattern match failure");
+          }
+        }
+      };
+    }
     const localSecond = argument0 => localSecond$function(captured, localFirst)(argument0);
     const localFirst = argument0 => localFirst$function(captured, localSecond)(argument0);
     return localFirst(condition);

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Data.Eq/index.js
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Data.Eq/index.js
@@ -1,39 +1,10 @@
-function eqInt$initialize$closure(argument0) {
-  return argument1 => {
-    return true;
-  };
-}
-
-function eqBoolean$initialize$closure(argument0) {
-  return argument1 => {
-    return true;
-  };
-}
-
-function eqRec$closure(argument0) {
-  return argument1 => {
-    return true;
-  };
-}
-
-function eqRecordNilType$initialize$closure(argument0) {
-  return argument1 => {
-    return argument2 => {
-      return true;
-    };
-  };
-}
-
-function eqRecordConsType$closure(argument0) {
-  return argument1 => {
-    return argument2 => {
-      return true;
-    };
-  };
-}
-
 export function eqRec(dictionary0) {
   return dictionary1 => {
+    function eqRec$closure(argument0) {
+      return argument1 => {
+        return true;
+      };
+    }
     return { eq: eqRec$closure };
   };
 }
@@ -42,14 +13,44 @@ export function eqRecordConsType(dictionary2) {
   return dictionary3 => {
     return dictionary4 => {
       return dictionary5 => {
+        function eqRecordConsType$closure(argument0) {
+          return argument1 => {
+            return argument2 => {
+              return true;
+            };
+          };
+        }
         return { eqRecord: eqRecordConsType$closure };
       };
     };
   };
 }
 
-export const eqInt = { eq: eqInt$initialize$closure };
+export const eqInt = (() => {
+  function eqInt$initialize$closure(argument0) {
+    return argument1 => {
+      return true;
+    };
+  }
+  return { eq: eqInt$initialize$closure };
+})();
 
-export const eqBoolean = { eq: eqBoolean$initialize$closure };
+export const eqBoolean = (() => {
+  function eqBoolean$initialize$closure(argument0) {
+    return argument1 => {
+      return true;
+    };
+  }
+  return { eq: eqBoolean$initialize$closure };
+})();
 
-export const eqRecordNilType = { eqRecord: eqRecordNilType$initialize$closure };
+export const eqRecordNilType = (() => {
+  function eqRecordNilType$initialize$closure(argument0) {
+    return argument1 => {
+      return argument2 => {
+        return true;
+      };
+    };
+  }
+  return { eqRecord: eqRecordNilType$initialize$closure };
+})();

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Origin/index.js
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Origin/index.js
@@ -4,50 +4,6 @@ import * as $foreign from "./foreign.js";
 export const Just = $value0 => ["Just", $value0];
 const Nothing = ["Nothing"];
 
-function eqOption$initialize$closure(left) {
-  return right => {
-    function case$1(left, right) {
-      if (Array.isArray(left) && left[0] === "Nothing") {
-        if (Array.isArray(right) && right[0] === "Nothing") {
-          return true;
-        } else {
-          return case$2();
-        }
-      } else {
-        return case$2();
-      }
-    }
-
-    function case$2() {
-      return false;
-    }
-
-    function if$join(result$1) {
-      return result$1;
-    }
-
-    if (Array.isArray(left) && left[0] === "Just") {
-      const left0 = left[1];
-      if (Array.isArray(right) && right[0] === "Just") {
-        const right0 = right[1];
-        if (Data_Eq.eqInt.eq(left0)(right0)) {
-          return if$join(true);
-        } else {
-          return if$join(false);
-        }
-      } else {
-        return case$1(left, right);
-      }
-    } else {
-      return case$1(left, right);
-    }
-  };
-}
-
-function measureInt$initialize$closure(value) {
-  return value;
-}
-
 export function visible(value) {
   return value;
 }
@@ -64,8 +20,54 @@ const hidden = 13 | 0;
 
 const $await = 17 | 0;
 
-export const eqOption = { eq: eqOption$initialize$closure };
+export const eqOption = (() => {
+  function eqOption$initialize$closure(left) {
+    return right => {
+      function case$1(left, right) {
+        if (Array.isArray(left) && left[0] === "Nothing") {
+          if (Array.isArray(right) && right[0] === "Nothing") {
+            return true;
+          } else {
+            return case$2();
+          }
+        } else {
+          return case$2();
+        }
+      }
 
-export const measureInt = { measure: measureInt$initialize$closure };
+      function case$2() {
+        return false;
+      }
+
+      function if$join(result$1) {
+        return result$1;
+      }
+
+      if (Array.isArray(left) && left[0] === "Just") {
+        const left0 = left[1];
+        if (Array.isArray(right) && right[0] === "Just") {
+          const right0 = right[1];
+          if (Data_Eq.eqInt.eq(left0)(right0)) {
+            return if$join(true);
+          } else {
+            return if$join(false);
+          }
+        } else {
+          return case$1(left, right);
+        }
+      } else {
+        return case$1(left, right);
+      }
+    };
+  }
+  return { eq: eqOption$initialize$closure };
+})();
+
+export const measureInt = (() => {
+  function measureInt$initialize$closure(value) {
+    return value;
+  }
+  return { measure: measureInt$initialize$closure };
+})();
 
 export { $await as "await" };

--- a/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/output/Main/index.js
@@ -1,10 +1,9 @@
-function choose$closure(value) {
-  return value;
-}
-
 export function choose(argument0) {
   return argument1 => {
     if (argument0 === (0 | 0)) {
+      function choose$closure(value) {
+        return value;
+      }
       return choose$closure(argument1);
     } else {
       return argument0;

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Data.Eq/index.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Data.Eq/index.js
@@ -1,33 +1,35 @@
-function eqInt$initialize$closure(argument0) {
-  return argument1 => {
-    return true;
-  };
-}
-
-function eqBoolean$initialize$closure(argument0) {
-  return argument1 => {
-    return true;
-  };
-}
-
-function eqArray$closure(argument0) {
-  return argument1 => {
-    return true;
-  };
-}
-
-function orderedInt$initialize$closure(argument0) {
-  return argument1 => {
-    return true;
-  };
-}
-
 export function eqArray(dictionary0) {
+  function eqArray$closure(argument0) {
+    return argument1 => {
+      return true;
+    };
+  }
   return { eq: eqArray$closure };
 }
 
-export const eqInt = { eq: eqInt$initialize$closure };
+export const eqInt = (() => {
+  function eqInt$initialize$closure(argument0) {
+    return argument1 => {
+      return true;
+    };
+  }
+  return { eq: eqInt$initialize$closure };
+})();
 
-export const eqBoolean = { eq: eqBoolean$initialize$closure };
+export const eqBoolean = (() => {
+  function eqBoolean$initialize$closure(argument0) {
+    return argument1 => {
+      return true;
+    };
+  }
+  return { eq: eqBoolean$initialize$closure };
+})();
 
-export const orderedInt = { superclass62: eqInt, lessThanOrEqual: orderedInt$initialize$closure };
+export const orderedInt = (() => {
+  function orderedInt$initialize$closure(argument0) {
+    return argument1 => {
+      return true;
+    };
+  }
+  return { superclass62: eqInt, lessThanOrEqual: orderedInt$initialize$closure };
+})();

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
@@ -1,99 +1,17 @@
 import * as Data_Eq from "../Data.Eq/index.js";
 
-function compareTwice$closure(dictionary0) {
-  return left => {
-    return right => {
-      if (dictionary0.eq(left)(right)) {
-        return dictionary0.eq(right)(left);
-      } else {
-        return false;
-      }
-    };
-  };
-}
-
-function compareGenericArraysTwice$closure(dictionary1) {
-  return left => {
-    return right => {
-      const call = Data_Eq.eqArray(dictionary1);
-      if (call.eq(left)(right)) {
-        return call.eq(right)(left);
-      } else {
-        return false;
-      }
-    };
-  };
-}
-
-function distinctGivens$closure(dictionary2, dictionary3) {
-  return leftA => {
-    return rightA => {
-      return leftB => {
-        return rightB => {
-          function if$join$1(result$1) {
-            return result$1;
-          }
-
-          const call = Data_Eq.eqArray(dictionary2);
-          const call$1 = Data_Eq.eqArray(dictionary3);
-          if (call.eq(leftA)(rightA)) {
-            return call.eq(rightA)(leftA);
-          } else {
-            if (call$1.eq(leftB)(rightB)) {
-              return if$join$1(call$1.eq(rightB)(leftB));
-            } else {
-              return if$join$1(false);
-            }
-          }
-        };
+export function compareTwice(dictionary0) {
+  function compareTwice$closure(dictionary0) {
+    return left => {
+      return right => {
+        if (dictionary0.eq(left)(right)) {
+          return dictionary0.eq(right)(left);
+        } else {
+          return false;
+        }
       };
     };
-  };
-}
-
-function compareSuperclassArraysTwice$closure(dictionary4) {
-  return left => {
-    return right => {
-      const call = Data_Eq.eqArray(dictionary4.superclass62);
-      if (call.eq(left)(right)) {
-        return call.eq(right)(left);
-      } else {
-        return false;
-      }
-    };
-  };
-}
-
-function compareSuperclassTwice$closure(dictionary5) {
-  return left => {
-    return right => {
-      if (dictionary5.superclass62.eq(left)(right)) {
-        return dictionary5.superclass62.eq(right)(left);
-      } else {
-        return false;
-      }
-    };
-  };
-}
-
-function lambdaScope$closure(lambdaLeft) {
-  return lambdaRight => {
-    const call = Data_Eq.eqArray(Data_Eq.eqInt);
-    if (call.eq(lambdaLeft)(lambdaRight)) {
-      return call.eq(lambdaRight)(lambdaLeft);
-    } else {
-      return false;
-    }
-  };
-}
-
-function whereIsolation$closure(helperLeft) {
-  return helperRight => {
-    return (Data_Eq.eqArray(Data_Eq.eqInt)).eq(helperLeft)(helperRight);
-  };
-}
-
-export function compareTwice(dictionary0) {
+  }
   return compareTwice$closure(dictionary0);
 }
 
@@ -125,6 +43,18 @@ export function compareArraysOnce(left) {
 }
 
 export function compareGenericArraysTwice(dictionary1) {
+  function compareGenericArraysTwice$closure(dictionary1) {
+    return left => {
+      return right => {
+        const call = Data_Eq.eqArray(dictionary1);
+        if (call.eq(left)(right)) {
+          return call.eq(right)(left);
+        } else {
+          return false;
+        }
+      };
+    };
+  }
   return compareGenericArraysTwice$closure(dictionary1);
 }
 
@@ -146,6 +76,31 @@ export function compareNestedArraysTwice(left) {
 
 export function distinctGivens(dictionary2) {
   return dictionary3 => {
+    function distinctGivens$closure(dictionary2, dictionary3) {
+      return leftA => {
+        return rightA => {
+          return leftB => {
+            return rightB => {
+              function if$join$1(result$1) {
+                return result$1;
+              }
+
+              const call = Data_Eq.eqArray(dictionary2);
+              const call$1 = Data_Eq.eqArray(dictionary3);
+              if (call.eq(leftA)(rightA)) {
+                return call.eq(rightA)(leftA);
+              } else {
+                if (call$1.eq(leftB)(rightB)) {
+                  return if$join$1(call$1.eq(rightB)(leftB));
+                } else {
+                  return if$join$1(false);
+                }
+              }
+            };
+          };
+        };
+      };
+    }
     return distinctGivens$closure(dictionary2, dictionary3);
   };
 }
@@ -205,16 +160,49 @@ export function compareNestedArraysWhole(left) {
 }
 
 export function compareSuperclassArraysTwice(dictionary4) {
+  function compareSuperclassArraysTwice$closure(dictionary4) {
+    return left => {
+      return right => {
+        const call = Data_Eq.eqArray(dictionary4.superclass62);
+        if (call.eq(left)(right)) {
+          return call.eq(right)(left);
+        } else {
+          return false;
+        }
+      };
+    };
+  }
   return compareSuperclassArraysTwice$closure(dictionary4);
 }
 
 export function compareSuperclassTwice(dictionary5) {
+  function compareSuperclassTwice$closure(dictionary5) {
+    return left => {
+      return right => {
+        if (dictionary5.superclass62.eq(left)(right)) {
+          return dictionary5.superclass62.eq(right)(left);
+        } else {
+          return false;
+        }
+      };
+    };
+  }
   return compareSuperclassTwice$closure(dictionary5);
 }
 
 export function lambdaScope(left) {
   return right => {
     if ((Data_Eq.eqArray(Data_Eq.eqInt)).eq(left)(right)) {
+      function lambdaScope$closure(lambdaLeft) {
+        return lambdaRight => {
+          const call = Data_Eq.eqArray(Data_Eq.eqInt);
+          if (call.eq(lambdaLeft)(lambdaRight)) {
+            return call.eq(lambdaRight)(lambdaLeft);
+          } else {
+            return false;
+          }
+        };
+      }
       return lambdaScope$closure(left)(right);
     } else {
       return false;
@@ -224,6 +212,11 @@ export function lambdaScope(left) {
 
 export function whereIsolation(left) {
   return right => {
+    function whereIsolation$closure(helperLeft) {
+      return helperRight => {
+        return (Data_Eq.eqArray(Data_Eq.eqInt)).eq(helperLeft)(helperRight);
+      };
+    }
     if (whereIsolation$closure(left)(right)) {
       return (Data_Eq.eqArray(Data_Eq.eqInt)).eq(left)(right);
     } else {

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/output/Main/index.js
@@ -1,13 +1,3 @@
-function inlineClosure$closure(item) {
-  return item;
-}
-
-function inlineCapturedClosure$closure(captured) {
-  return argument0 => {
-    return captured;
-  };
-}
-
 export function identity(value) {
   return value;
 }
@@ -29,6 +19,9 @@ export function inlineLiteral(condition) {
 }
 
 export function inlineClosure(value) {
+  function inlineClosure$closure(item) {
+    return item;
+  }
   return inlineClosure$closure(value);
 }
 
@@ -47,6 +40,11 @@ export function inlineRecord(value) {
 }
 
 export function inlineCapturedClosure(captured) {
+  function inlineCapturedClosure$closure(captured) {
+    return argument0 => {
+      return captured;
+    };
+  }
   return inlineCapturedClosure$closure(captured);
 }
 


### PR DESCRIPTION
## Summary

Emit JavaScript closure implementation functions at the SSA instruction that constructs each closure instead of floating every implementation to module scope. Explicit capture arguments remain unchanged, while implementation names are allocated within their containing function so unrelated lexical scopes can reuse descriptive names.

Closure construction remains eligible for safe single-use inlining after its implementation declaration is emitted. Top-level initializers containing closures use the existing IIFE statement form because their declarations cannot be represented inside a single initializer expression.

## Verification

- `just t backend`
- `cargo check -p javascript --tests`