### PR TITLE
[lsp] Model source and foreign file lifecycle

### DIFF
--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -683,12 +683,16 @@ fn did_close(state: &mut State, p: DidCloseTextDocumentParams) -> Result<(), Lsp
         let event = LifecycleEvent::Foreign { unit, event: ForeignEvent::Closed { disk } };
         apply_lifecycle_event(state, event)
     } else {
+        let document = DocumentKey::Source(SourceUnitKey::clone(&unit));
+        let was_open = state.files.read().is_open(&document);
         let event = LifecycleEvent::Source {
             unit: SourceUnitKey::clone(&unit),
             event: SourceEvent::Closed { disk },
         };
         let mut change = apply_lifecycle_event(state, event);
-        change.combine(observe_sibling_foreign(state, &unit)?);
+        if was_open {
+            change.combine(observe_sibling_foreign(state, &unit)?);
+        }
         change
     };
     finish_lifecycle_change(state, &change)?;

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -3,11 +3,14 @@ pub mod error;
 pub mod event;
 pub mod extension;
 
+#[cfg(test)]
+mod tests;
+
 use std::borrow::BorrowMut;
 use std::ops::ControlFlow;
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock};
-use std::{env, fs, mem, process};
+use std::{env, fs, io, mem, process};
 
 use analyzer::completion::SuggestionsCache;
 use analyzer::position::PositionEncoding;
@@ -20,7 +23,11 @@ use async_lsp::router::Router;
 use async_lsp::server::LifecycleLayer;
 use async_lsp::{ClientSocket, LanguageClient, ResponseError};
 use building::QueryEngine;
-use files::{FileId, Files, ForeignFiles};
+use building::lifecycle::{
+    AnalysisInvalidation, DiskObservation, DocumentKey, FileLifecycle, ForeignEvent,
+    LifecycleChange, LifecycleEvent, ReloadFailure, SourceEvent, SourceUnitKey,
+};
+use files::FileId;
 use itertools::Itertools;
 use lsp_types::notification::Notification;
 use lsp_types::request::Request;
@@ -39,16 +46,27 @@ use crate::walk;
 static PRIM_DIRECTORY: LazyLock<TempDir> =
     LazyLock::new(|| TempDir::new().expect("invariant violated: failed to create PRIM_DIRECTORY"));
 
-fn configure_materialized_prim(engine: &QueryEngine, files: &mut Files) {
+fn configure_materialized_prim(engine: &QueryEngine, files: &mut FileLifecycle<i32, bool>) {
     for (name, content) in MODULE_MAP {
         let path = PRIM_DIRECTORY.path().join(format!("{name}.purs"));
         fs::write(&path, content).expect("invariant violated: failed to materialize Prim module");
 
         let uri = Url::from_file_path(path)
             .expect("invariant violated: failed to create Prim module file URL");
-        let id = files.insert(uri.as_str(), *content);
-
-        engine.set_content(id, *content);
+        let unit = source_unit_from_source_uri(&uri)
+            .expect("invariant violated: failed to create Prim source unit");
+        let event = LifecycleEvent::Source {
+            unit,
+            event: SourceEvent::DiskObserved {
+                disk: DiskObservation::Found(Arc::from(*content)),
+                metadata: false,
+            },
+        };
+        let change = files.apply(engine, event);
+        let id = change
+            .changed_sources()
+            .next()
+            .expect("invariant violated: Prim source lifecycle did not insert a source");
         engine.set_module_file(name, id);
     }
 }
@@ -66,8 +84,8 @@ pub struct State {
     pub client: ClientSocket,
 
     pub engine: QueryEngine,
-    pub files: Arc<RwLock<LspFiles>>,
-    pub foreign_files: Arc<RwLock<ForeignFiles>>,
+    pub files: Arc<RwLock<FileLifecycle<i32, bool>>>,
+    pub diagnostics: event::DiagnosticScheduler,
 
     pub workspace_symbols_cache: Arc<RwLock<WorkspaceSymbolsCache>>,
     pub suggestions_cache: Arc<RwLock<SuggestionsCache>>,
@@ -81,14 +99,11 @@ pub struct State {
 impl State {
     fn new(config: Arc<LspConfig>, client: ClientSocket) -> State {
         let engine = QueryEngine::default();
-        let mut files = Files::default();
+        let mut files = FileLifecycle::default();
         configure_materialized_prim(&engine, &mut files);
 
-        let files = LspFiles::new(files);
         let files = Arc::new(RwLock::new(files));
-
-        let foreign_files = ForeignFiles::default();
-        let foreign_files = Arc::new(RwLock::new(foreign_files));
+        let diagnostics = event::DiagnosticScheduler::default();
 
         let workspace_symbols_cache = WorkspaceSymbolsCache::default();
         let workspace_symbols_cache = Arc::new(RwLock::new(workspace_symbols_cache));
@@ -106,7 +121,7 @@ impl State {
             client,
             engine,
             files,
-            foreign_files,
+            diagnostics,
             workspace_symbols_cache,
             suggestions_cache,
             root,
@@ -121,7 +136,7 @@ impl State {
         T: Send + 'static,
     {
         let snapshot = StateSnapshot {
-            client: self.client.clone(),
+            client: ClientSocket::clone(&self.client),
             engine: self.engine.snapshot(),
             files: Arc::clone(&self.files),
             workspace_symbols_cache: Arc::clone(&self.workspace_symbols_cache),
@@ -146,7 +161,7 @@ impl State {
 struct StateSnapshot {
     client: ClientSocket,
     engine: QueryEngine,
-    files: Arc<RwLock<LspFiles>>,
+    files: Arc<RwLock<FileLifecycle<i32, bool>>>,
     workspace_symbols_cache: Arc<RwLock<WorkspaceSymbolsCache>>,
     suggestions_cache: Arc<RwLock<SuggestionsCache>>,
     position_encoding: PositionEncoding,
@@ -166,72 +181,9 @@ impl StateSnapshot {
     }
 }
 
-pub struct LspFiles {
-    files: Files,
-    editable: FxHashSet<FileId>,
-    open: FxHashSet<FileId>,
-}
-
-impl LspFiles {
-    fn new(files: Files) -> LspFiles {
-        LspFiles { files, editable: FxHashSet::default(), open: FxHashSet::default() }
-    }
-
-    fn id(&self, uri: &str) -> Option<FileId> {
-        self.files.id(uri)
-    }
-
-    fn contains(&self, file_id: FileId) -> bool {
-        self.files.contains(file_id)
-    }
-
-    fn path(&self, file_id: FileId) -> Option<Arc<str>> {
-        self.files.contains(file_id).then(|| self.files.path(file_id))
-    }
-
-    fn iter_id(&self) -> impl Iterator<Item = FileId> + '_ {
-        self.files.iter_id()
-    }
-
-    fn is_editable(&self, file_id: FileId) -> bool {
-        self.editable.contains(&file_id)
-    }
-
-    fn is_open(&self, uri: &str) -> bool {
-        self.id(uri).is_some_and(|file_id| self.open.contains(&file_id))
-    }
-
-    fn insert(&mut self, uri: &str, content: &str, editable: Option<bool>) -> FileId {
-        let file_id = self.files.insert(uri, content);
-        if let Some(editable) = editable {
-            if editable {
-                self.editable.insert(file_id);
-            } else {
-                self.editable.remove(&file_id);
-            }
-        }
-        file_id
-    }
-
-    fn open(&mut self, file_id: FileId) {
-        self.open.insert(file_id);
-    }
-
-    fn close(&mut self, file_id: FileId) {
-        self.open.remove(&file_id);
-    }
-
-    fn remove(&mut self, uri: &str) -> Option<FileId> {
-        let file_id = self.files.remove(uri)?;
-        self.editable.remove(&file_id);
-        self.open.remove(&file_id);
-        Some(file_id)
-    }
-}
-
 struct LspAnalyzerHost<'a> {
     queries: &'a QueryEngine,
-    files: RwLockReadGuard<'a, LspFiles>,
+    files: RwLockReadGuard<'a, FileLifecycle<i32, bool>>,
 }
 
 impl AnalyzerHost for LspAnalyzerHost<'_> {
@@ -242,22 +194,22 @@ impl AnalyzerHost for LspAnalyzerHost<'_> {
     }
 
     fn file_id(&self, uri: &str) -> Option<FileId> {
-        self.files.id(uri)
+        self.files.source_id(uri)
     }
 
     fn file_uri(&self, file_id: FileId) -> Result<Option<Url>, url::ParseError> {
-        let Some(uri) = self.files.path(file_id) else {
+        let Some(uri) = self.files.source_path(file_id) else {
             return Ok(None);
         };
         Url::parse(&uri).map(Some)
     }
 
     fn active_files(&self) -> impl Iterator<Item = FileId> {
-        self.files.iter_id()
+        self.files.source_ids()
     }
 
     fn is_editable(&self, file_id: FileId) -> bool {
-        self.files.is_editable(file_id)
+        self.files.source_metadata(file_id).copied().unwrap_or(false)
     }
 }
 
@@ -380,7 +332,7 @@ fn register_file_watcher(state: &State) {
     }
 
     let parameters = file_watcher_registration();
-    let mut client = state.client.clone();
+    let mut client = ClientSocket::clone(&state.client);
     task::spawn(async move {
         if let Err(error) = client.register_capability(parameters).await {
             tracing::warn!("Failed to register source file watcher: {error}");
@@ -416,7 +368,7 @@ fn exit(_state: &mut State, (): ()) -> Result<(), LspError> {
 }
 
 fn initialized_manual(state: &mut State, command: &str) -> Result<(), LspError> {
-    let root = state.root.clone().ok_or(LspError::MissingRoot)?;
+    let root = Option::clone(&state.root).ok_or(LspError::MissingRoot)?;
 
     tracing::info!("Using '{}'", command);
 
@@ -463,18 +415,26 @@ fn load_files(
     let files = files.into_iter().collect_vec();
     tracing::info!("Loading {} files.", files.len());
 
+    let mut lifecycle_change = LifecycleChange::default();
     for (file, editable) in &files {
         let url = url::Url::from_file_path(file).map_err(|_| {
             let file = PathBuf::clone(file);
             LspError::PathParseFail(file)
         })?;
 
-        let uri = url.to_string();
-
         let text = fs::read_to_string(file)?;
-        on_change(state, &uri, &text, Some(*editable))?;
-        load_sibling_foreign(state, &url)?;
+        let unit = source_unit_from_source_uri(&url)?;
+        let event = LifecycleEvent::Source {
+            unit: SourceUnitKey::clone(&unit),
+            event: SourceEvent::DiskObserved {
+                disk: DiskObservation::Found(Arc::from(text)),
+                metadata: *editable,
+            },
+        };
+        lifecycle_change.combine(apply_lifecycle_event(state, event));
+        lifecycle_change.combine(observe_sibling_foreign(state, &unit)?);
     }
+    finish_lifecycle_change(state, &lifecycle_change)?;
 
     tracing::info!("Loaded {} files.", files.len());
 
@@ -648,21 +608,32 @@ fn semantic_tokens(
 
 fn did_change(state: &mut State, p: DidChangeTextDocumentParams) -> Result<(), LspError> {
     let uri = &p.text_document.uri;
-
-    for content_change in &p.content_changes {
-        let text = content_change.text.as_str();
-        if is_javascript_uri(uri) {
-            on_foreign_change(state, uri, text)?;
-        } else {
-            on_change(state, uri.as_str(), text, None)?;
+    let Some(content_change) = p.content_changes.last() else {
+        return Ok(());
+    };
+    let unit = source_unit_from_document_uri(uri)?;
+    let event = if is_javascript_uri(uri) {
+        LifecycleEvent::Foreign {
+            unit,
+            event: ForeignEvent::Changed {
+                text: Arc::from(content_change.text.as_str()),
+                version: p.text_document.version,
+            },
         }
-    }
-
-    state.invalidate_workspace_symbols();
-    state.invalidate_suggestions_cache();
+    } else {
+        LifecycleEvent::Source {
+            unit,
+            event: SourceEvent::Changed {
+                text: Arc::from(content_change.text.as_str()),
+                version: p.text_document.version,
+            },
+        }
+    };
+    let change = apply_lifecycle_event(state, event);
+    finish_lifecycle_change(state, &change)?;
 
     if state.config.diagnostics_on_change {
-        emit_associated_diagnostics(state, p.text_document.uri)?;
+        emit_associated_diagnostics(state, Url::clone(&p.text_document.uri))?;
     }
 
     Ok(())
@@ -670,36 +641,35 @@ fn did_change(state: &mut State, p: DidChangeTextDocumentParams) -> Result<(), L
 
 fn did_open(state: &mut State, p: DidOpenTextDocumentParams) -> Result<(), LspError> {
     let uri = &p.text_document.uri;
-    let text = p.text_document.text.as_str();
+    let unit = source_unit_from_document_uri(uri)?;
 
-    if is_javascript_uri(uri) {
-        on_foreign_change(state, uri, text)?;
-        if state.config.diagnostics_on_open {
-            emit_associated_diagnostics(state, uri.clone())?;
-        }
-        return Ok(());
-    }
-
-    let editable = {
-        let files = state.files.read();
-        let previous_id = files.id(uri.as_str());
-        previous_id.map(|file_id| files.is_editable(file_id))
-    }
-    .unwrap_or_else(|| {
-        let Some(root) = state.root.as_ref() else {
-            return true;
+    let change = if is_javascript_uri(uri) {
+        let event = LifecycleEvent::Foreign {
+            unit,
+            event: ForeignEvent::Opened {
+                text: Arc::from(p.text_document.text.as_str()),
+                version: p.text_document.version,
+            },
         };
-        p.text_document.uri.to_file_path().is_ok_and(|path| path.starts_with(root))
-    });
-    let file_id = on_change(state, uri.as_str(), text, Some(editable))?;
-    state.files.write().open(file_id);
-    load_sibling_foreign(state, uri)?;
-
-    state.invalidate_workspace_symbols();
-    state.invalidate_suggestions_cache();
+        apply_lifecycle_event(state, event)
+    } else {
+        let editable = source_editable(state, &unit, uri);
+        let event = LifecycleEvent::Source {
+            unit: SourceUnitKey::clone(&unit),
+            event: SourceEvent::Opened {
+                text: Arc::from(p.text_document.text.as_str()),
+                version: p.text_document.version,
+                metadata: editable,
+            },
+        };
+        let mut change = apply_lifecycle_event(state, event);
+        change.combine(observe_sibling_foreign(state, &unit)?);
+        change
+    };
+    finish_lifecycle_change(state, &change)?;
 
     if state.config.diagnostics_on_open {
-        event::emit_collect_diagnostics(state, p.text_document.uri)?;
+        emit_associated_diagnostics(state, p.text_document.uri)?;
     }
 
     Ok(())
@@ -707,22 +677,25 @@ fn did_open(state: &mut State, p: DidOpenTextDocumentParams) -> Result<(), LspEr
 
 fn did_close(state: &mut State, p: DidCloseTextDocumentParams) -> Result<(), LspError> {
     let uri = p.text_document.uri;
-    if is_javascript_uri(&uri) {
-        return Ok(());
-    }
-
-    let file_id = state.files.read().id(uri.as_str());
-    let Some(file_id) = file_id else {
-        return Ok(());
+    let unit = source_unit_from_document_uri(&uri)?;
+    let disk = observe_disk(&uri);
+    let change = if is_javascript_uri(&uri) {
+        let event = LifecycleEvent::Foreign { unit, event: ForeignEvent::Closed { disk } };
+        apply_lifecycle_event(state, event)
+    } else {
+        let source_found = matches!(disk, DiskObservation::Found(_));
+        let event = LifecycleEvent::Source {
+            unit: SourceUnitKey::clone(&unit),
+            event: SourceEvent::Closed { disk },
+        };
+        let mut change = apply_lifecycle_event(state, event);
+        if source_found {
+            change.combine(observe_sibling_foreign(state, &unit)?);
+        }
+        change
     };
-    state.files.write().close(file_id);
-
-    let reloaded = reload_source_file(state, &uri, None)?;
-    state.invalidate_workspace_symbols();
-    state.invalidate_suggestions_cache();
-    if reloaded {
-        event::emit_collect_all_diagnostics(state)?;
-    }
+    finish_lifecycle_change(state, &change)?;
+    emit_diagnostics_for_change(state, &change)?;
     Ok(())
 }
 
@@ -739,92 +712,63 @@ fn did_change_watched_files(
     state: &mut State,
     p: DidChangeWatchedFilesParams,
 ) -> Result<(), LspError> {
-    let mut source_changed = false;
+    let mut source_units = FxHashSet::default();
+    let mut foreign_units = FxHashSet::default();
     for change in p.changes {
         if is_javascript_uri(&change.uri) {
-            on_watched_foreign_change(state, change)?;
+            foreign_units.insert(source_unit_from_foreign_uri(&change.uri)?);
         } else if is_purescript_uri(&change.uri) {
-            source_changed |= on_watched_source_change(state, change)?;
+            source_units.insert(source_unit_from_source_uri(&change.uri)?);
         }
     }
 
-    if source_changed {
-        state.invalidate_workspace_symbols();
-        state.invalidate_suggestions_cache();
-        event::emit_collect_all_diagnostics(state)?;
-    }
-
-    Ok(())
-}
-
-fn on_watched_source_change(state: &mut State, change: FileEvent) -> Result<bool, LspError> {
-    if state.files.read().is_open(change.uri.as_str()) {
-        return Ok(false);
-    }
-
-    if change.typ == FileChangeType::DELETED {
-        remove_source_file(state, &change.uri)
-    } else {
-        let source_path = change.uri.to_file_path().ok();
-        let editable = match (&state.root, source_path) {
-            (Some(root), Some(path)) => path.starts_with(root),
-            (Some(_), None) => false,
-            (None, _) => true,
+    let mut lifecycle_change = LifecycleChange::default();
+    let mut observed_foreign = FxHashSet::default();
+    for unit in source_units {
+        let document = DocumentKey::Source(SourceUnitKey::clone(&unit));
+        if state.files.read().is_open(&document) {
+            continue;
+        }
+        let uri = Url::parse(unit.source())?;
+        let disk = observe_disk(&uri);
+        let source_found = matches!(disk, DiskObservation::Found(_));
+        let metadata = source_editable(state, &unit, &uri);
+        let event = LifecycleEvent::Source {
+            unit: SourceUnitKey::clone(&unit),
+            event: SourceEvent::DiskObserved { disk, metadata },
         };
-        reload_source_file(state, &change.uri, Some(editable))
-    }
-}
-
-fn reload_source_file(
-    state: &mut State,
-    uri: &Url,
-    editable: Option<bool>,
-) -> Result<bool, LspError> {
-    let Ok(path) = uri.to_file_path() else {
-        return Ok(false);
-    };
-    match fs::read_to_string(path) {
-        Ok(content) => {
-            on_change(state, uri.as_str(), &content, editable)?;
-            if let Err(error) = load_sibling_foreign(state, uri) {
-                tracing::warn!("Failed to reload sibling foreign file for {uri}: {error}");
-            }
-            Ok(true)
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            remove_source_file(state, uri)
-        }
-        Err(error) => {
-            tracing::warn!("Failed to reload {uri}: {error}");
-            Ok(false)
-        }
-    }
-}
-
-fn on_watched_foreign_change(state: &mut State, change: FileEvent) -> Result<(), LspError> {
-    let Some(source_uri) = source_uri_from_foreign(&change.uri) else {
-        return Ok(());
-    };
-    let source_tracked = state.files.read().id(source_uri.as_str()).is_some();
-    if !source_tracked && state.foreign_files.read().id(change.uri.as_str()).is_none() {
-        return Ok(());
-    }
-
-    if change.typ == FileChangeType::DELETED {
-        remove_foreign_file(state, &change.uri);
-    } else if let Ok(path) = change.uri.to_file_path() {
-        match fs::read_to_string(path) {
-            Ok(content) => on_foreign_change(state, &change.uri, &content)?,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                remove_foreign_file(state, &change.uri);
-            }
-            Err(error) => return Err(error.into()),
+        lifecycle_change.combine(apply_lifecycle_event(state, event));
+        if source_found {
+            lifecycle_change.combine(observe_sibling_foreign(state, &unit)?);
+            observed_foreign.insert(unit);
         }
     }
 
-    if source_tracked {
-        event::emit_collect_diagnostics(state, source_uri)?;
+    for unit in foreign_units {
+        if observed_foreign.contains(&unit) {
+            continue;
+        }
+        let document = DocumentKey::Foreign(SourceUnitKey::clone(&unit));
+        if state.files.read().is_open(&document) {
+            continue;
+        }
+        let tracked = {
+            let files = state.files.read();
+            files.source_id(unit.source()).is_some() || files.foreign_id(unit.foreign()).is_some()
+        };
+        if !tracked {
+            continue;
+        }
+        let uri = Url::parse(unit.foreign())?;
+        let event = LifecycleEvent::Foreign {
+            unit,
+            event: ForeignEvent::DiskObserved { disk: observe_disk(&uri) },
+        };
+        lifecycle_change.combine(apply_lifecycle_event(state, event));
     }
+
+    finish_lifecycle_change(state, &lifecycle_change)?;
+    emit_diagnostics_for_change(state, &lifecycle_change)?;
     Ok(())
 }
 
@@ -836,124 +780,122 @@ fn is_purescript_uri(uri: &Url) -> bool {
     uri.path().ends_with(".purs")
 }
 
-fn source_uri_from_foreign(uri: &Url) -> Option<Url> {
-    let path = uri.to_file_path().ok()?;
-    Url::from_file_path(path.with_extension("purs")).ok()
+fn source_unit_from_document_uri(uri: &Url) -> Result<SourceUnitKey, LspError> {
+    if is_javascript_uri(uri) {
+        source_unit_from_foreign_uri(uri)
+    } else {
+        source_unit_from_source_uri(uri)
+    }
 }
 
-fn load_sibling_foreign(state: &mut State, source_uri: &Url) -> Result<(), LspError> {
-    let Ok(source_path) = source_uri.to_file_path() else {
-        return Ok(());
-    };
+fn source_unit_from_source_uri(source_uri: &Url) -> Result<SourceUnitKey, LspError> {
+    let source_path =
+        source_uri.to_file_path().map_err(|()| LspError::InvalidFileUri(Url::clone(source_uri)))?;
     let foreign_path = source_path.with_extension("js");
     let foreign_uri = Url::from_file_path(&foreign_path)
-        .map_err(|()| LspError::PathParseFail(foreign_path.clone()))?;
+        .map_err(|()| LspError::PathParseFail(PathBuf::clone(&foreign_path)))?;
+    Ok(SourceUnitKey::new(source_uri.as_str(), foreign_uri.as_str()))
+}
 
-    match fs::read_to_string(foreign_path) {
-        Ok(content) => on_foreign_change(state, &foreign_uri, &content),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            remove_foreign_file(state, &foreign_uri);
-            Ok(())
-        }
-        Err(error) => Err(error.into()),
-    }
+fn source_unit_from_foreign_uri(foreign_uri: &Url) -> Result<SourceUnitKey, LspError> {
+    let foreign_path = foreign_uri
+        .to_file_path()
+        .map_err(|()| LspError::InvalidFileUri(Url::clone(foreign_uri)))?;
+    let source_path = foreign_path.with_extension("purs");
+    let source_uri = Url::from_file_path(&source_path)
+        .map_err(|()| LspError::PathParseFail(PathBuf::clone(&source_path)))?;
+    source_unit_from_source_uri(&source_uri)
 }
 
 fn emit_associated_diagnostics(state: &mut State, uri: Url) -> Result<(), LspError> {
-    let uri = if is_javascript_uri(&uri) {
-        let Some(source_uri) = source_uri_from_foreign(&uri) else {
-            return Ok(());
-        };
-        source_uri
-    } else {
-        uri
-    };
-    event::emit_collect_diagnostics(state, uri)
+    let unit = source_unit_from_document_uri(&uri)?;
+    event::emit_collect_diagnostics(state, Url::parse(unit.source())?)
 }
 
-fn on_foreign_change(state: &mut State, uri: &Url, content: &str) -> Result<(), LspError> {
+fn apply_lifecycle_event(state: &mut State, event: LifecycleEvent<i32, bool>) -> LifecycleChange {
+    // Cancel in-flight queries so that threads holding a read lock over the
+    // lifecycle finish before this write waits for expensive LSP requests.
     state.engine.request_cancel();
+    state.files.write().apply(&state.engine, event)
+}
 
-    let foreign_id = state.foreign_files.write().insert(uri.as_str(), content);
-    state.engine.set_foreign_content(foreign_id, content);
-
-    let Some(source_uri) = source_uri_from_foreign(uri) else {
-        return Ok(());
-    };
-    let Some(source_id) = state.files.read().id(source_uri.as_str()) else {
-        return Ok(());
-    };
-
-    state.engine.set_foreign_file(source_id, foreign_id);
-
+fn finish_lifecycle_change(state: &mut State, change: &LifecycleChange) -> Result<(), LspError> {
+    state.diagnostics.invalidate(change, &state.files.read());
+    if !matches!(change.analysis(), AnalysisInvalidation::None) {
+        state.invalidate_workspace_symbols();
+        state.invalidate_suggestions_cache();
+    }
+    for warning in change.warnings() {
+        tracing::warn!("{warning}");
+    }
+    for removed in change.removed_sources() {
+        state.client.publish_diagnostics(PublishDiagnosticsParams {
+            uri: Url::parse(&removed.locator)?,
+            diagnostics: Vec::new(),
+            version: None,
+        })?;
+    }
     Ok(())
 }
 
-fn remove_foreign_file(state: &mut State, uri: &Url) {
-    let foreign_id = state.foreign_files.write().remove(uri.as_str());
-    let Some(foreign_id) = foreign_id else {
-        return;
-    };
-
-    state.engine.remove_foreign_file(foreign_id);
-}
-
-fn remove_source_file(state: &mut State, uri: &Url) -> Result<bool, LspError> {
-    let file_id = state.files.read().id(uri.as_str());
-    let Some(file_id) = file_id else {
-        return Ok(false);
-    };
-
-    state.engine.remove_file(file_id);
-    let removed_id = state.files.write().remove(uri.as_str());
-    debug_assert_eq!(removed_id, Some(file_id));
-    state.client.publish_diagnostics(PublishDiagnosticsParams {
-        uri: uri.clone(),
-        diagnostics: Vec::new(),
-        version: None,
-    })?;
-    Ok(true)
-}
-
-fn on_change(
+fn observe_sibling_foreign(
     state: &mut State,
-    uri: &str,
-    content: &str,
-    editable: Option<bool>,
-) -> Result<FileId, LspError> {
-    let previous_id = state.files.read().id(uri);
-    let previous_name = if let Some(id) = previous_id {
-        let previous_content = state.engine.content(id)?;
-        let (parsed, _) = state.engine.parsed(id)?;
-        parsed.module_name(&previous_content)
-    } else {
-        None
+    unit: &SourceUnitKey,
+) -> Result<LifecycleChange, LspError> {
+    let document = DocumentKey::Foreign(SourceUnitKey::clone(unit));
+    if state.files.read().is_open(&document) {
+        return Ok(LifecycleChange::default());
+    }
+    let uri = Url::parse(unit.foreign())?;
+    let event = LifecycleEvent::Foreign {
+        unit: SourceUnitKey::clone(unit),
+        event: ForeignEvent::DiskObserved { disk: observe_disk(&uri) },
     };
+    Ok(apply_lifecycle_event(state, event))
+}
 
-    // Cancel in-flight queries so that threads holding a read lock
-    // over `files` are terminated quickly, compared to having to
-    // wait for expensive LSP requests to complete successfully.
-    state.engine.request_cancel();
-
-    let mut files = state.files.write();
-    let id = files.insert(uri, content, editable);
-
-    state.engine.set_content(id, content);
-
-    let (parsed, _) = state.engine.parsed(id)?;
-    let current_name = parsed.module_name(content);
-
-    if previous_name != current_name
-        && let Some(previous_name) = previous_name
-    {
-        state.engine.remove_module_file(&previous_name, id);
+fn observe_disk(uri: &Url) -> DiskObservation {
+    let Ok(path) = uri.to_file_path() else {
+        let message = format!("expected a file URI, received {uri}");
+        return DiskObservation::Failed(ReloadFailure::new(io::ErrorKind::InvalidInput, message));
+    };
+    match fs::read_to_string(path) {
+        Ok(content) => DiskObservation::Found(Arc::from(content)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => DiskObservation::NotFound,
+        Err(error) => {
+            let kind = error.kind();
+            DiskObservation::Failed(ReloadFailure::new(kind, error.to_string()))
+        }
     }
+}
 
-    if let Some(name) = current_name {
-        state.engine.set_module_file(&name, id);
+fn source_editable(state: &State, unit: &SourceUnitKey, uri: &Url) -> bool {
+    let previous = {
+        let files = state.files.read();
+        let file_id = files.source_id(unit.source());
+        file_id.and_then(|file_id| files.source_metadata(file_id)).copied()
+    };
+    previous.unwrap_or_else(|| match (&state.root, uri.to_file_path()) {
+        (Some(root), Ok(path)) => path.starts_with(root),
+        (Some(_), Err(())) => false,
+        (None, _) => true,
+    })
+}
+
+fn emit_diagnostics_for_change(
+    state: &mut State,
+    change: &LifecycleChange,
+) -> Result<(), LspError> {
+    match change.analysis() {
+        AnalysisInvalidation::None => Ok(()),
+        AnalysisInvalidation::Sources(sources) => {
+            for file_id in sources {
+                event::emit_collect_diagnostics_id(state, *file_id)?;
+            }
+            Ok(())
+        }
+        AnalysisInvalidation::Workspace => event::emit_collect_all_diagnostics(state),
     }
-
-    Ok(id)
 }
 
 trait RequestExtension: BorrowMut<Router<State>> {
@@ -1033,7 +975,8 @@ pub async fn async_start(config: Arc<LspConfig>) {
             .notification_ext::<notification::DidChangeConfiguration>(|_, _| Ok(()))
             .notification_ext::<notification::DidChangeTextDocument>(did_change)
             .notification_ext::<notification::DidChangeWatchedFiles>(did_change_watched_files)
-            .event_ext::<event::CollectDiagnostics>(event::collect_diagnostics);
+            .event_ext::<event::CollectDiagnostics>(event::collect_diagnostics)
+            .event_ext::<event::DiagnosticsFinished>(event::finish_diagnostics);
 
         ServiceBuilder::new()
             .layer(LifecycleLayer::default())

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -136,7 +136,6 @@ impl State {
         T: Send + 'static,
     {
         let snapshot = StateSnapshot {
-            client: ClientSocket::clone(&self.client),
             engine: self.engine.snapshot(),
             files: Arc::clone(&self.files),
             workspace_symbols_cache: Arc::clone(&self.workspace_symbols_cache),
@@ -159,7 +158,6 @@ impl State {
 }
 
 struct StateSnapshot {
-    client: ClientSocket,
     engine: QueryEngine,
     files: Arc<RwLock<FileLifecycle<i32, bool>>>,
     workspace_symbols_cache: Arc<RwLock<WorkspaceSymbolsCache>>,

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -788,23 +788,33 @@ fn source_unit_from_document_uri(uri: &Url) -> Result<SourceUnitKey, LspError> {
     }
 }
 
+fn file_uri_with_extension(uri: &Url, extension: &str) -> Result<Url, LspError> {
+    if uri.scheme() != "file" || uri.to_file_path().is_err() {
+        return Err(LspError::InvalidFileUri(Url::clone(uri)));
+    }
+    let uri_path = uri.path();
+    let file_name_start = uri_path.rfind('/').map_or(0, |index| index + 1);
+    let extension_start = uri_path[file_name_start..]
+        .rfind('.')
+        .filter(|index| *index > 0)
+        .map_or(uri_path.len(), |index| file_name_start + index);
+    let mut sibling_path = String::from(&uri_path[..extension_start]);
+    sibling_path.push('.');
+    sibling_path.push_str(extension);
+
+    let mut sibling_uri = Url::clone(uri);
+    sibling_uri.set_path(&sibling_path);
+    Ok(sibling_uri)
+}
+
 fn source_unit_from_source_uri(source_uri: &Url) -> Result<SourceUnitKey, LspError> {
-    let source_path =
-        source_uri.to_file_path().map_err(|()| LspError::InvalidFileUri(Url::clone(source_uri)))?;
-    let foreign_path = source_path.with_extension("js");
-    let foreign_uri = Url::from_file_path(&foreign_path)
-        .map_err(|()| LspError::PathParseFail(PathBuf::clone(&foreign_path)))?;
+    let foreign_uri = file_uri_with_extension(source_uri, "js")?;
     Ok(SourceUnitKey::new(source_uri.as_str(), foreign_uri.as_str()))
 }
 
 fn source_unit_from_foreign_uri(foreign_uri: &Url) -> Result<SourceUnitKey, LspError> {
-    let foreign_path = foreign_uri
-        .to_file_path()
-        .map_err(|()| LspError::InvalidFileUri(Url::clone(foreign_uri)))?;
-    let source_path = foreign_path.with_extension("purs");
-    let source_uri = Url::from_file_path(&source_path)
-        .map_err(|()| LspError::PathParseFail(PathBuf::clone(&source_path)))?;
-    source_unit_from_source_uri(&source_uri)
+    let source_uri = file_uri_with_extension(foreign_uri, "purs")?;
+    Ok(SourceUnitKey::new(source_uri.as_str(), foreign_uri.as_str()))
 }
 
 fn emit_associated_diagnostics(state: &mut State, uri: Url) -> Result<(), LspError> {
@@ -855,10 +865,7 @@ fn observe_sibling_foreign(
 }
 
 fn observe_disk(uri: &Url) -> DiskObservation {
-    let Ok(path) = uri.to_file_path() else {
-        let message = format!("expected a file URI, received {uri}");
-        return DiskObservation::Failed(ReloadFailure::new(io::ErrorKind::InvalidInput, message));
-    };
+    let path = uri.to_file_path().expect("invariant violated: expected a valid file URI");
     match fs::read_to_string(path) {
         Ok(content) => DiskObservation::Found(Arc::from(content)),
         Err(error) if error.kind() == io::ErrorKind::NotFound => DiskObservation::NotFound,

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -683,15 +683,12 @@ fn did_close(state: &mut State, p: DidCloseTextDocumentParams) -> Result<(), Lsp
         let event = LifecycleEvent::Foreign { unit, event: ForeignEvent::Closed { disk } };
         apply_lifecycle_event(state, event)
     } else {
-        let source_found = matches!(disk, DiskObservation::Found(_));
         let event = LifecycleEvent::Source {
             unit: SourceUnitKey::clone(&unit),
             event: SourceEvent::Closed { disk },
         };
         let mut change = apply_lifecycle_event(state, event);
-        if source_found {
-            change.combine(observe_sibling_foreign(state, &unit)?);
-        }
+        change.combine(observe_sibling_foreign(state, &unit)?);
         change
     };
     finish_lifecycle_change(state, &change)?;

--- a/compiler-bin/src/lsp/error.rs
+++ b/compiler-bin/src/lsp/error.rs
@@ -4,6 +4,7 @@ use std::{io, str};
 use analyzer::AnalyzerError;
 use async_lsp::ErrorCode;
 use building::QueryError;
+use lsp_types::Url;
 use spago::LockfileGlobSetError;
 use thiserror::Error;
 use tokio::task;
@@ -18,6 +19,10 @@ pub enum LspError {
     QueryError(#[from] QueryError),
     #[error("Failed to parse file {0}")]
     PathParseFail(PathBuf),
+    #[error("Expected a file URI, received {0}")]
+    InvalidFileUri(Url),
+    #[error("UrlParseError: {0}")]
+    UrlParseError(#[from] url::ParseError),
     #[error("Invalid or missing workspace root")]
     MissingRoot,
     #[error("Invalid or missing --source-command")]

--- a/compiler-bin/src/lsp/event.rs
+++ b/compiler-bin/src/lsp/event.rs
@@ -1,24 +1,129 @@
+use std::collections::hash_map::Entry;
+
+use analyzer::diagnostics::CollectedDiagnostics;
 use async_lsp::LanguageClient;
+use building::lifecycle::{AnalysisInvalidation, FileLifecycle, LifecycleChange};
 use files::FileId;
 use lsp_types::{PublishDiagnosticsParams, Url};
+use rustc_hash::FxHashMap;
 
 use crate::lsp::error::LspError;
 use crate::lsp::{State, StateSnapshot};
+
+#[derive(Default)]
+pub struct DiagnosticScheduler {
+    generations: FxHashMap<FileId, u64>,
+    jobs: FxHashMap<FileId, DiagnosticJob>,
+}
+
+struct DiagnosticJob {
+    running: DiagnosticTicket,
+    queued: Option<DiagnosticTicket>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DiagnosticTicket {
+    file_id: FileId,
+    generation: u64,
+    version: Option<i32>,
+}
+
+impl DiagnosticScheduler {
+    pub fn invalidate(&mut self, change: &LifecycleChange, files: &FileLifecycle<i32, bool>) {
+        match change.analysis() {
+            AnalysisInvalidation::None => {}
+            AnalysisInvalidation::Sources(sources) => {
+                for file_id in sources {
+                    self.invalidate_source(*file_id);
+                }
+            }
+            AnalysisInvalidation::Workspace => {
+                let source_ids = files.source_ids();
+                let source_ids = source_ids.collect::<Vec<_>>();
+                for file_id in source_ids {
+                    self.invalidate_source(file_id);
+                }
+            }
+        }
+        for removed in change.removed_sources() {
+            self.invalidate_source(removed.file_id);
+        }
+    }
+
+    fn invalidate_source(&mut self, file_id: FileId) {
+        let generation = self.generations.entry(file_id).or_default();
+        *generation = generation
+            .checked_add(1)
+            .expect("invariant violated: diagnostic generation overflowed");
+        if let Some(job) = self.jobs.get_mut(&file_id) {
+            job.queued = None;
+        }
+    }
+
+    fn schedule(&mut self, file_id: FileId, version: Option<i32>) -> Option<DiagnosticTicket> {
+        let generation = self.generations.get(&file_id).copied().unwrap_or_default();
+        let ticket = DiagnosticTicket { file_id, generation, version };
+        match self.jobs.entry(file_id) {
+            Entry::Vacant(entry) => {
+                entry.insert(DiagnosticJob { running: ticket, queued: None });
+                Some(ticket)
+            }
+            Entry::Occupied(mut entry) => {
+                let job = entry.get_mut();
+                if job.running != ticket && job.queued != Some(ticket) {
+                    job.queued = Some(ticket);
+                }
+                None
+            }
+        }
+    }
+
+    fn is_running(&self, ticket: DiagnosticTicket) -> bool {
+        self.jobs.get(&ticket.file_id).is_some_and(|job| job.running == ticket)
+    }
+
+    fn is_current(&self, ticket: DiagnosticTicket) -> bool {
+        self.generations.get(&ticket.file_id).copied().unwrap_or_default() == ticket.generation
+    }
+
+    fn complete(&mut self, ticket: DiagnosticTicket) -> Option<DiagnosticTicket> {
+        let job = self.jobs.get_mut(&ticket.file_id)?;
+        if job.running != ticket {
+            return None;
+        }
+        let next = job.queued.take();
+        if let Some(next) = next {
+            job.running = next;
+        } else {
+            self.jobs.remove(&ticket.file_id);
+        }
+        next
+    }
+}
 
 pub fn emit_collect_diagnostics(state: &mut State, uri: Url) -> Result<(), LspError> {
     let files = state.files.read();
     let uri = uri.as_str();
 
-    if let Some(file_id) = files.id(uri) {
+    if let Some(file_id) = files.source_id(uri) {
         state.client.emit(CollectDiagnostics(file_id))?;
     }
 
     Ok(())
 }
 
+pub fn emit_collect_diagnostics_id(state: &mut State, file_id: FileId) -> Result<(), LspError> {
+    if state.files.read().contains_source(file_id) {
+        state.client.emit(CollectDiagnostics(file_id))?;
+    }
+    Ok(())
+}
+
 pub fn emit_collect_all_diagnostics(state: &mut State) -> Result<(), LspError> {
     let files = state.files.read();
-    let editable_files = files.iter_id().filter(|file_id| files.is_editable(*file_id));
+    let editable_files = files
+        .source_ids()
+        .filter(|file_id| files.source_metadata(*file_id).copied().unwrap_or(false));
     for file_id in editable_files {
         state.client.emit(CollectDiagnostics(file_id))?;
     }
@@ -27,29 +132,153 @@ pub fn emit_collect_all_diagnostics(state: &mut State) -> Result<(), LspError> {
 
 pub struct CollectDiagnostics(FileId);
 
-pub fn collect_diagnostics(state: &mut State, id: CollectDiagnostics) -> Result<(), LspError> {
-    if !state.files.read().contains(id.0) {
-        return Ok(());
+pub fn collect_diagnostics(
+    state: &mut State,
+    CollectDiagnostics(file_id): CollectDiagnostics,
+) -> Result<(), LspError> {
+    let version = {
+        let files = state.files.read();
+        if !files.contains_source(file_id) {
+            return Ok(());
+        }
+        files.source_version(file_id)
+    };
+    if let Some(ticket) = state.diagnostics.schedule(file_id, version) {
+        start_diagnostics(state, ticket);
     }
-    state.spawn(move |snapshot| {
-        let _span = tracing::info_span!("collect_diagnostics").entered();
-        collect_diagnostics_core(snapshot, id).inspect_err(|error| error.emit_trace())
-    });
     Ok(())
 }
 
-fn collect_diagnostics_core(
-    mut snapshot: StateSnapshot,
-    CollectDiagnostics(id): CollectDiagnostics,
+fn start_diagnostics(state: &State, ticket: DiagnosticTicket) {
+    state.spawn(move |snapshot| {
+        let _span = tracing::info_span!("collect_diagnostics").entered();
+        collect_diagnostics_core(snapshot, ticket);
+    });
+}
+
+fn collect_diagnostics_core(snapshot: StateSnapshot, ticket: DiagnosticTicket) {
+    let result = snapshot.with_analyzer_context(|context| {
+        analyzer::diagnostics::implementation(context, ticket.file_id)
+    });
+    let collected = match result {
+        Ok(collected) => Some(collected),
+        Err(error) => {
+            LspError::from(error).emit_trace();
+            None
+        }
+    };
+    let event = DiagnosticsFinished { ticket, collected };
+    if let Err(error) = snapshot.client.emit(event) {
+        LspError::from(error).emit_trace();
+    }
+}
+
+pub struct DiagnosticsFinished {
+    ticket: DiagnosticTicket,
+    collected: Option<CollectedDiagnostics>,
+}
+
+pub fn finish_diagnostics(
+    state: &mut State,
+    DiagnosticsFinished { ticket, collected }: DiagnosticsFinished,
 ) -> Result<(), LspError> {
-    let collected = snapshot
-        .with_analyzer_context(|context| analyzer::diagnostics::implementation(context, id))?;
+    let running = state.diagnostics.is_running(ticket);
+    let current = running && state.diagnostics.is_current(ticket) && {
+        let files = state.files.read();
+        files.contains_source(ticket.file_id)
+            && files.source_version(ticket.file_id) == ticket.version
+    };
+    let next = state.diagnostics.complete(ticket);
 
-    snapshot.client.publish_diagnostics(PublishDiagnosticsParams {
-        uri: collected.uri,
-        diagnostics: collected.diagnostics,
-        version: None,
-    })?;
+    let publish_result = if current && let Some(collected) = collected {
+        state.client.publish_diagnostics(PublishDiagnosticsParams {
+            uri: collected.uri,
+            diagnostics: collected.diagnostics,
+            version: ticket.version,
+        })
+    } else {
+        Ok(())
+    };
+    if let Some(next) = next {
+        start_diagnostics(state, next);
+    }
+    publish_result.map_err(LspError::from)
+}
 
-    Ok(())
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use building::QueryEngine;
+    use building::lifecycle::{
+        DiskObservation, FileLifecycle, LifecycleEvent, SourceEvent, SourceUnitKey,
+    };
+    use files::Files;
+
+    use super::DiagnosticScheduler;
+
+    fn file_id() -> files::FileId {
+        let mut files = Files::default();
+        files.insert("file:///src/Main.purs", "module Main where\n")
+    }
+
+    #[test]
+    fn coalesces_requests_to_the_latest_generation() {
+        let file_id = file_id();
+        let mut scheduler = DiagnosticScheduler::default();
+        let first = scheduler.schedule(file_id, Some(1)).unwrap();
+
+        scheduler.invalidate_source(file_id);
+        assert_eq!(scheduler.schedule(file_id, Some(2)), None);
+        let queued = scheduler.jobs[&file_id].queued.unwrap();
+        assert_eq!(queued.version, Some(2));
+
+        assert_eq!(scheduler.complete(first), Some(queued));
+        assert!(scheduler.is_running(queued));
+    }
+
+    #[test]
+    fn invalidation_discards_a_queued_stale_request() {
+        let file_id = file_id();
+        let mut scheduler = DiagnosticScheduler::default();
+        let first = scheduler.schedule(file_id, Some(1)).unwrap();
+        scheduler.invalidate_source(file_id);
+        scheduler.schedule(file_id, Some(2));
+
+        scheduler.invalidate_source(file_id);
+        assert_eq!(scheduler.jobs[&file_id].queued, None);
+        assert_eq!(scheduler.complete(first), None);
+        assert!(!scheduler.is_current(first));
+    }
+
+    #[test]
+    fn workspace_change_invalidates_unrelated_running_diagnostics() {
+        let engine = QueryEngine::default();
+        let mut lifecycle = FileLifecycle::default();
+        let first_unit = SourceUnitKey::new("file:///src/Main.purs", "file:///src/Main.js");
+        let event = LifecycleEvent::Source {
+            unit: first_unit,
+            event: SourceEvent::DiskObserved {
+                disk: DiskObservation::Found(Arc::from("module Main where\n")),
+                metadata: true,
+            },
+        };
+        lifecycle.apply(&engine, event);
+        let first_id = lifecycle.source_id("file:///src/Main.purs").unwrap();
+
+        let mut scheduler = DiagnosticScheduler::default();
+        let ticket = scheduler.schedule(first_id, None).unwrap();
+        let second_unit = SourceUnitKey::new("file:///src/Library.purs", "file:///src/Library.js");
+        let event = LifecycleEvent::Source {
+            unit: second_unit,
+            event: SourceEvent::DiskObserved {
+                disk: DiskObservation::Found(Arc::from("module Library where\n")),
+                metadata: true,
+            },
+        };
+        let change = lifecycle.apply(&engine, event);
+        scheduler.invalidate(&change, &lifecycle);
+
+        assert!(!scheduler.is_current(ticket));
+    }
 }

--- a/compiler-bin/src/lsp/event.rs
+++ b/compiler-bin/src/lsp/event.rs
@@ -1,11 +1,12 @@
 use std::collections::hash_map::Entry;
 
 use analyzer::diagnostics::CollectedDiagnostics;
-use async_lsp::LanguageClient;
+use async_lsp::{ClientSocket, LanguageClient};
 use building::lifecycle::{AnalysisInvalidation, FileLifecycle, LifecycleChange};
 use files::FileId;
 use lsp_types::{PublishDiagnosticsParams, Url};
 use rustc_hash::FxHashMap;
+use tokio::task;
 
 use crate::lsp::error::LspError;
 use crate::lsp::{State, StateSnapshot};
@@ -150,26 +151,45 @@ pub fn collect_diagnostics(
 }
 
 fn start_diagnostics(state: &State, ticket: DiagnosticTicket) {
-    state.spawn(move |snapshot| {
+    let worker = state.spawn(move |snapshot| {
         let _span = tracing::info_span!("collect_diagnostics").entered();
-        collect_diagnostics_core(snapshot, ticket);
+        collect_diagnostics_core(snapshot, ticket)
+    });
+    let client = ClientSocket::clone(&state.client);
+    task::spawn(async move {
+        let collected = await_diagnostics(worker).await;
+        let event = DiagnosticsFinished { ticket, collected };
+        if let Err(error) = client.emit(event) {
+            LspError::from(error).emit_trace();
+        }
     });
 }
 
-fn collect_diagnostics_core(snapshot: StateSnapshot, ticket: DiagnosticTicket) {
+fn collect_diagnostics_core(
+    snapshot: StateSnapshot,
+    ticket: DiagnosticTicket,
+) -> Option<CollectedDiagnostics> {
     let result = snapshot.with_analyzer_context(|context| {
         analyzer::diagnostics::implementation(context, ticket.file_id)
     });
-    let collected = match result {
+    match result {
         Ok(collected) => Some(collected),
         Err(error) => {
             LspError::from(error).emit_trace();
             None
         }
-    };
-    let event = DiagnosticsFinished { ticket, collected };
-    if let Err(error) = snapshot.client.emit(event) {
-        LspError::from(error).emit_trace();
+    }
+}
+
+async fn await_diagnostics(
+    worker: task::JoinHandle<Option<CollectedDiagnostics>>,
+) -> Option<CollectedDiagnostics> {
+    match worker.await {
+        Ok(collected) => collected,
+        Err(error) => {
+            LspError::JoinError(error).emit_trace();
+            None
+        }
     }
 }
 
@@ -215,7 +235,7 @@ mod tests {
     };
     use files::Files;
 
-    use super::DiagnosticScheduler;
+    use super::{DiagnosticScheduler, await_diagnostics};
 
     fn file_id() -> files::FileId {
         let mut files = Files::default();
@@ -280,5 +300,16 @@ mod tests {
         scheduler.invalidate(&change, &lifecycle);
 
         assert!(!scheduler.is_current(ticket));
+    }
+
+    #[tokio::test]
+    async fn failed_diagnostics_worker_returns_no_result() {
+        let worker = tokio::spawn(async {
+            panic!("diagnostics worker failed");
+            #[allow(unreachable_code)]
+            None
+        });
+
+        assert!(await_diagnostics(worker).await.is_none());
     }
 }

--- a/compiler-bin/src/lsp/tests.rs
+++ b/compiler-bin/src/lsp/tests.rs
@@ -1,0 +1,45 @@
+use std::{fs, io};
+
+use building::lifecycle::DiskObservation;
+use lsp_types::Url;
+use tempfile::tempdir;
+
+use super::{observe_disk, source_unit_from_foreign_uri, source_unit_from_source_uri};
+
+#[test]
+fn source_and_foreign_uris_produce_the_same_unit_key() {
+    let directory = tempdir().unwrap();
+    let source_path = directory.path().join("Source Files").join("Main.purs");
+    let foreign_path = source_path.with_extension("js");
+    let source_uri = Url::from_file_path(source_path).unwrap();
+    let foreign_uri = Url::from_file_path(foreign_path).unwrap();
+
+    let from_source = source_unit_from_source_uri(&source_uri).unwrap();
+    let from_foreign = source_unit_from_foreign_uri(&foreign_uri).unwrap();
+
+    assert_eq!(from_source, from_foreign);
+    assert_eq!(from_source.source(), source_uri.as_str());
+    assert_eq!(from_source.foreign(), foreign_uri.as_str());
+}
+
+#[test]
+fn disk_observation_distinguishes_content_absence_and_invalid_locators() {
+    let directory = tempdir().unwrap();
+    let source_path = directory.path().join("Main.purs");
+    let source_uri = Url::from_file_path(&source_path).unwrap();
+
+    fs::write(&source_path, "module Main where\n").unwrap();
+    assert!(matches!(
+        observe_disk(&source_uri),
+        DiskObservation::Found(content) if content.as_ref() == "module Main where\n"
+    ));
+
+    fs::remove_file(source_path).unwrap();
+    assert_eq!(observe_disk(&source_uri), DiskObservation::NotFound);
+
+    let invalid_uri = Url::parse("untitled:Main.purs").unwrap();
+    assert!(matches!(
+        observe_disk(&invalid_uri),
+        DiskObservation::Failed(failure) if failure.kind() == io::ErrorKind::InvalidInput
+    ));
+}

--- a/compiler-bin/src/lsp/tests.rs
+++ b/compiler-bin/src/lsp/tests.rs
@@ -1,4 +1,4 @@
-use std::{fs, io};
+use std::fs;
 
 use building::lifecycle::DiskObservation;
 use lsp_types::Url;
@@ -23,7 +23,28 @@ fn source_and_foreign_uris_produce_the_same_unit_key() {
 }
 
 #[test]
-fn disk_observation_distinguishes_content_absence_and_invalid_locators() {
+fn localhost_source_and_foreign_uris_keep_the_same_authority() {
+    let source_uri =
+        Url::parse("file://localhost/workspace/Source%20Files/Main.purs?view=1#selection").unwrap();
+    let foreign_uri =
+        Url::parse("file://localhost/workspace/Source%20Files/Main.js?view=1#selection").unwrap();
+
+    let from_source = source_unit_from_source_uri(&source_uri).unwrap();
+    let from_foreign = source_unit_from_foreign_uri(&foreign_uri).unwrap();
+
+    assert_eq!(from_source, from_foreign);
+    assert_eq!(from_source.source(), source_uri.as_str());
+    assert_eq!(from_source.foreign(), foreign_uri.as_str());
+}
+
+#[test]
+fn non_file_document_uris_are_rejected() {
+    let source_uri = Url::parse("untitled:Main.purs").unwrap();
+    assert!(source_unit_from_source_uri(&source_uri).is_err());
+}
+
+#[test]
+fn disk_observation_distinguishes_content_and_absence() {
     let directory = tempdir().unwrap();
     let source_path = directory.path().join("Main.purs");
     let source_uri = Url::from_file_path(&source_path).unwrap();
@@ -36,10 +57,4 @@ fn disk_observation_distinguishes_content_absence_and_invalid_locators() {
 
     fs::remove_file(source_path).unwrap();
     assert_eq!(observe_disk(&source_uri), DiskObservation::NotFound);
-
-    let invalid_uri = Url::parse("untitled:Main.purs").unwrap();
-    assert!(matches!(
-        observe_disk(&invalid_uri),
-        DiskObservation::Failed(failure) if failure.kind() == io::ErrorKind::InvalidInput
-    ));
 }

--- a/compiler-bin/src/lsp/tests.rs
+++ b/compiler-bin/src/lsp/tests.rs
@@ -1,10 +1,64 @@
 use std::fs;
+use std::sync::Arc;
 
-use building::lifecycle::DiskObservation;
-use lsp_types::Url;
+use async_lsp::ResponseError;
+use async_lsp::router::Router;
+use building::lifecycle::{
+    ContentAuthority, DiskObservation, ForeignEvent, LifecycleEvent, SourceEvent, SourceUnitKey,
+};
+use lsp_types::{DidCloseTextDocumentParams, TextDocumentIdentifier, Url};
 use tempfile::tempdir;
 
-use super::{observe_disk, source_unit_from_foreign_uri, source_unit_from_source_uri};
+use super::{
+    LspConfig, State, apply_lifecycle_event, did_close, observe_disk, source_unit_from_foreign_uri,
+    source_unit_from_source_uri,
+};
+
+fn assert_source_close_result(
+    source_uri: Url,
+    foreign_uri: Url,
+    source_authority: Option<ContentAuthority>,
+) {
+    let unit = source_unit_from_source_uri(&source_uri).unwrap();
+    let config = Arc::new(LspConfig {
+        source_command: None,
+        diagnostics_on_open: false,
+        diagnostics_on_save: false,
+        diagnostics_on_change: false,
+    });
+
+    let (_server, _) = async_lsp::MainLoop::new_server(move |client| {
+        let mut state = State::new(Arc::clone(&config), client);
+        let event = LifecycleEvent::Source {
+            unit: SourceUnitKey::clone(&unit),
+            event: SourceEvent::Opened {
+                text: Arc::from("module Main where\n"),
+                version: 1,
+                metadata: true,
+            },
+        };
+        apply_lifecycle_event(&mut state, event);
+        let event = LifecycleEvent::Foreign {
+            unit: SourceUnitKey::clone(&unit),
+            event: ForeignEvent::DiskObserved {
+                disk: DiskObservation::Found(Arc::from("export const life = 42;\n")),
+            },
+        };
+        apply_lifecycle_event(&mut state, event);
+
+        let parameters = DidCloseTextDocumentParams {
+            text_document: TextDocumentIdentifier { uri: Url::clone(&source_uri) },
+        };
+        did_close(&mut state, parameters).unwrap();
+
+        let files = state.files.read();
+        assert_eq!(files.source_authority(&unit), source_authority);
+        assert_eq!(files.foreign_id(foreign_uri.as_str()), None);
+        drop(files);
+
+        Router::<State, ResponseError>::new(state)
+    });
+}
 
 #[test]
 fn source_and_foreign_uris_produce_the_same_unit_key() {
@@ -41,6 +95,27 @@ fn localhost_source_and_foreign_uris_keep_the_same_authority() {
 fn non_file_document_uris_are_rejected() {
     let source_uri = Url::parse("untitled:Main.purs").unwrap();
     assert!(source_unit_from_source_uri(&source_uri).is_err());
+}
+
+#[test]
+fn closing_a_deleted_source_also_removes_its_deleted_disk_foreign() {
+    let directory = tempdir().unwrap();
+    let source_path = directory.path().join("Main.purs");
+    let foreign_path = source_path.with_extension("js");
+    let source_uri = Url::from_file_path(source_path).unwrap();
+    let foreign_uri = Url::from_file_path(foreign_path).unwrap();
+    assert_source_close_result(source_uri, foreign_uri, None);
+}
+
+#[test]
+fn failed_source_reload_still_removes_its_deleted_disk_foreign() {
+    let directory = tempdir().unwrap();
+    let source_path = directory.path().join("Main.purs");
+    let foreign_path = source_path.with_extension("js");
+    fs::write(&source_path, [0xff]).unwrap();
+    let source_uri = Url::from_file_path(source_path).unwrap();
+    let foreign_uri = Url::from_file_path(foreign_path).unwrap();
+    assert_source_close_result(source_uri, foreign_uri, Some(ContentAuthority::Retained));
 }
 
 #[test]

--- a/compiler-bin/src/lsp/tests.rs
+++ b/compiler-bin/src/lsp/tests.rs
@@ -14,18 +14,22 @@ use super::{
     source_unit_from_source_uri,
 };
 
+fn test_config() -> Arc<LspConfig> {
+    Arc::new(LspConfig {
+        source_command: None,
+        diagnostics_on_open: false,
+        diagnostics_on_save: false,
+        diagnostics_on_change: false,
+    })
+}
+
 fn assert_source_close_result(
     source_uri: Url,
     foreign_uri: Url,
     source_authority: Option<ContentAuthority>,
 ) {
     let unit = source_unit_from_source_uri(&source_uri).unwrap();
-    let config = Arc::new(LspConfig {
-        source_command: None,
-        diagnostics_on_open: false,
-        diagnostics_on_save: false,
-        diagnostics_on_change: false,
-    });
+    let config = test_config();
 
     let (_server, _) = async_lsp::MainLoop::new_server(move |client| {
         let mut state = State::new(Arc::clone(&config), client);
@@ -116,6 +120,64 @@ fn failed_source_reload_still_removes_its_deleted_disk_foreign() {
     let source_uri = Url::from_file_path(source_path).unwrap();
     let foreign_uri = Url::from_file_path(foreign_path).unwrap();
     assert_source_close_result(source_uri, foreign_uri, Some(ContentAuthority::Retained));
+}
+
+#[test]
+fn duplicate_source_close_does_not_reconcile_foreign() {
+    let directory = tempdir().unwrap();
+    let source_path = directory.path().join("Main.purs");
+    let foreign_path = source_path.with_extension("js");
+    fs::write(&source_path, "module Main where\n").unwrap();
+    fs::write(&foreign_path, "export const life = 42;\n").unwrap();
+    let source_uri = Url::from_file_path(source_path).unwrap();
+    let foreign_uri = Url::from_file_path(&foreign_path).unwrap();
+    let unit = source_unit_from_source_uri(&source_uri).unwrap();
+    let config = test_config();
+
+    let (_server, _) = async_lsp::MainLoop::new_server(move |client| {
+        let mut state = State::new(Arc::clone(&config), client);
+        let event = LifecycleEvent::Source {
+            unit: SourceUnitKey::clone(&unit),
+            event: SourceEvent::Opened {
+                text: Arc::from("module Main where\n"),
+                version: 1,
+                metadata: true,
+            },
+        };
+        apply_lifecycle_event(&mut state, event);
+        let event = LifecycleEvent::Foreign {
+            unit: SourceUnitKey::clone(&unit),
+            event: ForeignEvent::DiskObserved {
+                disk: DiskObservation::Found(Arc::from("export const life = 42;\n")),
+            },
+        };
+        apply_lifecycle_event(&mut state, event);
+
+        let parameters = DidCloseTextDocumentParams {
+            text_document: TextDocumentIdentifier { uri: Url::clone(&source_uri) },
+        };
+        did_close(&mut state, parameters).unwrap();
+        fs::remove_file(foreign_path).unwrap();
+
+        let source_id = state.files.read().source_id(source_uri.as_str()).unwrap();
+        let foreign_id = state.files.read().foreign_id(foreign_uri.as_str()).unwrap();
+        let parameters = DidCloseTextDocumentParams {
+            text_document: TextDocumentIdentifier { uri: Url::clone(&source_uri) },
+        };
+        did_close(&mut state, parameters).unwrap();
+
+        let files = state.files.read();
+        assert_eq!(files.source_id(source_uri.as_str()), Some(source_id));
+        assert_eq!(files.foreign_id(foreign_uri.as_str()), Some(foreign_id));
+        assert_eq!(state.engine.foreign_file(source_id), Some(foreign_id));
+        assert_eq!(
+            state.engine.foreign_content(foreign_id).unwrap().as_ref(),
+            "export const life = 42;\n",
+        );
+        drop(files);
+
+        Router::<State, ResponseError>::new(state)
+    });
 }
 
 #[test]

--- a/compiler-core/building/src/lib.rs
+++ b/compiler-core/building/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod engine;
+pub mod lifecycle;
 pub mod prim;
 
 pub use building_types::*;
 pub use engine::*;
+pub use lifecycle::*;

--- a/compiler-core/building/src/lifecycle.rs
+++ b/compiler-core/building/src/lifecycle.rs
@@ -1,0 +1,230 @@
+use std::sync::Arc;
+
+use files::{FileId, Files, ForeignFileId, ForeignFiles};
+use rustc_hash::FxHashMap;
+
+use crate::{QueryEngine, QueryResult};
+
+mod change;
+mod event;
+mod foreign;
+mod source;
+
+#[cfg(test)]
+mod tests;
+
+pub use change::*;
+pub use event::*;
+
+#[derive(Debug)]
+pub struct FileLifecycle<Version, Metadata> {
+    units: FxHashMap<SourceUnitKey, SourceUnit<Version, Metadata>>,
+    source_units: FxHashMap<FileId, SourceUnitKey>,
+    source_files: Files,
+    foreign_files: ForeignFiles,
+}
+
+impl<Version, Metadata> Default for FileLifecycle<Version, Metadata> {
+    fn default() -> FileLifecycle<Version, Metadata> {
+        FileLifecycle {
+            units: FxHashMap::default(),
+            source_units: FxHashMap::default(),
+            source_files: Files::default(),
+            foreign_files: ForeignFiles::default(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SourceUnit<Version, Metadata> {
+    source: Member<SourceDocument<Version, Metadata>>,
+    foreign: Member<ForeignDocument<Version>>,
+}
+
+impl<Version, Metadata> Default for SourceUnit<Version, Metadata> {
+    fn default() -> SourceUnit<Version, Metadata> {
+        SourceUnit { source: Member::Missing, foreign: Member::Missing }
+    }
+}
+
+#[derive(Debug, Default)]
+enum Member<Document> {
+    #[default]
+    Missing,
+    Present(Document),
+}
+
+#[derive(Debug)]
+struct SourceDocument<Version, Metadata> {
+    id: FileId,
+    metadata: Metadata,
+    content: EffectiveContent<Version>,
+}
+
+#[derive(Debug)]
+struct ForeignDocument<Version> {
+    id: ForeignFileId,
+    content: EffectiveContent<Version>,
+}
+
+#[derive(Debug)]
+enum EffectiveContent<Version> {
+    Open { text: Arc<str>, version: Version },
+    Disk { text: Arc<str> },
+    Retained { text: Arc<str>, failure: ReloadFailure },
+}
+
+impl<Version> EffectiveContent<Version> {
+    fn authority(&self) -> ContentAuthority {
+        match self {
+            EffectiveContent::Open { .. } => ContentAuthority::Open,
+            EffectiveContent::Disk { .. } => ContentAuthority::Disk,
+            EffectiveContent::Retained { .. } => ContentAuthority::Retained,
+        }
+    }
+
+    fn text(&self) -> &Arc<str> {
+        match self {
+            EffectiveContent::Open { text, .. }
+            | EffectiveContent::Disk { text }
+            | EffectiveContent::Retained { text, .. } => text,
+        }
+    }
+
+    fn reload_failure(&self) -> Option<&ReloadFailure> {
+        let EffectiveContent::Retained { failure, .. } = self else {
+            return None;
+        };
+        Some(failure)
+    }
+}
+
+impl<Version, Metadata> FileLifecycle<Version, Metadata>
+where
+    Version: Clone + Ord,
+    Metadata: Clone + Eq,
+{
+    pub fn apply(
+        &mut self,
+        engine: &QueryEngine,
+        event: LifecycleEvent<Version, Metadata>,
+    ) -> QueryResult<LifecycleChange> {
+        match event {
+            LifecycleEvent::Source { unit, event } => self.apply_source(engine, unit, event),
+            LifecycleEvent::Foreign { unit, event } => self.apply_foreign(engine, unit, event),
+        }
+    }
+
+    pub fn is_open(&self, document: &DocumentKey) -> bool {
+        let (unit, kind) = match document {
+            DocumentKey::Source(unit) => (unit, DocumentKind::Source),
+            DocumentKey::Foreign(unit) => (unit, DocumentKind::Foreign),
+        };
+        let Some(source_unit) = self.units.get(unit) else {
+            return false;
+        };
+        match kind {
+            DocumentKind::Source => match &source_unit.source {
+                Member::Missing => false,
+                Member::Present(document) => document.content.authority() == ContentAuthority::Open,
+            },
+            DocumentKind::Foreign => match &source_unit.foreign {
+                Member::Missing => false,
+                Member::Present(document) => document.content.authority() == ContentAuthority::Open,
+            },
+        }
+    }
+
+    pub fn source_id(&self, locator: &str) -> Option<FileId> {
+        self.source_files.id(locator)
+    }
+
+    pub fn contains_source(&self, file_id: FileId) -> bool {
+        self.source_files.contains(file_id)
+    }
+
+    pub fn source_path(&self, file_id: FileId) -> Option<Arc<str>> {
+        self.source_files.contains(file_id).then(|| self.source_files.path(file_id))
+    }
+
+    pub fn source_ids(&self) -> impl Iterator<Item = FileId> + '_ {
+        self.source_files.iter_id()
+    }
+
+    pub fn source_metadata(&self, file_id: FileId) -> Option<&Metadata> {
+        let unit = self.source_units.get(&file_id)?;
+        let source_unit = self.units.get(unit)?;
+        let Member::Present(source) = &source_unit.source else {
+            return None;
+        };
+        Some(&source.metadata)
+    }
+
+    pub fn source_version(&self, file_id: FileId) -> Option<Version> {
+        let unit = self.source_units.get(&file_id)?;
+        let source_unit = self.units.get(unit)?;
+        let Member::Present(source) = &source_unit.source else {
+            return None;
+        };
+        let EffectiveContent::Open { version, .. } = &source.content else {
+            return None;
+        };
+        Some(Version::clone(version))
+    }
+
+    pub fn source_authority(&self, unit: &SourceUnitKey) -> Option<ContentAuthority> {
+        let source_unit = self.units.get(unit)?;
+        let Member::Present(source) = &source_unit.source else {
+            return None;
+        };
+        Some(source.content.authority())
+    }
+
+    pub fn source_reload_failure(&self, unit: &SourceUnitKey) -> Option<&ReloadFailure> {
+        let source_unit = self.units.get(unit)?;
+        let Member::Present(source) = &source_unit.source else {
+            return None;
+        };
+        source.content.reload_failure()
+    }
+
+    pub fn foreign_authority(&self, unit: &SourceUnitKey) -> Option<ContentAuthority> {
+        let source_unit = self.units.get(unit)?;
+        let Member::Present(foreign) = &source_unit.foreign else {
+            return None;
+        };
+        Some(foreign.content.authority())
+    }
+
+    pub fn foreign_reload_failure(&self, unit: &SourceUnitKey) -> Option<&ReloadFailure> {
+        let source_unit = self.units.get(unit)?;
+        let Member::Present(foreign) = &source_unit.foreign else {
+            return None;
+        };
+        foreign.content.reload_failure()
+    }
+
+    pub fn foreign_id(&self, locator: &str) -> Option<ForeignFileId> {
+        self.foreign_files.id(locator)
+    }
+}
+
+impl<Version, Metadata> SourceUnit<Version, Metadata> {
+    fn is_missing(&self) -> bool {
+        matches!(self.source, Member::Missing) && matches!(self.foreign, Member::Missing)
+    }
+
+    fn source_id(&self) -> Option<FileId> {
+        let Member::Present(source) = &self.source else {
+            return None;
+        };
+        Some(source.id)
+    }
+
+    fn foreign_id(&self) -> Option<ForeignFileId> {
+        let Member::Present(foreign) = &self.foreign else {
+            return None;
+        };
+        Some(foreign.id)
+    }
+}

--- a/compiler-core/building/src/lifecycle.rs
+++ b/compiler-core/building/src/lifecycle.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use files::{FileId, Files, ForeignFileId, ForeignFiles};
 use rustc_hash::FxHashMap;
 
-use crate::{QueryEngine, QueryResult};
+use crate::QueryEngine;
 
 mod change;
 mod event;
@@ -102,13 +102,12 @@ impl<Version> EffectiveContent<Version> {
 impl<Version, Metadata> FileLifecycle<Version, Metadata>
 where
     Version: Clone + Ord,
-    Metadata: Clone + Eq,
 {
     pub fn apply(
         &mut self,
         engine: &QueryEngine,
         event: LifecycleEvent<Version, Metadata>,
-    ) -> QueryResult<LifecycleChange> {
+    ) -> LifecycleChange {
         match event {
             LifecycleEvent::Source { unit, event } => self.apply_source(engine, unit, event),
             LifecycleEvent::Foreign { unit, event } => self.apply_foreign(engine, unit, event),

--- a/compiler-core/building/src/lifecycle.rs
+++ b/compiler-core/building/src/lifecycle.rs
@@ -19,6 +19,8 @@ pub use event::*;
 #[derive(Debug)]
 pub struct FileLifecycle<Version, Metadata> {
     units: FxHashMap<SourceUnitKey, SourceUnit<Version, Metadata>>,
+    source_owners: FxHashMap<Arc<str>, SourceUnitKey>,
+    foreign_owners: FxHashMap<Arc<str>, SourceUnitKey>,
     source_units: FxHashMap<FileId, SourceUnitKey>,
     source_files: Files,
     foreign_files: ForeignFiles,
@@ -28,6 +30,8 @@ impl<Version, Metadata> Default for FileLifecycle<Version, Metadata> {
     fn default() -> FileLifecycle<Version, Metadata> {
         FileLifecycle {
             units: FxHashMap::default(),
+            source_owners: FxHashMap::default(),
+            foreign_owners: FxHashMap::default(),
             source_units: FxHashMap::default(),
             source_files: Files::default(),
             foreign_files: ForeignFiles::default(),
@@ -108,6 +112,14 @@ where
         engine: &QueryEngine,
         event: LifecycleEvent<Version, Metadata>,
     ) -> LifecycleChange {
+        let unit = match &event {
+            LifecycleEvent::Source { unit, .. } | LifecycleEvent::Foreign { unit, .. } => unit,
+        };
+        if let Some(warning) = self.locator_conflict(unit) {
+            let mut change = LifecycleChange::default();
+            change.warnings.push(warning);
+            return change;
+        }
         match event {
             LifecycleEvent::Source { unit, event } => self.apply_source(engine, unit, event),
             LifecycleEvent::Foreign { unit, event } => self.apply_foreign(engine, unit, event),
@@ -205,6 +217,46 @@ where
 
     pub fn foreign_id(&self, locator: &str) -> Option<ForeignFileId> {
         self.foreign_files.id(locator)
+    }
+
+    fn locator_conflict(&self, unit: &SourceUnitKey) -> Option<LifecycleWarning> {
+        if let Some(owner) = self.source_owners.get(unit.source())
+            && owner != unit
+        {
+            return Some(LifecycleWarning::LocatorAlreadyOwned {
+                locator: Arc::clone(&unit.source),
+                owner: SourceUnitKey::clone(owner),
+                requested: SourceUnitKey::clone(unit),
+            });
+        }
+        if let Some(owner) = self.foreign_owners.get(unit.foreign())
+            && owner != unit
+        {
+            return Some(LifecycleWarning::LocatorAlreadyOwned {
+                locator: Arc::clone(&unit.foreign),
+                owner: SourceUnitKey::clone(owner),
+                requested: SourceUnitKey::clone(unit),
+            });
+        }
+        None
+    }
+
+    fn store_unit(&mut self, unit: SourceUnitKey, source_unit: SourceUnit<Version, Metadata>) {
+        if source_unit.is_missing() {
+            let source_owner = self.source_owners.remove(unit.source());
+            let foreign_owner = self.foreign_owners.remove(unit.foreign());
+            debug_assert!(source_owner.is_none_or(|owner| owner == unit));
+            debug_assert!(foreign_owner.is_none_or(|owner| owner == unit));
+            return;
+        }
+
+        let previous_source_owner =
+            self.source_owners.insert(Arc::clone(&unit.source), SourceUnitKey::clone(&unit));
+        let previous_foreign_owner =
+            self.foreign_owners.insert(Arc::clone(&unit.foreign), SourceUnitKey::clone(&unit));
+        debug_assert!(previous_source_owner.is_none_or(|owner| owner == unit));
+        debug_assert!(previous_foreign_owner.is_none_or(|owner| owner == unit));
+        self.units.insert(unit, source_unit);
     }
 }
 

--- a/compiler-core/building/src/lifecycle/change.rs
+++ b/compiler-core/building/src/lifecycle/change.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+use files::FileId;
+use rustc_hash::FxHashSet;
+
+use super::LifecycleWarning;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum AnalysisInvalidation {
+    #[default]
+    None,
+    Sources(FxHashSet<FileId>),
+    Workspace,
+}
+
+impl AnalysisInvalidation {
+    fn source(file_id: FileId) -> AnalysisInvalidation {
+        let mut sources = FxHashSet::default();
+        sources.insert(file_id);
+        AnalysisInvalidation::Sources(sources)
+    }
+
+    pub(super) fn include_source(&mut self, file_id: FileId) {
+        match self {
+            AnalysisInvalidation::None => {
+                *self = AnalysisInvalidation::source(file_id);
+            }
+            AnalysisInvalidation::Sources(sources) => {
+                sources.insert(file_id);
+            }
+            AnalysisInvalidation::Workspace => {}
+        }
+    }
+
+    fn combine(&mut self, other: AnalysisInvalidation) {
+        match other {
+            AnalysisInvalidation::None => {}
+            AnalysisInvalidation::Sources(other_sources) => {
+                for file_id in other_sources {
+                    self.include_source(file_id);
+                }
+            }
+            AnalysisInvalidation::Workspace => *self = AnalysisInvalidation::Workspace,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RemovedSource {
+    pub file_id: FileId,
+    pub locator: Arc<str>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct LifecycleChange {
+    pub(super) analysis: AnalysisInvalidation,
+    changed_sources: FxHashSet<FileId>,
+    pub(super) removed_sources: Vec<RemovedSource>,
+    pub(super) warnings: Vec<LifecycleWarning>,
+}
+
+impl LifecycleChange {
+    pub fn analysis(&self) -> &AnalysisInvalidation {
+        &self.analysis
+    }
+
+    pub fn changed_sources(&self) -> impl Iterator<Item = FileId> + '_ {
+        self.changed_sources.iter().copied()
+    }
+
+    pub fn removed_sources(&self) -> &[RemovedSource] {
+        &self.removed_sources
+    }
+
+    pub fn warnings(&self) -> &[LifecycleWarning] {
+        &self.warnings
+    }
+
+    pub fn combine(&mut self, other: LifecycleChange) {
+        self.analysis.combine(other.analysis);
+        self.changed_sources.extend(other.changed_sources);
+        self.removed_sources.extend(other.removed_sources);
+        self.warnings.extend(other.warnings);
+    }
+
+    pub(super) fn source_changed(&mut self, file_id: FileId, content_changed: bool) {
+        if content_changed {
+            self.analysis = AnalysisInvalidation::Workspace;
+        } else {
+            self.analysis.include_source(file_id);
+        }
+        self.changed_sources.insert(file_id);
+    }
+
+    pub(super) fn foreign_changed(&mut self, source_id: Option<FileId>) {
+        if let Some(source_id) = source_id {
+            self.analysis.include_source(source_id);
+            self.changed_sources.insert(source_id);
+        }
+    }
+}

--- a/compiler-core/building/src/lifecycle/event.rs
+++ b/compiler-core/building/src/lifecycle/event.rs
@@ -98,6 +98,7 @@ pub enum ContentAuthority {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LifecycleWarning {
+    LocatorAlreadyOwned { locator: Arc<str>, owner: SourceUnitKey, requested: SourceUnitKey },
     ChangedNonOpen { unit: SourceUnitKey, document: DocumentKind },
     ClosedNonOpen { unit: SourceUnitKey, document: DocumentKind },
     StaleChange { unit: SourceUnitKey, document: DocumentKind },
@@ -108,6 +109,14 @@ pub enum LifecycleWarning {
 impl fmt::Display for LifecycleWarning {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            LifecycleWarning::LocatorAlreadyOwned { locator, owner, requested } => {
+                write!(
+                    formatter,
+                    "ignored lifecycle event for {} because {locator} already belongs to {}",
+                    requested.source(),
+                    owner.source(),
+                )
+            }
             LifecycleWarning::ChangedNonOpen { unit, document } => {
                 write!(formatter, "ignored change for non-open {document:?} {}", unit.source())
             }

--- a/compiler-core/building/src/lifecycle/event.rs
+++ b/compiler-core/building/src/lifecycle/event.rs
@@ -1,0 +1,128 @@
+use core::fmt;
+use std::io;
+use std::sync::Arc;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SourceUnitKey {
+    pub(super) source: Arc<str>,
+    pub(super) foreign: Arc<str>,
+}
+
+impl SourceUnitKey {
+    pub fn new(source: impl Into<Arc<str>>, foreign: impl Into<Arc<str>>) -> SourceUnitKey {
+        SourceUnitKey { source: source.into(), foreign: foreign.into() }
+    }
+
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    pub fn foreign(&self) -> &str {
+        &self.foreign
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReloadFailure {
+    kind: io::ErrorKind,
+    message: Arc<str>,
+}
+
+impl ReloadFailure {
+    pub fn new(kind: io::ErrorKind, message: impl Into<Arc<str>>) -> ReloadFailure {
+        ReloadFailure { kind, message: message.into() }
+    }
+
+    pub fn kind(&self) -> io::ErrorKind {
+        self.kind
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for ReloadFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.kind, self.message)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DiskObservation {
+    Found(Arc<str>),
+    NotFound,
+    Failed(ReloadFailure),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LifecycleEvent<Version, Metadata> {
+    Source { unit: SourceUnitKey, event: SourceEvent<Version, Metadata> },
+    Foreign { unit: SourceUnitKey, event: ForeignEvent<Version> },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SourceEvent<Version, Metadata> {
+    Opened { text: Arc<str>, version: Version, metadata: Metadata },
+    Changed { text: Arc<str>, version: Version },
+    Closed { disk: DiskObservation },
+    DiskObserved { disk: DiskObservation, metadata: Metadata },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ForeignEvent<Version> {
+    Opened { text: Arc<str>, version: Version },
+    Changed { text: Arc<str>, version: Version },
+    Closed { disk: DiskObservation },
+    DiskObserved { disk: DiskObservation },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DocumentKey {
+    Source(SourceUnitKey),
+    Foreign(SourceUnitKey),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DocumentKind {
+    Source,
+    Foreign,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ContentAuthority {
+    Open,
+    Disk,
+    Retained,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LifecycleWarning {
+    ChangedNonOpen { unit: SourceUnitKey, document: DocumentKind },
+    ClosedNonOpen { unit: SourceUnitKey, document: DocumentKind },
+    StaleChange { unit: SourceUnitKey, document: DocumentKind },
+    DiskObservedWhileOpen { unit: SourceUnitKey, document: DocumentKind },
+    ReloadFailed { unit: SourceUnitKey, document: DocumentKind, failure: ReloadFailure },
+}
+
+impl fmt::Display for LifecycleWarning {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LifecycleWarning::ChangedNonOpen { unit, document } => {
+                write!(formatter, "ignored change for non-open {document:?} {}", unit.source())
+            }
+            LifecycleWarning::ClosedNonOpen { unit, document } => {
+                write!(formatter, "ignored close for non-open {document:?} {}", unit.source())
+            }
+            LifecycleWarning::StaleChange { unit, document } => {
+                write!(formatter, "ignored stale change for {document:?} {}", unit.source())
+            }
+            LifecycleWarning::DiskObservedWhileOpen { unit, document } => {
+                write!(formatter, "ignored disk event for open {document:?} {}", unit.source())
+            }
+            LifecycleWarning::ReloadFailed { unit, document, failure } => {
+                write!(formatter, "failed to reload {document:?} {}: {failure}", unit.source())
+            }
+        }
+    }
+}

--- a/compiler-core/building/src/lifecycle/foreign.rs
+++ b/compiler-core/building/src/lifecycle/foreign.rs
@@ -1,0 +1,205 @@
+use std::sync::Arc;
+
+use files::ForeignFileId;
+
+use super::*;
+use crate::{QueryEngine, QueryResult};
+
+impl<Version, Metadata> FileLifecycle<Version, Metadata>
+where
+    Version: Clone + Ord,
+    Metadata: Clone + Eq,
+{
+    pub(super) fn apply_foreign(
+        &mut self,
+        engine: &QueryEngine,
+        unit: SourceUnitKey,
+        event: ForeignEvent<Version>,
+    ) -> QueryResult<LifecycleChange> {
+        let mut source_unit = self.units.remove(&unit).unwrap_or_default();
+        let result = self.apply_foreign_event(engine, &unit, &mut source_unit, event);
+        if !source_unit.is_missing() {
+            self.units.insert(unit, source_unit);
+        }
+        result
+    }
+
+    fn apply_foreign_event(
+        &mut self,
+        engine: &QueryEngine,
+        unit: &SourceUnitKey,
+        source_unit: &mut SourceUnit<Version, Metadata>,
+        event: ForeignEvent<Version>,
+    ) -> QueryResult<LifecycleChange> {
+        let mut change = LifecycleChange::default();
+        let current = std::mem::take(&mut source_unit.foreign);
+        let next = match (current, event) {
+            (Member::Missing, ForeignEvent::Opened { text, version }) => {
+                let document = self.insert_foreign(engine, unit, source_unit, &text);
+                change.foreign_changed(source_unit.source_id());
+                Member::Present(ForeignDocument {
+                    id: document.id,
+                    content: EffectiveContent::Open { text, version },
+                })
+            }
+            (Member::Missing, ForeignEvent::DiskObserved { disk }) => match disk {
+                DiskObservation::Found(text) => {
+                    let document = self.insert_foreign(engine, unit, source_unit, &text);
+                    change.foreign_changed(source_unit.source_id());
+                    Member::Present(document)
+                }
+                DiskObservation::NotFound => Member::Missing,
+                DiskObservation::Failed(failure) => {
+                    change.warnings.push(LifecycleWarning::ReloadFailed {
+                        unit: SourceUnitKey::clone(unit),
+                        document: DocumentKind::Foreign,
+                        failure,
+                    });
+                    Member::Missing
+                }
+            },
+            (Member::Missing, ForeignEvent::Changed { .. }) => {
+                change.warnings.push(LifecycleWarning::ChangedNonOpen {
+                    unit: SourceUnitKey::clone(unit),
+                    document: DocumentKind::Foreign,
+                });
+                Member::Missing
+            }
+            (Member::Missing, ForeignEvent::Closed { .. }) => {
+                change.warnings.push(LifecycleWarning::ClosedNonOpen {
+                    unit: SourceUnitKey::clone(unit),
+                    document: DocumentKind::Foreign,
+                });
+                Member::Missing
+            }
+            (Member::Present(mut document), ForeignEvent::Opened { text, version }) => {
+                self.set_foreign_content(engine, document.id, &text);
+                document.content = EffectiveContent::Open { text, version };
+                change.foreign_changed(source_unit.source_id());
+                Member::Present(document)
+            }
+            (Member::Present(mut document), ForeignEvent::Changed { text, version }) => {
+                match &document.content {
+                    EffectiveContent::Open { version: current_version, .. }
+                        if version > *current_version =>
+                    {
+                        self.set_foreign_content(engine, document.id, &text);
+                        document.content = EffectiveContent::Open { text, version };
+                        change.foreign_changed(source_unit.source_id());
+                    }
+                    EffectiveContent::Open { .. } => {
+                        change.warnings.push(LifecycleWarning::StaleChange {
+                            unit: SourceUnitKey::clone(unit),
+                            document: DocumentKind::Foreign,
+                        });
+                    }
+                    EffectiveContent::Disk { .. } | EffectiveContent::Retained { .. } => {
+                        change.warnings.push(LifecycleWarning::ChangedNonOpen {
+                            unit: SourceUnitKey::clone(unit),
+                            document: DocumentKind::Foreign,
+                        });
+                    }
+                }
+                Member::Present(document)
+            }
+            (Member::Present(document), ForeignEvent::Closed { disk }) => {
+                if !matches!(document.content, EffectiveContent::Open { .. }) {
+                    change.warnings.push(LifecycleWarning::ClosedNonOpen {
+                        unit: SourceUnitKey::clone(unit),
+                        document: DocumentKind::Foreign,
+                    });
+                    Member::Present(document)
+                } else {
+                    self.reconcile_foreign(engine, unit, source_unit, document, disk, &mut change)
+                }
+            }
+            (Member::Present(document), ForeignEvent::DiskObserved { disk }) => {
+                if matches!(document.content, EffectiveContent::Open { .. }) {
+                    change.warnings.push(LifecycleWarning::DiskObservedWhileOpen {
+                        unit: SourceUnitKey::clone(unit),
+                        document: DocumentKind::Foreign,
+                    });
+                    Member::Present(document)
+                } else {
+                    self.reconcile_foreign(engine, unit, source_unit, document, disk, &mut change)
+                }
+            }
+        };
+        source_unit.foreign = next;
+        Ok(change)
+    }
+
+    fn reconcile_foreign(
+        &mut self,
+        engine: &QueryEngine,
+        unit: &SourceUnitKey,
+        source_unit: &SourceUnit<Version, Metadata>,
+        mut document: ForeignDocument<Version>,
+        disk: DiskObservation,
+        change: &mut LifecycleChange,
+    ) -> Member<ForeignDocument<Version>> {
+        match disk {
+            DiskObservation::Found(text) => {
+                self.set_foreign_content(engine, document.id, &text);
+                document.content = EffectiveContent::Disk { text };
+                change.foreign_changed(source_unit.source_id());
+                Member::Present(document)
+            }
+            DiskObservation::NotFound => {
+                self.remove_foreign(engine, unit, document.id);
+                change.foreign_changed(source_unit.source_id());
+                Member::Missing
+            }
+            DiskObservation::Failed(failure) => {
+                let text = Arc::clone(document.content.text());
+                let retained_failure = ReloadFailure::clone(&failure);
+                document.content = EffectiveContent::Retained { text, failure: retained_failure };
+                change.foreign_changed(source_unit.source_id());
+                change.warnings.push(LifecycleWarning::ReloadFailed {
+                    unit: SourceUnitKey::clone(unit),
+                    document: DocumentKind::Foreign,
+                    failure,
+                });
+                Member::Present(document)
+            }
+        }
+    }
+
+    fn insert_foreign(
+        &mut self,
+        engine: &QueryEngine,
+        unit: &SourceUnitKey,
+        source_unit: &SourceUnit<Version, Metadata>,
+        text: &Arc<str>,
+    ) -> ForeignDocument<Version> {
+        let id = self.foreign_files.insert(Arc::clone(&unit.foreign), Arc::clone(text));
+        engine.set_foreign_content(id, Arc::clone(text));
+        if let Some(source_id) = source_unit.source_id() {
+            engine.set_foreign_file(source_id, id);
+        }
+        ForeignDocument { id, content: EffectiveContent::Disk { text: Arc::clone(text) } }
+    }
+
+    fn set_foreign_content(
+        &mut self,
+        engine: &QueryEngine,
+        id: ForeignFileId,
+        text: &Arc<str>,
+    ) -> bool {
+        let previous_content = self.foreign_files.content(id);
+        if previous_content == *text {
+            return false;
+        }
+        let path = self.foreign_files.path(id);
+        let inserted_id = self.foreign_files.insert(path, Arc::clone(text));
+        debug_assert_eq!(inserted_id, id);
+        engine.set_foreign_content(id, Arc::clone(text));
+        true
+    }
+
+    fn remove_foreign(&mut self, engine: &QueryEngine, unit: &SourceUnitKey, id: ForeignFileId) {
+        engine.remove_foreign_file(id);
+        let removed_id = self.foreign_files.remove(unit.foreign());
+        debug_assert_eq!(removed_id, Some(id));
+    }
+}

--- a/compiler-core/building/src/lifecycle/foreign.rs
+++ b/compiler-core/building/src/lifecycle/foreign.rs
@@ -3,19 +3,18 @@ use std::sync::Arc;
 use files::ForeignFileId;
 
 use super::*;
-use crate::{QueryEngine, QueryResult};
+use crate::QueryEngine;
 
 impl<Version, Metadata> FileLifecycle<Version, Metadata>
 where
     Version: Clone + Ord,
-    Metadata: Clone + Eq,
 {
     pub(super) fn apply_foreign(
         &mut self,
         engine: &QueryEngine,
         unit: SourceUnitKey,
         event: ForeignEvent<Version>,
-    ) -> QueryResult<LifecycleChange> {
+    ) -> LifecycleChange {
         let mut source_unit = self.units.remove(&unit).unwrap_or_default();
         let result = self.apply_foreign_event(engine, &unit, &mut source_unit, event);
         if !source_unit.is_missing() {
@@ -30,7 +29,7 @@ where
         unit: &SourceUnitKey,
         source_unit: &mut SourceUnit<Version, Metadata>,
         event: ForeignEvent<Version>,
-    ) -> QueryResult<LifecycleChange> {
+    ) -> LifecycleChange {
         let mut change = LifecycleChange::default();
         let current = std::mem::take(&mut source_unit.foreign);
         let next = match (current, event) {
@@ -126,7 +125,7 @@ where
             }
         };
         source_unit.foreign = next;
-        Ok(change)
+        change
     }
 
     fn reconcile_foreign(

--- a/compiler-core/building/src/lifecycle/foreign.rs
+++ b/compiler-core/building/src/lifecycle/foreign.rs
@@ -177,21 +177,15 @@ where
         ForeignDocument { id, content: EffectiveContent::Disk { text: Arc::clone(text) } }
     }
 
-    fn set_foreign_content(
-        &mut self,
-        engine: &QueryEngine,
-        id: ForeignFileId,
-        text: &Arc<str>,
-    ) -> bool {
+    fn set_foreign_content(&mut self, engine: &QueryEngine, id: ForeignFileId, text: &Arc<str>) {
         let previous_content = self.foreign_files.content(id);
         if previous_content == *text {
-            return false;
+            return;
         }
         let path = self.foreign_files.path(id);
         let inserted_id = self.foreign_files.insert(path, Arc::clone(text));
         debug_assert_eq!(inserted_id, id);
         engine.set_foreign_content(id, Arc::clone(text));
-        true
     }
 
     fn remove_foreign(&mut self, engine: &QueryEngine, unit: &SourceUnitKey, id: ForeignFileId) {

--- a/compiler-core/building/src/lifecycle/foreign.rs
+++ b/compiler-core/building/src/lifecycle/foreign.rs
@@ -17,9 +17,7 @@ where
     ) -> LifecycleChange {
         let mut source_unit = self.units.remove(&unit).unwrap_or_default();
         let result = self.apply_foreign_event(engine, &unit, &mut source_unit, event);
-        if !source_unit.is_missing() {
-            self.units.insert(unit, source_unit);
-        }
+        self.store_unit(unit, source_unit);
         result
     }
 

--- a/compiler-core/building/src/lifecycle/source.rs
+++ b/compiler-core/building/src/lifecycle/source.rs
@@ -111,7 +111,7 @@ where
                     });
                     Member::Present(document)
                 } else {
-                    self.reconcile_closed_source(engine, unit, document, disk, &mut change)
+                    self.reconcile_source(engine, unit, document, disk, None, &mut change)
                 }
             }
             (Member::Present(document), SourceEvent::DiskObserved { disk, metadata }) => {
@@ -122,7 +122,7 @@ where
                     });
                     Member::Present(document)
                 } else {
-                    self.reconcile_disk_source(engine, unit, document, disk, metadata, &mut change)
+                    self.reconcile_source(engine, unit, document, disk, Some(metadata), &mut change)
                 }
             }
         };
@@ -130,58 +130,21 @@ where
         change
     }
 
-    fn reconcile_closed_source(
+    fn reconcile_source(
         &mut self,
         engine: &QueryEngine,
         unit: &SourceUnitKey,
         mut document: SourceDocument<Version, Metadata>,
         disk: DiskObservation,
+        metadata: Option<Metadata>,
         change: &mut LifecycleChange,
     ) -> Member<SourceDocument<Version, Metadata>> {
         match disk {
             DiskObservation::Found(text) => {
                 let content_changed = self.set_source_content(engine, document.id, &text);
-                document.content = EffectiveContent::Disk { text };
-                change.source_changed(document.id, content_changed);
-                Member::Present(document)
-            }
-            DiskObservation::NotFound => {
-                self.remove_source(engine, unit, document.id);
-                change.analysis = AnalysisInvalidation::Workspace;
-                change.removed_sources.push(RemovedSource {
-                    file_id: document.id,
-                    locator: Arc::clone(&unit.source),
-                });
-                Member::Missing
-            }
-            DiskObservation::Failed(failure) => {
-                let text = Arc::clone(document.content.text());
-                let retained_failure = ReloadFailure::clone(&failure);
-                document.content = EffectiveContent::Retained { text, failure: retained_failure };
-                change.source_changed(document.id, false);
-                change.warnings.push(LifecycleWarning::ReloadFailed {
-                    unit: SourceUnitKey::clone(unit),
-                    document: DocumentKind::Source,
-                    failure,
-                });
-                Member::Present(document)
-            }
-        }
-    }
-
-    fn reconcile_disk_source(
-        &mut self,
-        engine: &QueryEngine,
-        unit: &SourceUnitKey,
-        mut document: SourceDocument<Version, Metadata>,
-        disk: DiskObservation,
-        metadata: Metadata,
-        change: &mut LifecycleChange,
-    ) -> Member<SourceDocument<Version, Metadata>> {
-        match disk {
-            DiskObservation::Found(text) => {
-                let content_changed = self.set_source_content(engine, document.id, &text);
-                document.metadata = metadata;
+                if let Some(metadata) = metadata {
+                    document.metadata = metadata;
+                }
                 document.content = EffectiveContent::Disk { text };
                 change.source_changed(document.id, content_changed);
                 Member::Present(document)

--- a/compiler-core/building/src/lifecycle/source.rs
+++ b/compiler-core/building/src/lifecycle/source.rs
@@ -1,0 +1,277 @@
+use std::sync::Arc;
+
+use files::FileId;
+
+use super::*;
+use crate::{QueryEngine, QueryResult};
+
+impl<Version, Metadata> FileLifecycle<Version, Metadata>
+where
+    Version: Clone + Ord,
+    Metadata: Clone + Eq,
+{
+    pub(super) fn apply_source(
+        &mut self,
+        engine: &QueryEngine,
+        unit: SourceUnitKey,
+        event: SourceEvent<Version, Metadata>,
+    ) -> QueryResult<LifecycleChange> {
+        let mut source_unit = self.units.remove(&unit).unwrap_or_default();
+        let result = self.apply_source_event(engine, &unit, &mut source_unit, event);
+        if !source_unit.is_missing() {
+            self.units.insert(unit, source_unit);
+        }
+        result
+    }
+
+    fn apply_source_event(
+        &mut self,
+        engine: &QueryEngine,
+        unit: &SourceUnitKey,
+        source_unit: &mut SourceUnit<Version, Metadata>,
+        event: SourceEvent<Version, Metadata>,
+    ) -> QueryResult<LifecycleChange> {
+        let mut change = LifecycleChange::default();
+        let current = std::mem::take(&mut source_unit.source);
+        let next = match (current, event) {
+            (Member::Missing, SourceEvent::Opened { text, version, metadata }) => {
+                let document = self.insert_source(engine, unit, source_unit, text, metadata)?;
+                change.source_changed(document.id, true);
+                Member::Present(SourceDocument {
+                    content: EffectiveContent::Open {
+                        text: self.source_files.content(document.id),
+                        version,
+                    },
+                    ..document
+                })
+            }
+            (Member::Missing, SourceEvent::DiskObserved { disk, metadata }) => match disk {
+                DiskObservation::Found(text) => {
+                    let document = self.insert_source(engine, unit, source_unit, text, metadata)?;
+                    change.source_changed(document.id, true);
+                    Member::Present(document)
+                }
+                DiskObservation::NotFound => Member::Missing,
+                DiskObservation::Failed(failure) => {
+                    change.warnings.push(LifecycleWarning::ReloadFailed {
+                        unit: SourceUnitKey::clone(unit),
+                        document: DocumentKind::Source,
+                        failure,
+                    });
+                    Member::Missing
+                }
+            },
+            (Member::Missing, SourceEvent::Changed { .. }) => {
+                change.warnings.push(LifecycleWarning::ChangedNonOpen {
+                    unit: SourceUnitKey::clone(unit),
+                    document: DocumentKind::Source,
+                });
+                Member::Missing
+            }
+            (Member::Missing, SourceEvent::Closed { .. }) => {
+                change.warnings.push(LifecycleWarning::ClosedNonOpen {
+                    unit: SourceUnitKey::clone(unit),
+                    document: DocumentKind::Source,
+                });
+                Member::Missing
+            }
+            (Member::Present(mut document), SourceEvent::Opened { text, version, metadata }) => {
+                let content_changed = self.set_source_content(engine, document.id, &text)?;
+                let metadata_changed = document.metadata != metadata;
+                document.metadata = metadata;
+                document.content = EffectiveContent::Open { text, version };
+                change.source_changed(document.id, content_changed || metadata_changed);
+                Member::Present(document)
+            }
+            (Member::Present(mut document), SourceEvent::Changed { text, version }) => {
+                match &document.content {
+                    EffectiveContent::Open { version: current_version, .. }
+                        if version > *current_version =>
+                    {
+                        let content_changed =
+                            self.set_source_content(engine, document.id, &text)?;
+                        document.content = EffectiveContent::Open { text, version };
+                        change.source_changed(document.id, content_changed);
+                    }
+                    EffectiveContent::Open { .. } => {
+                        change.warnings.push(LifecycleWarning::StaleChange {
+                            unit: SourceUnitKey::clone(unit),
+                            document: DocumentKind::Source,
+                        });
+                    }
+                    EffectiveContent::Disk { .. } | EffectiveContent::Retained { .. } => {
+                        change.warnings.push(LifecycleWarning::ChangedNonOpen {
+                            unit: SourceUnitKey::clone(unit),
+                            document: DocumentKind::Source,
+                        });
+                    }
+                }
+                Member::Present(document)
+            }
+            (Member::Present(document), SourceEvent::Closed { disk }) => {
+                if !matches!(document.content, EffectiveContent::Open { .. }) {
+                    change.warnings.push(LifecycleWarning::ClosedNonOpen {
+                        unit: SourceUnitKey::clone(unit),
+                        document: DocumentKind::Source,
+                    });
+                    Member::Present(document)
+                } else {
+                    self.reconcile_closed_source(engine, unit, document, disk, &mut change)?
+                }
+            }
+            (Member::Present(document), SourceEvent::DiskObserved { disk, metadata }) => {
+                if matches!(document.content, EffectiveContent::Open { .. }) {
+                    change.warnings.push(LifecycleWarning::DiskObservedWhileOpen {
+                        unit: SourceUnitKey::clone(unit),
+                        document: DocumentKind::Source,
+                    });
+                    Member::Present(document)
+                } else {
+                    self.reconcile_disk_source(engine, unit, document, disk, metadata, &mut change)?
+                }
+            }
+        };
+        source_unit.source = next;
+        Ok(change)
+    }
+
+    fn reconcile_closed_source(
+        &mut self,
+        engine: &QueryEngine,
+        unit: &SourceUnitKey,
+        mut document: SourceDocument<Version, Metadata>,
+        disk: DiskObservation,
+        change: &mut LifecycleChange,
+    ) -> QueryResult<Member<SourceDocument<Version, Metadata>>> {
+        match disk {
+            DiskObservation::Found(text) => {
+                let content_changed = self.set_source_content(engine, document.id, &text)?;
+                document.content = EffectiveContent::Disk { text };
+                change.source_changed(document.id, content_changed);
+                Ok(Member::Present(document))
+            }
+            DiskObservation::NotFound => {
+                self.remove_source(engine, unit, document.id);
+                change.analysis = AnalysisInvalidation::Workspace;
+                change.removed_sources.push(RemovedSource {
+                    file_id: document.id,
+                    locator: Arc::clone(&unit.source),
+                });
+                Ok(Member::Missing)
+            }
+            DiskObservation::Failed(failure) => {
+                let text = Arc::clone(document.content.text());
+                let retained_failure = ReloadFailure::clone(&failure);
+                document.content = EffectiveContent::Retained { text, failure: retained_failure };
+                change.source_changed(document.id, false);
+                change.warnings.push(LifecycleWarning::ReloadFailed {
+                    unit: SourceUnitKey::clone(unit),
+                    document: DocumentKind::Source,
+                    failure,
+                });
+                Ok(Member::Present(document))
+            }
+        }
+    }
+
+    fn reconcile_disk_source(
+        &mut self,
+        engine: &QueryEngine,
+        unit: &SourceUnitKey,
+        mut document: SourceDocument<Version, Metadata>,
+        disk: DiskObservation,
+        metadata: Metadata,
+        change: &mut LifecycleChange,
+    ) -> QueryResult<Member<SourceDocument<Version, Metadata>>> {
+        match disk {
+            DiskObservation::Found(text) => {
+                let content_changed = self.set_source_content(engine, document.id, &text)?;
+                let metadata_changed = document.metadata != metadata;
+                document.metadata = metadata;
+                document.content = EffectiveContent::Disk { text };
+                change.source_changed(document.id, content_changed || metadata_changed);
+                Ok(Member::Present(document))
+            }
+            DiskObservation::NotFound => {
+                self.remove_source(engine, unit, document.id);
+                change.analysis = AnalysisInvalidation::Workspace;
+                change.removed_sources.push(RemovedSource {
+                    file_id: document.id,
+                    locator: Arc::clone(&unit.source),
+                });
+                Ok(Member::Missing)
+            }
+            DiskObservation::Failed(failure) => {
+                let text = Arc::clone(document.content.text());
+                let retained_failure = ReloadFailure::clone(&failure);
+                document.content = EffectiveContent::Retained { text, failure: retained_failure };
+                change.source_changed(document.id, false);
+                change.warnings.push(LifecycleWarning::ReloadFailed {
+                    unit: SourceUnitKey::clone(unit),
+                    document: DocumentKind::Source,
+                    failure,
+                });
+                Ok(Member::Present(document))
+            }
+        }
+    }
+
+    fn insert_source(
+        &mut self,
+        engine: &QueryEngine,
+        unit: &SourceUnitKey,
+        source_unit: &SourceUnit<Version, Metadata>,
+        text: Arc<str>,
+        metadata: Metadata,
+    ) -> QueryResult<SourceDocument<Version, Metadata>> {
+        let id = self.source_files.insert(Arc::clone(&unit.source), Arc::clone(&text));
+        self.source_units.insert(id, SourceUnitKey::clone(unit));
+        engine.set_content(id, Arc::clone(&text));
+        let (parsed, _) = engine.parsed(id)?;
+        if let Some(name) = parsed.module_name(&text) {
+            engine.set_module_file(&name, id);
+        }
+        if let Some(foreign_id) = source_unit.foreign_id() {
+            engine.set_foreign_file(id, foreign_id);
+        }
+        Ok(SourceDocument { id, metadata, content: EffectiveContent::Disk { text } })
+    }
+
+    fn set_source_content(
+        &mut self,
+        engine: &QueryEngine,
+        id: FileId,
+        text: &Arc<str>,
+    ) -> QueryResult<bool> {
+        let previous_content = self.source_files.content(id);
+        if previous_content == *text {
+            return Ok(false);
+        }
+        let (previous_parsed, _) = engine.parsed(id)?;
+        let previous_name = previous_parsed.module_name(&previous_content);
+
+        let path = self.source_files.path(id);
+        let inserted_id = self.source_files.insert(path, Arc::clone(text));
+        debug_assert_eq!(inserted_id, id);
+        engine.set_content(id, Arc::clone(text));
+
+        let (current_parsed, _) = engine.parsed(id)?;
+        let current_name = current_parsed.module_name(text);
+        if previous_name != current_name
+            && let Some(previous_name) = previous_name
+        {
+            engine.remove_module_file(&previous_name, id);
+        }
+        if let Some(current_name) = current_name {
+            engine.set_module_file(&current_name, id);
+        }
+        Ok(true)
+    }
+
+    fn remove_source(&mut self, engine: &QueryEngine, unit: &SourceUnitKey, id: FileId) {
+        engine.remove_file(id);
+        let removed_id = self.source_files.remove(unit.source());
+        debug_assert_eq!(removed_id, Some(id));
+        self.source_units.remove(&id);
+    }
+}

--- a/compiler-core/building/src/lifecycle/source.rs
+++ b/compiler-core/building/src/lifecycle/source.rs
@@ -3,19 +3,18 @@ use std::sync::Arc;
 use files::FileId;
 
 use super::*;
-use crate::{QueryEngine, QueryResult};
+use crate::QueryEngine;
 
 impl<Version, Metadata> FileLifecycle<Version, Metadata>
 where
     Version: Clone + Ord,
-    Metadata: Clone + Eq,
 {
     pub(super) fn apply_source(
         &mut self,
         engine: &QueryEngine,
         unit: SourceUnitKey,
         event: SourceEvent<Version, Metadata>,
-    ) -> QueryResult<LifecycleChange> {
+    ) -> LifecycleChange {
         let mut source_unit = self.units.remove(&unit).unwrap_or_default();
         let result = self.apply_source_event(engine, &unit, &mut source_unit, event);
         if !source_unit.is_missing() {
@@ -30,12 +29,12 @@ where
         unit: &SourceUnitKey,
         source_unit: &mut SourceUnit<Version, Metadata>,
         event: SourceEvent<Version, Metadata>,
-    ) -> QueryResult<LifecycleChange> {
+    ) -> LifecycleChange {
         let mut change = LifecycleChange::default();
         let current = std::mem::take(&mut source_unit.source);
         let next = match (current, event) {
             (Member::Missing, SourceEvent::Opened { text, version, metadata }) => {
-                let document = self.insert_source(engine, unit, source_unit, text, metadata)?;
+                let document = self.insert_source(engine, unit, source_unit, text, metadata);
                 change.source_changed(document.id, true);
                 Member::Present(SourceDocument {
                     content: EffectiveContent::Open {
@@ -47,7 +46,7 @@ where
             }
             (Member::Missing, SourceEvent::DiskObserved { disk, metadata }) => match disk {
                 DiskObservation::Found(text) => {
-                    let document = self.insert_source(engine, unit, source_unit, text, metadata)?;
+                    let document = self.insert_source(engine, unit, source_unit, text, metadata);
                     change.source_changed(document.id, true);
                     Member::Present(document)
                 }
@@ -76,11 +75,10 @@ where
                 Member::Missing
             }
             (Member::Present(mut document), SourceEvent::Opened { text, version, metadata }) => {
-                let content_changed = self.set_source_content(engine, document.id, &text)?;
-                let metadata_changed = document.metadata != metadata;
+                let content_changed = self.set_source_content(engine, document.id, &text);
                 document.metadata = metadata;
                 document.content = EffectiveContent::Open { text, version };
-                change.source_changed(document.id, content_changed || metadata_changed);
+                change.source_changed(document.id, content_changed);
                 Member::Present(document)
             }
             (Member::Present(mut document), SourceEvent::Changed { text, version }) => {
@@ -88,8 +86,7 @@ where
                     EffectiveContent::Open { version: current_version, .. }
                         if version > *current_version =>
                     {
-                        let content_changed =
-                            self.set_source_content(engine, document.id, &text)?;
+                        let content_changed = self.set_source_content(engine, document.id, &text);
                         document.content = EffectiveContent::Open { text, version };
                         change.source_changed(document.id, content_changed);
                     }
@@ -116,7 +113,7 @@ where
                     });
                     Member::Present(document)
                 } else {
-                    self.reconcile_closed_source(engine, unit, document, disk, &mut change)?
+                    self.reconcile_closed_source(engine, unit, document, disk, &mut change)
                 }
             }
             (Member::Present(document), SourceEvent::DiskObserved { disk, metadata }) => {
@@ -127,12 +124,12 @@ where
                     });
                     Member::Present(document)
                 } else {
-                    self.reconcile_disk_source(engine, unit, document, disk, metadata, &mut change)?
+                    self.reconcile_disk_source(engine, unit, document, disk, metadata, &mut change)
                 }
             }
         };
         source_unit.source = next;
-        Ok(change)
+        change
     }
 
     fn reconcile_closed_source(
@@ -142,13 +139,13 @@ where
         mut document: SourceDocument<Version, Metadata>,
         disk: DiskObservation,
         change: &mut LifecycleChange,
-    ) -> QueryResult<Member<SourceDocument<Version, Metadata>>> {
+    ) -> Member<SourceDocument<Version, Metadata>> {
         match disk {
             DiskObservation::Found(text) => {
-                let content_changed = self.set_source_content(engine, document.id, &text)?;
+                let content_changed = self.set_source_content(engine, document.id, &text);
                 document.content = EffectiveContent::Disk { text };
                 change.source_changed(document.id, content_changed);
-                Ok(Member::Present(document))
+                Member::Present(document)
             }
             DiskObservation::NotFound => {
                 self.remove_source(engine, unit, document.id);
@@ -157,7 +154,7 @@ where
                     file_id: document.id,
                     locator: Arc::clone(&unit.source),
                 });
-                Ok(Member::Missing)
+                Member::Missing
             }
             DiskObservation::Failed(failure) => {
                 let text = Arc::clone(document.content.text());
@@ -169,7 +166,7 @@ where
                     document: DocumentKind::Source,
                     failure,
                 });
-                Ok(Member::Present(document))
+                Member::Present(document)
             }
         }
     }
@@ -182,15 +179,14 @@ where
         disk: DiskObservation,
         metadata: Metadata,
         change: &mut LifecycleChange,
-    ) -> QueryResult<Member<SourceDocument<Version, Metadata>>> {
+    ) -> Member<SourceDocument<Version, Metadata>> {
         match disk {
             DiskObservation::Found(text) => {
-                let content_changed = self.set_source_content(engine, document.id, &text)?;
-                let metadata_changed = document.metadata != metadata;
+                let content_changed = self.set_source_content(engine, document.id, &text);
                 document.metadata = metadata;
                 document.content = EffectiveContent::Disk { text };
-                change.source_changed(document.id, content_changed || metadata_changed);
-                Ok(Member::Present(document))
+                change.source_changed(document.id, content_changed);
+                Member::Present(document)
             }
             DiskObservation::NotFound => {
                 self.remove_source(engine, unit, document.id);
@@ -199,7 +195,7 @@ where
                     file_id: document.id,
                     locator: Arc::clone(&unit.source),
                 });
-                Ok(Member::Missing)
+                Member::Missing
             }
             DiskObservation::Failed(failure) => {
                 let text = Arc::clone(document.content.text());
@@ -211,7 +207,7 @@ where
                     document: DocumentKind::Source,
                     failure,
                 });
-                Ok(Member::Present(document))
+                Member::Present(document)
             }
         }
     }
@@ -223,31 +219,30 @@ where
         source_unit: &SourceUnit<Version, Metadata>,
         text: Arc<str>,
         metadata: Metadata,
-    ) -> QueryResult<SourceDocument<Version, Metadata>> {
+    ) -> SourceDocument<Version, Metadata> {
         let id = self.source_files.insert(Arc::clone(&unit.source), Arc::clone(&text));
         self.source_units.insert(id, SourceUnitKey::clone(unit));
         engine.set_content(id, Arc::clone(&text));
-        let (parsed, _) = engine.parsed(id)?;
+        let lexed = lexing::lex(&text);
+        let tokens = lexing::layout(&lexed);
+        let (parsed, _) = parsing::parse(&lexed, &tokens);
         if let Some(name) = parsed.module_name(&text) {
             engine.set_module_file(&name, id);
         }
         if let Some(foreign_id) = source_unit.foreign_id() {
             engine.set_foreign_file(id, foreign_id);
         }
-        Ok(SourceDocument { id, metadata, content: EffectiveContent::Disk { text } })
+        SourceDocument { id, metadata, content: EffectiveContent::Disk { text } }
     }
 
-    fn set_source_content(
-        &mut self,
-        engine: &QueryEngine,
-        id: FileId,
-        text: &Arc<str>,
-    ) -> QueryResult<bool> {
+    fn set_source_content(&mut self, engine: &QueryEngine, id: FileId, text: &Arc<str>) -> bool {
         let previous_content = self.source_files.content(id);
         if previous_content == *text {
-            return Ok(false);
+            return false;
         }
-        let (previous_parsed, _) = engine.parsed(id)?;
+        let previous_lexed = lexing::lex(&previous_content);
+        let previous_tokens = lexing::layout(&previous_lexed);
+        let (previous_parsed, _) = parsing::parse(&previous_lexed, &previous_tokens);
         let previous_name = previous_parsed.module_name(&previous_content);
 
         let path = self.source_files.path(id);
@@ -255,7 +250,9 @@ where
         debug_assert_eq!(inserted_id, id);
         engine.set_content(id, Arc::clone(text));
 
-        let (current_parsed, _) = engine.parsed(id)?;
+        let current_lexed = lexing::lex(text);
+        let current_tokens = lexing::layout(&current_lexed);
+        let (current_parsed, _) = parsing::parse(&current_lexed, &current_tokens);
         let current_name = current_parsed.module_name(text);
         if previous_name != current_name
             && let Some(previous_name) = previous_name
@@ -265,7 +262,7 @@ where
         if let Some(current_name) = current_name {
             engine.set_module_file(&current_name, id);
         }
-        Ok(true)
+        true
     }
 
     fn remove_source(&mut self, engine: &QueryEngine, unit: &SourceUnitKey, id: FileId) {

--- a/compiler-core/building/src/lifecycle/source.rs
+++ b/compiler-core/building/src/lifecycle/source.rs
@@ -17,9 +17,7 @@ where
     ) -> LifecycleChange {
         let mut source_unit = self.units.remove(&unit).unwrap_or_default();
         let result = self.apply_source_event(engine, &unit, &mut source_unit, event);
-        if !source_unit.is_missing() {
-            self.units.insert(unit, source_unit);
-        }
+        self.store_unit(unit, source_unit);
         result
     }
 

--- a/compiler-core/building/src/lifecycle/tests.rs
+++ b/compiler-core/building/src/lifecycle/tests.rs
@@ -1,0 +1,148 @@
+use std::sync::Arc;
+
+use super::{
+    AnalysisInvalidation, ContentAuthority, DiskObservation, DocumentKey, FileLifecycle,
+    ForeignEvent, LifecycleEvent, ReloadFailure, SourceEvent, SourceUnitKey,
+};
+use crate::QueryEngine;
+
+fn unit() -> SourceUnitKey {
+    SourceUnitKey::new("file:///src/Main.purs", "file:///src/Main.js")
+}
+
+fn text(content: &str) -> Arc<str> {
+    Arc::from(content)
+}
+
+fn source_opened(version: i32, content: &str) -> LifecycleEvent<i32, bool> {
+    LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::Opened { text: text(content), version, metadata: true },
+    }
+}
+
+fn source_disk(content: &str) -> LifecycleEvent<i32, bool> {
+    LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::DiskObserved {
+            disk: DiskObservation::Found(text(content)),
+            metadata: true,
+        },
+    }
+}
+
+fn foreign_opened(version: i32, content: &str) -> LifecycleEvent<i32, bool> {
+    LifecycleEvent::Foreign {
+        unit: unit(),
+        event: ForeignEvent::Opened { text: text(content), version },
+    }
+}
+
+#[test]
+fn open_source_ignores_disk_events_and_rejects_stale_changes() {
+    let engine = QueryEngine::default();
+    let mut files = FileLifecycle::default();
+    let content = "module Main where\n";
+    files.apply(&engine, source_opened(2, content)).unwrap();
+    let file_id = files.source_id(unit().source()).unwrap();
+
+    let event = LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::DiskObserved { disk: DiskObservation::NotFound, metadata: true },
+    };
+    files.apply(&engine, event).unwrap();
+    assert_eq!(files.source_id(unit().source()), Some(file_id));
+    assert_eq!(files.source_authority(&unit()), Some(ContentAuthority::Open));
+
+    let event = LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::Changed { text: text("module Newer where\n"), version: 1 },
+    };
+    files.apply(&engine, event).unwrap();
+    assert_eq!(engine.content(file_id).unwrap().as_ref(), content);
+}
+
+#[test]
+fn source_close_reloads_retains_or_removes() {
+    let engine = QueryEngine::default();
+    let mut files = FileLifecycle::default();
+    files.apply(&engine, source_opened(1, "module Main where\n")).unwrap();
+    let file_id = files.source_id(unit().source()).unwrap();
+
+    let event = LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::Closed {
+            disk: DiskObservation::Failed(ReloadFailure::new(
+                std::io::ErrorKind::PermissionDenied,
+                "permission denied",
+            )),
+        },
+    };
+    files.apply(&engine, event).unwrap();
+    assert_eq!(files.source_authority(&unit()), Some(ContentAuthority::Retained));
+    assert_eq!(engine.content(file_id).unwrap().as_ref(), "module Main where\n");
+
+    files.apply(&engine, source_opened(2, "module Main where\n")).unwrap();
+    let event = LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::Closed { disk: DiskObservation::NotFound },
+    };
+    let change = files.apply(&engine, event).unwrap();
+    assert_eq!(files.source_id(unit().source()), None);
+    assert_eq!(change.removed_sources()[0].file_id, file_id);
+    assert!(matches!(change.analysis(), AnalysisInvalidation::Workspace));
+}
+
+#[test]
+fn removed_and_recreated_source_gets_new_identity() {
+    let engine = QueryEngine::default();
+    let mut files = FileLifecycle::default();
+    files.apply(&engine, source_disk("module Main where\n")).unwrap();
+    let removed_id = files.source_id(unit().source()).unwrap();
+
+    let event = LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::DiskObserved { disk: DiskObservation::NotFound, metadata: true },
+    };
+    files.apply(&engine, event).unwrap();
+    files.apply(&engine, source_disk("module Main where\n")).unwrap();
+    let recreated_id = files.source_id(unit().source()).unwrap();
+    assert!(recreated_id > removed_id);
+}
+
+#[test]
+fn foreign_only_unit_associates_when_source_appears() {
+    let engine = QueryEngine::default();
+    let mut files = FileLifecycle::default();
+    files.apply(&engine, foreign_opened(1, "export const life = 42;\n")).unwrap();
+    let foreign_id = files.foreign_id(unit().foreign()).unwrap();
+    assert_eq!(files.foreign_authority(&unit()), Some(ContentAuthority::Open));
+
+    files.apply(&engine, source_disk("module Main where\n")).unwrap();
+    let source_id = files.source_id(unit().source()).unwrap();
+    assert_eq!(engine.foreign_file(source_id), Some(foreign_id));
+}
+
+#[test]
+fn open_foreign_ignores_disk_deletion_until_close() {
+    let engine = QueryEngine::default();
+    let mut files = FileLifecycle::default();
+    files.apply(&engine, source_disk("module Main where\n")).unwrap();
+    files.apply(&engine, foreign_opened(1, "export const life = 42;\n")).unwrap();
+    let foreign_id = files.foreign_id(unit().foreign()).unwrap();
+
+    let event = LifecycleEvent::Foreign {
+        unit: unit(),
+        event: ForeignEvent::DiskObserved { disk: DiskObservation::NotFound },
+    };
+    files.apply(&engine, event).unwrap();
+    assert_eq!(files.foreign_id(unit().foreign()), Some(foreign_id));
+    assert!(files.is_open(&DocumentKey::Foreign(unit())));
+
+    let event = LifecycleEvent::Foreign {
+        unit: unit(),
+        event: ForeignEvent::Closed { disk: DiskObservation::NotFound },
+    };
+    files.apply(&engine, event).unwrap();
+    assert_eq!(files.foreign_id(unit().foreign()), None);
+}

--- a/compiler-core/building/src/lifecycle/tests.rs
+++ b/compiler-core/building/src/lifecycle/tests.rs
@@ -39,6 +39,13 @@ fn foreign_opened(version: i32, content: &str) -> LifecycleEvent<i32, bool> {
     }
 }
 
+fn foreign_disk(content: &str) -> LifecycleEvent<i32, bool> {
+    LifecycleEvent::Foreign {
+        unit: unit(),
+        event: ForeignEvent::DiskObserved { disk: DiskObservation::Found(text(content)) },
+    }
+}
+
 #[test]
 fn open_source_ignores_disk_events_and_rejects_stale_changes() {
     let engine = QueryEngine::default();
@@ -374,4 +381,115 @@ fn foreign_changes_reject_stale_versions_and_recover_retained_content() {
     assert_eq!(files.foreign_authority(&unit()), Some(ContentAuthority::Disk));
     assert_eq!(files.foreign_reload_failure(&unit()), None);
     assert_eq!(engine.foreign_content(foreign_id).unwrap().as_ref(), "export const life = 44;\n");
+}
+
+#[test]
+fn one_source_locator_cannot_belong_to_two_sibling_pairs() {
+    let engine = QueryEngine::default();
+    let mut files = FileLifecycle::default();
+    let original = unit();
+    let conflicting = SourceUnitKey::new(original.source(), "file:///src/Alternate.js");
+
+    files.apply(&engine, source_disk("module Main where\n"));
+    files.apply(&engine, foreign_disk("export const life = 42;\n"));
+    let original_source_id = files.source_id(original.source()).unwrap();
+
+    let event = LifecycleEvent::Source {
+        unit: SourceUnitKey::clone(&conflicting),
+        event: SourceEvent::DiskObserved {
+            disk: DiskObservation::Found(text("module Conflict where\n")),
+            metadata: false,
+        },
+    };
+    let change = files.apply(&engine, event);
+    assert!(matches!(
+        change.warnings(),
+        [LifecycleWarning::LocatorAlreadyOwned { locator, owner, requested }]
+            if locator.as_ref() == original.source()
+                && owner == &original
+                && requested == &conflicting
+    ));
+    assert_eq!(files.source_id(original.source()), Some(original_source_id));
+    assert_eq!(files.foreign_id(conflicting.foreign()), None);
+
+    let event = LifecycleEvent::Source {
+        unit: SourceUnitKey::clone(&original),
+        event: SourceEvent::DiskObserved { disk: DiskObservation::NotFound, metadata: true },
+    };
+    files.apply(&engine, event);
+    let event = LifecycleEvent::Source {
+        unit: SourceUnitKey::clone(&conflicting),
+        event: SourceEvent::DiskObserved {
+            disk: DiskObservation::Found(text("module Conflict where\n")),
+            metadata: false,
+        },
+    };
+    let change = files.apply(&engine, event);
+    assert!(matches!(change.warnings(), [LifecycleWarning::LocatorAlreadyOwned { .. }]));
+
+    let event = LifecycleEvent::Foreign {
+        unit: SourceUnitKey::clone(&original),
+        event: ForeignEvent::DiskObserved { disk: DiskObservation::NotFound },
+    };
+    files.apply(&engine, event);
+    let event = LifecycleEvent::Source {
+        unit: SourceUnitKey::clone(&conflicting),
+        event: SourceEvent::DiskObserved {
+            disk: DiskObservation::Found(text("module Conflict where\n")),
+            metadata: false,
+        },
+    };
+    files.apply(&engine, event);
+    let replacement_source_id = files.source_id(conflicting.source()).unwrap();
+    assert!(replacement_source_id > original_source_id);
+}
+
+#[test]
+fn one_foreign_locator_cannot_belong_to_two_sibling_pairs() {
+    let engine = QueryEngine::default();
+    let mut files = FileLifecycle::default();
+    let original = unit();
+    let conflicting = SourceUnitKey::new("file:///src/Alternate.purs", original.foreign());
+
+    files.apply(&engine, source_disk("module Main where\n"));
+    files.apply(&engine, foreign_disk("export const life = 42;\n"));
+    let original_foreign_id = files.foreign_id(original.foreign()).unwrap();
+
+    let event = LifecycleEvent::Foreign {
+        unit: SourceUnitKey::clone(&conflicting),
+        event: ForeignEvent::DiskObserved {
+            disk: DiskObservation::Found(text("export const conflict = 1;\n")),
+        },
+    };
+    let change = files.apply(&engine, event);
+    assert!(matches!(
+        change.warnings(),
+        [LifecycleWarning::LocatorAlreadyOwned { locator, owner, requested }]
+            if locator.as_ref() == original.foreign()
+                && owner == &original
+                && requested == &conflicting
+    ));
+    assert_eq!(files.foreign_id(original.foreign()), Some(original_foreign_id));
+    assert_eq!(files.source_id(conflicting.source()), None);
+
+    let event = LifecycleEvent::Source {
+        unit: SourceUnitKey::clone(&original),
+        event: SourceEvent::DiskObserved { disk: DiskObservation::NotFound, metadata: true },
+    };
+    files.apply(&engine, event);
+    let event = LifecycleEvent::Foreign {
+        unit: SourceUnitKey::clone(&original),
+        event: ForeignEvent::DiskObserved { disk: DiskObservation::NotFound },
+    };
+    files.apply(&engine, event);
+
+    let event = LifecycleEvent::Foreign {
+        unit: SourceUnitKey::clone(&conflicting),
+        event: ForeignEvent::DiskObserved {
+            disk: DiskObservation::Found(text("export const conflict = 1;\n")),
+        },
+    };
+    files.apply(&engine, event);
+    let replacement_foreign_id = files.foreign_id(conflicting.foreign()).unwrap();
+    assert!(replacement_foreign_id > original_foreign_id);
 }

--- a/compiler-core/building/src/lifecycle/tests.rs
+++ b/compiler-core/building/src/lifecycle/tests.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
 use super::{
-    AnalysisInvalidation, ContentAuthority, DiskObservation, DocumentKey, FileLifecycle,
-    ForeignEvent, LifecycleEvent, ReloadFailure, SourceEvent, SourceUnitKey,
+    AnalysisInvalidation, ContentAuthority, DiskObservation, DocumentKey, DocumentKind,
+    FileLifecycle, ForeignEvent, LifecycleEvent, LifecycleWarning, ReloadFailure, SourceEvent,
+    SourceUnitKey,
 };
 use crate::QueryEngine;
 
@@ -43,14 +44,14 @@ fn open_source_ignores_disk_events_and_rejects_stale_changes() {
     let engine = QueryEngine::default();
     let mut files = FileLifecycle::default();
     let content = "module Main where\n";
-    files.apply(&engine, source_opened(2, content)).unwrap();
+    files.apply(&engine, source_opened(2, content));
     let file_id = files.source_id(unit().source()).unwrap();
 
     let event = LifecycleEvent::Source {
         unit: unit(),
         event: SourceEvent::DiskObserved { disk: DiskObservation::NotFound, metadata: true },
     };
-    files.apply(&engine, event).unwrap();
+    files.apply(&engine, event);
     assert_eq!(files.source_id(unit().source()), Some(file_id));
     assert_eq!(files.source_authority(&unit()), Some(ContentAuthority::Open));
 
@@ -58,7 +59,7 @@ fn open_source_ignores_disk_events_and_rejects_stale_changes() {
         unit: unit(),
         event: SourceEvent::Changed { text: text("module Newer where\n"), version: 1 },
     };
-    files.apply(&engine, event).unwrap();
+    files.apply(&engine, event);
     assert_eq!(engine.content(file_id).unwrap().as_ref(), content);
 }
 
@@ -66,7 +67,7 @@ fn open_source_ignores_disk_events_and_rejects_stale_changes() {
 fn source_close_reloads_retains_or_removes() {
     let engine = QueryEngine::default();
     let mut files = FileLifecycle::default();
-    files.apply(&engine, source_opened(1, "module Main where\n")).unwrap();
+    files.apply(&engine, source_opened(1, "module Main where\n"));
     let file_id = files.source_id(unit().source()).unwrap();
 
     let event = LifecycleEvent::Source {
@@ -78,16 +79,16 @@ fn source_close_reloads_retains_or_removes() {
             )),
         },
     };
-    files.apply(&engine, event).unwrap();
+    files.apply(&engine, event);
     assert_eq!(files.source_authority(&unit()), Some(ContentAuthority::Retained));
     assert_eq!(engine.content(file_id).unwrap().as_ref(), "module Main where\n");
 
-    files.apply(&engine, source_opened(2, "module Main where\n")).unwrap();
+    files.apply(&engine, source_opened(2, "module Main where\n"));
     let event = LifecycleEvent::Source {
         unit: unit(),
         event: SourceEvent::Closed { disk: DiskObservation::NotFound },
     };
-    let change = files.apply(&engine, event).unwrap();
+    let change = files.apply(&engine, event);
     assert_eq!(files.source_id(unit().source()), None);
     assert_eq!(change.removed_sources()[0].file_id, file_id);
     assert!(matches!(change.analysis(), AnalysisInvalidation::Workspace));
@@ -97,15 +98,15 @@ fn source_close_reloads_retains_or_removes() {
 fn removed_and_recreated_source_gets_new_identity() {
     let engine = QueryEngine::default();
     let mut files = FileLifecycle::default();
-    files.apply(&engine, source_disk("module Main where\n")).unwrap();
+    files.apply(&engine, source_disk("module Main where\n"));
     let removed_id = files.source_id(unit().source()).unwrap();
 
     let event = LifecycleEvent::Source {
         unit: unit(),
         event: SourceEvent::DiskObserved { disk: DiskObservation::NotFound, metadata: true },
     };
-    files.apply(&engine, event).unwrap();
-    files.apply(&engine, source_disk("module Main where\n")).unwrap();
+    files.apply(&engine, event);
+    files.apply(&engine, source_disk("module Main where\n"));
     let recreated_id = files.source_id(unit().source()).unwrap();
     assert!(recreated_id > removed_id);
 }
@@ -114,11 +115,11 @@ fn removed_and_recreated_source_gets_new_identity() {
 fn foreign_only_unit_associates_when_source_appears() {
     let engine = QueryEngine::default();
     let mut files = FileLifecycle::default();
-    files.apply(&engine, foreign_opened(1, "export const life = 42;\n")).unwrap();
+    files.apply(&engine, foreign_opened(1, "export const life = 42;\n"));
     let foreign_id = files.foreign_id(unit().foreign()).unwrap();
     assert_eq!(files.foreign_authority(&unit()), Some(ContentAuthority::Open));
 
-    files.apply(&engine, source_disk("module Main where\n")).unwrap();
+    files.apply(&engine, source_disk("module Main where\n"));
     let source_id = files.source_id(unit().source()).unwrap();
     assert_eq!(engine.foreign_file(source_id), Some(foreign_id));
 }
@@ -127,15 +128,15 @@ fn foreign_only_unit_associates_when_source_appears() {
 fn open_foreign_ignores_disk_deletion_until_close() {
     let engine = QueryEngine::default();
     let mut files = FileLifecycle::default();
-    files.apply(&engine, source_disk("module Main where\n")).unwrap();
-    files.apply(&engine, foreign_opened(1, "export const life = 42;\n")).unwrap();
+    files.apply(&engine, source_disk("module Main where\n"));
+    files.apply(&engine, foreign_opened(1, "export const life = 42;\n"));
     let foreign_id = files.foreign_id(unit().foreign()).unwrap();
 
     let event = LifecycleEvent::Foreign {
         unit: unit(),
         event: ForeignEvent::DiskObserved { disk: DiskObservation::NotFound },
     };
-    files.apply(&engine, event).unwrap();
+    files.apply(&engine, event);
     assert_eq!(files.foreign_id(unit().foreign()), Some(foreign_id));
     assert!(files.is_open(&DocumentKey::Foreign(unit())));
 
@@ -143,6 +144,234 @@ fn open_foreign_ignores_disk_deletion_until_close() {
         unit: unit(),
         event: ForeignEvent::Closed { disk: DiskObservation::NotFound },
     };
-    files.apply(&engine, event).unwrap();
+    files.apply(&engine, event);
     assert_eq!(files.foreign_id(unit().foreign()), None);
+}
+
+#[test]
+fn invalid_events_are_ignored_with_typed_warnings() {
+    let engine = QueryEngine::default();
+    let mut files = FileLifecycle::default();
+
+    let event = LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::Changed { text: text("module Main where\n"), version: 1 },
+    };
+    let change = files.apply(&engine, event);
+    assert!(matches!(
+        change.warnings(),
+        [LifecycleWarning::ChangedNonOpen { document: DocumentKind::Source, .. }]
+    ));
+
+    let event = LifecycleEvent::Foreign {
+        unit: unit(),
+        event: ForeignEvent::Closed { disk: DiskObservation::NotFound },
+    };
+    let change = files.apply(&engine, event);
+    assert!(matches!(
+        change.warnings(),
+        [LifecycleWarning::ClosedNonOpen { document: DocumentKind::Foreign, .. }]
+    ));
+
+    let failure = ReloadFailure::new(std::io::ErrorKind::PermissionDenied, "permission denied");
+    let event = LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::DiskObserved {
+            disk: DiskObservation::Failed(ReloadFailure::clone(&failure)),
+            metadata: true,
+        },
+    };
+    let change = files.apply(&engine, event);
+    assert!(matches!(
+        change.warnings(),
+        [LifecycleWarning::ReloadFailed {
+            document: DocumentKind::Source,
+            failure: observed,
+            ..
+        }] if *observed == failure
+    ));
+    assert_eq!(files.source_id(unit().source()), None);
+}
+
+#[test]
+fn source_updates_preserve_identity_and_module_ownership() {
+    let engine = QueryEngine::default();
+    let mut files = FileLifecycle::default();
+    files.apply(&engine, source_disk("module Main where\n"));
+    let file_id = files.source_id(unit().source()).unwrap();
+    assert_eq!(engine.module_file("Main"), Some(file_id));
+
+    let event = LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::DiskObserved {
+            disk: DiskObservation::Found(text("module Library where\n")),
+            metadata: false,
+        },
+    };
+    let change = files.apply(&engine, event);
+    assert_eq!(files.source_id(unit().source()), Some(file_id));
+    assert_eq!(files.source_metadata(file_id), Some(&false));
+    assert_eq!(engine.module_file("Main"), None);
+    assert_eq!(engine.module_file("Library"), Some(file_id));
+    assert!(matches!(change.analysis(), AnalysisInvalidation::Workspace));
+
+    let event = LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::Opened {
+            text: text("module Library where\n"),
+            version: 3,
+            metadata: true,
+        },
+    };
+    let change = files.apply(&engine, event);
+    assert_eq!(files.source_version(file_id), Some(3));
+    assert!(matches!(change.analysis(), AnalysisInvalidation::Sources(_)));
+
+    let event = LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::Changed { text: text("module Newer where\n"), version: 4 },
+    };
+    files.apply(&engine, event);
+    assert_eq!(engine.module_file("Library"), None);
+    assert_eq!(engine.module_file("Newer"), Some(file_id));
+
+    let event = LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::Closed { disk: DiskObservation::Found(text("module Disk where\n")) },
+    };
+    files.apply(&engine, event);
+    assert_eq!(files.source_id(unit().source()), Some(file_id));
+    assert_eq!(files.source_version(file_id), None);
+    assert_eq!(files.source_authority(&unit()), Some(ContentAuthority::Disk));
+    assert_eq!(engine.module_file("Newer"), None);
+    assert_eq!(engine.module_file("Disk"), Some(file_id));
+}
+
+#[test]
+fn retained_source_recovers_without_changing_identity() {
+    let engine = QueryEngine::default();
+    let mut files = FileLifecycle::default();
+    files.apply(&engine, source_disk("module Main where\n"));
+    let file_id = files.source_id(unit().source()).unwrap();
+    let failure = ReloadFailure::new(std::io::ErrorKind::TimedOut, "timed out");
+
+    let event = LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::DiskObserved {
+            disk: DiskObservation::Failed(ReloadFailure::clone(&failure)),
+            metadata: true,
+        },
+    };
+    files.apply(&engine, event);
+    assert_eq!(files.source_authority(&unit()), Some(ContentAuthority::Retained));
+    assert_eq!(files.source_reload_failure(&unit()), Some(&failure));
+    assert_eq!(engine.content(file_id).unwrap().as_ref(), "module Main where\n");
+
+    let event = LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::DiskObserved {
+            disk: DiskObservation::Found(text("module Recovered where\n")),
+            metadata: true,
+        },
+    };
+    files.apply(&engine, event);
+    assert_eq!(files.source_id(unit().source()), Some(file_id));
+    assert_eq!(files.source_authority(&unit()), Some(ContentAuthority::Disk));
+    assert_eq!(files.source_reload_failure(&unit()), None);
+    assert_eq!(engine.content(file_id).unwrap().as_ref(), "module Recovered where\n");
+}
+
+#[test]
+fn sibling_identity_and_association_follow_delete_and_recreate() {
+    let engine = QueryEngine::default();
+    let mut files = FileLifecycle::default();
+    files.apply(&engine, source_disk("module Main where\n"));
+    let event = LifecycleEvent::Foreign {
+        unit: unit(),
+        event: ForeignEvent::DiskObserved {
+            disk: DiskObservation::Found(text("export const life = 42;\n")),
+        },
+    };
+    files.apply(&engine, event);
+    let source_id = files.source_id(unit().source()).unwrap();
+    let foreign_id = files.foreign_id(unit().foreign()).unwrap();
+    assert_eq!(engine.foreign_file(source_id), Some(foreign_id));
+
+    let event = LifecycleEvent::Source {
+        unit: unit(),
+        event: SourceEvent::DiskObserved { disk: DiskObservation::NotFound, metadata: true },
+    };
+    files.apply(&engine, event);
+    assert_eq!(files.foreign_id(unit().foreign()), Some(foreign_id));
+
+    files.apply(&engine, source_disk("module Main where\n"));
+    let recreated_source_id = files.source_id(unit().source()).unwrap();
+    assert!(recreated_source_id > source_id);
+    assert_eq!(engine.foreign_file(recreated_source_id), Some(foreign_id));
+
+    let event = LifecycleEvent::Foreign {
+        unit: unit(),
+        event: ForeignEvent::DiskObserved { disk: DiskObservation::NotFound },
+    };
+    files.apply(&engine, event);
+    assert_eq!(files.foreign_id(unit().foreign()), None);
+    assert_eq!(engine.foreign_file(recreated_source_id), None);
+
+    let event = LifecycleEvent::Foreign {
+        unit: unit(),
+        event: ForeignEvent::DiskObserved {
+            disk: DiskObservation::Found(text("export const life = 43;\n")),
+        },
+    };
+    files.apply(&engine, event);
+    let recreated_foreign_id = files.foreign_id(unit().foreign()).unwrap();
+    assert!(recreated_foreign_id > foreign_id);
+    assert_eq!(engine.foreign_file(recreated_source_id), Some(recreated_foreign_id));
+}
+
+#[test]
+fn foreign_changes_reject_stale_versions_and_recover_retained_content() {
+    let engine = QueryEngine::default();
+    let mut files = FileLifecycle::default();
+    files.apply(&engine, source_disk("module Main where\n"));
+    files.apply(&engine, foreign_opened(2, "export const life = 42;\n"));
+    let foreign_id = files.foreign_id(unit().foreign()).unwrap();
+
+    let event = LifecycleEvent::Foreign {
+        unit: unit(),
+        event: ForeignEvent::Changed { text: text("export const life = 1;\n"), version: 1 },
+    };
+    let change = files.apply(&engine, event);
+    assert!(matches!(change.warnings(), [LifecycleWarning::StaleChange { .. }]));
+    assert_eq!(engine.foreign_content(foreign_id).unwrap().as_ref(), "export const life = 42;\n");
+
+    let event = LifecycleEvent::Foreign {
+        unit: unit(),
+        event: ForeignEvent::Changed { text: text("export const life = 43;\n"), version: 3 },
+    };
+    files.apply(&engine, event);
+    assert_eq!(engine.foreign_content(foreign_id).unwrap().as_ref(), "export const life = 43;\n");
+
+    let failure = ReloadFailure::new(std::io::ErrorKind::Interrupted, "interrupted");
+    let event = LifecycleEvent::Foreign {
+        unit: unit(),
+        event: ForeignEvent::Closed {
+            disk: DiskObservation::Failed(ReloadFailure::clone(&failure)),
+        },
+    };
+    files.apply(&engine, event);
+    assert_eq!(files.foreign_authority(&unit()), Some(ContentAuthority::Retained));
+    assert_eq!(files.foreign_reload_failure(&unit()), Some(&failure));
+
+    let event = LifecycleEvent::Foreign {
+        unit: unit(),
+        event: ForeignEvent::DiskObserved {
+            disk: DiskObservation::Found(text("export const life = 44;\n")),
+        },
+    };
+    files.apply(&engine, event);
+    assert_eq!(files.foreign_id(unit().foreign()), Some(foreign_id));
+    assert_eq!(files.foreign_authority(&unit()), Some(ContentAuthority::Disk));
+    assert_eq!(files.foreign_reload_failure(&unit()), None);
+    assert_eq!(engine.foreign_content(foreign_id).unwrap().as_ref(), "export const life = 44;\n");
 }


### PR DESCRIPTION
## Problem

The LSP previously coordinated PureScript sources, sibling JavaScript files, open documents, disk reloads, query invalidation, and diagnostics in separate handlers. Correctness depended on handler ordering when files were open, deleted, recreated, or temporarily unreadable.

## API design

- Add `FileLifecycle<Version, Metadata>` to `building` as the owner of source/foreign lifecycle state.
- Address one `.purs`/`.js` pair with `SourceUnitKey`.
- Split `LifecycleEvent` into `SourceEvent` and `ForeignEvent` payloads.
- Represent disk reads as `DiskObservation::{Found, NotFound, Failed}`.
- Keep open-buffer, disk-backed, retained-after-reload-failure, and missing states distinct.
- Apply engine content, module ownership, foreign association, identity retirement, and query invalidation inside `FileLifecycle::apply`.
- Return `LifecycleChange` with changed and removed identities, invalidation scope, and typed warnings. Callers remain responsible for I/O and diagnostics scheduling.
- Reject source or foreign locators already owned by a different `SourceUnitKey`. Ownership is released after both members are missing.

The reducer has no LSP dependency. A batch compiler or watch-mode process can translate its watcher and editor inputs into the same events without reimplementing lifecycle transitions.

## LSP integration

Startup loading, document open/change/close, watched-file notifications, and sibling reconciliation now use the reducer. Duplicate source closes do not reload or delete a sibling foreign file. Diagnostics jobs are keyed by source identity, document version, and invalidation generation; a panicking or cancelled worker now still completes its scheduler job without publishing diagnostics.

### URI boundary

The LSP lifecycle adapter accepts only valid, locally convertible `file:` document URIs. All other schemes are rejected before lifecycle state is created. Virtual documents are outside this PR; they require a separate explicit abstraction. Prim currently materializes temporary files and therefore remains within the file-backed path.

This PR deliberately does not infer sibling files for `untitled:` or arbitrary URI schemes.

## Deferred work

Source changes currently parse old and new content when determining module-name changes. This is acceptable for now and tracked separately in #361.

## Validation

- `cargo nextest run -p building` — 53 passed
- `cargo nextest run -p purescript-alexandrite` — 43 passed
- `just t lsp` — all tests passed, no pending snapshots
- `just format`