### PR TITLE
[backend] Compose JavaScript blocks with pretty documents

### DIFF
--- a/compiler-backend/javascript/src/convert/generator.rs
+++ b/compiler-backend/javascript/src/convert/generator.rs
@@ -200,11 +200,9 @@ impl<'m> Generator<'m> {
                 writer.expression_line(format!("{export}const {name} = "), tree, expression, ";");
             } else {
                 let context = FunctionContext::new(self, function);
-                writer.line(format!("{export}const {name} = (() => {{"));
-                writer.indent();
-                self.render_function_body(tree, writer, function, &context)?;
-                writer.dedent();
-                writer.line("})();");
+                writer.block(format!("{export}const {name} = (() => {{"), "})();", |writer| {
+                    self.render_function_body(tree, writer, function, &context)
+                })?;
             }
             writer.blank();
         }

--- a/compiler-backend/javascript/src/convert/generator/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/render.rs
@@ -56,20 +56,26 @@ impl Generator<'_> {
         };
 
         let export = if exported { "export " } else { "" };
-        writer.line(format!("{export}function {name}({}) {{", function_parameters.join(", ")));
-        writer.indent();
-        for parameter in &arrow_parameters {
-            writer.line(format!("return {parameter} => {{"));
-            writer.indent();
-        }
-        self.render_function_body(tree, writer, function, &context)?;
-        for _ in arrow_parameters.iter().rev() {
-            writer.dedent();
-            writer.line("};");
-        }
-        writer.dedent();
-        writer.line("}");
-        Ok(())
+        let header = format!("{export}function {name}({}) {{", function_parameters.join(", "));
+        writer.block(header, "}", |writer| {
+            self.render_curried_function_body(tree, writer, function, &context, &arrow_parameters)
+        })
+    }
+
+    fn render_curried_function_body(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        function: &Function,
+        context: &FunctionContext,
+        parameters: &[String],
+    ) -> ModuleResult<()> {
+        let Some((parameter, parameters)) = parameters.split_first() else {
+            return self.render_function_body(tree, writer, function, context);
+        };
+        writer.block(format!("return {parameter} => {{"), "};", |writer| {
+            self.render_curried_function_body(tree, writer, function, context, parameters)
+        })
     }
 
     pub(super) fn render_function_body(
@@ -116,16 +122,12 @@ impl Generator<'_> {
                 helpers.captures[&block_id].iter().map(|capture| context.value(*capture));
             let parameters = parameters.into_iter().chain(captures);
             let parameters = parameters.collect_vec();
-            writer.line(format!(
-                "function {}({}) {{",
-                context.block(block_id),
-                parameters.join(", ")
-            ));
-            writer.indent();
-            let mut output = RenderingOutput { tree, writer };
-            self.render_acyclic_block(&mut output, block_id, context, control_flow, &helpers)?;
-            writer.dedent();
-            writer.line("}");
+            let header =
+                format!("function {}({}) {{", context.block(block_id), parameters.join(", "));
+            writer.block(header, "}", |writer| {
+                let mut output = RenderingOutput { tree, writer };
+                self.render_acyclic_block(&mut output, block_id, context, control_flow, &helpers)
+            })?;
             writer.blank();
         }
         let mut output = RenderingOutput { tree, writer };
@@ -178,29 +180,32 @@ impl Generator<'_> {
             }
             Terminator::Branch { condition, then_target, else_target } => {
                 let condition = expressions.expression(output.tree, *condition);
-                output.writer.expression_line("if (", output.tree, condition, ") {");
-                output.writer.indent();
-                self.render_acyclic_target(
-                    output,
-                    then_target,
-                    context,
-                    &expressions,
-                    control_flow,
-                    helpers,
+                output.writer.if_else(
+                    output.tree,
+                    condition,
+                    |tree, writer| {
+                        let mut output = RenderingOutput { tree, writer };
+                        self.render_acyclic_target(
+                            &mut output,
+                            then_target,
+                            context,
+                            &expressions,
+                            control_flow,
+                            helpers,
+                        )
+                    },
+                    |tree, writer| {
+                        let mut output = RenderingOutput { tree, writer };
+                        self.render_acyclic_target(
+                            &mut output,
+                            else_target,
+                            context,
+                            &expressions,
+                            control_flow,
+                            helpers,
+                        )
+                    },
                 )?;
-                output.writer.dedent();
-                output.writer.line("} else {");
-                output.writer.indent();
-                self.render_acyclic_target(
-                    output,
-                    else_target,
-                    context,
-                    &expressions,
-                    control_flow,
-                    helpers,
-                )?;
-                output.writer.dedent();
-                output.writer.line("}");
             }
             Terminator::Fail { failure } => self.render_failure(output.writer, *failure),
             Terminator::Unreachable => {
@@ -288,34 +293,46 @@ impl Generator<'_> {
             control_flow.index(function.entry)
         ));
         writer.line(format!("let {} = [];", context.dispatch_arguments));
-        writer.line("while (true) {");
-        writer.indent();
-        writer.line(format!("switch ({}) {{", context.dispatch_block));
-        writer.indent();
-        for block_id in function.blocks.iter().copied() {
-            let block = &self.module.storage[block_id];
-            writer.line(format!("case {}: {{", control_flow.index(block_id)));
-            writer.indent();
-            for (position, parameter) in block.parameters.iter().enumerate() {
-                writer.line(format!(
-                    "{} = {}[{}];",
-                    context.value(*parameter),
-                    context.dispatch_arguments,
-                    position
-                ));
-            }
-            for instruction in &block.instructions {
-                self.render_instruction(tree, writer, instruction, context, context, false)?;
-            }
-            self.render_cyclic_terminator(tree, writer, &block.terminator, context, control_flow);
-            writer.dedent();
-            writer.line("}");
-        }
-        writer.dedent();
-        writer.line("}");
-        writer.dedent();
-        writer.line("}");
-        Ok(())
+        writer.block("while (true) {", "}", |writer| {
+            writer.block(format!("switch ({}) {{", context.dispatch_block), "}", |writer| {
+                for block_id in function.blocks.iter().copied() {
+                    let block = &self.module.storage[block_id];
+                    writer.block(
+                        format!("case {}: {{", control_flow.index(block_id)),
+                        "}",
+                        |writer| -> ModuleResult<()> {
+                            for (position, parameter) in block.parameters.iter().enumerate() {
+                                writer.line(format!(
+                                    "{} = {}[{}];",
+                                    context.value(*parameter),
+                                    context.dispatch_arguments,
+                                    position
+                                ));
+                            }
+                            for instruction in &block.instructions {
+                                self.render_instruction(
+                                    tree,
+                                    writer,
+                                    instruction,
+                                    context,
+                                    context,
+                                    false,
+                                )?;
+                            }
+                            self.render_cyclic_terminator(
+                                tree,
+                                writer,
+                                &block.terminator,
+                                context,
+                                control_flow,
+                            )?;
+                            Ok(())
+                        },
+                    )?;
+                }
+                Ok(())
+            })
+        })
     }
 
     fn render_cyclic_terminator(
@@ -325,7 +342,7 @@ impl Generator<'_> {
         terminator: &Terminator,
         context: &FunctionContext,
         control_flow: &ControlFlow,
-    ) {
+    ) -> ModuleResult<()> {
         match terminator {
             Terminator::Return { value } => {
                 let value = context.expression(tree, *value);
@@ -336,21 +353,25 @@ impl Generator<'_> {
             }
             Terminator::Branch { condition, then_target, else_target } => {
                 let condition = context.expression(tree, *condition);
-                writer.expression_line("if (", tree, condition, ") {");
-                writer.indent();
-                self.render_cyclic_target(tree, writer, then_target, context, control_flow);
-                writer.dedent();
-                writer.line("} else {");
-                writer.indent();
-                self.render_cyclic_target(tree, writer, else_target, context, control_flow);
-                writer.dedent();
-                writer.line("}");
+                writer.if_else(
+                    tree,
+                    condition,
+                    |tree, writer| -> ModuleResult<()> {
+                        self.render_cyclic_target(tree, writer, then_target, context, control_flow);
+                        Ok(())
+                    },
+                    |tree, writer| -> ModuleResult<()> {
+                        self.render_cyclic_target(tree, writer, else_target, context, control_flow);
+                        Ok(())
+                    },
+                )?;
             }
             Terminator::Fail { failure } => self.render_failure(writer, *failure),
             Terminator::Unreachable => {
                 writer.line("throw new Error(\"unreachable SSA block\");");
             }
         }
+        Ok(())
     }
 
     fn render_cyclic_target(

--- a/compiler-backend/javascript/src/pretty.rs
+++ b/compiler-backend/javascript/src/pretty.rs
@@ -243,12 +243,11 @@ pub(crate) fn render_string(value: &str) -> String {
 pub(crate) struct Writer<'a> {
     arena: &'a Arena<'a>,
     lines: Vec<Option<Doc<'a>>>,
-    indentation: usize,
 }
 
 impl<'a> Writer<'a> {
     pub(crate) fn new(arena: &'a Arena<'a>) -> Writer<'a> {
-        Writer { arena, lines: Vec::new(), indentation: 0 }
+        Writer { arena, lines: Vec::new() }
     }
 
     pub(crate) fn line(&mut self, line: impl Into<String>) {
@@ -264,11 +263,48 @@ impl<'a> Writer<'a> {
         suffix: &'static str,
     ) {
         let expression = Printer { arena: self.arena, tree }.expression(expression);
-        let indentation = isize::try_from(self.indentation * 2)
-            .expect("invariant violated: JavaScript writer indentation exceeds address space");
-        let line =
-            self.arena.text(prefix.into()).append(expression.nest(indentation)).append(suffix);
+        let line = self.arena.text(prefix.into()).append(expression).append(suffix);
         self.push_line(line);
+    }
+
+    pub(crate) fn block<R>(
+        &mut self,
+        header: impl Into<String>,
+        footer: &'static str,
+        render: impl FnOnce(&mut Writer<'a>) -> R,
+    ) -> R {
+        let header = self.arena.text(header.into());
+        self.document_block(header, footer, render)
+    }
+
+    pub(crate) fn if_else<E>(
+        &mut self,
+        tree: &mut Tree,
+        condition: ExpressionId,
+        render_then: impl FnOnce(&mut Tree, &mut Writer<'a>) -> Result<(), E>,
+        render_else: impl FnOnce(&mut Tree, &mut Writer<'a>) -> Result<(), E>,
+    ) -> Result<(), E> {
+        let mut then_writer = Writer::new(self.arena);
+        render_then(tree, &mut then_writer)?;
+        let mut else_writer = Writer::new(self.arena);
+        render_else(tree, &mut else_writer)?;
+
+        let condition = Printer { arena: self.arena, tree }.expression(condition);
+        let then_document = then_writer.document();
+        let else_document = else_writer.document();
+        let document = self
+            .arena
+            .text("if (")
+            .append(condition)
+            .append(") {")
+            .append(self.arena.hardline().append(then_document).nest(2))
+            .append(self.arena.hardline())
+            .append("} else {")
+            .append(self.arena.hardline().append(else_document).nest(2))
+            .append(self.arena.hardline())
+            .append("}");
+        self.push_line(document);
+        Ok(())
     }
 
     pub(crate) fn re_export(&mut self, specifiers: impl IntoIterator<Item = String>, path: &str) {
@@ -290,8 +326,7 @@ impl<'a> Writer<'a> {
     }
 
     fn push_line(&mut self, line: Doc<'a>) {
-        let indentation = "  ".repeat(self.indentation);
-        self.lines.push(Some(self.arena.text(indentation).append(line)));
+        self.lines.push(Some(line));
     }
 
     pub(crate) fn blank(&mut self) {
@@ -300,31 +335,48 @@ impl<'a> Writer<'a> {
         }
     }
 
-    pub(crate) fn indent(&mut self) {
-        self.indentation += 1;
+    fn document_block<R>(
+        &mut self,
+        header: Doc<'a>,
+        footer: &'static str,
+        render: impl FnOnce(&mut Writer<'a>) -> R,
+    ) -> R {
+        let mut writer = Writer::new(self.arena);
+        let result = render(&mut writer);
+        let body = writer.document();
+        let document = header
+            .append(self.arena.hardline().append(body).nest(2))
+            .append(self.arena.hardline())
+            .append(footer);
+        self.push_line(document);
+        result
     }
 
-    pub(crate) fn dedent(&mut self) {
-        self.indentation = self
-            .indentation
-            .checked_sub(1)
-            .expect("invariant violated: JavaScript writer indentation underflow");
-    }
-
-    pub(crate) fn finish(mut self) -> String {
+    fn document(mut self) -> Doc<'a> {
         if self.lines.last().is_some_and(Option::is_none) {
             self.lines.pop();
         }
+        let lines = self.lines.into_iter().map(|line| line.unwrap_or_else(|| self.arena.nil()));
+        self.arena.intersperse(lines, self.arena.hardline())
+    }
+
+    pub(crate) fn finish(self) -> String {
         if self.lines.is_empty() {
             return String::new();
         }
-        let lines = self.lines.into_iter().map(|line| line.unwrap_or_else(|| self.arena.nil()));
-        let document = self.arena.intersperse(lines, self.arena.hardline());
-        let document = document.append(self.arena.hardline());
+        let arena = self.arena;
+        let document = self.document().append(arena.hardline());
         let mut output = String::new();
         document
             .render_fmt(DEFAULT_WIDTH, &mut output)
             .expect("critical failure: failed to render JavaScript module");
-        output
+        // Nested hard lines carry their indentation onto empty lines. Remove that rendering
+        // artifact so generated modules contain no trailing whitespace.
+        let mut normalized = String::with_capacity(output.len());
+        for line in output.lines() {
+            normalized.push_str(line.trim_end());
+            normalized.push('\n');
+        }
+        normalized
     }
 }


### PR DESCRIPTION
## Summary

Replace the JavaScript writer's mutable indentation state with structural `pretty` documents for functions, initializers, conditionals, loops, switches, and cases.

The expression tree and precedence printer remain unchanged. This keeps the refactor focused on statement composition while making block indentation and delimiters correct by construction.

Nested hard lines inherit indentation from `pretty`, including on empty lines, so final rendering removes trailing whitespace to preserve the existing generated-source invariant.

## Verification

- `cargo check -p javascript --tests`
- `just t backend`
- `just format`
- `git diff --check`

The backend fixture suite passes without generated output changes or pending snapshots.
