### PR TITLE
[tests] Generate JavaScript during compatibility checks

### DIFF
--- a/compiler-backend/javascript/src/convert/generator.rs
+++ b/compiler-backend/javascript/src/convert/generator.rs
@@ -421,14 +421,19 @@ impl<'m> Generator<'m> {
             .expect("invariant violated: referenced module has no dependency metadata")
     }
 
-    fn global_expression(&self, tree: &mut Tree, global: &Global) -> ExpressionId {
+    fn global_expression(&self, tree: &mut Tree, global: &Global) -> ModuleResult<ExpressionId> {
         let file_id = identity_file(global.identity);
-        if file_id == self.module.file_id {
+        let expression = if file_id == self.module.file_id {
             if let Some(lazy_name) = self.lazy_global_names.get(&global.identity) {
                 let lazy = tree.identifier(lazy_name);
                 tree.call(lazy, vec![])
             } else {
-                tree.identifier(self.global_name(global.identity))
+                let name = self.global_names.get(&global.identity).ok_or_else(|| {
+                    self.unsupported(UnsupportedState::MissingGlobal {
+                        name: global.item_name.to_string(),
+                    })
+                })?;
+                tree.identifier(name)
             }
         } else {
             let namespace = self
@@ -437,7 +442,8 @@ impl<'m> Generator<'m> {
                 .expect("invariant violated: external JavaScript global has no module namespace");
             let namespace = tree.identifier(namespace);
             tree.member(namespace, global.item_name.as_str())
-        }
+        };
+        Ok(expression)
     }
 
     fn unsupported(&self, state: UnsupportedState) -> ModuleError {

--- a/compiler-backend/javascript/src/convert/generator/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/render.rs
@@ -478,8 +478,8 @@ impl Generator<'_> {
                 let record = context.expression(tree, *record);
                 Ok(project_field(tree, record, field))
             }
-            InstructionValue::Constructor { global } => Ok(self.global_expression(tree, global)),
-            InstructionValue::Global { global } => Ok(self.global_expression(tree, global)),
+            InstructionValue::Constructor { global } => self.global_expression(tree, global),
+            InstructionValue::Global { global } => self.global_expression(tree, global),
             InstructionValue::Closure { function, captures } => {
                 let name = tree.identifier(context.closure(*function));
                 if captures.is_empty() {

--- a/compiler-backend/javascript/src/error.rs
+++ b/compiler-backend/javascript/src/error.rs
@@ -17,4 +17,6 @@ pub enum UnsupportedState {
     InvalidNumber { value: String },
     #[error("top-level value initializers form a cycle")]
     CyclicInitializers,
+    #[error("local global {name:?} has no JavaScript declaration")]
+    MissingGlobal { name: String },
 }

--- a/tests-compatibility/src/verifier/comparison.rs
+++ b/tests-compatibility/src/verifier/comparison.rs
@@ -33,6 +33,7 @@ impl ReportPathFormat {
 }
 
 const COMPARISON_REPORT_SCHEMA_VERSION: u32 = 1;
+const JAVASCRIPT_STAGE_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "camelCase")]
@@ -142,15 +143,28 @@ pub fn compare_reports(
     base.recompute_summary();
     candidate.recompute_summary();
 
-    let diagnostic_changes = compare_diagnostics(&base.diagnostics, &candidate.diagnostics);
+    let mut base_diagnostics = base.diagnostics.clone();
+    let mut candidate_diagnostics = candidate.diagnostics.clone();
+    let mut base_verifier_errors = base.verifier_errors.clone();
+    let mut candidate_verifier_errors = candidate.verifier_errors.clone();
+    if base.schema_version < JAVASCRIPT_STAGE_SCHEMA_VERSION
+        || candidate.schema_version < JAVASCRIPT_STAGE_SCHEMA_VERSION
+    {
+        base_diagnostics.retain(|diagnostic| diagnostic.stage != CompilationStage::JavaScript);
+        candidate_diagnostics.retain(|diagnostic| diagnostic.stage != CompilationStage::JavaScript);
+        base_verifier_errors.retain(|issue| issue.stage != Some(CompilationStage::JavaScript));
+        candidate_verifier_errors.retain(|issue| issue.stage != Some(CompilationStage::JavaScript));
+    }
+
+    let diagnostic_changes = compare_diagnostics(&base_diagnostics, &candidate_diagnostics);
     let verifier_issue_identity = if base.schema_version == 0 || candidate.schema_version == 0 {
         VerifierIssueIdentity::LegacySchema
     } else {
         VerifierIssueIdentity::StructuredSchema
     };
     let verifier_changes = compare_verifier_issues(
-        &base.verifier_errors,
-        &candidate.verifier_errors,
+        &base_verifier_errors,
+        &candidate_verifier_errors,
         verifier_issue_identity,
     );
     let summary = comparison_summary(&diagnostic_changes, &verifier_changes);
@@ -432,6 +446,38 @@ mod tests {
         assert_eq!(comparison.summary.fixed_compiler_warnings, 0);
         assert_eq!(comparison.summary.introduced_verifier_errors, 1);
         assert!(comparison.has_regressions());
+    }
+
+    #[test]
+    fn establishes_javascript_baseline_for_previous_report_schema() {
+        let mut base = report();
+        base.schema_version = 1;
+        let mut candidate = report();
+        let mut javascript_diagnostic = diagnostic(
+            DiagnosticSeverity::Error,
+            "JavaScriptError",
+            "unsupported JavaScript",
+            "src/Prelude.purs",
+            1,
+        );
+        javascript_diagnostic.stage = CompilationStage::JavaScript;
+        candidate.diagnostics.push(javascript_diagnostic);
+        candidate.verifier_errors.push(VerifierIssue::query_error(
+            "prelude",
+            "6.0.2",
+            "src/Prelude.purs",
+            CompilationStage::JavaScript,
+            "query failed".to_string(),
+        ));
+        candidate.recompute_summary();
+
+        let comparison = compare_reports(&base, &candidate).unwrap();
+
+        assert!(comparison.diagnostic_changes.is_empty());
+        assert!(comparison.verifier_changes.is_empty());
+        assert!(!comparison.has_regressions());
+        assert_eq!(comparison.candidate_summary.compiler_errors, 1);
+        assert_eq!(comparison.candidate_summary.verifier_errors, 1);
     }
 
     #[test]

--- a/tests-compatibility/src/verifier/compile.rs
+++ b/tests-compatibility/src/verifier/compile.rs
@@ -5,7 +5,7 @@ use building::{QueryEngine, QueryError, prim};
 use diagnostics::{
     Diagnostic, DiagnosticsContext, Severity, Span, ToDiagnostics, format_rustc_with_path,
 };
-use files::{FileId, Files};
+use files::{FileId, Files, ForeignFiles};
 use rayon::prelude::*;
 use url::Url;
 
@@ -33,6 +33,7 @@ struct FileMetadata {
 pub fn compile_sources(source_files: &[SourceFile]) -> Result<CompileReport, VerifierError> {
     let mut engine = QueryEngine::default();
     let mut files = Files::default();
+    let mut foreign_files = ForeignFiles::default();
     prim::configure(&mut engine, &mut files);
 
     let mut report = CompileReport::default();
@@ -47,6 +48,7 @@ pub fn compile_sources(source_files: &[SourceFile]) -> Result<CompileReport, Ver
             .to_string();
         let file_id = files.insert(uri, content.clone());
         engine.set_content(file_id, content.clone());
+        register_foreign_module(&engine, &mut foreign_files, source, file_id)?;
         file_ids.push(file_id);
         file_metadata.insert(
             file_id,
@@ -80,6 +82,28 @@ pub fn compile_sources(source_files: &[SourceFile]) -> Result<CompileReport, Ver
     }
 
     Ok(report)
+}
+
+fn register_foreign_module(
+    engine: &QueryEngine,
+    foreign_files: &mut ForeignFiles,
+    source: &SourceFile,
+    file_id: FileId,
+) -> Result<(), VerifierError> {
+    let foreign_path = source.path.with_extension("js");
+    if !foreign_path.is_file() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&foreign_path)?;
+    let absolute_path = fs::canonicalize(&foreign_path)?;
+    let uri = Url::from_file_path(&absolute_path)
+        .map_err(|_| VerifierError::FileUrl(absolute_path.clone()))?
+        .to_string();
+    let foreign_id = foreign_files.insert(uri, content.clone());
+    engine.set_foreign_content(foreign_id, content);
+    engine.set_foreign_file(file_id, foreign_id);
+    Ok(())
 }
 
 fn register_modules(
@@ -236,6 +260,27 @@ fn collect_file(
                     ));
                 }
             });
+            if checked.errors.is_empty() {
+                match engine.javascript(file_id) {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(error)) => {
+                        let diagnostic = Diagnostic::error(
+                            "JavaScriptError",
+                            error.to_string(),
+                            Span::new(0, metadata.content.len() as u32),
+                            CompilationStage::JavaScript.as_str(),
+                        );
+                        report.diagnostics.push(compiler_diagnostic(
+                            metadata,
+                            CompilationStage::JavaScript,
+                            diagnostic,
+                        ));
+                    }
+                    Err(error) => {
+                        push_query_error(report, metadata, CompilationStage::JavaScript, error)
+                    }
+                }
+            }
         }
         Err(error) => push_query_error(report, metadata, CompilationStage::Checking, error),
     }
@@ -399,6 +444,46 @@ mod tests {
 
         assert!(report.verifier_errors.is_empty(), "{:#?}", report.verifier_errors);
         assert!(report.diagnostics.is_empty(), "{:#?}", report.diagnostics);
+    }
+
+    #[test]
+    fn loads_foreign_modules_for_checking_and_javascript_generation() {
+        let dir = tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("src")).unwrap();
+        let main = dir.path().join("src/Main.purs");
+        fs::write(
+            &main,
+            "module Main where\n\nforeign import answer :: Int\n\nresult :: Int\nresult = answer\n",
+        )
+        .unwrap();
+        fs::write(dir.path().join("src/Main.js"), "export const answer = 42;\n").unwrap();
+
+        let report = compile_sources(&[source("fixture", "1.0.0", &main)]).unwrap();
+
+        assert!(report.verifier_errors.is_empty(), "{:#?}", report.verifier_errors);
+        assert!(report.diagnostics.is_empty(), "{:#?}", report.diagnostics);
+    }
+
+    #[test]
+    fn reports_javascript_generation_errors() {
+        let dir = tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("src")).unwrap();
+        let main = dir.path().join("src/Main.purs");
+        fs::write(
+            &main,
+            "module Main where\n\nfirst :: Int\nfirst = second\n\nsecond :: Int\nsecond = first\n",
+        )
+        .unwrap();
+
+        let report = compile_sources(&[source("fixture", "1.0.0", &main)]).unwrap();
+        let diagnostic = report
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.stage == CompilationStage::JavaScript)
+            .expect("JavaScript generation diagnostic");
+
+        assert_eq!(diagnostic.code, "JavaScriptError");
+        assert!(diagnostic.message.contains("top-level value initializers form a cycle"));
     }
 
     #[test]

--- a/tests-compatibility/src/verifier/report.rs
+++ b/tests-compatibility/src/verifier/report.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use super::error::VerifierError;
 use super::selection::{SelectedPackage, SelectionMode};
 
-pub const REPORT_SCHEMA_VERSION: u32 = 1;
+pub const REPORT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -72,6 +72,7 @@ pub enum CompilationStage {
     Bracketing,
     Sectioning,
     Checking,
+    JavaScript,
 }
 
 impl CompilationStage {
@@ -86,6 +87,7 @@ impl CompilationStage {
             CompilationStage::Bracketing => "bracketing",
             CompilationStage::Sectioning => "sectioning",
             CompilationStage::Checking => "checking",
+            CompilationStage::JavaScript => "javascript",
         }
     }
 }
@@ -337,6 +339,7 @@ impl Report {
         println!("  resolving errors: {}", self.stage_error_count(CompilationStage::Resolving));
         println!("  lowering errors: {}", self.stage_error_count(CompilationStage::Lowering));
         println!("  checking errors: {}", self.stage_error_count(CompilationStage::Checking));
+        println!("  JavaScript errors: {}", self.stage_error_count(CompilationStage::JavaScript));
         println!("  compiler errors: {}", self.summary.compiler_errors);
         println!("  compiler warnings: {}", self.summary.compiler_warnings);
         println!("  packages with errors: {}", self.summary.packages_with_errors);
@@ -355,7 +358,7 @@ impl Report {
     pub fn read_json(path: &Path) -> Result<Report, VerifierError> {
         let content = fs::read_to_string(path)?;
         let schema: ReportSchema = serde_json::from_str(&content)?;
-        if !matches!(schema.schema_version, 0 | REPORT_SCHEMA_VERSION) {
+        if schema.schema_version > REPORT_SCHEMA_VERSION {
             return Err(VerifierError::UnsupportedReportSchemaVersion {
                 found: schema.schema_version,
                 latest_supported: REPORT_SCHEMA_VERSION,


### PR DESCRIPTION
## Summary

Run JavaScript code generation for modules that pass checking in the package compatibility verifier, including loading paired JavaScript FFI modules. Report backend conversion failures as JavaScript-stage diagnostics so future backend regressions and fixes are tracked across the package corpus.

Bump the report schema to establish the current JavaScript failures as the initial baseline. Comparisons against schema-v1 reports continue comparing existing compiler stages while excluding JavaScript diagnostics until both reports support that stage.

The package corpus also exposed a JavaScript generator panic for an undeclared local global. Convert that invariant failure into a typed unsupported-state error so verification can report the affected module and continue through the corpus.

## Verification

- `cargo nextest run -p javascript -p tests-compatibility`
- `cargo check -p javascript -p tests-compatibility --tests`
- `just compatibility` — 631 packages and 7,356 source files; established 485 JavaScript errors with no compatibility regressions