### PR TITLE
[files] Remove deleted PureScript files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,8 +825,6 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 name = "files"
 version = "0.1.0"
 dependencies = [
- "indexmap",
- "la-arena",
  "rayon",
  "rustc-hash",
 ]

--- a/compiler-backend/nbe/src/convert.rs
+++ b/compiler-backend/nbe/src/convert.rs
@@ -129,7 +129,7 @@ where
     Q: checking::ExternalQueries,
 {
     fn new(queries: &'c Q, file_id: FileId) -> ConversionResult<Context<'c, Q>> {
-        let content = queries.content(file_id);
+        let content = queries.content(file_id)?;
         let (parsed, _) = queries.parsed(file_id)?;
         let module_name = parsed
             .module_name(&content)
@@ -212,9 +212,7 @@ fn convert(mut context: Context<'_, impl checking::ExternalQueries>) -> Conversi
     });
     let mut dependencies = dependencies.collect_vec();
     dependencies.sort_by(|left, right| {
-        left.module_name.cmp(&right.module_name).then_with(|| {
-            left.file_id.into_raw().into_u32().cmp(&right.file_id.into_raw().into_u32())
-        })
+        left.module_name.cmp(&right.module_name).then_with(|| left.file_id.cmp(&right.file_id))
     });
 
     Ok(Module {
@@ -264,9 +262,9 @@ fn runtime_exports(
         }
     }
     indirect.sort_by(|left, right| {
-        context.dependencies[&left.file_id].cmp(&context.dependencies[&right.file_id]).then_with(
-            || left.file_id.into_raw().into_u32().cmp(&right.file_id.into_raw().into_u32()),
-        )
+        context.dependencies[&left.file_id]
+            .cmp(&context.dependencies[&right.file_id])
+            .then_with(|| left.file_id.cmp(&right.file_id))
     });
 
     let surface = ModuleSurface { indirect: indirect.into() };
@@ -1451,7 +1449,7 @@ where
         if file_id == self.file_id {
             return Ok(SmolStr::clone(&self.module_name));
         }
-        let content = self.queries.content(file_id);
+        let content = self.queries.content(file_id)?;
         let (parsed, _) = self.queries.parsed(file_id)?;
         let name = parsed
             .module_name(&content)

--- a/compiler-bin/src/docs.rs
+++ b/compiler-bin/src/docs.rs
@@ -453,7 +453,7 @@ fn load_modules(compiler: &mut Compiler, files: Vec<PathBuf>) -> Result<Vec<File
 
 fn populate_module_file(compiler: &mut Compiler) -> Result<(), DocsError> {
     let results = compiler.files.par_iter_id().map(|id| {
-        let content = compiler.engine.content(id);
+        let content = compiler.engine.content(id)?;
         let (parsed, _) = compiler.engine.parsed(id)?;
         Ok((id, content, parsed))
     });

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -169,19 +169,24 @@ impl StateSnapshot {
 pub struct LspFiles {
     files: Files,
     editable: FxHashSet<FileId>,
+    open: FxHashSet<FileId>,
 }
 
 impl LspFiles {
     fn new(files: Files) -> LspFiles {
-        LspFiles { files, editable: FxHashSet::default() }
+        LspFiles { files, editable: FxHashSet::default(), open: FxHashSet::default() }
     }
 
     fn id(&self, uri: &str) -> Option<FileId> {
         self.files.id(uri)
     }
 
-    fn path(&self, file_id: FileId) -> Arc<str> {
-        self.files.path(file_id)
+    fn contains(&self, file_id: FileId) -> bool {
+        self.files.contains(file_id)
+    }
+
+    fn path(&self, file_id: FileId) -> Option<Arc<str>> {
+        self.files.contains(file_id).then(|| self.files.path(file_id))
     }
 
     fn iter_id(&self) -> impl Iterator<Item = FileId> + '_ {
@@ -190,6 +195,10 @@ impl LspFiles {
 
     fn is_editable(&self, file_id: FileId) -> bool {
         self.editable.contains(&file_id)
+    }
+
+    fn is_open(&self, uri: &str) -> bool {
+        self.id(uri).is_some_and(|file_id| self.open.contains(&file_id))
     }
 
     fn insert(&mut self, uri: &str, content: &str, editable: Option<bool>) -> FileId {
@@ -202,6 +211,21 @@ impl LspFiles {
             }
         }
         file_id
+    }
+
+    fn open(&mut self, file_id: FileId) {
+        self.open.insert(file_id);
+    }
+
+    fn close(&mut self, file_id: FileId) {
+        self.open.remove(&file_id);
+    }
+
+    fn remove(&mut self, uri: &str) -> Option<FileId> {
+        let file_id = self.files.remove(uri)?;
+        self.editable.remove(&file_id);
+        self.open.remove(&file_id);
+        Some(file_id)
     }
 }
 
@@ -222,7 +246,9 @@ impl AnalyzerHost for LspAnalyzerHost<'_> {
     }
 
     fn file_uri(&self, file_id: FileId) -> Result<Option<Url>, url::ParseError> {
-        let uri = self.files.path(file_id);
+        let Some(uri) = self.files.path(file_id) else {
+            return Ok(None);
+        };
         Url::parse(&uri).map(Some)
     }
 
@@ -338,7 +364,7 @@ fn shutdown(_state: &mut State, (): ()) -> impl Future<Output = Result<(), Respo
 
 fn initialized(state: &mut State, _: InitializedParams) -> Result<(), LspError> {
     let _span = tracing::info_span!("initialization").entered();
-    register_foreign_file_watcher(state);
+    register_file_watcher(state);
 
     let config = Arc::clone(&state.config);
     if let Some(command) = config.source_command.as_deref() {
@@ -348,31 +374,37 @@ fn initialized(state: &mut State, _: InitializedParams) -> Result<(), LspError> 
     }
 }
 
-fn register_foreign_file_watcher(state: &State) {
+fn register_file_watcher(state: &State) {
     if !state.watched_files_dynamic_registration {
         return;
     }
 
-    let parameters = foreign_file_watcher_registration();
+    let parameters = file_watcher_registration();
     let mut client = state.client.clone();
     task::spawn(async move {
         if let Err(error) = client.register_capability(parameters).await {
-            tracing::warn!("Failed to register JavaScript FFI file watcher: {error}");
+            tracing::warn!("Failed to register source file watcher: {error}");
         }
     });
 }
 
-fn foreign_file_watcher_registration() -> RegistrationParams {
+fn file_watcher_registration() -> RegistrationParams {
     let options = DidChangeWatchedFilesRegistrationOptions {
-        watchers: vec![FileSystemWatcher {
-            glob_pattern: GlobPattern::String("**/*.js".to_string()),
-            kind: None,
-        }],
+        watchers: vec![
+            FileSystemWatcher {
+                glob_pattern: GlobPattern::String("**/*.purs".to_string()),
+                kind: None,
+            },
+            FileSystemWatcher {
+                glob_pattern: GlobPattern::String("**/*.js".to_string()),
+                kind: None,
+            },
+        ],
     };
     let register_options = serde_json::to_value(options)
         .expect("invariant violated: watched file registration options must serialize");
     let registration = Registration {
-        id: "javascript-ffi-files".to_string(),
+        id: "purescript-source-files".to_string(),
         method: notification::DidChangeWatchedFiles::METHOD.to_string(),
         register_options: Some(register_options),
     };
@@ -659,7 +691,8 @@ fn did_open(state: &mut State, p: DidOpenTextDocumentParams) -> Result<(), LspEr
         };
         p.text_document.uri.to_file_path().is_ok_and(|path| path.starts_with(root))
     });
-    on_change(state, uri.as_str(), text, Some(editable))?;
+    let file_id = on_change(state, uri.as_str(), text, Some(editable))?;
+    state.files.write().open(file_id);
     load_sibling_foreign(state, uri)?;
 
     state.invalidate_workspace_symbols();
@@ -670,6 +703,25 @@ fn did_open(state: &mut State, p: DidOpenTextDocumentParams) -> Result<(), LspEr
     }
 
     Ok(())
+}
+
+fn did_close(state: &mut State, p: DidCloseTextDocumentParams) -> Result<(), LspError> {
+    let uri = p.text_document.uri;
+    if is_javascript_uri(&uri) {
+        return Ok(());
+    }
+
+    let file_id = state.files.read().id(uri.as_str());
+    let Some(file_id) = file_id else {
+        return Ok(());
+    };
+    state.files.write().close(file_id);
+
+    reload_source_file(state, &uri, None)?;
+
+    state.invalidate_workspace_symbols();
+    state.invalidate_suggestions_cache();
+    event::emit_collect_all_diagnostics(state)
 }
 
 fn did_save(state: &mut State, p: DidSaveTextDocumentParams) -> Result<(), LspError> {
@@ -686,40 +738,91 @@ fn did_change_watched_files(
     p: DidChangeWatchedFilesParams,
 ) -> Result<(), LspError> {
     for change in p.changes {
-        if !is_javascript_uri(&change.uri) {
-            continue;
-        }
-
-        let Some(source_uri) = source_uri_from_foreign(&change.uri) else {
-            continue;
-        };
-        let source_tracked = state.files.read().id(source_uri.as_str()).is_some();
-        if !source_tracked && state.foreign_files.read().id(change.uri.as_str()).is_none() {
-            continue;
-        }
-
-        if change.typ == FileChangeType::DELETED {
-            remove_foreign_file(state, &change.uri);
-        } else if let Ok(path) = change.uri.to_file_path() {
-            match fs::read_to_string(path) {
-                Ok(content) => on_foreign_change(state, &change.uri, &content)?,
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                    remove_foreign_file(state, &change.uri);
-                }
-                Err(error) => return Err(error.into()),
-            }
-        }
-
-        if source_tracked {
-            event::emit_collect_diagnostics(state, source_uri)?;
+        if is_javascript_uri(&change.uri) {
+            on_watched_foreign_change(state, change)?;
+        } else if is_purescript_uri(&change.uri) {
+            on_watched_source_change(state, change)?;
         }
     }
 
     Ok(())
 }
 
+fn on_watched_source_change(state: &mut State, change: FileEvent) -> Result<(), LspError> {
+    if state.files.read().is_open(change.uri.as_str()) {
+        return Ok(());
+    }
+
+    if change.typ == FileChangeType::DELETED {
+        remove_source_file(state, &change.uri)?;
+    } else {
+        let source_path = change.uri.to_file_path().ok();
+        let editable = match (&state.root, source_path) {
+            (Some(root), Some(path)) => path.starts_with(root),
+            (Some(_), None) => false,
+            (None, _) => true,
+        };
+        reload_source_file(state, &change.uri, Some(editable))?;
+    }
+
+    state.invalidate_workspace_symbols();
+    state.invalidate_suggestions_cache();
+    event::emit_collect_all_diagnostics(state)
+}
+
+fn reload_source_file(
+    state: &mut State,
+    uri: &Url,
+    editable: Option<bool>,
+) -> Result<(), LspError> {
+    let Ok(path) = uri.to_file_path() else {
+        return Ok(());
+    };
+    match fs::read_to_string(path) {
+        Ok(content) => {
+            on_change(state, uri.as_str(), &content, editable)?;
+            load_sibling_foreign(state, uri)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            remove_source_file(state, uri)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn on_watched_foreign_change(state: &mut State, change: FileEvent) -> Result<(), LspError> {
+    let Some(source_uri) = source_uri_from_foreign(&change.uri) else {
+        return Ok(());
+    };
+    let source_tracked = state.files.read().id(source_uri.as_str()).is_some();
+    if !source_tracked && state.foreign_files.read().id(change.uri.as_str()).is_none() {
+        return Ok(());
+    }
+
+    if change.typ == FileChangeType::DELETED {
+        remove_foreign_file(state, &change.uri);
+    } else if let Ok(path) = change.uri.to_file_path() {
+        match fs::read_to_string(path) {
+            Ok(content) => on_foreign_change(state, &change.uri, &content)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                remove_foreign_file(state, &change.uri);
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    if source_tracked {
+        event::emit_collect_diagnostics(state, source_uri)?;
+    }
+    Ok(())
+}
+
 fn is_javascript_uri(uri: &Url) -> bool {
     uri.path().ends_with(".js")
+}
+
+fn is_purescript_uri(uri: &Url) -> bool {
+    uri.path().ends_with(".purs")
 }
 
 fn source_uri_from_foreign(uri: &Url) -> Option<Url> {
@@ -791,15 +894,32 @@ fn remove_foreign_file(state: &mut State, uri: &Url) {
     state.engine.remove_foreign_file(foreign_id);
 }
 
+fn remove_source_file(state: &mut State, uri: &Url) -> Result<(), LspError> {
+    let file_id = state.files.read().id(uri.as_str());
+    let Some(file_id) = file_id else {
+        return Ok(());
+    };
+
+    state.engine.remove_file(file_id);
+    let removed_id = state.files.write().remove(uri.as_str());
+    debug_assert_eq!(removed_id, Some(file_id));
+    state.client.publish_diagnostics(PublishDiagnosticsParams {
+        uri: uri.clone(),
+        diagnostics: Vec::new(),
+        version: None,
+    })?;
+    Ok(())
+}
+
 fn on_change(
     state: &mut State,
     uri: &str,
     content: &str,
     editable: Option<bool>,
-) -> Result<(), LspError> {
+) -> Result<FileId, LspError> {
     let previous_id = state.files.read().id(uri);
     let previous_name = if let Some(id) = previous_id {
-        let previous_content = state.engine.content(id);
+        let previous_content = state.engine.content(id)?;
         let (parsed, _) = state.engine.parsed(id)?;
         parsed.module_name(&previous_content)
     } else {
@@ -829,7 +949,7 @@ fn on_change(
         state.engine.set_module_file(&name, id);
     }
 
-    Ok(())
+    Ok(id)
 }
 
 trait RequestExtension: BorrowMut<Router<State>> {
@@ -905,7 +1025,7 @@ pub async fn async_start(config: Arc<LspConfig>) {
             .notification_ext::<notification::Exit>(exit)
             .notification_ext::<notification::DidOpenTextDocument>(did_open)
             .notification_ext::<notification::DidSaveTextDocument>(did_save)
-            .notification_ext::<notification::DidCloseTextDocument>(|_, _| Ok(()))
+            .notification_ext::<notification::DidCloseTextDocument>(did_close)
             .notification_ext::<notification::DidChangeConfiguration>(|_, _| Ok(()))
             .notification_ext::<notification::DidChangeTextDocument>(did_change)
             .notification_ext::<notification::DidChangeWatchedFiles>(did_change_watched_files)

--- a/compiler-bin/src/lsp/event.rs
+++ b/compiler-bin/src/lsp/event.rs
@@ -16,9 +16,21 @@ pub fn emit_collect_diagnostics(state: &mut State, uri: Url) -> Result<(), LspEr
     Ok(())
 }
 
+pub fn emit_collect_all_diagnostics(state: &mut State) -> Result<(), LspError> {
+    let files = state.files.read();
+    let editable_files = files.iter_id().filter(|file_id| files.is_editable(*file_id));
+    for file_id in editable_files {
+        state.client.emit(CollectDiagnostics(file_id))?;
+    }
+    Ok(())
+}
+
 pub struct CollectDiagnostics(FileId);
 
 pub fn collect_diagnostics(state: &mut State, id: CollectDiagnostics) -> Result<(), LspError> {
+    if !state.files.read().contains(id.0) {
+        return Ok(());
+    }
     state.spawn(move |snapshot| {
         let _span = tracing::info_span!("collect_diagnostics").entered();
         collect_diagnostics_core(snapshot, id).inspect_err(|error| error.emit_trace())

--- a/compiler-core/building-types/src/lib.rs
+++ b/compiler-core/building-types/src/lib.rs
@@ -37,6 +37,8 @@ pub enum QueryError {
     Cancelled,
     #[error("Cycle detected")]
     Cycle { stack: Arc<[QueryKey]> },
+    #[error("Missing content for {file_id:?}")]
+    MissingContent { file_id: FileId },
 }
 
 pub type QueryResult<T> = Result<T, QueryError>;
@@ -54,7 +56,7 @@ pub trait QueryProxy {
     type Checked;
     type Documented;
 
-    fn content(&self, id: FileId) -> Arc<str>;
+    fn content(&self, id: FileId) -> QueryResult<Arc<str>>;
 
     fn parsed(&self, id: FileId) -> QueryResult<Self::Parsed>;
 

--- a/compiler-core/building/src/engine.rs
+++ b/compiler-core/building/src/engine.rs
@@ -157,6 +157,47 @@ struct InternedStorage {
     checking: checking::CoreInterners,
 }
 
+fn query_references_file(query: QueryKey, file_id: FileId) -> bool {
+    match query {
+        QueryKey::Content(id)
+        | QueryKey::Foreign(id)
+        | QueryKey::ForeignValidation(id)
+        | QueryKey::Parsed(id)
+        | QueryKey::Stabilized(id)
+        | QueryKey::Indexed(id)
+        | QueryKey::Lowered(id)
+        | QueryKey::Grouped(id)
+        | QueryKey::Resolved(id)
+        | QueryKey::Exported(id)
+        | QueryKey::Bracketed(id)
+        | QueryKey::Sectioned(id)
+        | QueryKey::Checked(id)
+        | QueryKey::Documented(id)
+        | QueryKey::Nbe(id)
+        | QueryKey::Ssa(id)
+        | QueryKey::JavaScript(id) => id == file_id,
+        QueryKey::ForeignContent(_)
+        | QueryKey::ForeignModule(_)
+        | QueryKey::Module(_)
+        | QueryKey::CheckedCore => false,
+    }
+}
+
+fn state_references_removed_file<T>(
+    state: &DerivedState<T>,
+    file_id: FileId,
+    removed_modules: &FxHashSet<ModuleNameId>,
+) -> bool {
+    let DerivedState::Computed { dependencies, .. } = state else {
+        return false;
+    };
+    let mut dependencies = dependencies.iter();
+    dependencies.any(|dependency| {
+        query_references_file(*dependency, file_id)
+            || matches!(dependency, QueryKey::Module(module) if removed_modules.contains(module))
+    })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct SnapshotId(u32);
 
@@ -746,10 +787,77 @@ impl QueryEngine {
         self.set_input(id, |input| &input.content, content.into());
     }
 
-    pub fn content(&self, id: FileId) -> Arc<str> {
-        self.get_input(QueryKey::Content(id), id, |input| &input.content).unwrap_or_else(|| {
-            panic!("invariant violated: set_content({id:?}, ..)");
-        })
+    pub fn content(&self, id: FileId) -> QueryResult<Arc<str>> {
+        self.get_input(QueryKey::Content(id), id, |input| &input.content)
+            .ok_or(QueryError::MissingContent { file_id: id })
+    }
+
+    fn remove_file_queries<T>(
+        &self,
+        file_id: FileId,
+        removed_modules: &FxHashSet<ModuleNameId>,
+        queries: &Shards<FileId, DerivedState<T>>,
+    ) {
+        for shard in &queries.inner {
+            let mut queries = shard.write();
+            queries.retain(|query_file_id, state| {
+                *query_file_id != file_id
+                    && !state_references_removed_file(state, file_id, removed_modules)
+            });
+        }
+    }
+
+    pub fn remove_file(&self, file_id: FileId) {
+        self.control.global.cancelled.store(true, Ordering::Relaxed);
+        let _query_lock = self.control.global.query_lock.write();
+
+        self.control.global.revision.fetch_add(1, Ordering::Relaxed);
+        self.input.content.remove(&file_id);
+        self.input.foreign.remove(&file_id);
+
+        let mut removed_modules = FxHashSet::default();
+        for shard in &self.input.module.inner {
+            let mut modules = shard.write();
+            modules.retain(|module, state| {
+                if state.value != Some(file_id) {
+                    return true;
+                }
+                removed_modules.insert(*module);
+                false
+            });
+        }
+
+        macro_rules! remove_file_queries {
+            ($($field:ident),* $(,)?) => {
+                $(self.remove_file_queries(file_id, &removed_modules, &self.derived.$field);)*
+            };
+        }
+        remove_file_queries!(
+            foreign_validation,
+            parsed,
+            stabilized,
+            indexed,
+            lowered,
+            grouped,
+            resolved,
+            exported,
+            bracketed,
+            sectioned,
+            checked,
+            documented,
+            nbe,
+            ssa,
+            javascript,
+        );
+
+        for shard in &self.derived.checked_core.inner {
+            let mut queries = shard.write();
+            queries.retain(|_, state| {
+                !state_references_removed_file(state, file_id, &removed_modules)
+            });
+        }
+
+        self.control.global.cancelled.store(false, Ordering::Relaxed);
     }
 
     pub fn set_foreign_content(&self, id: ForeignFileId, content: impl Into<Arc<str>>) {
@@ -860,7 +968,7 @@ impl QueryEngine {
             id,
             |derived| &derived.parsed,
             |this| {
-                let content = this.content(id);
+                let content = this.content(id)?;
 
                 let lexed = lexing::lex(&content);
                 let tokens = lexing::layout(&lexed);
@@ -890,7 +998,7 @@ impl QueryEngine {
             id,
             |derived| &derived.indexed,
             |this| {
-                let content = this.content(id);
+                let content = this.content(id)?;
                 let (parsed, _) = this.parsed(id)?;
                 let stabilized = this.stabilized(id)?;
 
@@ -908,7 +1016,7 @@ impl QueryEngine {
             id,
             |derived| &derived.lowered,
             |this| {
-                let content = this.content(id);
+                let content = this.content(id)?;
                 let (parsed, _) = this.parsed(id)?;
 
                 let prim = {
@@ -1070,7 +1178,7 @@ impl QueryEngine {
             id,
             |derived| &derived.documented,
             |this| {
-                let content = this.content(id);
+                let content = this.content(id)?;
                 let (parsed, _) = this.parsed(id)?;
                 let stabilized = this.stabilized(id)?;
                 let indexed = this.indexed(id)?;
@@ -1109,7 +1217,7 @@ impl QueryProxy for QueryEngine {
 
     type Documented = Arc<documenting::DocumentedModule>;
 
-    fn content(&self, id: FileId) -> Arc<str> {
+    fn content(&self, id: FileId) -> QueryResult<Arc<str>> {
         QueryEngine::content(self, id)
     }
 
@@ -1247,7 +1355,6 @@ mod tests {
     use building_types::{QueryError, QueryResult};
     use files::{FileId, Files, ForeignFiles};
     use foreign_javascript::ForeignError;
-    use la_arena::RawIdx;
     use resolving::ResolvedModule;
 
     use crate::prim;
@@ -1294,8 +1401,8 @@ mod tests {
 
     #[test]
     fn test_equal_input_write_cost() {
-        const SOURCE: FileId = FileId::from_raw(RawIdx::from_u32(0));
-        const QUERY: FileId = FileId::from_raw(RawIdx::from_u32(1));
+        const SOURCE: FileId = FileId::new(0);
+        const QUERY: FileId = FileId::new(1);
 
         let engine = QueryEngine::default();
         let initial_content: Arc<str> = Arc::from("module Main where\n\nvalue = 42");
@@ -1305,7 +1412,7 @@ mod tests {
         let recomputations = AtomicUsize::new(0);
         let compute = |engine: &QueryEngine| {
             recomputations.fetch_add(1, Ordering::Relaxed);
-            engine.content(SOURCE);
+            engine.content(SOURCE)?;
             engine.parsed(SOURCE)
         };
 
@@ -1341,7 +1448,7 @@ mod tests {
 
     #[test]
     fn test_equal_input_write_does_not_cancel_live_snapshot() {
-        const SOURCE: FileId = FileId::from_raw(RawIdx::from_u32(0));
+        const SOURCE: FileId = FileId::new(0);
 
         let engine = QueryEngine::default();
         let initial_content: Arc<str> = Arc::from("module Main where");
@@ -1355,7 +1462,7 @@ mod tests {
         drop(snapshot);
 
         let revision_after = engine.control.global.revision.load(Ordering::Relaxed);
-        let stored_content = engine.content(SOURCE);
+        let stored_content = engine.content(SOURCE).unwrap();
         assert_eq!(revision_after, revision_before);
         assert!(!engine.control.global.cancelled.load(Ordering::Relaxed));
         assert!(Arc::ptr_eq(&stored_content, &initial_content));
@@ -1363,7 +1470,7 @@ mod tests {
 
     #[test]
     fn test_concurrent_input_writes_advance_revision_once() {
-        const SOURCE: FileId = FileId::from_raw(RawIdx::from_u32(0));
+        const SOURCE: FileId = FileId::new(0);
 
         let engine = QueryEngine::default();
         engine.set_content(SOURCE, "module Main where\n\nvalue = 1");
@@ -1417,8 +1524,8 @@ mod tests {
 
     #[test]
     fn test_equal_module_input_write_preserves_revision() {
-        const MODULE_FILE: FileId = FileId::from_raw(RawIdx::from_u32(0));
-        const REPLACEMENT_FILE: FileId = FileId::from_raw(RawIdx::from_u32(1));
+        const MODULE_FILE: FileId = FileId::new(0);
+        const REPLACEMENT_FILE: FileId = FileId::new(1);
 
         let engine = QueryEngine::default();
         engine.set_module_file("Main", MODULE_FILE);
@@ -1502,6 +1609,64 @@ mod tests {
         engine.remove_module_file("Old", library);
 
         assert_eq!(engine.module_file("Old"), Some(replacement));
+    }
+
+    #[test]
+    fn test_remove_file() {
+        let engine = QueryEngine::default();
+        let mut files = Files::default();
+
+        let main = files.insert("Main.purs", "module Main where\n\nimport Library\n\nvalue = life");
+        let library = files.insert("Library.purs", "module Library where\n\nlife = 42");
+        engine.set_content(main, files.content(main));
+        engine.set_content(library, files.content(library));
+        engine.set_module_file("Main", main);
+        engine.set_module_file("Library", library);
+
+        let resolved = engine.resolved(main).unwrap();
+        assert!(resolved.unqualified.contains_key("Library"));
+
+        engine.remove_file(library);
+        assert_eq!(engine.module_file("Library"), None);
+        assert_eq!(engine.parsed(library), Err(QueryError::MissingContent { file_id: library }));
+
+        let resolved = engine.resolved(main).unwrap();
+        assert!(!resolved.unqualified.contains_key("Library"));
+
+        assert_eq!(files.remove("Library.purs"), Some(library));
+        let replacement = files.insert("Library.purs", "module Library where\n\nlife = 43");
+        assert_ne!(replacement, library);
+        engine.set_content(replacement, files.content(replacement));
+        engine.set_module_file("Library", replacement);
+
+        let resolved = engine.resolved(main).unwrap();
+        assert!(resolved.unqualified.contains_key("Library"));
+    }
+
+    #[test]
+    fn test_remove_files_discards_query_state() {
+        let engine = QueryEngine::default();
+        let mut files = Files::default();
+
+        for number in 0..32 {
+            let path = format!("Temporary{number}.purs");
+            let module_name = format!("Temporary{number}");
+            let content = format!("module {module_name} where");
+            let file_id = files.insert(path.as_str(), content.as_str());
+            engine.set_content(file_id, content);
+            engine.set_module_file(&module_name, file_id);
+            engine.parsed(file_id).unwrap();
+
+            engine.remove_file(file_id);
+            assert_eq!(files.remove(&path), Some(file_id));
+        }
+
+        let content_states = engine.input.content.inner.iter().map(|shard| shard.read().len());
+        let module_states = engine.input.module.inner.iter().map(|shard| shard.read().len());
+        let parsed_states = engine.derived.parsed.inner.iter().map(|shard| shard.read().len());
+        assert_eq!(content_states.sum::<usize>(), 0);
+        assert_eq!(module_states.sum::<usize>(), 0);
+        assert_eq!(parsed_states.sum::<usize>(), 0);
     }
 
     #[test]
@@ -2212,7 +2377,7 @@ mod tests {
 
     #[test]
     fn test_cycle_detection() {
-        const ID: FileId = FileId::from_raw(RawIdx::from_u32(0));
+        const ID: FileId = FileId::new(0);
         const KEY: QueryKey = QueryKey::Resolved(ID);
 
         fn fake_query_a(engine: &QueryEngine) -> QueryResult<Arc<ResolvedModule>> {
@@ -2226,7 +2391,7 @@ mod tests {
 
     #[test]
     fn test_cycle_recovery() {
-        const ID: FileId = FileId::from_raw(RawIdx::from_u32(0));
+        const ID: FileId = FileId::new(0);
 
         fn fake_query_a(engine: &QueryEngine) -> QueryResult<Arc<ResolvedModule>> {
             engine.query(
@@ -2244,8 +2409,8 @@ mod tests {
 
     #[test]
     fn test_snapshot_cycle_detection() {
-        const ID_A: FileId = FileId::from_raw(RawIdx::from_u32(0));
-        const ID_B: FileId = FileId::from_raw(RawIdx::from_u32(1));
+        const ID_A: FileId = FileId::new(0);
+        const ID_B: FileId = FileId::new(1);
 
         fn fake_query_a(engine: &QueryEngine) -> QueryResult<Arc<ResolvedModule>> {
             engine.query(QueryKey::Resolved(ID_A), ID_A, |derived| &derived.resolved, fake_query_b)
@@ -2276,8 +2441,8 @@ mod tests {
 
     #[test]
     fn test_snapshot_cycle_recovery() {
-        const ID_A: FileId = FileId::from_raw(RawIdx::from_u32(0));
-        const ID_B: FileId = FileId::from_raw(RawIdx::from_u32(1));
+        const ID_A: FileId = FileId::new(0);
+        const ID_B: FileId = FileId::new(1);
 
         fn fake_query_a(engine: &QueryEngine) -> QueryResult<Arc<ResolvedModule>> {
             engine.query(

--- a/compiler-core/checking/src/core/pretty.rs
+++ b/compiler-core/checking/src/core/pretty.rs
@@ -413,7 +413,7 @@ where
     }
 
     fn lookup_module_name(&self, file_id: files::FileId) -> Option<SmolStr> {
-        let content = self.queries.content(file_id);
+        let content = self.queries.content(file_id).ok()?;
         let (parsed, _) = self.queries.parsed(file_id).ok()?;
         parsed.module_name(&content)
     }

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -225,7 +225,9 @@ where
             return name.to_string();
         }
 
-        let content = self.queries.content(self.file_id);
+        let Ok(content) = self.queries.content(self.file_id) else {
+            return name.to_string();
+        };
 
         let Ok((parsed, _)) = self.queries.parsed(self.file_id) else {
             return name.to_string();

--- a/compiler-core/files/Cargo.toml
+++ b/compiler-core/files/Cargo.toml
@@ -4,7 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-indexmap = "2.14.0"
-la-arena = "0.3.1"
 rayon = "1.12.0"
 rustc-hash = "2.1.3"

--- a/compiler-core/files/src/lib.rs
+++ b/compiler-core/files/src/lib.rs
@@ -1,37 +1,54 @@
-use core::str;
+use core::{fmt, str};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use indexmap::IndexMap;
-use la_arena::{Idx, RawIdx};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::FxHashMap;
 
 #[derive(Debug, Default)]
 pub struct Files {
-    files: IndexMap<Arc<str>, Arc<str>, FxBuildHasher>,
+    paths: FxHashMap<Arc<str>, FileId>,
+    files: BTreeMap<FileId, FileData>,
+    next_id: u32,
 }
 
-pub struct File;
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FileId {
+    index: u32,
+}
 
-pub type FileId = Idx<File>;
+impl fmt::Debug for FileId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Idx::<File>({})", self.index)
+    }
+}
+
+impl FileId {
+    pub const fn new(index: u32) -> FileId {
+        FileId { index }
+    }
+
+    pub const fn into_raw(self) -> u32 {
+        self.index
+    }
+}
+
+#[derive(Debug)]
+struct FileData {
+    path: Arc<str>,
+    content: Arc<str>,
+}
 
 #[derive(Debug, Default)]
 pub struct ForeignFiles {
     paths: FxHashMap<Arc<str>, ForeignFileId>,
-    files: Vec<ForeignFileSlot>,
-    free: Vec<u32>,
+    files: FxHashMap<ForeignFileId, ForeignFileData>,
+    next_id: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ForeignFileId {
     index: u32,
-    generation: u32,
-}
-
-#[derive(Debug)]
-struct ForeignFileSlot {
-    generation: u32,
-    file: Option<ForeignFileData>,
 }
 
 #[derive(Debug)]
@@ -41,45 +58,63 @@ struct ForeignFileData {
 }
 
 impl Files {
-    pub fn insert(&mut self, k: impl Into<Arc<str>>, v: impl Into<Arc<str>>) -> FileId {
-        let k = k.into();
-        let v = v.into();
-        let (index, _) = self.files.insert_full(k, v);
-        Idx::from_raw(RawIdx::from_u32(index as u32))
+    pub fn insert(&mut self, path: impl Into<Arc<str>>, content: impl Into<Arc<str>>) -> FileId {
+        let path = path.into();
+        let content = content.into();
+        if let Some(file_id) = self.paths.get(path.as_ref()).copied() {
+            let file = self.file_mut(file_id);
+            file.content = content;
+            return file_id;
+        }
+
+        let file_id = FileId { index: self.next_id };
+        self.next_id = self.next_id.checked_add(1).expect("invariant violated: too many files");
+        let file = FileData { path: Arc::clone(&path), content };
+        self.paths.insert(path, file_id);
+        self.files.insert(file_id, file);
+        file_id
     }
 
-    pub fn id(&self, k: &str) -> Option<FileId> {
-        self.files.get_full(k).map(|(index, _, _)| Idx::from_raw(RawIdx::from_u32(index as u32)))
+    pub fn id(&self, path: &str) -> Option<FileId> {
+        self.paths.get(path).copied()
     }
 
-    pub fn path(&self, id: FileId) -> Arc<str> {
-        let index = id.into_raw().into_u32() as usize;
-        let (path, _) =
-            self.files.get_index(index).expect("invariant violated: expected valid FileId");
-        Arc::clone(path)
+    pub fn contains(&self, file_id: FileId) -> bool {
+        self.files.contains_key(&file_id)
     }
 
-    pub fn content(&self, id: FileId) -> Arc<str> {
-        let index = id.into_raw().into_u32() as usize;
-        let (_, contents) =
-            self.files.get_index(index).expect("invariant violated: expected valid FileId");
-        Arc::clone(contents)
+    pub fn path(&self, file_id: FileId) -> Arc<str> {
+        let file = self.file(file_id);
+        Arc::clone(&file.path)
     }
 
-    pub fn iter_id(&self) -> impl Iterator<Item = FileId> + use<> {
-        let length = self.files.len();
-        (0..length).map(|index| {
-            let index = RawIdx::from_u32(index as u32);
-            Idx::from_raw(index)
-        })
+    pub fn content(&self, file_id: FileId) -> Arc<str> {
+        let file = self.file(file_id);
+        Arc::clone(&file.content)
+    }
+
+    pub fn remove(&mut self, path: &str) -> Option<FileId> {
+        let file_id = self.paths.remove(path)?;
+        self.files.remove(&file_id).expect("invariant violated: expected valid FileId");
+        Some(file_id)
+    }
+
+    pub fn iter_id(&self) -> impl Iterator<Item = FileId> + '_ {
+        self.files.keys().copied()
     }
 
     pub fn par_iter_id(&self) -> impl ParallelIterator<Item = FileId> {
-        let length = self.files.len();
-        (0..length).into_par_iter().map(|index| {
-            let index = RawIdx::from_u32(index as u32);
-            Idx::from_raw(index)
-        })
+        let file_ids = self.files.keys().copied();
+        let file_ids = file_ids.collect::<Vec<_>>();
+        file_ids.into_par_iter()
+    }
+
+    fn file(&self, file_id: FileId) -> &FileData {
+        self.files.get(&file_id).expect("invariant violated: expected valid FileId")
+    }
+
+    fn file_mut(&mut self, file_id: FileId) -> &mut FileData {
+        self.files.get_mut(&file_id).expect("invariant violated: expected valid FileId")
     }
 }
 
@@ -91,74 +126,51 @@ impl ForeignFiles {
     ) -> ForeignFileId {
         let path = path.into();
         let content = content.into();
-        if let Some(id) = self.paths.get(path.as_ref()).copied() {
-            let file = self.file_mut(id);
+        if let Some(foreign_file_id) = self.paths.get(path.as_ref()).copied() {
+            let file = self.file_mut(foreign_file_id);
             file.content = content;
-            return id;
+            return foreign_file_id;
         }
 
+        let foreign_file_id = ForeignFileId { index: self.next_id };
+        self.next_id =
+            self.next_id.checked_add(1).expect("invariant violated: too many foreign files");
         let file = ForeignFileData { path: Arc::clone(&path), content };
-        let id = if let Some(index) = self.free.pop() {
-            let slot = &mut self.files[index as usize];
-            slot.file = Some(file);
-            ForeignFileId { index, generation: slot.generation }
-        } else {
-            let index = u32::try_from(self.files.len())
-                .expect("invariant violated: too many foreign files");
-            let slot = ForeignFileSlot { generation: 0, file: Some(file) };
-            self.files.push(slot);
-            ForeignFileId { index, generation: 0 }
-        };
-        self.paths.insert(path, id);
-        id
+        self.paths.insert(path, foreign_file_id);
+        self.files.insert(foreign_file_id, file);
+        foreign_file_id
     }
 
     pub fn id(&self, path: &str) -> Option<ForeignFileId> {
         self.paths.get(path).copied()
     }
 
-    pub fn path(&self, id: ForeignFileId) -> Arc<str> {
-        let file = self.file(id);
+    pub fn path(&self, foreign_file_id: ForeignFileId) -> Arc<str> {
+        let file = self.file(foreign_file_id);
         Arc::clone(&file.path)
     }
 
-    pub fn content(&self, id: ForeignFileId) -> Arc<str> {
-        let file = self.file(id);
+    pub fn content(&self, foreign_file_id: ForeignFileId) -> Arc<str> {
+        let file = self.file(foreign_file_id);
         Arc::clone(&file.content)
     }
 
     pub fn remove(&mut self, path: &str) -> Option<ForeignFileId> {
-        let id = self.paths.remove(path)?;
-        let slot = &mut self.files[id.index as usize];
-        assert_eq!(
-            slot.generation, id.generation,
-            "invariant violated: expected valid ForeignFileId"
-        );
-        slot.file.take().expect("invariant violated: expected valid ForeignFileId");
-        slot.generation = slot
-            .generation
-            .checked_add(1)
-            .expect("invariant violated: exhausted ForeignFileId generations");
-        self.free.push(id.index);
-        Some(id)
+        let foreign_file_id = self.paths.remove(path)?;
+        self.files
+            .remove(&foreign_file_id)
+            .expect("invariant violated: expected valid ForeignFileId");
+        Some(foreign_file_id)
     }
 
-    fn file(&self, id: ForeignFileId) -> &ForeignFileData {
-        let slot = &self.files[id.index as usize];
-        assert_eq!(
-            slot.generation, id.generation,
-            "invariant violated: expected valid ForeignFileId"
-        );
-        slot.file.as_ref().expect("invariant violated: expected valid ForeignFileId")
+    fn file(&self, foreign_file_id: ForeignFileId) -> &ForeignFileData {
+        self.files.get(&foreign_file_id).expect("invariant violated: expected valid ForeignFileId")
     }
 
-    fn file_mut(&mut self, id: ForeignFileId) -> &mut ForeignFileData {
-        let slot = &mut self.files[id.index as usize];
-        assert_eq!(
-            slot.generation, id.generation,
-            "invariant violated: expected valid ForeignFileId"
-        );
-        slot.file.as_mut().expect("invariant violated: expected valid ForeignFileId")
+    fn file_mut(&mut self, foreign_file_id: ForeignFileId) -> &mut ForeignFileData {
+        self.files
+            .get_mut(&foreign_file_id)
+            .expect("invariant violated: expected valid ForeignFileId")
     }
 }
 
@@ -181,6 +193,32 @@ mod tests {
     }
 
     #[test]
+    fn test_remove_files() {
+        let mut files = Files::default();
+        let content = "module Main where\n";
+        let removed_id = files.insert("src/Main.purs", content);
+        let retained_id = files.insert("src/Retained.purs", "module Retained where\n");
+
+        assert_eq!(files.remove("src/Main.purs"), Some(removed_id));
+        assert_eq!(files.id("src/Main.purs"), None);
+        assert_eq!(files.path(retained_id).as_ref(), "src/Retained.purs");
+
+        let replacement_id = files.insert("src/Main.purs", content);
+        assert_ne!(replacement_id, removed_id);
+
+        let retained_file_count = files.files.len();
+        let mut previous_id = replacement_id;
+        for number in 0..32 {
+            let path = format!("src/Temporary-{number}.purs");
+            let temporary_id = files.insert(path.as_str(), content);
+            assert!(temporary_id > previous_id);
+            assert_eq!(files.remove(&path), Some(temporary_id));
+            previous_id = temporary_id;
+        }
+        assert_eq!(files.files.len(), retained_file_count);
+    }
+
+    #[test]
     fn test_foreign_files() {
         let mut files = ForeignFiles::default();
 
@@ -197,19 +235,22 @@ mod tests {
 
         assert_eq!(files.remove(path), Some(id));
         assert_eq!(files.id(path), None);
-        assert!(files.files[id.index as usize].file.is_none());
+        assert!(!files.files.contains_key(&id));
         assert_eq!(files.path(retained_id).as_ref(), retained_path);
 
         let replacement_id = files.insert(path, content);
         assert_ne!(replacement_id, id);
         assert_eq!(files.remove(path), Some(replacement_id));
 
-        let slots = files.files.len();
+        let retained_file_count = files.files.len();
+        let mut previous_id = replacement_id;
         for number in 0..32 {
             let path = format!("src/Temporary-{number}.js");
             let temporary_id = files.insert(path.as_str(), content);
+            assert!(temporary_id > previous_id);
             assert_eq!(files.remove(&path), Some(temporary_id));
+            previous_id = temporary_id;
         }
-        assert_eq!(files.files.len(), slots);
+        assert_eq!(files.files.len(), retained_file_count);
     }
 }

--- a/compiler-core/resolving/src/lib.rs
+++ b/compiler-core/resolving/src/lib.rs
@@ -342,7 +342,7 @@ pub fn export_module(module: &ResolvedModule) -> ExportedModule {
         IndirectExports { file_id, terms: terms.into() }
     });
     let mut indirect = indirect.collect::<Vec<_>>();
-    indirect.sort_by_key(|exports| exports.file_id.into_raw().into_u32());
+    indirect.sort_by_key(|exports| exports.file_id);
 
     ExportedModule { local: local.into(), indirect: indirect.into() }
 }

--- a/compiler-lsp/analyzer/src/code_action.rs
+++ b/compiler-lsp/analyzer/src/code_action.rs
@@ -20,7 +20,7 @@ pub fn implementation(
         language.file_id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
-    let content = language.queries().content(file);
+    let content = language.queries().content(file)?;
     let position =
         position::protocol_position_to_utf8(&content, range.start, language.position_encoding())
             .ok_or(AnalyzerError::NonFatal)?;
@@ -77,7 +77,7 @@ pub fn expression_range(
     request: &CodeActionRequest<impl crate::AnalyzerHost>,
     expression_id: ExpressionId,
 ) -> Result<Range, AnalyzerError> {
-    let content = request.language.queries().content(request.file);
+    let content = request.language.queries().content(request.file)?;
     let (parsed, _) = request.language.queries().parsed(request.file)?;
     let stabilized = request.language.queries().stabilized(request.file)?;
 
@@ -92,7 +92,7 @@ pub fn type_range(
     request: &CodeActionRequest<impl crate::AnalyzerHost>,
     type_id: TypeId,
 ) -> Result<Range, AnalyzerError> {
-    let content = request.language.queries().content(request.file);
+    let content = request.language.queries().content(request.file)?;
     let (parsed, _) = request.language.queries().parsed(request.file)?;
     let stabilized = request.language.queries().stabilized(request.file)?;
 

--- a/compiler-lsp/analyzer/src/common.rs
+++ b/compiler-lsp/analyzer/src/common.rs
@@ -15,7 +15,7 @@ pub fn file_term_location(
     term_id: TermItemId,
 ) -> Result<Location, AnalyzerError> {
     let engine = context.queries();
-    let content = engine.content(file_id);
+    let content = engine.content(file_id)?;
     let (parsed, _) = engine.parsed(file_id)?;
 
     let stabilized = engine.stabilized(file_id)?;
@@ -37,7 +37,7 @@ pub fn file_type_location(
     type_id: TypeItemId,
 ) -> Result<Location, AnalyzerError> {
     let engine = context.queries();
-    let content = engine.content(file_id);
+    let content = engine.content(file_id)?;
     let (parsed, _) = engine.parsed(file_id)?;
 
     let stabilized = engine.stabilized(file_id)?;
@@ -79,7 +79,7 @@ fn file_source_location<T: AstNode>(
     file_id: FileId,
     source_id: stabilizing::AstId<T>,
 ) -> Result<Location, AnalyzerError> {
-    let content = context.queries().content(file_id);
+    let content = context.queries().content(file_id)?;
     let stabilized = context.queries().stabilized(file_id)?;
     let range =
         locate::id_range(&content, &context.queries().parsed(file_id)?.0, &stabilized, source_id)

--- a/compiler-lsp/analyzer/src/completion.rs
+++ b/compiler-lsp/analyzer/src/completion.rs
@@ -51,7 +51,7 @@ pub fn implementation(
     let engine = language.queries();
     let encoding = language.position_encoding();
     let prim_id = engine.prim_id();
-    let content = engine.content(current_file);
+    let content = engine.content(current_file)?;
     let position = position::protocol_position_to_utf8(&content, position, encoding)
         .ok_or(AnalyzerError::NonFatal)?;
     let (parsed, _) = engine.parsed(current_file)?;

--- a/compiler-lsp/analyzer/src/completion/resolve.rs
+++ b/compiler-lsp/analyzer/src/completion/resolve.rs
@@ -30,7 +30,10 @@ pub fn implementation(
 
     match resolve {
         CompletionResolveData::Import(file_id) => {
-            let content = engine.content(file_id);
+            let content = match engine.content(file_id) {
+                Ok(content) => content,
+                Err(error) => return Err((error.into(), item)),
+            };
             match AnnotationSyntaxRange::of_file(engine, file_id) {
                 Ok(range) => Ok(resolve_documentation(&content, range, item)),
                 Err(error) => Err((error, item)),
@@ -85,7 +88,10 @@ fn resolve_term_item(
     term_id: TermItemId,
     mut item: CompletionItem,
 ) -> Result<CompletionItem, Box<(AnalyzerError, CompletionItem)>> {
-    let content = engine.content(file_id);
+    let content = match engine.content(file_id) {
+        Ok(content) => content,
+        Err(error) => return Err(Box::new((error.into(), item))),
+    };
     if let Ok(range) = AnnotationSyntaxRange::of_file_term(engine, file_id, term_id) {
         let annotation = range.annotation.map(|range| extract_annotation(&content, range));
         item.documentation = annotation.map(|annotation| {
@@ -125,7 +131,10 @@ fn resolve_type_item(
     type_id: TypeItemId,
     mut item: CompletionItem,
 ) -> Result<CompletionItem, Box<(AnalyzerError, CompletionItem)>> {
-    let content = engine.content(file_id);
+    let content = match engine.content(file_id) {
+        Ok(content) => content,
+        Err(error) => return Err(Box::new((error.into(), item))),
+    };
     if let Ok(range) = AnnotationSyntaxRange::of_file_type(engine, file_id, type_id) {
         let annotation = range.annotation.map(|range| extract_annotation(&content, range));
         item.documentation = annotation.map(|annotation| {
@@ -250,21 +259,41 @@ fn render_local_signature(
 
 #[derive(Serialize, Deserialize)]
 pub(crate) enum CompletionResolveData {
-    Import(#[serde(with = "id")] FileId),
-    TermItem(#[serde(with = "id")] FileId, #[serde(with = "id")] TermItemId),
-    TypeItem(#[serde(with = "id")] FileId, #[serde(with = "id")] TypeItemId),
-    Binder(#[serde(with = "id")] FileId, #[serde(with = "ast_id")] BinderId),
-    Let(#[serde(with = "id")] FileId, #[serde(with = "id")] LetBindingNameGroupId),
-    RecordPun(#[serde(with = "id")] FileId, #[serde(with = "ast_id")] RecordPunId),
+    Import(#[serde(with = "file_id")] FileId),
+    TermItem(#[serde(with = "file_id")] FileId, #[serde(with = "id")] TermItemId),
+    TypeItem(#[serde(with = "file_id")] FileId, #[serde(with = "id")] TypeItemId),
+    Binder(#[serde(with = "file_id")] FileId, #[serde(with = "ast_id")] BinderId),
+    Let(#[serde(with = "file_id")] FileId, #[serde(with = "id")] LetBindingNameGroupId),
+    RecordPun(#[serde(with = "file_id")] FileId, #[serde(with = "ast_id")] RecordPunId),
     ForallTypeVariable(
-        #[serde(with = "id")] FileId,
+        #[serde(with = "file_id")] FileId,
         #[serde(with = "ast_id")] TypeVariableBindingId,
     ),
     ImplicitTypeVariable(
-        #[serde(with = "id")] FileId,
+        #[serde(with = "file_id")] FileId,
         #[serde(with = "id")] GraphNodeId,
         #[serde(with = "id")] ImplicitBindingId,
     ),
+}
+
+mod file_id {
+    use files::FileId;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub(super) fn serialize<S>(file_id: &FileId, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        file_id.into_raw().serialize(serializer)
+    }
+
+    pub(super) fn deserialize<'d, D>(deserializer: D) -> Result<FileId, D::Error>
+    where
+        D: Deserializer<'d>,
+    {
+        let value = u32::deserialize(deserializer)?;
+        Ok(FileId::new(value))
+    }
 }
 
 mod id {

--- a/compiler-lsp/analyzer/src/completion/sources.rs
+++ b/compiler-lsp/analyzer/src/completion/sources.rs
@@ -22,7 +22,7 @@ fn module_name(
     context: &CompletionContext<impl crate::AnalyzerHost>,
     file_id: FileId,
 ) -> Result<Option<String>, AnalyzerError> {
-    let content = context.language.queries().content(file_id);
+    let content = context.language.queries().content(file_id)?;
     let (parsed, _) = context.language.queries().parsed(file_id)?;
     Ok(parsed.module_name(&content).map(|name| name.to_string()))
 }

--- a/compiler-lsp/analyzer/src/definition.rs
+++ b/compiler-lsp/analyzer/src/definition.rs
@@ -25,7 +25,7 @@ pub fn implementation(
         context.file_id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let position =
         position::protocol_position_to_utf8(&content, position, context.position_encoding())
             .ok_or(AnalyzerError::NonFatal)?;
@@ -97,7 +97,7 @@ fn definition_module_name(
     module_name: AstPtr<cst::ModuleName>,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let engine = context.queries();
-    let content = engine.content(current_file);
+    let content = engine.content(current_file)?;
     let (parsed, _) = engine.parsed(current_file)?;
 
     let root = parsed.syntax_node();
@@ -106,7 +106,7 @@ fn definition_module_name(
     let module_name = module_name.syntax().text(&content).to_smolstr();
     let module_id = engine.module_file(&module_name).ok_or(AnalyzerError::NonFatal)?;
 
-    let content = engine.content(module_id);
+    let content = engine.content(module_id)?;
 
     let (parsed, _) = engine.parsed(module_id)?;
     let root = parsed.syntax_node();
@@ -126,7 +126,7 @@ fn definition_import(
     import_id: ImportItemId,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let engine = context.queries();
-    let content = engine.content(current_file);
+    let content = engine.content(current_file)?;
     let (parsed, _) = engine.parsed(current_file)?;
     let stabilized = engine.stabilized(current_file)?;
 
@@ -230,7 +230,7 @@ fn definition_expression(
     expression_id: ExpressionId,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let engine = context.queries();
-    let content = engine.content(current_file);
+    let content = engine.content(current_file)?;
     let (parsed, _) = engine.parsed(current_file)?;
 
     let stabilized = engine.stabilized(current_file)?;
@@ -323,7 +323,7 @@ fn definition_type(
     type_id: TypeId,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let engine = context.queries();
-    let content = engine.content(current_file);
+    let content = engine.content(current_file)?;
     let (parsed, _) = engine.parsed(current_file)?;
     let stabilized = engine.stabilized(current_file)?;
     let lowered = engine.lowered(current_file)?;
@@ -390,7 +390,7 @@ fn definition_let_binding(
     let_id: LetBindingNameGroupId,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let engine = context.queries();
-    let content = engine.content(file_id);
+    let content = engine.content(file_id)?;
     let (parsed, _) = engine.parsed(file_id)?;
     let stabilized = engine.stabilized(file_id)?;
     let lowered = engine.lowered(file_id)?;

--- a/compiler-lsp/analyzer/src/diagnostics.rs
+++ b/compiler-lsp/analyzer/src/diagnostics.rs
@@ -21,7 +21,7 @@ where
     Host::Queries: diagnostics::ExternalQueries + ForeignQueries,
 {
     let queries = context.queries();
-    let content = queries.content(file_id);
+    let content = queries.content(file_id)?;
 
     let (parsed, _) = queries.parsed(file_id)?;
     let root = parsed.syntax_node();

--- a/compiler-lsp/analyzer/src/document_highlight.rs
+++ b/compiler-lsp/analyzer/src/document_highlight.rs
@@ -30,7 +30,7 @@ pub fn implementation(
         context.file_id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let position =
         position::protocol_position_to_utf8(&content, position, context.position_encoding())
             .ok_or(AnalyzerError::NonFatal)?;
@@ -129,7 +129,7 @@ fn highlight_import(
     }
     .unwrap_or_default();
 
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
     let root = parsed.syntax_node();
     let stabilized = context.queries().stabilized(current_file)?;
@@ -150,7 +150,7 @@ fn import_target(
     current_file: FileId,
     import_id: ImportItemId,
 ) -> Result<HighlightTarget, AnalyzerError> {
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
     let stabilized = context.queries().stabilized(current_file)?;
 
@@ -230,7 +230,7 @@ fn highlight_binder(
     current_file: FileId,
     binder_id: BinderId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
     let stabilized = context.queries().stabilized(current_file)?;
     let lowered = context.queries().lowered(current_file)?;
@@ -335,7 +335,7 @@ fn highlight_type_variable(
     current_file: FileId,
     binding_id: TypeVariableBindingId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
     let stabilized = context.queries().stabilized(current_file)?;
     let lowered = context.queries().lowered(current_file)?;
@@ -376,7 +376,7 @@ fn highlight_file_term(
     file_id: FileId,
     term_id: TermItemId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
     let root = parsed.syntax_node();
     let stabilized = context.queries().stabilized(current_file)?;
@@ -483,7 +483,7 @@ fn highlight_file_type(
     file_id: FileId,
     type_id: TypeItemId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
     let root = parsed.syntax_node();
     let stabilized = context.queries().stabilized(current_file)?;
@@ -592,7 +592,7 @@ fn highlight_let(
     current_file: FileId,
     let_binding_id: LetBindingNameGroupId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
     let stabilized = context.queries().stabilized(current_file)?;
     let lowered = context.queries().lowered(current_file)?;
@@ -652,7 +652,7 @@ fn highlight_binder_pun(
     current_file: FileId,
     pun_id: RecordPunId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
     let stabilized = context.queries().stabilized(current_file)?;
     let lowered = context.queries().lowered(current_file)?;
@@ -858,7 +858,7 @@ fn push_name_highlight<T>(
 where
     T: AstNode,
 {
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
     let root = parsed.syntax_node();
     let stabilized = context.queries().stabilized(current_file)?;

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -29,7 +29,7 @@ pub fn implementation(
     };
 
     let engine = context.queries();
-    let content = engine.content(current_file);
+    let content = engine.content(current_file)?;
     let position =
         position::protocol_position_to_utf8(&content, position, context.position_encoding())
             .ok_or(AnalyzerError::NonFatal)?;
@@ -150,7 +150,7 @@ fn hover_module_name(
     current_file: FileId,
     module_name: AstPtr<cst::ModuleName>,
 ) -> Result<Option<Hover>, AnalyzerError> {
-    let content = engine.content(current_file);
+    let content = engine.content(current_file)?;
     let (parsed, _) = engine.parsed(current_file)?;
 
     let root = parsed.syntax_node();
@@ -159,7 +159,7 @@ fn hover_module_name(
     let module_name = module_name.syntax().text(&content).to_smolstr();
     let module_id = engine.module_file(&module_name).ok_or(AnalyzerError::NonFatal)?;
 
-    let content = engine.content(module_id);
+    let content = engine.content(module_id)?;
     let range = AnnotationSyntaxRange::of_file(engine, module_id)?;
 
     let annotation = range.annotation.and_then(|range| render_annotation(&content, range));
@@ -177,7 +177,7 @@ fn hover_import(
     current_file: FileId,
     import_id: ImportItemId,
 ) -> Result<Option<Hover>, AnalyzerError> {
-    let content = engine.content(current_file);
+    let content = engine.content(current_file)?;
     let (parsed, _) = engine.parsed(current_file)?;
     let stabilized = engine.stabilized(current_file)?;
 
@@ -426,7 +426,7 @@ fn hover_file_term(
     file_id: FileId,
     term_id: TermItemId,
 ) -> Result<Option<Hover>, AnalyzerError> {
-    let content = engine.content(file_id);
+    let content = engine.content(file_id)?;
     let indexed = engine.indexed(file_id)?;
     let checked = engine.checked(file_id)?;
 
@@ -455,7 +455,7 @@ fn hover_file_type(
     file_id: FileId,
     type_id: TypeItemId,
 ) -> Result<Option<Hover>, AnalyzerError> {
-    let content = engine.content(file_id);
+    let content = engine.content(file_id)?;
     let indexed = engine.indexed(file_id)?;
     let checked = engine.checked(file_id)?;
 

--- a/compiler-lsp/analyzer/src/locate.rs
+++ b/compiler-lsp/analyzer/src/locate.rs
@@ -223,7 +223,7 @@ pub(crate) fn locate_with_token(
     id: FileId,
     position: Utf8Position,
 ) -> Result<(Located, Option<SyntaxToken>), AnalyzerError> {
-    let content = engine.content(id);
+    let content = engine.content(id)?;
 
     let (parsed, _) = engine.parsed(id)?;
     let stabilized = engine.stabilized(id)?;

--- a/compiler-lsp/analyzer/src/references.rs
+++ b/compiler-lsp/analyzer/src/references.rs
@@ -26,7 +26,7 @@ pub fn implementation(
         context.file_id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let position =
         position::protocol_position_to_utf8(&content, position, context.position_encoding())
             .ok_or(AnalyzerError::NonFatal)?;
@@ -102,7 +102,7 @@ fn references_module_name(
     module_name: AstPtr<cst::ModuleName>,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let engine = context.queries();
-    let content = engine.content(current_file);
+    let content = engine.content(current_file)?;
     let (parsed, _) = engine.parsed(current_file)?;
 
     let root = parsed.syntax_node();
@@ -117,7 +117,7 @@ fn references_module_name(
     for (candidate_id, import_id) in candidates {
         let uri = common::file_uri(context, candidate_id)?;
 
-        let content = engine.content(candidate_id);
+        let content = engine.content(candidate_id)?;
         let (parsed, _) = engine.parsed(candidate_id)?;
         let root = parsed.syntax_node();
 
@@ -139,7 +139,7 @@ fn references_import(
     import_id: ImportItemId,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let engine = context.queries();
-    let content = engine.content(current_file);
+    let content = engine.content(current_file)?;
     let (parsed, _) = engine.parsed(current_file)?;
     let stabilized = engine.stabilized(current_file)?;
 
@@ -227,7 +227,7 @@ fn references_binder(
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let uri = common::file_uri(context, current_file)?;
 
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
 
     let stabilized = context.queries().stabilized(current_file)?;
@@ -338,7 +338,7 @@ fn references_type_variable(
     binding_id: TypeVariableBindingId,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let uri = common::file_uri(context, current_file)?;
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
     let stabilized = context.queries().stabilized(current_file)?;
     let lowered = context.queries().lowered(current_file)?;
@@ -393,7 +393,7 @@ fn references_file_term(
     for candidate_id in candidates {
         let uri = common::file_uri(context, candidate_id)?;
 
-        let content = engine.content(candidate_id);
+        let content = engine.content(candidate_id)?;
         let (parsed, _) = engine.parsed(candidate_id)?;
         let stabilized = engine.stabilized(candidate_id)?;
         let indexed = engine.indexed(candidate_id)?;
@@ -483,7 +483,7 @@ fn references_file_type(
     for candidate_id in candidates {
         let uri = common::file_uri(context, candidate_id)?;
 
-        let content = engine.content(candidate_id);
+        let content = engine.content(candidate_id)?;
         let (parsed, _) = engine.parsed(candidate_id)?;
 
         let stabilized = engine.stabilized(candidate_id)?;
@@ -637,7 +637,7 @@ fn references_let(
     let engine = context.queries();
     let uri = common::file_uri(context, current_file)?;
 
-    let content = engine.content(current_file);
+    let content = engine.content(current_file)?;
     let (parsed, _) = engine.parsed(current_file)?;
 
     let stabilized = engine.stabilized(current_file)?;
@@ -681,7 +681,7 @@ fn references_binder_pun(
     let engine = context.queries();
     let uri = common::file_uri(context, current_file)?;
 
-    let content = engine.content(current_file);
+    let content = engine.content(current_file)?;
     let (parsed, _) = engine.parsed(current_file)?;
 
     let stabilized = engine.stabilized(current_file)?;

--- a/compiler-lsp/analyzer/src/rename.rs
+++ b/compiler-lsp/analyzer/src/rename.rs
@@ -503,7 +503,7 @@ fn target_at_position(
         context.file_id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let utf8_position =
         position::protocol_position_to_utf8(&content, position, context.position_encoding())
             .ok_or(AnalyzerError::NonFatal)?;
@@ -524,7 +524,7 @@ fn rename_range(
     position: position::Utf8Position,
     old_name: &str,
 ) -> Result<Range, AnalyzerError> {
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let offset =
         position::utf8_position_to_offset(&content, position).ok_or(AnalyzerError::NonFatal)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
@@ -562,7 +562,7 @@ fn qualifier_target(
     current_file: FileId,
     position: position::Utf8Position,
 ) -> Result<Option<RenameTarget>, AnalyzerError> {
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let offset =
         position::utf8_position_to_offset(&content, position).ok_or(AnalyzerError::NonFatal)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
@@ -723,7 +723,7 @@ fn module_target(
     current_file: FileId,
     module_name: AstPtr<cst::ModuleName>,
 ) -> Result<RenameTarget, AnalyzerError> {
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
     let root = parsed.syntax_node();
     let module_name = module_name.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
@@ -749,7 +749,7 @@ fn import_target(
     current_file: FileId,
     import_id: ImportItemId,
 ) -> Result<RenameTarget, AnalyzerError> {
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
     let stabilized = context.queries().stabilized(current_file)?;
 
@@ -886,7 +886,7 @@ fn target_name(
             name.map(|name| (name.to_string(), NameKind::Lower))
         }
         RenameTarget::TypeVariable(file_id, binding_id) => {
-            let content = context.queries().content(file_id);
+            let content = context.queries().content(file_id)?;
             let (parsed, _) = context.queries().parsed(file_id)?;
             let stabilized = context.queries().stabilized(file_id)?;
 
@@ -902,7 +902,7 @@ fn target_name(
             binding.name.as_ref().map(|name| (name.to_string(), NameKind::Lower))
         }
         RenameTarget::RecordPun(file_id, pun_id) => {
-            let content = context.queries().content(file_id);
+            let content = context.queries().content(file_id)?;
             let (parsed, _) = context.queries().parsed(file_id)?;
             let stabilized = context.queries().stabilized(file_id)?;
 
@@ -922,7 +922,7 @@ fn target_name(
             name.map(|name| (name.to_string(), NameKind::Upper))
         }
         RenameTarget::Module(file_id) => {
-            let content = context.queries().content(file_id);
+            let content = context.queries().content(file_id)?;
             let (parsed, _) = context.queries().parsed(file_id)?;
 
             parsed.module_name(&content).map(|name| (name.to_string(), NameKind::Module))

--- a/compiler-lsp/analyzer/src/rename/edit.rs
+++ b/compiler-lsp/analyzer/src/rename/edit.rs
@@ -58,7 +58,7 @@ where
             .and_then(|import| import.alias.as_deref())
             .ok_or(AnalyzerError::NonFatal)?;
 
-        let content = self.context.queries().content(file_id);
+        let content = self.context.queries().content(file_id)?;
         let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
 
@@ -188,7 +188,7 @@ where
         target_file: FileId,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let content = self.context.queries().content(file_id);
+        let content = self.context.queries().content(file_id)?;
         let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
         let indexed = self.context.queries().indexed(file_id)?;
@@ -314,7 +314,7 @@ where
         name_kind: NameKind,
         new_name: &str,
     ) -> Result<(Range, String), AnalyzerError> {
-        let content = self.context.queries().content(file_id);
+        let content = self.context.queries().content(file_id)?;
         let position = position::protocol_position_to_utf8(
             &content,
             range.start,
@@ -485,7 +485,7 @@ where
         binder_id: BinderId,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let content = self.context.queries().content(file_id);
+        let content = self.context.queries().content(file_id)?;
         let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
         let stabilized = self.context.queries().stabilized(file_id)?;
@@ -558,7 +558,7 @@ where
         pun_id: RecordPunId,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let content = self.context.queries().content(file_id);
+        let content = self.context.queries().content(file_id)?;
         let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
         let stabilized = self.context.queries().stabilized(file_id)?;
@@ -834,7 +834,7 @@ where
         import_item_id: ImportItemId,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let content = self.context.queries().content(file_id);
+        let content = self.context.queries().content(file_id)?;
         let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
         let stabilized = self.context.queries().stabilized(file_id)?;
@@ -853,7 +853,7 @@ where
         export_item_id: indexing::ExportItemId,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let content = self.context.queries().content(file_id);
+        let content = self.context.queries().content(file_id)?;
         let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
         let stabilized = self.context.queries().stabilized(file_id)?;
@@ -915,7 +915,7 @@ where
         old_name: &str,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let content = self.context.queries().content(file_id);
+        let content = self.context.queries().content(file_id)?;
         let cst::TypeItems::TypeItemsList(items) = type_items else {
             return Ok(());
         };
@@ -943,7 +943,7 @@ where
         range: TextRange,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let content = self.context.queries().content(file_id);
+        let content = self.context.queries().content(file_id)?;
         let range =
             position::text_range_to_utf8_range(&content, range).ok_or(AnalyzerError::NonFatal)?;
 
@@ -956,7 +956,7 @@ where
         range: Utf8Range,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let content = self.context.queries().content(file_id);
+        let content = self.context.queries().content(file_id)?;
         let range =
             position::utf8_range_to_protocol(&content, range, self.context.position_encoding())
                 .ok_or(AnalyzerError::NonFatal)?;
@@ -977,7 +977,7 @@ where
             return Ok(());
         };
 
-        let content = self.context.queries().content(file_id);
+        let content = self.context.queries().content(file_id)?;
         let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
         let stabilized = self.context.queries().stabilized(file_id)?;
@@ -1007,7 +1007,7 @@ where
         range: Range,
         new_name: &str,
     ) -> Result<String, AnalyzerError> {
-        let content = self.context.queries().content(file_id);
+        let content = self.context.queries().content(file_id)?;
         let start = position::protocol_position_to_utf8(
             &content,
             range.start,
@@ -1039,7 +1039,7 @@ where
     ) -> Result<Option<WorkspaceEdit>, AnalyzerError> {
         self.edits.sort_by_key(|(file_id, edit)| {
             (
-                file_id.into_raw().into_u32(),
+                *file_id,
                 edit.range.start.line,
                 edit.range.start.character,
                 edit.range.end.line,

--- a/compiler-lsp/analyzer/src/semantic_tokens.rs
+++ b/compiler-lsp/analyzer/src/semantic_tokens.rs
@@ -66,7 +66,7 @@ pub fn implementation(
         context.file_id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
-    let content = context.queries().content(current_file);
+    let content = context.queries().content(current_file)?;
     let (parsed, _) = context.queries().parsed(current_file)?;
     let root = parsed.syntax_node();
     let line_index = LineIndex::new(&content);

--- a/compiler-lsp/documentation/src/render.rs
+++ b/compiler-lsp/documentation/src/render.rs
@@ -20,7 +20,7 @@ pub struct PackageInput<'a> {
 }
 
 fn module_name(engine: &QueryEngine, file_id: FileId) -> Result<Option<String>, Error> {
-    let content = engine.content(file_id);
+    let content = engine.content(file_id)?;
     let (parsed, _) = engine.parsed(file_id)?;
     Ok(parsed.module_name(&content).map(|name| name.to_string()))
 }

--- a/docs/src/wasm/src/engine.rs
+++ b/docs/src/wasm/src/engine.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 use std::sync::Arc;
 
 use analyzer::AnalyzerHost;
-use building_types::{ModuleNameId, ModuleNameInterner, QueryProxy, QueryResult};
+use building_types::{ModuleNameId, ModuleNameInterner, QueryError, QueryProxy, QueryResult};
 use documenting::DocumentedModule;
 use files::{FileId, Files};
 use indexing::IndexedModule;
@@ -190,7 +190,7 @@ impl WasmQueryEngine {
             return Ok(cached.clone());
         }
 
-        let content = self.content(id);
+        let content = self.content(id)?;
         let (parsed, _) = self.parsed(id)?;
         let stabilized = self.stabilized(id)?;
         let indexed = self.indexed(id)?;
@@ -200,8 +200,8 @@ impl WasmQueryEngine {
         Ok(documented)
     }
 
-    fn content(&self, id: FileId) -> Arc<str> {
-        self.input.content.get(&id).cloned().expect("invariant violated: content must exist")
+    fn content(&self, id: FileId) -> QueryResult<Arc<str>> {
+        self.input.content.get(&id).cloned().ok_or(QueryError::MissingContent { file_id: id })
     }
 }
 
@@ -218,7 +218,7 @@ impl QueryProxy for WasmQueryEngine {
     type Checked = Arc<checking::CheckedModule>;
     type Documented = Arc<DocumentedModule>;
 
-    fn content(&self, id: FileId) -> Arc<str> {
+    fn content(&self, id: FileId) -> QueryResult<Arc<str>> {
         WasmQueryEngine::content(self, id)
     }
 
@@ -227,7 +227,7 @@ impl QueryProxy for WasmQueryEngine {
             return Ok(cached.clone());
         }
 
-        let content = self.content(id);
+        let content = self.content(id)?;
         let lexed = lexing::lex(&content);
         let tokens = lexing::layout(&lexed);
         let parsed = parsing::parse(&lexed, &tokens);
@@ -254,7 +254,7 @@ impl QueryProxy for WasmQueryEngine {
             return Ok(cached.clone());
         }
 
-        let content = self.content(id);
+        let content = self.content(id)?;
         let (parsed, _) = self.parsed(id)?;
         let stabilized = self.stabilized(id)?;
 
@@ -270,7 +270,7 @@ impl QueryProxy for WasmQueryEngine {
             return Ok(cached.clone());
         }
 
-        let content = self.content(id);
+        let content = self.content(id)?;
         let (parsed, _) = self.parsed(id)?;
         let prim = self.resolved(self.prim_id)?;
         let stabilized = self.stabilized(id)?;

--- a/tests-compatibility/src/lib.rs
+++ b/tests-compatibility/src/lib.rs
@@ -172,8 +172,8 @@ pub fn build_warmed_engine(sources: &[(String, String)]) -> WarmedEngine {
     }
 
     for &file_id in &candidates {
-        let content = engine.content(file_id);
-        if let Ok((parsed, _)) = engine.parsed(file_id)
+        if let Ok(content) = engine.content(file_id)
+            && let Ok((parsed, _)) = engine.parsed(file_id)
             && let Some(module_name) = parsed.module_name(&content)
         {
             engine.set_module_file(module_name.as_ref(), file_id);

--- a/tests-compatibility/tests/parsing.rs
+++ b/tests-compatibility/tests/parsing.rs
@@ -171,7 +171,7 @@ fn test_parallel_parse_package_set() {
     println!("Parsing {parsing:?}");
 
     let names = source.iter().filter_map(|&id| {
-        let content = engine.content(id);
+        let content = engine.content(id).ok()?;
         let (parsed, _) = engine.parsed(id).ok()?;
         let module_name = parsed.module_name(&content)?;
         Some((module_name, id))

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -113,7 +113,7 @@ pub fn report_resolved(engine: &QueryEngine, id: FileId, name: &str) -> String {
 }
 
 pub fn report_lowered(engine: &QueryEngine, id: FileId, name: &str) -> String {
-    let content = engine.content(id);
+    let content = engine.content(id).unwrap();
     let (parsed, _) = engine.parsed(id).unwrap();
 
     let stabilized = engine.stabilized(id).unwrap();
@@ -357,7 +357,7 @@ pub fn report_foreign(engine: &QueryEngine, id: FileId) -> String {
         return String::new();
     }
 
-    let content = engine.content(id);
+    let content = engine.content(id).unwrap();
     let (parsed, _) = engine.parsed(id).unwrap();
     let root = parsed.syntax_node();
     let stabilized = engine.stabilized(id).unwrap();
@@ -462,7 +462,7 @@ fn write_checked_diagnostics(
     indexed: &indexing::IndexedModule,
     checked: &checking::CheckedModule,
 ) {
-    let content = engine.content(id);
+    let content = engine.content(id).unwrap();
     let (parsed, _) = engine.parsed(id).unwrap();
     let root = parsed.syntax_node();
     let stabilized = engine.stabilized(id).unwrap();

--- a/tests-integration/src/generated/docs.rs
+++ b/tests-integration/src/generated/docs.rs
@@ -54,7 +54,7 @@ pub fn report(engine: &QueryEngine, files: &Files, root: &Path) -> Result<String
 }
 
 fn module_name(engine: &QueryEngine, id: FileId) -> Option<String> {
-    let content = engine.content(id);
+    let content = engine.content(id).ok()?;
     let (parsed, _) = engine.parsed(id).ok()?;
     parsed.module_name(&content).map(|name| name.to_string())
 }

--- a/tests-integration/src/generated/lsp.rs
+++ b/tests-integration/src/generated/lsp.rs
@@ -172,7 +172,7 @@ pub fn report(engine: &QueryEngine, files: &Files, id: FileId) -> String {
         Url::parse(&path).unwrap()
     };
 
-    let content = engine.content(id);
+    let content = engine.content(id).unwrap();
     let line_index = LineIndex::new(&content);
     let requests = extract_requests(&content);
 
@@ -506,7 +506,7 @@ fn dispatch_cursor(
         }
         CursorKind::Hover => {
             let file_id = host.file_id(uri.as_str()).expect("hover URI references a loaded file");
-            let content = engine.content(file_id);
+            let content = engine.content(file_id).unwrap();
             if let Ok(Some(response)) = analyzer::hover::implementation(&context, uri, position) {
                 let convert = |marked: MarkedString| -> String {
                     match marked {
@@ -709,7 +709,7 @@ fn rename_target_name(
     encoding: PositionEncoding,
 ) -> Option<String> {
     let file_id = files.id(uri.as_str())?;
-    let content = engine.content(file_id);
+    let content = engine.content(file_id).ok()?;
     let position = analyzer::position::protocol_position_to_utf8(&content, position, encoding)?;
     let offset = analyzer::position::utf8_position_to_offset(&content, position)?;
     let (parsed, _) = engine.parsed(file_id).ok()?;


### PR DESCRIPTION
## Summary

- remove deleted PureScript files from active file and query storage without reusing file IDs
- handle watched PureScript file creation, changes, and deletion while preserving open document contents
- invalidate dependent compiler queries and clear diagnostics for deleted files

Closes #357.

## Verification

- cargo check -p building --tests
- cargo check -p analyzer --tests
- cargo check -p purescript-alexandrite --tests
- cargo check -p docs-lib --tests
- cargo check -p tests-integration --tests
- cargo nextest run -p files
- cargo nextest run -p building
- cargo nextest run -p analyzer
- cargo nextest run -p purescript-alexandrite
- cargo check -p nbe --tests
- just format
- git diff --check