### PR TITLE
[foreign-javascript] Validate JavaScript FFI exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "checking",
  "diagnostics",
  "files",
+ "foreign-javascript",
  "indexing",
  "insta",
  "itertools 0.15.0",
@@ -269,6 +270,7 @@ dependencies = [
  "checking",
  "documenting",
  "files",
+ "foreign-javascript",
  "indexing",
  "interner",
  "javascript",
@@ -329,6 +331,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -481,6 +492,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79fcda08c33bb58b97008b2cdada6622500e949e060f5913361763121abd2416"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "static_assertions",
+ "zmij",
+]
+
+[[package]]
 name = "compiler-scripts"
 version = "0.1.0"
 dependencies = [
@@ -530,6 +554,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cow-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
 name = "cpufeatures"
@@ -633,6 +663,7 @@ version = "0.1.0"
 dependencies = [
  "checking",
  "files",
+ "foreign-javascript",
  "indexing",
  "itertools 0.15.0",
  "line-index",
@@ -714,6 +745,12 @@ dependencies = [
  "stabilizing",
  "syntax",
 ]
+
+[[package]]
+name = "dragonbox_ecma"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
 
 [[package]]
 name = "drop_bomb"
@@ -844,6 +881,20 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-javascript"
+version = "0.1.0"
+dependencies = [
+ "building-types",
+ "files",
+ "indexing",
+ "oxc_allocator",
+ "oxc_parser",
+ "oxc_span",
+ "oxc_syntax",
+ "smol_str",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -1360,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "javascript"
@@ -1611,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minicov"
@@ -1680,12 +1731,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1738,6 +1814,197 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "oxc_allocator"
+version = "0.146.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064fce871c5cb07e557049ed27c8ca2aa530db797f73424c67e4bb8cfe61175e"
+dependencies = [
+ "allocator-api2",
+ "hashbrown 0.17.1",
+ "oxc_data_structures",
+ "rustc-hash",
+]
+
+[[package]]
+name = "oxc_ast"
+version = "0.146.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a999fd4494b604fc0328fc43443bc1298722500587d87d7e993118bd82c65d7b"
+dependencies = [
+ "bitflags 2.13.1",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_estree",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
+]
+
+[[package]]
+name = "oxc_ast_macros"
+version = "0.146.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d715e3c300c95b1d797b05526567161fd86fcac2ac68235101c61b736f216cde"
+dependencies = [
+ "phf",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "oxc_data_structures"
+version = "0.146.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15a23b57a931fda6bc9a4fdc3fbabcac6a2edfd0b7216cb7c81432f0e9f54d9"
+
+[[package]]
+name = "oxc_diagnostics"
+version = "0.146.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d0ce1ec51b07b6501eecedd5ab50835b7ebe5c8463cada3b2e6d984d0943af"
+dependencies = [
+ "bytecount",
+ "cow-utils",
+ "itoa",
+ "memchr",
+ "owo-colors",
+ "oxc_span",
+ "percent-encoding",
+ "smallvec",
+ "textwrap",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "oxc_ecmascript"
+version = "0.146.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5d3d07165b7aadcd021f62cd95fb7d62cb6977b8bbfb42fa12adbfb7e75257"
+dependencies = [
+ "dragonbox_ecma",
+ "itoa",
+ "num-bigint",
+ "num-traits",
+ "oxc_ast",
+ "oxc_data_structures",
+ "oxc_span",
+ "oxc_syntax",
+]
+
+[[package]]
+name = "oxc_estree"
+version = "0.146.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7af86a59b7aeb2845ffea2cc21ae259053865b175e9ac936a7d72f2744abe5"
+
+[[package]]
+name = "oxc_index"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "191884bee6c3744909a51acc7d78d4ae370d817b25875b10642f632327b6296e"
+dependencies = [
+ "nonmax",
+ "serde",
+]
+
+[[package]]
+name = "oxc_parser"
+version = "0.146.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311c29dfdf55ea8bf065cf300b3d0dca5fe1c0fb8059c9ba70a6c98cce75306e"
+dependencies = [
+ "bitflags 2.13.1",
+ "cow-utils",
+ "memchr",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_ecmascript",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
+ "rustc-hash",
+ "seq-macro",
+]
+
+[[package]]
+name = "oxc_regular_expression"
+version = "0.146.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31839a373ad02a37fad54244a3eb710f9a94b5e2e16ca0e1d28a37b4c75b8ebc"
+dependencies = [
+ "bitflags 2.13.1",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_diagnostics",
+ "oxc_span",
+ "oxc_str",
+ "phf",
+ "rustc-hash",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "oxc_span"
+version = "0.146.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c355ae1fa3e865c28cb8a85735ecafd1bb6340a5b880c638d127c1f2d61a98a5"
+dependencies = [
+ "compact_str",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
+ "oxc_str",
+]
+
+[[package]]
+name = "oxc_str"
+version = "0.146.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba45ef9efa8296e647aa37b2b21936cb520953031edc1ef6352281bbea22faa"
+dependencies = [
+ "compact_str",
+ "hashbrown 0.17.1",
+ "oxc_allocator",
+ "oxc_estree",
+]
+
+[[package]]
+name = "oxc_syntax"
+version = "0.146.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0970d9be099a082711b574d58add258549580a70fe6546b99a067bbd7ad4a264"
+dependencies = [
+ "bitflags 2.13.1",
+ "cow-utils",
+ "dragonbox_ecma",
+ "nonmax",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
+ "oxc_index",
+ "oxc_span",
+ "oxc_str",
+ "phf",
+ "unicode-id-start",
 ]
 
 [[package]]
@@ -1844,6 +2111,49 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2437,6 +2747,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2574,6 +2890,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,9 +2903,18 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "smawk"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "smol_str"
@@ -2655,6 +2986,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string-interner"
@@ -2903,6 +3240,17 @@ name = "text-size"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -3157,10 +3505,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
+name = "unicode-id-start"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b79ad29b5e19de4260020f8919b443b2ef0277d242ce532ec7b7a2cc8b6007"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"

--- a/compiler-backend/foreign-javascript/Cargo.toml
+++ b/compiler-backend/foreign-javascript/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "foreign-javascript"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+building-types = { version = "0.1.0", path = "../../compiler-core/building-types" }
+files = { version = "0.1.0", path = "../../compiler-core/files" }
+indexing = { version = "0.1.0", path = "../../compiler-core/indexing" }
+oxc_allocator = "0.146.0"
+oxc_parser = "0.146.0"
+oxc_span = "0.146.0"
+oxc_syntax = "0.146.0"
+smol_str = "0.3.6"

--- a/compiler-backend/foreign-javascript/src/lib.rs
+++ b/compiler-backend/foreign-javascript/src/lib.rs
@@ -30,7 +30,7 @@ pub enum ForeignError {
 }
 
 pub trait ForeignQueries {
-    fn foreign_module(&self, id: ForeignFileId) -> QueryResult<Arc<ForeignModule>>;
+    fn foreign_module(&self, id: ForeignFileId) -> QueryResult<Option<Arc<ForeignModule>>>;
 
     fn foreign_validation(&self, id: FileId) -> QueryResult<Arc<ForeignValidation>>;
 }

--- a/compiler-backend/foreign-javascript/src/lib.rs
+++ b/compiler-backend/foreign-javascript/src/lib.rs
@@ -1,0 +1,106 @@
+use std::collections::BTreeSet;
+use std::iter;
+use std::sync::Arc;
+
+use building_types::QueryResult;
+use files::{FileId, ForeignFileId};
+use indexing::{IndexedModule, IndexedTermItemKind, TermItemId};
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use oxc_syntax::module_record::{ExportEntry, ExportExportName};
+use smol_str::SmolStr;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForeignModule {
+    pub exports: BTreeSet<SmolStr>,
+    pub errors: Arc<[Arc<str>]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForeignValidation {
+    pub errors: Arc<[ForeignError]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ForeignError {
+    MissingModule { declaration: TermItemId, name: SmolStr },
+    MissingImplementation { declaration: TermItemId, name: SmolStr },
+    Parse { declaration: TermItemId, message: Arc<str> },
+}
+
+pub trait ForeignQueries {
+    fn foreign_module(&self, id: ForeignFileId) -> QueryResult<Arc<ForeignModule>>;
+
+    fn foreign_validation(&self, id: FileId) -> QueryResult<Arc<ForeignValidation>>;
+}
+
+pub fn parse_module(content: &str) -> ForeignModule {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, content, SourceType::mjs()).parse();
+
+    let local_exports = parsed.module_record.local_export_entries.iter();
+    let indirect_exports = parsed.module_record.indirect_export_entries.iter();
+    let entries = iter::chain(local_exports, indirect_exports);
+    let exports = entries.filter_map(export_name);
+    let exports = exports.collect();
+
+    let errors = parsed.diagnostics.into_iter().map(|diagnostic| diagnostic.to_string().into());
+    let errors = errors.collect();
+
+    ForeignModule { exports, errors }
+}
+
+fn export_name(entry: &ExportEntry<'_>) -> Option<SmolStr> {
+    let ExportExportName::Name(name) = &entry.export_name else {
+        return None;
+    };
+    Some(SmolStr::new(name.name.as_str()))
+}
+
+pub fn validate_module(
+    indexed: &IndexedModule,
+    foreign: Option<&ForeignModule>,
+) -> ForeignValidation {
+    let declarations = indexed.items.iter_terms().filter_map(|(declaration, item)| {
+        if !matches!(item.kind, IndexedTermItemKind::Foreign { .. }) {
+            return None;
+        }
+        let name = item.name.clone()?;
+        Some((declaration, name))
+    });
+    let declarations = declarations.collect::<Vec<_>>();
+
+    let mut errors = Vec::new();
+    let Some(foreign) = foreign else {
+        let missing_modules = declarations
+            .into_iter()
+            .map(|(declaration, name)| ForeignError::MissingModule { declaration, name });
+        errors.extend(missing_modules);
+        return ForeignValidation { errors: errors.into() };
+    };
+
+    if let Some((declaration, _)) = declarations.first() {
+        for message in foreign.errors.iter() {
+            errors.push(ForeignError::Parse {
+                declaration: *declaration,
+                message: Arc::clone(message),
+            });
+        }
+    }
+
+    if !foreign.errors.is_empty() {
+        return ForeignValidation { errors: errors.into() };
+    }
+
+    let missing_implementations = declarations.into_iter().filter_map(|(declaration, name)| {
+        if foreign.exports.contains(&name) {
+            None
+        } else {
+            Some(ForeignError::MissingImplementation { declaration, name })
+        }
+    });
+    errors.extend(missing_implementations);
+
+    ForeignValidation { errors: errors.into() }
+}

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -18,9 +18,9 @@ use async_lsp::concurrency::ConcurrencyLayer;
 use async_lsp::panic::CatchUnwindLayer;
 use async_lsp::router::Router;
 use async_lsp::server::LifecycleLayer;
-use async_lsp::{ClientSocket, ResponseError};
+use async_lsp::{ClientSocket, LanguageClient, ResponseError};
 use building::QueryEngine;
-use files::{FileId, Files};
+use files::{FileId, Files, ForeignFiles};
 use itertools::Itertools;
 use lsp_types::notification::Notification;
 use lsp_types::request::Request;
@@ -67,6 +67,7 @@ pub struct State {
 
     pub engine: QueryEngine,
     pub files: Arc<RwLock<LspFiles>>,
+    pub foreign_files: Arc<RwLock<ForeignFiles>>,
 
     pub workspace_symbols_cache: Arc<RwLock<WorkspaceSymbolsCache>>,
     pub suggestions_cache: Arc<RwLock<SuggestionsCache>>,
@@ -74,6 +75,7 @@ pub struct State {
     pub root: Option<PathBuf>,
     pub position_encoding: PositionEncoding,
     pub analyzer_capabilities: AnalyzerCapabilities,
+    pub watched_files_dynamic_registration: bool,
 }
 
 impl State {
@@ -85,6 +87,9 @@ impl State {
         let files = LspFiles::new(files);
         let files = Arc::new(RwLock::new(files));
 
+        let foreign_files = ForeignFiles::default();
+        let foreign_files = Arc::new(RwLock::new(foreign_files));
+
         let workspace_symbols_cache = WorkspaceSymbolsCache::default();
         let workspace_symbols_cache = Arc::new(RwLock::new(workspace_symbols_cache));
 
@@ -94,17 +99,20 @@ impl State {
         let root = None;
         let position_encoding = PositionEncoding::Utf16;
         let analyzer_capabilities = AnalyzerCapabilities::default();
+        let watched_files_dynamic_registration = false;
 
         State {
             config,
             client,
             engine,
             files,
+            foreign_files,
             workspace_symbols_cache,
             suggestions_cache,
             root,
             position_encoding,
             analyzer_capabilities,
+            watched_files_dynamic_registration,
         }
     }
 
@@ -237,6 +245,8 @@ fn initialize(
     let position_encoding = negotiate_position_encoding(&p.initialize_params);
     state.position_encoding = position_encoding;
     state.analyzer_capabilities = negotiate_analyzer_capabilities(&p.initialize_params);
+    state.watched_files_dynamic_registration =
+        watched_files_dynamic_registration(&p.initialize_params.capabilities);
 
     state.root = p
         .initialize_params
@@ -313,18 +323,60 @@ fn initialize(
     }
 }
 
+fn watched_files_dynamic_registration(capabilities: &ClientCapabilities) -> bool {
+    capabilities
+        .workspace
+        .as_ref()
+        .and_then(|workspace| workspace.did_change_watched_files.as_ref())
+        .and_then(|watched_files| watched_files.dynamic_registration)
+        .unwrap_or(false)
+}
+
 fn shutdown(_state: &mut State, (): ()) -> impl Future<Output = Result<(), ResponseError>> + use<> {
     async { Ok(()) }
 }
 
 fn initialized(state: &mut State, _: InitializedParams) -> Result<(), LspError> {
     let _span = tracing::info_span!("initialization").entered();
+    register_foreign_file_watcher(state);
+
     let config = Arc::clone(&state.config);
     if let Some(command) = config.source_command.as_deref() {
         initialized_manual(state, command)
     } else {
         initialized_spago(state)
     }
+}
+
+fn register_foreign_file_watcher(state: &State) {
+    if !state.watched_files_dynamic_registration {
+        return;
+    }
+
+    let parameters = foreign_file_watcher_registration();
+    let mut client = state.client.clone();
+    task::spawn(async move {
+        if let Err(error) = client.register_capability(parameters).await {
+            tracing::warn!("Failed to register JavaScript FFI file watcher: {error}");
+        }
+    });
+}
+
+fn foreign_file_watcher_registration() -> RegistrationParams {
+    let options = DidChangeWatchedFilesRegistrationOptions {
+        watchers: vec![FileSystemWatcher {
+            glob_pattern: GlobPattern::String("**/*.js".to_string()),
+            kind: None,
+        }],
+    };
+    let register_options = serde_json::to_value(options)
+        .expect("invariant violated: watched file registration options must serialize");
+    let registration = Registration {
+        id: "javascript-ffi-files".to_string(),
+        method: notification::DidChangeWatchedFiles::METHOD.to_string(),
+        register_options: Some(register_options),
+    };
+    RegistrationParams { registrations: vec![registration] }
 }
 
 fn exit(_state: &mut State, (): ()) -> Result<(), LspError> {
@@ -389,6 +441,7 @@ fn load_files(
 
         let text = fs::read_to_string(file)?;
         on_change(state, &uri, &text, Some(*editable))?;
+        load_sibling_foreign(state, &url)?;
     }
 
     tracing::info!("Loaded {} files.", files.len());
@@ -562,30 +615,42 @@ fn semantic_tokens(
 }
 
 fn did_change(state: &mut State, p: DidChangeTextDocumentParams) -> Result<(), LspError> {
-    let uri = p.text_document.uri.as_str();
+    let uri = &p.text_document.uri;
 
     for content_change in &p.content_changes {
         let text = content_change.text.as_str();
-        on_change(state, uri, text, None)?;
+        if is_javascript_uri(uri) {
+            on_foreign_change(state, uri, text)?;
+        } else {
+            on_change(state, uri.as_str(), text, None)?;
+        }
     }
 
     state.invalidate_workspace_symbols();
     state.invalidate_suggestions_cache();
 
     if state.config.diagnostics_on_change {
-        event::emit_collect_diagnostics(state, p.text_document.uri)?;
+        emit_associated_diagnostics(state, p.text_document.uri)?;
     }
 
     Ok(())
 }
 
 fn did_open(state: &mut State, p: DidOpenTextDocumentParams) -> Result<(), LspError> {
-    let uri = p.text_document.uri.as_str();
+    let uri = &p.text_document.uri;
     let text = p.text_document.text.as_str();
+
+    if is_javascript_uri(uri) {
+        on_foreign_change(state, uri, text)?;
+        if state.config.diagnostics_on_open {
+            emit_associated_diagnostics(state, uri.clone())?;
+        }
+        return Ok(());
+    }
 
     let editable = {
         let files = state.files.read();
-        let previous_id = files.id(uri);
+        let previous_id = files.id(uri.as_str());
         previous_id.map(|file_id| files.is_editable(file_id))
     }
     .unwrap_or_else(|| {
@@ -594,7 +659,8 @@ fn did_open(state: &mut State, p: DidOpenTextDocumentParams) -> Result<(), LspEr
         };
         p.text_document.uri.to_file_path().is_ok_and(|path| path.starts_with(root))
     });
-    on_change(state, uri, text, Some(editable))?;
+    on_change(state, uri.as_str(), text, Some(editable))?;
+    load_sibling_foreign(state, uri)?;
 
     state.invalidate_workspace_symbols();
     state.invalidate_suggestions_cache();
@@ -610,9 +676,119 @@ fn did_save(state: &mut State, p: DidSaveTextDocumentParams) -> Result<(), LspEr
     state.invalidate_suggestions_cache();
 
     if state.config.diagnostics_on_save {
-        event::emit_collect_diagnostics(state, p.text_document.uri)?;
+        emit_associated_diagnostics(state, p.text_document.uri)?;
     }
     Ok(())
+}
+
+fn did_change_watched_files(
+    state: &mut State,
+    p: DidChangeWatchedFilesParams,
+) -> Result<(), LspError> {
+    for change in p.changes {
+        if !is_javascript_uri(&change.uri) {
+            continue;
+        }
+
+        let Some(source_uri) = source_uri_from_foreign(&change.uri) else {
+            continue;
+        };
+        let source_tracked = state.files.read().id(source_uri.as_str()).is_some();
+        if !source_tracked && state.foreign_files.read().id(change.uri.as_str()).is_none() {
+            continue;
+        }
+
+        if change.typ == FileChangeType::DELETED {
+            remove_foreign_file(state, &change.uri);
+        } else if let Ok(path) = change.uri.to_file_path() {
+            match fs::read_to_string(path) {
+                Ok(content) => on_foreign_change(state, &change.uri, &content)?,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    remove_foreign_file(state, &change.uri);
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+
+        if source_tracked {
+            event::emit_collect_diagnostics(state, source_uri)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn is_javascript_uri(uri: &Url) -> bool {
+    uri.path().ends_with(".js")
+}
+
+fn source_uri_from_foreign(uri: &Url) -> Option<Url> {
+    let path = uri.to_file_path().ok()?;
+    Url::from_file_path(path.with_extension("purs")).ok()
+}
+
+fn load_sibling_foreign(state: &mut State, source_uri: &Url) -> Result<(), LspError> {
+    let Ok(source_path) = source_uri.to_file_path() else {
+        return Ok(());
+    };
+    let foreign_path = source_path.with_extension("js");
+    let foreign_uri = Url::from_file_path(&foreign_path)
+        .map_err(|()| LspError::PathParseFail(foreign_path.clone()))?;
+
+    let foreign_id = state.foreign_files.read().id(foreign_uri.as_str());
+    if let Some(foreign_id) = foreign_id {
+        let source_id = state.files.read().id(source_uri.as_str());
+        if let Some(source_id) = source_id {
+            state.engine.set_foreign_file(source_id, foreign_id);
+        }
+        return Ok(());
+    }
+
+    if !foreign_path.is_file() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(foreign_path)?;
+    on_foreign_change(state, &foreign_uri, &content)
+}
+
+fn emit_associated_diagnostics(state: &mut State, uri: Url) -> Result<(), LspError> {
+    let uri = if is_javascript_uri(&uri) {
+        let Some(source_uri) = source_uri_from_foreign(&uri) else {
+            return Ok(());
+        };
+        source_uri
+    } else {
+        uri
+    };
+    event::emit_collect_diagnostics(state, uri)
+}
+
+fn on_foreign_change(state: &mut State, uri: &Url, content: &str) -> Result<(), LspError> {
+    state.engine.request_cancel();
+
+    let foreign_id = state.foreign_files.write().insert(uri.as_str(), content);
+    state.engine.set_foreign_content(foreign_id, content);
+
+    let Some(source_uri) = source_uri_from_foreign(uri) else {
+        return Ok(());
+    };
+    let Some(source_id) = state.files.read().id(source_uri.as_str()) else {
+        return Ok(());
+    };
+
+    state.engine.set_foreign_file(source_id, foreign_id);
+
+    Ok(())
+}
+
+fn remove_foreign_file(state: &mut State, uri: &Url) {
+    let foreign_id = state.foreign_files.write().remove(uri.as_str());
+    let Some(foreign_id) = foreign_id else {
+        return;
+    };
+
+    state.engine.remove_foreign_file(foreign_id);
 }
 
 fn on_change(
@@ -732,7 +908,7 @@ pub async fn async_start(config: Arc<LspConfig>) {
             .notification_ext::<notification::DidCloseTextDocument>(|_, _| Ok(()))
             .notification_ext::<notification::DidChangeConfiguration>(|_, _| Ok(()))
             .notification_ext::<notification::DidChangeTextDocument>(did_change)
-            .notification_ext::<notification::DidChangeWatchedFiles>(|_, _| Ok(()))
+            .notification_ext::<notification::DidChangeWatchedFiles>(did_change_watched_files)
             .event_ext::<event::CollectDiagnostics>(event::collect_diagnostics);
 
         ServiceBuilder::new()

--- a/compiler-core/building-types/src/lib.rs
+++ b/compiler-core/building-types/src/lib.rs
@@ -3,12 +3,14 @@ pub use module_name_map::*;
 
 use std::sync::Arc;
 
-use files::FileId;
+use files::{FileId, ForeignFileId};
 use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum QueryKey {
     Content(FileId),
+    Foreign(FileId),
+    ForeignContent(ForeignFileId),
     Module(ModuleNameId),
     Parsed(FileId),
     Stabilized(FileId),

--- a/compiler-core/building-types/src/lib.rs
+++ b/compiler-core/building-types/src/lib.rs
@@ -11,6 +11,8 @@ pub enum QueryKey {
     Content(FileId),
     Foreign(FileId),
     ForeignContent(ForeignFileId),
+    ForeignModule(ForeignFileId),
+    ForeignValidation(FileId),
     Module(ModuleNameId),
     Parsed(FileId),
     Stabilized(FileId),

--- a/compiler-core/building/Cargo.toml
+++ b/compiler-core/building/Cargo.toml
@@ -8,6 +8,7 @@ building-types = { version = "0.1.0", path = "../building-types" }
 checking = { version = "0.1.0", path = "../checking" }
 documenting = { version = "0.1.0", path = "../documenting" }
 files = { version = "0.1.0", path = "../files" }
+foreign-javascript = { version = "0.1.0", path = "../../compiler-backend/foreign-javascript" }
 indexing = { version = "0.1.0", path = "../indexing" }
 interner = { version = "0.1.0", path = "../interner" }
 javascript = { version = "0.1.0", path = "../../compiler-backend/javascript" }

--- a/compiler-core/building/src/engine.rs
+++ b/compiler-core/building/src/engine.rs
@@ -113,6 +113,13 @@ where
         let hash = FxBuildHasher.hash_one(key);
         &self.inner[(hash as usize) & SHARD_MASK]
     }
+
+    fn remove(&self, key: &K) -> Option<V>
+    where
+        K: Eq,
+    {
+        self.shard(key).write().remove(key)
+    }
 }
 
 #[derive(Default)]
@@ -125,7 +132,7 @@ struct InputStorage {
 
 #[derive(Default)]
 struct DerivedStorage {
-    foreign_module: Shards<ForeignFileId, DerivedState<Arc<ForeignModule>>>,
+    foreign_module: Shards<ForeignFileId, DerivedState<Option<Arc<ForeignModule>>>>,
     foreign_validation: Shards<FileId, DerivedState<Arc<ForeignValidation>>>,
     parsed: Shards<FileId, DerivedState<FullParsedModule>>,
     stabilized: Shards<FileId, DerivedState<Arc<StabilizedModule>>>,
@@ -749,39 +756,59 @@ impl QueryEngine {
         self.set_input(id, |input| &input.foreign_content, content.into());
     }
 
-    pub fn foreign_content(&self, id: ForeignFileId) -> Arc<str> {
+    pub fn foreign_content(&self, id: ForeignFileId) -> Option<Arc<str>> {
         self.get_input(QueryKey::ForeignContent(id), id, |input| &input.foreign_content)
-            .unwrap_or_else(|| {
-                panic!("invariant violated: set_foreign_content({id:?}, ..)");
-            })
     }
 
     pub fn set_foreign_file(&self, source_id: FileId, foreign_id: ForeignFileId) {
         self.set_input(source_id, |input| &input.foreign, Some(foreign_id));
     }
 
-    pub fn remove_foreign_file(&self, source_id: FileId, foreign_id: ForeignFileId) {
-        let current =
-            self.get_input(QueryKey::Foreign(source_id), source_id, |input| &input.foreign);
-        if current != Some(Some(foreign_id)) {
-            return;
+    pub fn remove_foreign_file(&self, foreign_id: ForeignFileId) {
+        self.control.global.cancelled.store(true, Ordering::Relaxed);
+        let _query_lock = self.control.global.query_lock.write();
+
+        let changed = self.control.global.revision.fetch_add(1, Ordering::Relaxed) + 1;
+        for shard in &self.input.foreign.inner {
+            let mut associations = shard.write();
+            for state in associations.values_mut() {
+                if state.value == Some(foreign_id) {
+                    state.value = None;
+                    state.changed = changed;
+                }
+            }
         }
 
-        self.set_input(source_id, |input| &input.foreign, None);
+        self.input.foreign_content.remove(&foreign_id);
+        self.derived.foreign_module.remove(&foreign_id);
+        let dependency = QueryKey::ForeignModule(foreign_id);
+        for shard in &self.derived.foreign_validation.inner {
+            let mut validations = shard.write();
+            validations.retain(|_, state| {
+                let DerivedState::Computed { dependencies, .. } = state else {
+                    return true;
+                };
+                !dependencies.contains(&dependency)
+            });
+        }
+
+        self.control.global.cancelled.store(false, Ordering::Relaxed);
     }
 
     pub fn foreign_file(&self, source_id: FileId) -> Option<ForeignFileId> {
         self.get_input(QueryKey::Foreign(source_id), source_id, |input| &input.foreign).flatten()
     }
 
-    pub fn foreign_module(&self, id: ForeignFileId) -> QueryResult<Arc<ForeignModule>> {
+    pub fn foreign_module(&self, id: ForeignFileId) -> QueryResult<Option<Arc<ForeignModule>>> {
         self.query(
             QueryKey::ForeignModule(id),
             id,
             |derived| &derived.foreign_module,
             |this| {
-                let content = this.foreign_content(id);
-                Ok(Arc::new(foreign_javascript::parse_module(&content)))
+                let module = this
+                    .foreign_content(id)
+                    .map(|content| Arc::new(foreign_javascript::parse_module(&content)));
+                Ok(module)
             },
         )
     }
@@ -794,7 +821,7 @@ impl QueryEngine {
             |this| {
                 let indexed = this.indexed(id)?;
                 let foreign = if let Some(foreign_id) = this.foreign_file(id) {
-                    Some(this.foreign_module(foreign_id)?)
+                    this.foreign_module(foreign_id)?
                 } else {
                     None
                 };
@@ -1202,7 +1229,7 @@ impl resolving::ExternalQueries for QueryEngine {}
 impl sugar::ExternalQueries for QueryEngine {}
 
 impl foreign_javascript::ForeignQueries for QueryEngine {
-    fn foreign_module(&self, id: ForeignFileId) -> QueryResult<Arc<ForeignModule>> {
+    fn foreign_module(&self, id: ForeignFileId) -> QueryResult<Option<Arc<ForeignModule>>> {
         QueryEngine::foreign_module(self, id)
     }
 
@@ -1506,24 +1533,35 @@ mod tests {
         let mut files = Files::default();
         let mut foreign_files = ForeignFiles::default();
 
-        let source_id = files.insert("src/Main.purs", "module Main where");
-        let first_id = foreign_files.insert("src/Main.js", "export const first = 1;");
-        let second_id = foreign_files.insert("src/Other.js", "export const second = 2;");
+        let source = "module Main where\n\nforeign import life :: Int";
+        let source_id = files.insert("src/Main.purs", source);
+        let first_id = foreign_files.insert("src/Main.js", "export const life = 1;");
+        let second_id = foreign_files.insert("src/Other.js", "export const life = 2;");
+        engine.set_content(source_id, source);
 
         assert_eq!(engine.foreign_file(source_id), None);
 
         engine.set_foreign_content(first_id, foreign_files.content(first_id));
         engine.set_foreign_file(source_id, first_id);
         assert_eq!(engine.foreign_file(source_id), Some(first_id));
-        assert_eq!(engine.foreign_content(first_id).as_ref(), "export const first = 1;");
+        assert_eq!(engine.foreign_content(first_id).as_deref(), Some("export const life = 1;"));
+        assert!(engine.foreign_validation(source_id).unwrap().errors.is_empty());
 
         engine.set_foreign_content(second_id, foreign_files.content(second_id));
         engine.set_foreign_file(source_id, second_id);
-        engine.remove_foreign_file(source_id, first_id);
+        engine.remove_foreign_file(first_id);
         assert_eq!(engine.foreign_file(source_id), Some(second_id));
+        assert_eq!(engine.foreign_content(first_id), None);
+        assert_eq!(engine.foreign_module(first_id).unwrap(), None);
+        assert!(
+            !engine.derived.foreign_validation.shard(&source_id).read().contains_key(&source_id)
+        );
+        assert!(engine.foreign_validation(source_id).unwrap().errors.is_empty());
 
-        engine.remove_foreign_file(source_id, second_id);
+        engine.remove_foreign_file(second_id);
         assert_eq!(engine.foreign_file(source_id), None);
+        let validation = engine.foreign_validation(source_id).unwrap();
+        assert!(matches!(validation.errors.as_ref(), [ForeignError::MissingModule { .. }]));
     }
 
     #[test]
@@ -1562,6 +1600,42 @@ mod tests {
         );
         let body_changed = engine.foreign_validation(source_id).unwrap();
         assert!(Arc::ptr_eq(&valid, &body_changed));
+
+        engine.remove_foreign_file(foreign_id);
+        assert_eq!(foreign_files.remove("src/Main.js"), Some(foreign_id));
+
+        for number in 0..32 {
+            let path = format!("src/Main-{number}.js");
+            let foreign_id = foreign_files.insert(path.as_str(), "export const life = 42;");
+            engine.set_foreign_content(foreign_id, foreign_files.content(foreign_id));
+            engine.set_foreign_file(source_id, foreign_id);
+
+            let valid = engine.foreign_validation(source_id).unwrap();
+            assert!(valid.errors.is_empty());
+
+            engine.remove_foreign_file(foreign_id);
+            assert_eq!(foreign_files.remove(&path), Some(foreign_id));
+            assert!(
+                !engine.input.foreign_content.shard(&foreign_id).read().contains_key(&foreign_id)
+            );
+            assert!(
+                !engine.derived.foreign_module.shard(&foreign_id).read().contains_key(&foreign_id)
+            );
+            assert!(
+                !engine
+                    .derived
+                    .foreign_validation
+                    .shard(&source_id)
+                    .read()
+                    .contains_key(&source_id)
+            );
+
+            let missing_module = engine.foreign_validation(source_id).unwrap();
+            assert!(matches!(
+                missing_module.errors.as_ref(),
+                [ForeignError::MissingModule { name, .. }] if name == "life"
+            ));
+        }
     }
 
     #[test]

--- a/compiler-core/building/src/engine.rs
+++ b/compiler-core/building/src/engine.rs
@@ -36,7 +36,7 @@ use building_types::{
 };
 use checking::CheckedModule;
 use documenting::DocumentedModule;
-use files::FileId;
+use files::{FileId, ForeignFileId};
 use graph::SnapshotGraph;
 use indexing::IndexedModule;
 use lock_api::{RawRwLock, RawRwLockRecursive};
@@ -117,6 +117,8 @@ where
 #[derive(Default)]
 struct InputStorage {
     content: Shards<FileId, InputState<Arc<str>>>,
+    foreign: Shards<FileId, InputState<Option<ForeignFileId>>>,
+    foreign_content: Shards<ForeignFileId, InputState<Arc<str>>>,
     module: Shards<ModuleNameId, InputState<Option<FileId>>>,
 }
 
@@ -497,6 +499,8 @@ impl QueryEngine {
         for dependency in dependencies {
             match dependency {
                 QueryKey::Content(k) => input_changed!(content, k),
+                QueryKey::Foreign(k) => input_changed!(foreign, k),
+                QueryKey::ForeignContent(k) => input_changed!(foreign_content, k),
                 QueryKey::Module(k) => input_changed!(module, k),
                 QueryKey::Parsed(k) => derived_changed!(parsed, k),
                 QueryKey::Stabilized(k) => derived_changed!(stabilized, k),
@@ -734,6 +738,35 @@ impl QueryEngine {
         self.get_input(QueryKey::Content(id), id, |input| &input.content).unwrap_or_else(|| {
             panic!("invariant violated: set_content({id:?}, ..)");
         })
+    }
+
+    pub fn set_foreign_content(&self, id: ForeignFileId, content: impl Into<Arc<str>>) {
+        self.set_input(id, |input| &input.foreign_content, content.into());
+    }
+
+    pub fn foreign_content(&self, id: ForeignFileId) -> Arc<str> {
+        self.get_input(QueryKey::ForeignContent(id), id, |input| &input.foreign_content)
+            .unwrap_or_else(|| {
+                panic!("invariant violated: set_foreign_content({id:?}, ..)");
+            })
+    }
+
+    pub fn set_foreign_file(&self, source_id: FileId, foreign_id: ForeignFileId) {
+        self.set_input(source_id, |input| &input.foreign, Some(foreign_id));
+    }
+
+    pub fn remove_foreign_file(&self, source_id: FileId, foreign_id: ForeignFileId) {
+        let current =
+            self.get_input(QueryKey::Foreign(source_id), source_id, |input| &input.foreign);
+        if current != Some(Some(foreign_id)) {
+            return;
+        }
+
+        self.set_input(source_id, |input| &input.foreign, None);
+    }
+
+    pub fn foreign_file(&self, source_id: FileId) -> Option<ForeignFileId> {
+        self.get_input(QueryKey::Foreign(source_id), source_id, |input| &input.foreign).flatten()
     }
 
     pub fn set_module_file(&self, name: &str, file_id: FileId) {
@@ -1140,7 +1173,7 @@ mod tests {
     use std::sync::{Arc, Barrier};
 
     use building_types::{QueryError, QueryResult};
-    use files::{FileId, Files};
+    use files::{FileId, Files, ForeignFiles};
     use la_arena::RawIdx;
     use resolving::ResolvedModule;
 
@@ -1419,6 +1452,32 @@ mod tests {
         let index_a = engine.indexed(id).unwrap();
         let index_b = engine.indexed(id).unwrap();
         assert!(Arc::ptr_eq(&index_a, &index_b));
+    }
+
+    #[test]
+    fn test_foreign_inputs() {
+        let engine = QueryEngine::default();
+        let mut files = Files::default();
+        let mut foreign_files = ForeignFiles::default();
+
+        let source_id = files.insert("src/Main.purs", "module Main where");
+        let first_id = foreign_files.insert("src/Main.js", "export const first = 1;");
+        let second_id = foreign_files.insert("src/Other.js", "export const second = 2;");
+
+        assert_eq!(engine.foreign_file(source_id), None);
+
+        engine.set_foreign_content(first_id, foreign_files.content(first_id));
+        engine.set_foreign_file(source_id, first_id);
+        assert_eq!(engine.foreign_file(source_id), Some(first_id));
+        assert_eq!(engine.foreign_content(first_id).as_ref(), "export const first = 1;");
+
+        engine.set_foreign_content(second_id, foreign_files.content(second_id));
+        engine.set_foreign_file(source_id, second_id);
+        engine.remove_foreign_file(source_id, first_id);
+        assert_eq!(engine.foreign_file(source_id), Some(second_id));
+
+        engine.remove_foreign_file(source_id, second_id);
+        assert_eq!(engine.foreign_file(source_id), None);
     }
 
     #[test]

--- a/compiler-core/building/src/engine.rs
+++ b/compiler-core/building/src/engine.rs
@@ -37,6 +37,7 @@ use building_types::{
 use checking::CheckedModule;
 use documenting::DocumentedModule;
 use files::{FileId, ForeignFileId};
+use foreign_javascript::{ForeignModule, ForeignValidation};
 use graph::SnapshotGraph;
 use indexing::IndexedModule;
 use lock_api::{RawRwLock, RawRwLockRecursive};
@@ -124,6 +125,8 @@ struct InputStorage {
 
 #[derive(Default)]
 struct DerivedStorage {
+    foreign_module: Shards<ForeignFileId, DerivedState<Arc<ForeignModule>>>,
+    foreign_validation: Shards<FileId, DerivedState<Arc<ForeignValidation>>>,
     parsed: Shards<FileId, DerivedState<FullParsedModule>>,
     stabilized: Shards<FileId, DerivedState<Arc<StabilizedModule>>>,
     indexed: Shards<FileId, DerivedState<Arc<IndexedModule>>>,
@@ -501,6 +504,8 @@ impl QueryEngine {
                 QueryKey::Content(k) => input_changed!(content, k),
                 QueryKey::Foreign(k) => input_changed!(foreign, k),
                 QueryKey::ForeignContent(k) => input_changed!(foreign_content, k),
+                QueryKey::ForeignModule(k) => derived_changed!(foreign_module, k),
+                QueryKey::ForeignValidation(k) => derived_changed!(foreign_validation, k),
                 QueryKey::Module(k) => input_changed!(module, k),
                 QueryKey::Parsed(k) => derived_changed!(parsed, k),
                 QueryKey::Stabilized(k) => derived_changed!(stabilized, k),
@@ -767,6 +772,36 @@ impl QueryEngine {
 
     pub fn foreign_file(&self, source_id: FileId) -> Option<ForeignFileId> {
         self.get_input(QueryKey::Foreign(source_id), source_id, |input| &input.foreign).flatten()
+    }
+
+    pub fn foreign_module(&self, id: ForeignFileId) -> QueryResult<Arc<ForeignModule>> {
+        self.query(
+            QueryKey::ForeignModule(id),
+            id,
+            |derived| &derived.foreign_module,
+            |this| {
+                let content = this.foreign_content(id);
+                Ok(Arc::new(foreign_javascript::parse_module(&content)))
+            },
+        )
+    }
+
+    pub fn foreign_validation(&self, id: FileId) -> QueryResult<Arc<ForeignValidation>> {
+        self.query(
+            QueryKey::ForeignValidation(id),
+            id,
+            |derived| &derived.foreign_validation,
+            |this| {
+                let indexed = this.indexed(id)?;
+                let foreign = if let Some(foreign_id) = this.foreign_file(id) {
+                    Some(this.foreign_module(foreign_id)?)
+                } else {
+                    None
+                };
+                let validation = foreign_javascript::validate_module(&indexed, foreign.as_deref());
+                Ok(Arc::new(validation))
+            },
+        )
     }
 
     pub fn set_module_file(&self, name: &str, file_id: FileId) {
@@ -1166,6 +1201,16 @@ impl resolving::ExternalQueries for QueryEngine {}
 
 impl sugar::ExternalQueries for QueryEngine {}
 
+impl foreign_javascript::ForeignQueries for QueryEngine {
+    fn foreign_module(&self, id: ForeignFileId) -> QueryResult<Arc<ForeignModule>> {
+        QueryEngine::foreign_module(self, id)
+    }
+
+    fn foreign_validation(&self, id: FileId) -> QueryResult<Arc<ForeignValidation>> {
+        QueryEngine::foreign_validation(self, id)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fmt::Debug;
@@ -1174,6 +1219,7 @@ mod tests {
 
     use building_types::{QueryError, QueryResult};
     use files::{FileId, Files, ForeignFiles};
+    use foreign_javascript::ForeignError;
     use la_arena::RawIdx;
     use resolving::ResolvedModule;
 
@@ -1478,6 +1524,44 @@ mod tests {
 
         engine.remove_foreign_file(source_id, second_id);
         assert_eq!(engine.foreign_file(source_id), None);
+    }
+
+    #[test]
+    fn test_foreign_validation_invalidation() {
+        let engine = QueryEngine::default();
+        let mut files = Files::default();
+        let mut foreign_files = ForeignFiles::default();
+
+        let source_id =
+            files.insert("src/Main.purs", "module Main where\n\nforeign import life :: Int");
+        engine.set_content(source_id, files.content(source_id));
+
+        let missing_module = engine.foreign_validation(source_id).unwrap();
+        assert!(matches!(
+            missing_module.errors.as_ref(),
+            [ForeignError::MissingModule { name, .. }] if name == "life"
+        ));
+
+        let foreign_id = foreign_files.insert("src/Main.js", "export const other = 42;");
+        engine.set_foreign_content(foreign_id, foreign_files.content(foreign_id));
+        engine.set_foreign_file(source_id, foreign_id);
+
+        let missing_implementation = engine.foreign_validation(source_id).unwrap();
+        assert!(matches!(
+            missing_implementation.errors.as_ref(),
+            [ForeignError::MissingImplementation { name, .. }] if name == "life"
+        ));
+
+        engine.set_foreign_content(foreign_id, "export const life = 42;");
+        let valid = engine.foreign_validation(source_id).unwrap();
+        assert!(valid.errors.is_empty());
+
+        engine.set_foreign_content(
+            foreign_id,
+            "// The implementation changed.\nexport const life = 43;",
+        );
+        let body_changed = engine.foreign_validation(source_id).unwrap();
+        assert!(Arc::ptr_eq(&valid, &body_changed));
     }
 
     #[test]

--- a/compiler-core/diagnostics/Cargo.toml
+++ b/compiler-core/diagnostics/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 files = { version = "0.1.0", path = "../files" }
+foreign-javascript = { version = "0.1.0", path = "../../compiler-backend/foreign-javascript" }
 indexing = { version = "0.1.0", path = "../indexing" }
 lowering = { version = "0.1.0", path = "../lowering" }
 resolving = { version = "0.1.0", path = "../resolving" }

--- a/compiler-core/diagnostics/src/convert.rs
+++ b/compiler-core/diagnostics/src/convert.rs
@@ -1,5 +1,6 @@
 use checking::error::{CheckingError, ErrorKind};
 use checking::holes::HoleBinding;
+use foreign_javascript::ForeignError;
 use indexing::{IndexedTypeItemKind, IndexingError};
 use itertools::Itertools;
 use lowering::LoweringError;
@@ -13,6 +14,50 @@ pub trait ToDiagnostics {
     fn to_diagnostics<Q>(&self, context: &DiagnosticsContext<'_, Q>) -> Vec<Diagnostic>
     where
         Q: ExternalQueries;
+}
+
+impl ToDiagnostics for ForeignError {
+    fn to_diagnostics<Q>(&self, context: &DiagnosticsContext<'_, Q>) -> Vec<Diagnostic>
+    where
+        Q: ExternalQueries,
+    {
+        let declaration = match self {
+            ForeignError::MissingModule { declaration, .. }
+            | ForeignError::MissingImplementation { declaration, .. }
+            | ForeignError::Parse { declaration, .. } => declaration,
+        };
+        let Some(span) = context
+            .indexed
+            .term_item_ptr(context.stabilized, *declaration)
+            .next()
+            .and_then(|pointer| context.span_from_syntax_ptr(&pointer))
+        else {
+            return vec![];
+        };
+
+        let diagnostic = match self {
+            ForeignError::MissingModule { name, .. } => Diagnostic::error(
+                "MissingFFIModule",
+                format!("No JavaScript FFI module was found for foreign import '{name}'"),
+                span,
+                "foreign-javascript",
+            ),
+            ForeignError::MissingImplementation { name, .. } => Diagnostic::error(
+                "MissingFFIImplementation",
+                format!("JavaScript FFI module does not export '{name}'"),
+                span,
+                "foreign-javascript",
+            ),
+            ForeignError::Parse { message, .. } => Diagnostic::error(
+                "ErrorParsingFFIModule",
+                format!("Unable to parse JavaScript FFI module: {message}"),
+                span,
+                "foreign-javascript",
+            ),
+        };
+
+        vec![diagnostic]
+    }
 }
 
 impl ToDiagnostics for LoweringError {

--- a/compiler-core/files/src/lib.rs
+++ b/compiler-core/files/src/lib.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use indexmap::IndexMap;
 use la_arena::{Idx, RawIdx};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use rustc_hash::FxBuildHasher;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 #[derive(Debug, Default)]
 pub struct Files {
@@ -14,6 +14,31 @@ pub struct Files {
 pub struct File;
 
 pub type FileId = Idx<File>;
+
+#[derive(Debug, Default)]
+pub struct ForeignFiles {
+    paths: FxHashMap<Arc<str>, ForeignFileId>,
+    files: Vec<ForeignFileSlot>,
+    free: Vec<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ForeignFileId {
+    index: u32,
+    generation: u32,
+}
+
+#[derive(Debug)]
+struct ForeignFileSlot {
+    generation: u32,
+    file: Option<ForeignFileData>,
+}
+
+#[derive(Debug)]
+struct ForeignFileData {
+    path: Arc<str>,
+    content: Arc<str>,
+}
 
 impl Files {
     pub fn insert(&mut self, k: impl Into<Arc<str>>, v: impl Into<Arc<str>>) -> FileId {
@@ -58,9 +83,88 @@ impl Files {
     }
 }
 
+impl ForeignFiles {
+    pub fn insert(
+        &mut self,
+        path: impl Into<Arc<str>>,
+        content: impl Into<Arc<str>>,
+    ) -> ForeignFileId {
+        let path = path.into();
+        let content = content.into();
+        if let Some(id) = self.paths.get(path.as_ref()).copied() {
+            let file = self.file_mut(id);
+            file.content = content;
+            return id;
+        }
+
+        let file = ForeignFileData { path: Arc::clone(&path), content };
+        let id = if let Some(index) = self.free.pop() {
+            let slot = &mut self.files[index as usize];
+            slot.file = Some(file);
+            ForeignFileId { index, generation: slot.generation }
+        } else {
+            let index = u32::try_from(self.files.len())
+                .expect("invariant violated: too many foreign files");
+            let slot = ForeignFileSlot { generation: 0, file: Some(file) };
+            self.files.push(slot);
+            ForeignFileId { index, generation: 0 }
+        };
+        self.paths.insert(path, id);
+        id
+    }
+
+    pub fn id(&self, path: &str) -> Option<ForeignFileId> {
+        self.paths.get(path).copied()
+    }
+
+    pub fn path(&self, id: ForeignFileId) -> Arc<str> {
+        let file = self.file(id);
+        Arc::clone(&file.path)
+    }
+
+    pub fn content(&self, id: ForeignFileId) -> Arc<str> {
+        let file = self.file(id);
+        Arc::clone(&file.content)
+    }
+
+    pub fn remove(&mut self, path: &str) -> Option<ForeignFileId> {
+        let id = self.paths.remove(path)?;
+        let slot = &mut self.files[id.index as usize];
+        assert_eq!(
+            slot.generation, id.generation,
+            "invariant violated: expected valid ForeignFileId"
+        );
+        slot.file.take().expect("invariant violated: expected valid ForeignFileId");
+        slot.generation = slot
+            .generation
+            .checked_add(1)
+            .expect("invariant violated: exhausted ForeignFileId generations");
+        self.free.push(id.index);
+        Some(id)
+    }
+
+    fn file(&self, id: ForeignFileId) -> &ForeignFileData {
+        let slot = &self.files[id.index as usize];
+        assert_eq!(
+            slot.generation, id.generation,
+            "invariant violated: expected valid ForeignFileId"
+        );
+        slot.file.as_ref().expect("invariant violated: expected valid ForeignFileId")
+    }
+
+    fn file_mut(&mut self, id: ForeignFileId) -> &mut ForeignFileData {
+        let slot = &mut self.files[id.index as usize];
+        assert_eq!(
+            slot.generation, id.generation,
+            "invariant violated: expected valid ForeignFileId"
+        );
+        slot.file.as_mut().expect("invariant violated: expected valid ForeignFileId")
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::Files;
+    use super::{Files, ForeignFiles};
 
     #[test]
     fn test_basic() {
@@ -74,5 +178,38 @@ mod tests {
         assert_eq!(files.id(k), Some(id));
         assert_eq!(files.path(id).as_ref(), k);
         assert_eq!(files.content(id).as_ref(), v);
+    }
+
+    #[test]
+    fn test_foreign_files() {
+        let mut files = ForeignFiles::default();
+
+        let path = "src/Main.js";
+        let content = "export const life = 42;\n";
+        let id = files.insert(path, content);
+
+        assert_eq!(files.id(path), Some(id));
+        assert_eq!(files.path(id).as_ref(), path);
+        assert_eq!(files.content(id).as_ref(), content);
+
+        let retained_path = "src/Retained.js";
+        let retained_id = files.insert(retained_path, "export const retained = 1;");
+
+        assert_eq!(files.remove(path), Some(id));
+        assert_eq!(files.id(path), None);
+        assert!(files.files[id.index as usize].file.is_none());
+        assert_eq!(files.path(retained_id).as_ref(), retained_path);
+
+        let replacement_id = files.insert(path, content);
+        assert_ne!(replacement_id, id);
+        assert_eq!(files.remove(path), Some(replacement_id));
+
+        let slots = files.files.len();
+        for number in 0..32 {
+            let path = format!("src/Temporary-{number}.js");
+            let temporary_id = files.insert(path.as_str(), content);
+            assert_eq!(files.remove(&path), Some(temporary_id));
+        }
+        assert_eq!(files.files.len(), slots);
     }
 }

--- a/compiler-lsp/analyzer/Cargo.toml
+++ b/compiler-lsp/analyzer/Cargo.toml
@@ -8,6 +8,7 @@ building-types = { version = "0.1.0", path = "../../compiler-core/building-types
 checking = { version = "0.1.0", path = "../../compiler-core/checking" }
 diagnostics = { version = "0.1.0", path = "../../compiler-core/diagnostics" }
 files = { version = "0.1.0", path = "../../compiler-core/files" }
+foreign-javascript = { version = "0.1.0", path = "../../compiler-backend/foreign-javascript" }
 indexing = { version = "0.1.0", path = "../../compiler-core/indexing" }
 itertools = "0.15.0"
 la-arena = "0.3.1"

--- a/compiler-lsp/analyzer/src/diagnostics.rs
+++ b/compiler-lsp/analyzer/src/diagnostics.rs
@@ -1,6 +1,7 @@
 use building_types::QueryProxy;
 use diagnostics::{DiagnosticsContext, ToDiagnostics};
 use files::FileId;
+use foreign_javascript::ForeignQueries;
 use line_index::LineIndex;
 use lsp_types::{Diagnostic, Url};
 
@@ -17,7 +18,7 @@ pub fn implementation<Host>(
 ) -> Result<CollectedDiagnostics, AnalyzerError>
 where
     Host: AnalyzerHost,
-    Host::Queries: diagnostics::ExternalQueries,
+    Host::Queries: diagnostics::ExternalQueries + ForeignQueries,
 {
     let queries = context.queries();
     let content = queries.content(file_id);
@@ -30,6 +31,7 @@ where
     let resolved = queries.resolved(file_id)?;
     let lowered = queries.lowered(file_id)?;
     let checked = queries.checked(file_id)?;
+    let foreign = queries.foreign_validation(file_id)?;
 
     let uri = common::file_uri(context, file_id)?;
     let diagnostics_context = DiagnosticsContext::new(
@@ -53,6 +55,10 @@ where
     }
 
     for error in &checked.errors {
+        all_diagnostics.extend(error.to_diagnostics(&diagnostics_context));
+    }
+
+    for error in foreign.errors.iter() {
         all_diagnostics.extend(error.to_diagnostics(&diagnostics_context));
     }
 

--- a/tests-integration/fixtures/backend/1787021280_literals_arrays_and_records/Main.snap
+++ b/tests-integration/fixtures/backend/1787021280_literals_arrays_and_records/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 integer :: Prim.Int

--- a/tests-integration/fixtures/backend/1787021340_record_updates/Main.snap
+++ b/tests-integration/fixtures/backend/1787021340_record_updates/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 model :: Main.Model

--- a/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.snap
+++ b/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 integer :: Prim.Int -> Prim.Boolean

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.snap
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 Empty :: forall @a. Main.Choice a

--- a/tests-integration/fixtures/backend/1787021520_array_patterns/Main.snap
+++ b/tests-integration/fixtures/backend/1787021520_array_patterns/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 describe :: Prim.Array Prim.Int -> Prim.Int

--- a/tests-integration/fixtures/backend/1787021580_record_patterns/Main.snap
+++ b/tests-integration/fixtures/backend/1787021580_record_patterns/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 select :: { first :: Prim.Int, nested :: { second :: Prim.String } } -> Prim.String

--- a/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/Main.snap
+++ b/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 choose :: Prim.Boolean -> Prim.Boolean -> Prim.Int

--- a/tests-integration/fixtures/backend/1787021700_guards/Main.snap
+++ b/tests-integration/fixtures/backend/1787021700_guards/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 55
-expression: checking_report
+expression: diagnostics_report
 ---
 Terms
 Empty :: forall @a. Main.Choice a

--- a/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.snap
+++ b/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 Identity :: forall @a. a -> Main.Identity a

--- a/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/Main.snap
+++ b/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 131
-expression: checking_report
+expression: diagnostics_report
 ---
 Terms
 mutual :: Prim.Boolean -> Prim.Int

--- a/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/Main.snap
+++ b/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 259
-expression: checking_report
+expression: diagnostics_report
 ---
 Terms
 forward :: Prim.Int

--- a/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.js
+++ b/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.js
@@ -1,0 +1,2 @@
+export const equalInt = left => right => left === right;
+export const lessThanInt = left => right => left < right;

--- a/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.snap
+++ b/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 equal :: forall @a. Main.Equal a => a -> a -> Prim.Boolean

--- a/tests-integration/fixtures/backend/1787021940_type_class_evidence/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787021940_type_class_evidence/output/Main/foreign.js
@@ -1,0 +1,2 @@
+export const equalInt = left => right => left === right;
+export const lessThanInt = left => right => left < right;

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.snap
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 232
-expression: checking_report
+expression: diagnostics_report
 ---
 Terms
 firstAction :: Effect.Effect Prim.Int

--- a/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.js
+++ b/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.js
@@ -1,0 +1,2 @@
+export const foreignValue = undefined;
+export const foreignFunction = () => 0;

--- a/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.snap
+++ b/tests-integration/fixtures/backend/1787022060_foreign_declarations/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 foreignValue :: Main.Opaque

--- a/tests-integration/fixtures/backend/1787022060_foreign_declarations/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787022060_foreign_declarations/output/Main/foreign.js
@@ -1,0 +1,2 @@
+export const foreignValue = undefined;
+export const foreignFunction = () => 0;

--- a/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.snap
+++ b/tests-integration/fixtures/backend/1787022120_cross_module_references/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 unbox :: Library.Box Prim.Int -> Prim.Int

--- a/tests-integration/fixtures/backend/1787022180_desugared_source_forms/Main.snap
+++ b/tests-integration/fixtures/backend/1787022180_desugared_source_forms/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 add :: Prim.Int -> Prim.Int -> Prim.Int

--- a/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/Main.snap
+++ b/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 apply :: forall a b. (a -> b) -> a -> b

--- a/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.js
+++ b/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.js
@@ -1,0 +1,2 @@
+export const addInt = left => right => (left + right) | 0;
+export const multiplyInt = left => right => Math.imul(left, right);

--- a/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.snap
+++ b/tests-integration/fixtures/backend/1787022300_integer_primitives/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 addInt :: Prim.Int -> Prim.Int -> Prim.Int

--- a/tests-integration/fixtures/backend/1787022300_integer_primitives/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787022300_integer_primitives/output/Main/foreign.js
@@ -1,0 +1,2 @@
+export const addInt = left => right => (left + right) | 0;
+export const multiplyInt = left => right => Math.imul(left, right);

--- a/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.js
+++ b/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.js
@@ -1,0 +1,3 @@
+const awaitValue = 0;
+
+export { awaitValue as await };

--- a/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.snap
+++ b/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 await :: Prim.Int

--- a/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787022360_javascript_identifier_boundaries/output/Main/foreign.js
@@ -1,0 +1,3 @@
+const awaitValue = 0;
+
+export { awaitValue as await };

--- a/tests-integration/fixtures/backend/1787080920_derived_instance/Main.snap
+++ b/tests-integration/fixtures/backend/1787080920_derived_instance/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 55
-expression: checking_report
+expression: diagnostics_report
 ---
 Terms
 Box :: Main.Box

--- a/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.snap
+++ b/tests-integration/fixtures/backend/1787080920_synthesized_evidence/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 55
-expression: checking_report
+expression: diagnostics_report
 ---
 Terms
 symbol :: Prim.String

--- a/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.snap
+++ b/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 55
-expression: checking_report
+expression: diagnostics_report
 ---
 Terms
 sequence :: Prim.Int -> Prim.Int

--- a/tests-integration/fixtures/backend/1787081220_javascript_execution/Main.snap
+++ b/tests-integration/fixtures/backend/1787081220_javascript_execution/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 255
-expression: checking_report
+expression: diagnostics_report
 ---
 Terms
 addInt :: Prim.Int -> Prim.Int -> Prim.Int

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/Main.snap
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 141
-expression: checking_report
+expression: diagnostics_report
 ---
 Terms
 constructorValue :: Origin.Option

--- a/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.snap
+++ b/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
-expression: report
+expression: diagnostics_report
 ---
 Terms
 choose :: Prim.Int -> Prim.Int -> Prim.Int

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.snap
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 255
-expression: checking_report
+expression: diagnostics_report
 ---
 Terms
 compareTwice :: forall a. Data.Eq.Eq a => a -> a -> Prim.Boolean

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.snap
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 255
-expression: checking_report
+expression: diagnostics_report
 ---
 Terms
 identity :: forall a. a -> a

--- a/tests-integration/fixtures/backend/1787315820_descriptive_dictionary_parameter_names/Main.snap
+++ b/tests-integration/fixtures/backend/1787315820_descriptive_dictionary_parameter_names/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 255
-expression: checking_report
+expression: diagnostics_report
 ---
 Terms
 equal :: forall @a. Main.Equal a => a -> a -> Prim.Boolean

--- a/tests-integration/fixtures/backend/1787317740_descriptive_closure_argument_names/Main.snap
+++ b/tests-integration/fixtures/backend/1787317740_descriptive_closure_argument_names/Main.snap
@@ -1,7 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 255
-expression: checking_report
+expression: diagnostics_report
 ---
 Terms
 None :: Main.Choice

--- a/tests-integration/fixtures/backend/1787330460_ffi_matching_implementation/Main.js
+++ b/tests-integration/fixtures/backend/1787330460_ffi_matching_implementation/Main.js
@@ -1,0 +1,1 @@
+export const requested = 42;

--- a/tests-integration/fixtures/backend/1787330460_ffi_matching_implementation/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787330460_ffi_matching_implementation/Main.nbe.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export foreign requested

--- a/tests-integration/fixtures/backend/1787330460_ffi_matching_implementation/Main.purs
+++ b/tests-integration/fixtures/backend/1787330460_ffi_matching_implementation/Main.purs
@@ -1,0 +1,3 @@
+module Main where
+
+foreign import requested :: Int

--- a/tests-integration/fixtures/backend/1787330460_ffi_matching_implementation/Main.snap
+++ b/tests-integration/fixtures/backend/1787330460_ffi_matching_implementation/Main.snap
@@ -1,0 +1,8 @@
+---
+source: tests-integration/src/fixtures.rs
+expression: diagnostics_report
+---
+Terms
+requested :: Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787330460_ffi_matching_implementation/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787330460_ffi_matching_implementation/Main.ssa.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 265
+expression: ssa_report
+---
+@export foreign const requested;

--- a/tests-integration/fixtures/backend/1787330460_ffi_matching_implementation/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787330460_ffi_matching_implementation/output/Main/foreign.js
@@ -1,0 +1,1 @@
+export const requested = 42;

--- a/tests-integration/fixtures/backend/1787330460_ffi_matching_implementation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787330460_ffi_matching_implementation/output/Main/index.js
@@ -1,0 +1,3 @@
+import * as $foreign from "./foreign.js";
+
+export const requested = $foreign["requested"];

--- a/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/Main.js
+++ b/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/Main.js
@@ -1,0 +1,1 @@
+export const other = 42;

--- a/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/Main.nbe.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export foreign requested

--- a/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/Main.purs
+++ b/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/Main.purs
@@ -1,0 +1,3 @@
+module Main where
+
+foreign import requested :: Int

--- a/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/Main.snap
+++ b/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+expression: diagnostics_report
+---
+Terms
+requested :: Prim.Int
+
+Types
+
+Diagnostics
+error[MissingFFIImplementation]: JavaScript FFI module does not export 'requested'
+  --> 3:1..3:32
+  |
+3 | foreign import requested :: Int
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/Main.ssa.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 265
+expression: ssa_report
+---
+@export foreign const requested;

--- a/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/output/Main/foreign.js
@@ -1,0 +1,1 @@
+export const other = 42;

--- a/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/output/Main/index.js
@@ -1,0 +1,3 @@
+import * as $foreign from "./foreign.js";
+
+export const requested = $foreign["requested"];

--- a/tests-integration/fixtures/backend/1787330460_ffi_missing_module/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787330460_ffi_missing_module/Main.nbe.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export foreign requested

--- a/tests-integration/fixtures/backend/1787330460_ffi_missing_module/Main.purs
+++ b/tests-integration/fixtures/backend/1787330460_ffi_missing_module/Main.purs
@@ -1,0 +1,3 @@
+module Main where
+
+foreign import requested :: Int

--- a/tests-integration/fixtures/backend/1787330460_ffi_missing_module/Main.snap
+++ b/tests-integration/fixtures/backend/1787330460_ffi_missing_module/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+expression: diagnostics_report
+---
+Terms
+requested :: Prim.Int
+
+Types
+
+Diagnostics
+error[MissingFFIModule]: No JavaScript FFI module was found for foreign import 'requested'
+  --> 3:1..3:32
+  |
+3 | foreign import requested :: Int
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/backend/1787330460_ffi_missing_module/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787330460_ffi_missing_module/Main.ssa.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 265
+expression: ssa_report
+---
+@export foreign const requested;

--- a/tests-integration/fixtures/backend/1787330460_ffi_missing_module/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787330460_ffi_missing_module/output/Main/index.js
@@ -1,0 +1,3 @@
+import * as $foreign from "./foreign.js";
+
+export const requested = $foreign["requested"];

--- a/tests-integration/fixtures/backend/1787331420_ffi_parse_error/Main.js
+++ b/tests-integration/fixtures/backend/1787331420_ffi_parse_error/Main.js
@@ -1,0 +1,1 @@
+export const requested = ;

--- a/tests-integration/fixtures/backend/1787331420_ffi_parse_error/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787331420_ffi_parse_error/Main.nbe.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export foreign requested

--- a/tests-integration/fixtures/backend/1787331420_ffi_parse_error/Main.purs
+++ b/tests-integration/fixtures/backend/1787331420_ffi_parse_error/Main.purs
@@ -1,0 +1,3 @@
+module Main where
+
+foreign import requested :: Int

--- a/tests-integration/fixtures/backend/1787331420_ffi_parse_error/Main.snap
+++ b/tests-integration/fixtures/backend/1787331420_ffi_parse_error/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+expression: diagnostics_report
+---
+Terms
+requested :: Prim.Int
+
+Types
+
+Diagnostics
+error[ErrorParsingFFIModule]: Unable to parse JavaScript FFI module: Unexpected token
+  --> 3:1..3:32
+  |
+3 | foreign import requested :: Int
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/backend/1787331420_ffi_parse_error/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787331420_ffi_parse_error/Main.ssa.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 265
+expression: ssa_report
+---
+@export foreign const requested;

--- a/tests-integration/fixtures/backend/1787331420_ffi_parse_error/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787331420_ffi_parse_error/output/Main/foreign.js
@@ -1,0 +1,1 @@
+export const requested = ;

--- a/tests-integration/fixtures/backend/1787331420_ffi_parse_error/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787331420_ffi_parse_error/output/Main/index.js
@@ -1,0 +1,3 @@
+import * as $foreign from "./foreign.js";
+
+export const requested = $foreign["requested"];

--- a/tests-integration/src/fixtures.rs
+++ b/tests-integration/src/fixtures.rs
@@ -242,6 +242,8 @@ pub fn backend(path: &Path) -> FixtureResult {
     };
 
     let checking_report = crate::generated::basic::report_checked(&engine, id);
+    let foreign_report = crate::generated::basic::report_foreign(&engine, id);
+    let diagnostics_report = format!("{checking_report}{foreign_report}");
     let ssa_report = match engine.ssa(id)? {
         Ok(module) => ssa::pretty::render(&module),
         Err(error) => error.to_string(),
@@ -259,7 +261,7 @@ pub fn backend(path: &Path) -> FixtureResult {
     settings.set_snapshot_path(fixture);
     settings.set_prepend_module_to_snapshot(false);
     settings.bind(|| {
-        insta::assert_snapshot!(file, checking_report);
+        insta::assert_snapshot!(file, diagnostics_report);
         insta::assert_snapshot!(ssa_snapshot, ssa_report);
     });
 

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -351,6 +351,33 @@ pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
     out
 }
 
+pub fn report_foreign(engine: &QueryEngine, id: FileId) -> String {
+    let validation = engine.foreign_validation(id).unwrap();
+    if validation.errors.is_empty() {
+        return String::new();
+    }
+
+    let content = engine.content(id);
+    let (parsed, _) = engine.parsed(id).unwrap();
+    let root = parsed.syntax_node();
+    let stabilized = engine.stabilized(id).unwrap();
+    let indexed = engine.indexed(id).unwrap();
+    let lowered = engine.lowered(id).unwrap();
+    let checked = engine.checked(id).unwrap();
+    let context =
+        DiagnosticsContext::new(engine, &content, &root, &stabilized, &indexed, &lowered, &checked);
+
+    let mut diagnostics = Vec::new();
+    for error in validation.errors.iter() {
+        diagnostics.extend(error.to_diagnostics(&context));
+    }
+
+    let mut out = String::new();
+    heading(&mut out, "Diagnostics");
+    out.push_str(&format_rustc(&diagnostics, &content));
+    out
+}
+
 fn write_literal_expression(
     content: &str,
     stabilized: &stabilizing::StabilizedModule,

--- a/tests-integration/src/lib.rs
+++ b/tests-integration/src/lib.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use building::QueryEngine;
-use files::Files;
+use files::{Files, ForeignFiles};
 use glob::glob;
 use prim_constants::MODULE_MAP;
 use tempfile::TempDir;
@@ -29,7 +29,12 @@ fn configure_materialized_prim(engine: &QueryEngine, files: &mut Files) {
     }
 }
 
-fn load_file(engine: &mut QueryEngine, files: &mut Files, path: &Path) {
+fn load_file(
+    engine: &mut QueryEngine,
+    files: &mut Files,
+    foreign_files: &mut ForeignFiles,
+    path: &Path,
+) {
     let url = Url::from_file_path(path).unwrap();
     let file = fs::read_to_string(path).unwrap();
     let file = file.replace("\r\n", "\n");
@@ -46,6 +51,16 @@ fn load_file(engine: &mut QueryEngine, files: &mut Files, path: &Path) {
     if let Some(name) = parsed.module_name(&content) {
         engine.set_module_file(&name, id);
     }
+
+    let foreign_path = path.with_extension("js");
+    if foreign_path.is_file() {
+        let foreign_url = Url::from_file_path(&foreign_path).unwrap();
+        let foreign_content = fs::read_to_string(foreign_path).unwrap();
+        let foreign_content = foreign_content.replace("\r\n", "\n");
+        let foreign_id = foreign_files.insert(foreign_url.as_str(), foreign_content);
+        engine.set_foreign_content(foreign_id, foreign_files.content(foreign_id));
+        engine.set_foreign_file(id, foreign_id);
+    }
 }
 
 fn load_folder(folder: &Path) -> impl Iterator<Item = PathBuf> {
@@ -58,6 +73,7 @@ fn load_folder(folder: &Path) -> impl Iterator<Item = PathBuf> {
 pub fn load_compiler(folder: &Path) -> (QueryEngine, Files) {
     let mut engine = QueryEngine::default();
     let mut files = Files::default();
+    let mut foreign_files = ForeignFiles::default();
     configure_materialized_prim(&engine, &mut files);
 
     if folder.starts_with("fixtures/backend/")
@@ -66,12 +82,12 @@ pub fn load_compiler(folder: &Path) -> (QueryEngine, Files) {
     {
         let prelude = Path::new("fixtures/checking/prelude");
         load_folder(prelude).for_each(|path| {
-            load_file(&mut engine, &mut files, &path);
+            load_file(&mut engine, &mut files, &mut foreign_files, &path);
         });
     }
 
     load_folder(folder).for_each(|path| {
-        load_file(&mut engine, &mut files, &path);
+        load_file(&mut engine, &mut files, &mut foreign_files, &path);
     });
     (engine, files)
 }


### PR DESCRIPTION
## Summary

- add distinct foreign-file identities and query inputs for sibling FFI sources
- parse JavaScript module exports and diagnose missing files, missing implementations, and malformed modules
- load JavaScript FFI files in backend builds and keep LSP inputs synchronized through watched-file notifications
- cover successful and failing FFI validation through backend integration fixtures

## Verification

- `cargo check -p purescript-alexandrite --tests`
- `cargo check -p foreign-javascript --tests`
- `cargo check -p building --tests`
- `cargo check -p diagnostics --tests`
- `cargo check -p analyzer --tests`
- `just t backend`
- `just t lsp`