### PR TITLE
[lowering] Preserve escaped double-quote character literals

### DIFF
--- a/compiler-core/lowering/src/algorithm/recursive.rs
+++ b/compiler-core/lowering/src/algorithm/recursive.rs
@@ -60,6 +60,7 @@ fn char_literal(text: &str) -> Option<char> {
             "r" => Some('\r'),
             "t" => Some('\t'),
             "\\" => Some('\\'),
+            "\"" => Some('"'),
             "'" => Some('\''),
             "0" => Some('\0'),
             escaped => {

--- a/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.nbe.snap
@@ -24,15 +24,24 @@ expression: report
     _ ->
       false
 
-@export string = \$string%3 ->
-  case $string%3 of
+@export escapedDoubleQuote = '"'
+
+@export matchesEscapedDoubleQuote = \$char%3 ->
+  case $char%3 of
+    '"' ->
+      true
+    _ ->
+      false
+
+@export string = \$string%4 ->
+  case $string%4 of
     "alexandrite" ->
       true
     _ ->
       false
 
-@export boolean = \$boolean%4 ->
-  case $boolean%4 of
+@export boolean = \$boolean%5 ->
+  case $boolean%5 of
     true ->
       true
     false ->

--- a/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.purs
+++ b/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.purs
@@ -12,6 +12,13 @@ character :: Char -> Boolean
 character 'a' = true
 character _ = false
 
+escapedDoubleQuote :: Char
+escapedDoubleQuote = '\"'
+
+matchesEscapedDoubleQuote :: Char -> Boolean
+matchesEscapedDoubleQuote '\"' = true
+matchesEscapedDoubleQuote _ = false
+
 string :: String -> Boolean
 string "alexandrite" = true
 string _ = false

--- a/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.snap
+++ b/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.snap
@@ -1,11 +1,14 @@
 ---
 source: tests-integration/src/fixtures.rs
+assertion_line: 268
 expression: diagnostics_report
 ---
 Terms
 integer :: Prim.Int -> Prim.Boolean
 number :: Prim.Number -> Prim.Boolean
 character :: Prim.Char -> Prim.Boolean
+escapedDoubleQuote :: Prim.Char
+matchesEscapedDoubleQuote :: Prim.Char -> Prim.Boolean
 string :: Prim.String -> Prim.Boolean
 boolean :: Prim.Boolean -> Prim.Boolean
 

--- a/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021400_literal_patterns/Main.ssa.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 256
+assertion_line: 269
 expression: ssa_report
 ---
 @export function integer($int) {
@@ -65,6 +65,41 @@ expression: ssa_report
   }
   case$0() {
     const matches = pattern.literal($char, 'a');
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const literal$1 = false;
+    case$join(literal$1);
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const literal = true;
+    case$join(literal);
+  }
+}
+
+@export const escapedDoubleQuote = initialize {
+  entry() {
+    const literal = '"';
+    return literal;
+  }
+}
+
+@export function matchesEscapedDoubleQuote($char) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal($char, '"');
     if (matches) {
       match$success();
     } else {

--- a/tests-integration/fixtures/backend/1787021400_literal_patterns/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021400_literal_patterns/output/Main/index.js
@@ -22,6 +22,14 @@ export function character($char) {
   }
 }
 
+export function matchesEscapedDoubleQuote($char) {
+  if ($char === "\"") {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 export function string($string) {
   if ($string === "alexandrite") {
     return true;
@@ -41,3 +49,5 @@ export function boolean($boolean) {
     }
   }
 }
+
+export const escapedDoubleQuote = "\"";

--- a/tests-integration/fixtures/backend/1787021400_literal_patterns/verify.mjs
+++ b/tests-integration/fixtures/backend/1787021400_literal_patterns/verify.mjs
@@ -1,0 +1,15 @@
+import { deepStrictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+const actual = {
+  escapedDoubleQuote: Main.escapedDoubleQuote,
+  matchesEscapedDoubleQuote: Main.matchesEscapedDoubleQuote(Main.escapedDoubleQuote),
+  rejectsOtherCharacter: Main.matchesEscapedDoubleQuote("x"),
+};
+const expected = {
+  escapedDoubleQuote: '"',
+  matchesEscapedDoubleQuote: true,
+  rejectsOtherCharacter: false,
+};
+
+deepStrictEqual(actual, expected, "unexpected escaped double-quote character behavior");

--- a/tests-integration/fixtures/lowering/1783421700_literal_payloads/Main.purs
+++ b/tests-integration/fixtures/lowering/1783421700_literal_payloads/Main.purs
@@ -6,6 +6,11 @@ rawString = """hello"""
 
 char = '\n'
 
+charDoubleQuote = '\"'
+
+charDoubleQuoteBinder '\"' = true
+charDoubleQuoteBinder _ = false
+
 charUnicode = '\x2603'
 
 charMalformedNamed = '\n2'

--- a/tests-integration/fixtures/lowering/1783421700_literal_payloads/Main.snap
+++ b/tests-integration/fixtures/lowering/1783421700_literal_payloads/Main.snap
@@ -1,27 +1,29 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 85
+assertion_line: 323
 expression: report
 ---
 module Main
 
 Expressions:
 
-1.25@16:8
-  -> number 1.25
-0x2a@14:9
+'ab'@17:18
+  -> char (missing)
+0x2a@19:9
   -> integer 42
-'ab'@12:18
+'\n2'@15:20
   -> char (missing)
-'\n2'@10:20
-  -> char (missing)
-'\x2603'@8:13
+'\x2603'@13:13
   -> char '☃'
+'\"'@8:17
+  -> char (missing)
 '\n'@6:6
   -> char '\n'
 """hello"""@4:11
   -> string RawString "hello"
 "hello"@2:8
   -> string String "hello"
+1.25@21:8
+  -> number 1.25
 
 Types:

--- a/tests-integration/fixtures/lowering/1783421700_literal_payloads/Main.snap
+++ b/tests-integration/fixtures/lowering/1783421700_literal_payloads/Main.snap
@@ -16,7 +16,7 @@ Expressions:
 '\x2603'@13:13
   -> char '☃'
 '\"'@8:17
-  -> char (missing)
+  -> char '"'
 '\n'@6:6
   -> char '\n'
 """hello"""@4:11


### PR DESCRIPTION
## Summary

- preserve the double-quote payload when lowering the PureScript character literal `'\"'`
- cover both expression and binder lowering paths in the literal fixture
- exercise generated JavaScript and runtime matching in the backend literal fixture

## Context

The lexer and parser accept `'\"'`, but character lowering omitted that escape from its explicit mapping. The missing payload became an error expression during checking and later surfaced as a JavaScript generation failure.

The fix adds only the missing double-quote match arm, leaving all existing escape behavior unchanged.

## Verification

- `just t lowering 1783421700`
- `just t backend 1787021400`
- `just t lowering`
- `just t backend`
- `just t semantic 1784777100`
- `cargo check -p lowering --tests`
- `cargo check -p tests-integration --tests`
- `cargo test -p tests-compatibility --lib`
- package-scoped compatibility comparison for `optparse` and `parsing`: 2 fixed JavaScript errors, 0 introduced errors

Fixes #373