### PR TITLE
[lsp] Harden file lifecycle cleanup

### DIFF
--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -717,11 +717,13 @@ fn did_close(state: &mut State, p: DidCloseTextDocumentParams) -> Result<(), Lsp
     };
     state.files.write().close(file_id);
 
-    reload_source_file(state, &uri, None)?;
-
+    let reloaded = reload_source_file(state, &uri, None)?;
     state.invalidate_workspace_symbols();
     state.invalidate_suggestions_cache();
-    event::emit_collect_all_diagnostics(state)
+    if reloaded {
+        event::emit_collect_all_diagnostics(state)?;
+    }
+    Ok(())
 }
 
 fn did_save(state: &mut State, p: DidSaveTextDocumentParams) -> Result<(), LspError> {
@@ -737,24 +739,31 @@ fn did_change_watched_files(
     state: &mut State,
     p: DidChangeWatchedFilesParams,
 ) -> Result<(), LspError> {
+    let mut source_changed = false;
     for change in p.changes {
         if is_javascript_uri(&change.uri) {
             on_watched_foreign_change(state, change)?;
         } else if is_purescript_uri(&change.uri) {
-            on_watched_source_change(state, change)?;
+            source_changed |= on_watched_source_change(state, change)?;
         }
+    }
+
+    if source_changed {
+        state.invalidate_workspace_symbols();
+        state.invalidate_suggestions_cache();
+        event::emit_collect_all_diagnostics(state)?;
     }
 
     Ok(())
 }
 
-fn on_watched_source_change(state: &mut State, change: FileEvent) -> Result<(), LspError> {
+fn on_watched_source_change(state: &mut State, change: FileEvent) -> Result<bool, LspError> {
     if state.files.read().is_open(change.uri.as_str()) {
-        return Ok(());
+        return Ok(false);
     }
 
     if change.typ == FileChangeType::DELETED {
-        remove_source_file(state, &change.uri)?;
+        remove_source_file(state, &change.uri)
     } else {
         let source_path = change.uri.to_file_path().ok();
         let editable = match (&state.root, source_path) {
@@ -762,31 +771,33 @@ fn on_watched_source_change(state: &mut State, change: FileEvent) -> Result<(), 
             (Some(_), None) => false,
             (None, _) => true,
         };
-        reload_source_file(state, &change.uri, Some(editable))?;
+        reload_source_file(state, &change.uri, Some(editable))
     }
-
-    state.invalidate_workspace_symbols();
-    state.invalidate_suggestions_cache();
-    event::emit_collect_all_diagnostics(state)
 }
 
 fn reload_source_file(
     state: &mut State,
     uri: &Url,
     editable: Option<bool>,
-) -> Result<(), LspError> {
+) -> Result<bool, LspError> {
     let Ok(path) = uri.to_file_path() else {
-        return Ok(());
+        return Ok(false);
     };
     match fs::read_to_string(path) {
         Ok(content) => {
             on_change(state, uri.as_str(), &content, editable)?;
-            load_sibling_foreign(state, uri)
+            if let Err(error) = load_sibling_foreign(state, uri) {
+                tracing::warn!("Failed to reload sibling foreign file for {uri}: {error}");
+            }
+            Ok(true)
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             remove_source_file(state, uri)
         }
-        Err(error) => Err(error.into()),
+        Err(error) => {
+            tracing::warn!("Failed to reload {uri}: {error}");
+            Ok(false)
+        }
     }
 }
 
@@ -838,21 +849,14 @@ fn load_sibling_foreign(state: &mut State, source_uri: &Url) -> Result<(), LspEr
     let foreign_uri = Url::from_file_path(&foreign_path)
         .map_err(|()| LspError::PathParseFail(foreign_path.clone()))?;
 
-    let foreign_id = state.foreign_files.read().id(foreign_uri.as_str());
-    if let Some(foreign_id) = foreign_id {
-        let source_id = state.files.read().id(source_uri.as_str());
-        if let Some(source_id) = source_id {
-            state.engine.set_foreign_file(source_id, foreign_id);
+    match fs::read_to_string(foreign_path) {
+        Ok(content) => on_foreign_change(state, &foreign_uri, &content),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            remove_foreign_file(state, &foreign_uri);
+            Ok(())
         }
-        return Ok(());
+        Err(error) => Err(error.into()),
     }
-
-    if !foreign_path.is_file() {
-        return Ok(());
-    }
-
-    let content = fs::read_to_string(foreign_path)?;
-    on_foreign_change(state, &foreign_uri, &content)
 }
 
 fn emit_associated_diagnostics(state: &mut State, uri: Url) -> Result<(), LspError> {
@@ -894,10 +898,10 @@ fn remove_foreign_file(state: &mut State, uri: &Url) {
     state.engine.remove_foreign_file(foreign_id);
 }
 
-fn remove_source_file(state: &mut State, uri: &Url) -> Result<(), LspError> {
+fn remove_source_file(state: &mut State, uri: &Url) -> Result<bool, LspError> {
     let file_id = state.files.read().id(uri.as_str());
     let Some(file_id) = file_id else {
-        return Ok(());
+        return Ok(false);
     };
 
     state.engine.remove_file(file_id);
@@ -908,7 +912,7 @@ fn remove_source_file(state: &mut State, uri: &Url) -> Result<(), LspError> {
         diagnostics: Vec::new(),
         version: None,
     })?;
-    Ok(())
+    Ok(true)
 }
 
 fn on_change(

--- a/compiler-core/building/src/engine.rs
+++ b/compiler-core/building/src/engine.rs
@@ -800,10 +800,26 @@ impl QueryEngine {
     ) {
         for shard in &queries.inner {
             let mut queries = shard.write();
-            queries.retain(|query_file_id, state| {
-                *query_file_id != file_id
-                    && !state_references_removed_file(state, file_id, removed_modules)
+            let removed_query_file_ids = queries.iter().filter_map(|(query_file_id, state)| {
+                let remove = matches!(state, DerivedState::InProgress { .. })
+                    || *query_file_id == file_id
+                    || state_references_removed_file(state, file_id, removed_modules);
+                remove.then_some(*query_file_id)
             });
+            let removed_query_file_ids = removed_query_file_ids.collect::<Vec<_>>();
+            for query_file_id in removed_query_file_ids {
+                let state = queries
+                    .remove(&query_file_id)
+                    .expect("invariant violated: expected removable query state");
+                self.discard_query_state(state);
+            }
+        }
+    }
+
+    fn discard_query_state<T>(&self, state: DerivedState<T>) {
+        if let DerivedState::InProgress { id, waiters } = state {
+            let waiters = waiters.into_inner();
+            self.remove_waiter_edges(id, &waiters);
         }
     }
 
@@ -852,9 +868,16 @@ impl QueryEngine {
 
         for shard in &self.derived.checked_core.inner {
             let mut queries = shard.write();
-            queries.retain(|_, state| {
-                !state_references_removed_file(state, file_id, &removed_modules)
+            let remove = queries.get(&()).is_some_and(|state| {
+                matches!(state, DerivedState::InProgress { .. })
+                    || state_references_removed_file(state, file_id, &removed_modules)
             });
+            if remove {
+                let state = queries
+                    .remove(&())
+                    .expect("invariant violated: expected removable checked core state");
+                self.discard_query_state(state);
+            }
         }
 
         self.control.global.cancelled.store(false, Ordering::Relaxed);
@@ -1355,11 +1378,13 @@ mod tests {
     use building_types::{QueryError, QueryResult};
     use files::{FileId, Files, ForeignFiles};
     use foreign_javascript::ForeignError;
+    use parking_lot::Mutex;
     use resolving::ResolvedModule;
 
     use crate::prim;
 
-    use super::{DerivedState, QueryEngine, QueryKey, SnapshotId};
+    use super::promise::Future;
+    use super::{DerivedState, QueryEngine, QueryKey, SnapshotId, Waiter};
 
     #[derive(Debug)]
     struct Trace<'a> {
@@ -1641,6 +1666,25 @@ mod tests {
 
         let resolved = engine.resolved(main).unwrap();
         assert!(resolved.unqualified.contains_key("Library"));
+    }
+
+    #[test]
+    fn test_remove_file_discards_in_progress_waiter_edges() {
+        let engine = QueryEngine::default();
+        let file_id = FileId::new(0);
+        engine.set_content(file_id, "module Main where");
+
+        let computing = SnapshotId(1);
+        let waiting = SnapshotId(2);
+        let (_, promise) = Future::new();
+        let waiter = Waiter { id: waiting, promise };
+        let state = DerivedState::InProgress { id: computing, waiters: Mutex::new(vec![waiter]) };
+        engine.derived.parsed.shard(&file_id).write().insert(file_id, state);
+        assert!(engine.control.global.graph.lock().add_edge(waiting, computing));
+
+        engine.remove_file(file_id);
+
+        assert!(engine.control.global.graph.lock().add_edge(computing, waiting));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- batch diagnostics refreshes after watched PureScript source changes
- log transient source reload failures and continue processing watched-file batches
- remove waiter graph edges when stale in-progress query states are discarded

Follow-up to #358.

## Notes

Diagnostics remain workspace-wide because source changes can affect transitive importers and the query engine does not expose a reverse dependency set. This PR reduces a watched-file batch to one refresh rather than one refresh per file. The existing diagnostics flags specifically govern `textDocument` open, save, and change notifications, so external filesystem events remain unconditional.

## Verification

- cargo check --workspace --all-targets
- cargo nextest run -p building
- cargo nextest run -p purescript-alexandrite
- just format
- git diff --check