### PR TITLE
[backend] Add output update command

### DIFF
--- a/.agents/skills/workflow-integration-tests/SKILL.md
+++ b/.agents/skills/workflow-integration-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-integration-tests
-description: "Workflow for adding and updating Alexandrite integration-test fixtures for checking, semantic trees, lowering, resolving, and LSP behavior. Use when creating compiler integration tests, reviewing fixture snapshots, or using `just t <category>`."
+description: "Workflow for adding and updating Alexandrite integration-test fixtures for backend, checking, semantic trees, lowering, resolving, and LSP behavior. Use when creating compiler integration tests, reviewing fixture snapshots or generated JavaScript, or using `just t <category>`."
 ---
 
 # Workflow: Alexandrite Integration Tests
@@ -13,6 +13,7 @@ Use the command reference at `reference/compiler-scripts.md` for test runner syn
 
 | Category | Alias | Use for | Harness pattern |
 |----------|-------|---------|-----------------|
+| `backend` | `b` | SSA, generated JavaScript, foreign modules, and JavaScript execution | `Main.purs`, generated `output/`, optional `verify.mjs` |
 | `checking` | `c` | Type checking, inference, kinds, roles, constraints, diagnostics after checking | `Main.purs` only |
 | `semantic` | `s` | Checked semantic tree declarations, typed expressions and binders, and explicit evidence | `Main.purs` only |
 | `lowering` | `l` | Lowered core output, binding/equation structure, source-to-core name links | every `.purs` file |
@@ -36,6 +37,10 @@ Tests are auto-discovered by `build.rs`.
 ### 2. Write focused PureScript modules
 
 Keep each fixture about one behavior. Use a small `Main.purs` by default, and add supporting modules only when imports, exports, qualification, or cross-module behavior are part of the test.
+
+#### Backend fixtures
+
+Use backend fixtures for SSA or generated JavaScript behavior. The harness compares generated JavaScript with the fixture's tracked `output/` tree. Add `verify.mjs` when the behavior must also be executed with Node, and use foreign `.js` modules only when foreign imports are part of the scenario.
 
 #### Checking fixtures
 
@@ -75,6 +80,14 @@ Use `Main.purs` as the scenario driver. Add supporting modules for imported symb
 ```bash
 just t <category> NNN MMM
 ```
+
+When an intentional backend change affects generated JavaScript, review the reported files and update only the relevant fixtures:
+
+```bash
+just t backend NNN --update-output
+```
+
+Ordinary backend runs must remain read-only. Do not set `ALEXANDRITE_UPDATE_JAVASCRIPT_OUTPUT` directly; `compiler-scripts` owns that implementation detail.
 
 ### 4. Accept or reject snapshots
 
@@ -122,6 +135,10 @@ test = Just life
 
 ## Snapshot Review Focus
 
+### Backend
+
+Review SSA snapshots and every changed file under `output/`. Check module paths, imports, exports, foreign-module copies, and emitted expressions. When a fixture has `verify.mjs`, confirm the Node verification passes after updating output.
+
 ### Checking
 
 ```
@@ -160,6 +177,7 @@ Check hover text, definitions, completions, edits, and reported positions. Revie
 Before accepting, verify:
 
 1. **The category is appropriate**
+   - Backend owns SSA and generated or executed JavaScript behavior
    - Checking owns type inference/checking behavior
    - Semantic owns the typed semantic tree produced by checking
    - Lowering owns lowered core/source-link behavior
@@ -171,6 +189,7 @@ Before accepting, verify:
    - Supporting modules exist only when they clarify the behavior
 
 3. **Snapshots are intentional**
+   - Backend SSA and generated JavaScript changes are correct
    - Checking types are correct
    - `test :: Array Int -> Int` - signature preserved
    - `test' :: forall t. Array t -> t` - polymorphism inferred

--- a/.agents/skills/workflow-integration-tests/reference/compiler-scripts.md
+++ b/.agents/skills/workflow-integration-tests/reference/compiler-scripts.md
@@ -21,6 +21,7 @@ just t backend --update-output [filters...] # Update generated JavaScript fixtur
 
 | Category | Alias | Description |
 |----------|-------|-------------|
+| backend | b | SSA and JavaScript backend tests |
 | checking | c | Type checker tests |
 | semantic | s | Checked semantic tree tests |
 | lowering | l | Lowering tests |

--- a/.agents/skills/workflow-integration-tests/reference/compiler-scripts.md
+++ b/.agents/skills/workflow-integration-tests/reference/compiler-scripts.md
@@ -14,6 +14,7 @@ just t <category> --debug [filters...] # Enable tracing
 just t <category> --verbose [filters...] # Show test progress
 just t <category> --create "name"  # Scaffold a new fixture
 just t <category> --delete "name"  # Dry-run fixture deletion (use --confirm)
+just t backend --update-output [filters...] # Update generated JavaScript fixture output
 ```
 
 ### Categories

--- a/compiler-scripts/src/test_runner/cli.rs
+++ b/compiler-scripts/src/test_runner/cli.rs
@@ -22,6 +22,10 @@ pub struct RunArgs {
     #[arg(long)]
     pub reject: bool,
 
+    /// Update generated JavaScript output for backend fixtures
+    #[arg(long)]
+    pub update_output: bool,
+
     /// Test name, timestamp, or slug filters (passed through to nextest)
     #[arg(num_args = 0..)]
     pub filters: Vec<String>,

--- a/compiler-scripts/src/test_runner/nextest.rs
+++ b/compiler-scripts/src/test_runner/nextest.rs
@@ -31,6 +31,7 @@ pub fn build_nextest_command(category: TestCategory, args: &RunArgs) -> Command 
     }
 
     cmd.env("INSTA_FORCE_PASS", "1");
+    cmd.env_remove(UPDATE_JAVASCRIPT_OUTPUT);
     if matches!(category, TestCategory::Backend) && args.update_output {
         cmd.env(UPDATE_JAVASCRIPT_OUTPUT, "1");
     }
@@ -98,10 +99,8 @@ mod tests {
         command.get_args().collect()
     }
 
-    fn environment_value<'a>(command: &'a Command, name: &str) -> Option<&'a OsStr> {
-        command
-            .get_envs()
-            .find_map(|(variable, value)| (variable == name).then_some(value).flatten())
+    fn environment_setting<'a>(command: &'a Command, name: &str) -> Option<Option<&'a OsStr>> {
+        command.get_envs().find(|(variable, _)| *variable == name).map(|(_, value)| value)
     }
 
     #[test]
@@ -145,13 +144,16 @@ mod tests {
 
         let command = build_nextest_command(TestCategory::Backend, &run_args);
 
-        assert_eq!(environment_value(&command, UPDATE_JAVASCRIPT_OUTPUT), Some(OsStr::new("1")));
+        assert_eq!(
+            environment_setting(&command, UPDATE_JAVASCRIPT_OUTPUT),
+            Some(Some(OsStr::new("1")))
+        );
     }
 
     #[test]
     fn ordinary_test_runs_do_not_update_backend_output() {
         let command = build_nextest_command(TestCategory::Backend, &args(&[], false));
 
-        assert_eq!(environment_value(&command, UPDATE_JAVASCRIPT_OUTPUT), None);
+        assert_eq!(environment_setting(&command, UPDATE_JAVASCRIPT_OUTPUT), Some(None));
     }
 }

--- a/compiler-scripts/src/test_runner/nextest.rs
+++ b/compiler-scripts/src/test_runner/nextest.rs
@@ -7,6 +7,8 @@ use console::style;
 use crate::test_runner::category::TestCategory;
 use crate::test_runner::cli::RunArgs;
 
+const UPDATE_JAVASCRIPT_OUTPUT: &str = "ALEXANDRITE_UPDATE_JAVASCRIPT_OUTPUT";
+
 pub fn build_nextest_command(category: TestCategory, args: &RunArgs) -> Command {
     let mut cmd = Command::new("cargo");
     cmd.arg("nextest").arg("run").arg("-p").arg("tests-integration");
@@ -29,6 +31,9 @@ pub fn build_nextest_command(category: TestCategory, args: &RunArgs) -> Command 
     }
 
     cmd.env("INSTA_FORCE_PASS", "1");
+    if matches!(category, TestCategory::Backend) && args.update_output {
+        cmd.env(UPDATE_JAVASCRIPT_OUTPUT, "1");
+    }
 
     cmd
 }
@@ -52,6 +57,7 @@ pub fn run_nextest(category: TestCategory, args: &RunArgs) -> anyhow::Result<boo
                 confirm: false,
                 accept: false,
                 reject: false,
+                update_output: args.update_output,
                 filters: args.filters.clone(),
                 verbose: true,
                 diff: args.diff,
@@ -79,6 +85,7 @@ mod tests {
             confirm: false,
             accept: false,
             reject: false,
+            update_output: false,
             filters: filters.iter().map(|filter| (*filter).to_string()).collect(),
             verbose,
             diff: false,
@@ -89,6 +96,12 @@ mod tests {
 
     fn command_arguments(command: &Command) -> Vec<&OsStr> {
         command.get_args().collect()
+    }
+
+    fn environment_value<'a>(command: &'a Command, name: &str) -> Option<&'a OsStr> {
+        command
+            .get_envs()
+            .find_map(|(variable, value)| (variable == name).then_some(value).flatten())
     }
 
     #[test]
@@ -123,5 +136,22 @@ mod tests {
             ["nextest", "run", "-p", "tests-integration", "--test", "checking"]
         );
         assert!(arguments.contains(&OsStr::new("--status-level=fail")));
+    }
+
+    #[test]
+    fn backend_output_updates_are_explicitly_enabled_for_nextest() {
+        let mut run_args = args(&["javascript_execution"], false);
+        run_args.update_output = true;
+
+        let command = build_nextest_command(TestCategory::Backend, &run_args);
+
+        assert_eq!(environment_value(&command, UPDATE_JAVASCRIPT_OUTPUT), Some(OsStr::new("1")));
+    }
+
+    #[test]
+    fn ordinary_test_runs_do_not_update_backend_output() {
+        let command = build_nextest_command(TestCategory::Backend, &args(&[], false));
+
+        assert_eq!(environment_value(&command, UPDATE_JAVASCRIPT_OUTPUT), None);
     }
 }

--- a/tests-integration/src/fixtures.rs
+++ b/tests-integration/src/fixtures.rs
@@ -181,9 +181,16 @@ fn verify_output(expected: &Path, generated: &Path) -> FixtureResult {
         .chain(changed.map(|path| format!("changed {path}")));
     let changes = changes.collect_vec();
     let changes = changes.join("\n  ");
+    let fixture_name = expected
+        .parent()
+        .and_then(|fixture| fixture.file_name())
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            invalid_data(format!("fixture output has no valid parent: {}", expected.display()))
+        })?;
     let message = format!(
         "generated JavaScript differs from {}:\n  {changes}\nrun \
-         `just t backend --update-output` to update fixture output",
+         `just t backend {fixture_name} --update-output` to update fixture output",
         expected.display()
     );
     Err(invalid_data(message).into())

--- a/tests-integration/src/fixtures.rs
+++ b/tests-integration/src/fixtures.rs
@@ -183,7 +183,7 @@ fn verify_output(expected: &Path, generated: &Path) -> FixtureResult {
     let changes = changes.join("\n  ");
     let message = format!(
         "generated JavaScript differs from {}:\n  {changes}\nrun \
-         `{UPDATE_JAVASCRIPT_OUTPUT}=1 just t backend` to update fixture output",
+         `just t backend --update-output` to update fixture output",
         expected.display()
     );
     Err(invalid_data(message).into())


### PR DESCRIPTION
## Summary

Add an explicit `--update-output` option to the integration-test runner for regenerating tracked JavaScript fixture output. The runner keeps ordinary backend test runs read-only and sets the harness environment variable only when this option is requested.

Update backend mismatch guidance and the integration-test skill so contributors use the runner command instead of setting the environment variable directly.

## Verification

- `cargo test -p compiler-scripts test_runner::nextest::tests`
- `cargo check -p tests-integration --tests`
- `just t backend 1787081220 --update-output`