### PR TITLE
[checking] Preserve evidence applications in inferred case alternatives

### DIFF
--- a/compiler-core/checking/src/source/terms/forms.rs
+++ b/compiler-core/checking/src/source/terms/forms.rs
@@ -295,10 +295,8 @@ where
         let guarded_expression = if let Some(guarded_source) = &branch.guarded_expression {
             match mode {
                 CaseOfMode::Infer => {
-                    let checked_guarded =
-                        guarded::infer_guarded_expression(state, context, guarded_source)?;
-                    unification::subtype(state, context, checked_guarded.type_id, expected)?;
-                    checked_guarded.guarded_expression
+                    guarded::subtype_guarded_expression(state, context, guarded_source, expected)?
+                        .guarded_expression
                 }
                 CaseOfMode::Check { .. } => {
                     guarded::check_guarded_expression(state, context, guarded_source, expected)?

--- a/compiler-core/checking/src/source/terms/guarded.rs
+++ b/compiler-core/checking/src/source/terms/guarded.rs
@@ -22,6 +22,7 @@ pub struct ElaboratedWhereExpression {
 #[derive(Copy, Clone, Debug)]
 enum GuardedExpressionMode {
     Infer,
+    Subtype { expected: TypeId },
     Check { expected: TypeId },
 }
 
@@ -54,6 +55,20 @@ where
     guarded_expression_core(state, context, guarded, GuardedExpressionMode::Check { expected })
 }
 
+/// Infers a guarded expression against a shared result type while retaining
+/// implicit applications introduced on the inferred side.
+pub fn subtype_guarded_expression<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    guarded: &lowering::GuardedExpression,
+    expected: TypeId,
+) -> QueryResult<ElaboratedGuardedExpression>
+where
+    Q: ExternalQueries,
+{
+    guarded_expression_core(state, context, guarded, GuardedExpressionMode::Subtype { expected })
+}
+
 fn guarded_expression_core<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
@@ -68,7 +83,8 @@ where
             let Some(where_expression) = where_expression else {
                 let type_id = match mode {
                     GuardedExpressionMode::Infer => context.unknown("missing guarded expression"),
-                    GuardedExpressionMode::Check { expected } => expected,
+                    GuardedExpressionMode::Subtype { expected }
+                    | GuardedExpressionMode::Check { expected } => expected,
                 };
                 let expression = state.allocate_error_expression(type_id);
                 let where_expression = tree::WhereExpression::new(expression);
@@ -79,6 +95,11 @@ where
             let where_expression = match mode {
                 GuardedExpressionMode::Infer => {
                     infer_where_expression(state, context, where_expression)?
+                }
+                GuardedExpressionMode::Subtype { expected } => {
+                    let where_expression =
+                        infer_where_expression(state, context, where_expression)?;
+                    subtype_where_expression(state, context, where_expression, expected)?
                 }
                 GuardedExpressionMode::Check { expected } => {
                     check_where_expression(state, context, where_expression, expected)?
@@ -94,7 +115,8 @@ where
                 GuardedExpressionMode::Infer => {
                     state.fresh_unification(context.queries, context.prim.t)
                 }
-                GuardedExpressionMode::Check { expected } => expected,
+                GuardedExpressionMode::Subtype { expected }
+                | GuardedExpressionMode::Check { expected } => expected,
             };
 
             let mut alternatives = vec![];
@@ -170,6 +192,27 @@ where
     Q: ExternalQueries,
 {
     where_expression_core(state, context, where_expression, WhereExpressionMode::Infer)
+}
+
+fn subtype_where_expression<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    where_expression: ElaboratedWhereExpression,
+    expected: TypeId,
+) -> QueryResult<ElaboratedWhereExpression>
+where
+    Q: ExternalQueries,
+{
+    let expression = terms::ElaboratedExpression {
+        type_id: where_expression.type_id,
+        expression: where_expression.where_expression.expression,
+    };
+    let expression = terms::application::subtype_expression(state, context, expression, expected)?;
+    let where_expression = tree::WhereExpression {
+        expression: expression.expression,
+        ..where_expression.where_expression
+    };
+    Ok(ElaboratedWhereExpression { type_id: expected, where_expression })
 }
 
 fn check_where_expression<Q>(

--- a/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/Main.nbe.snap
@@ -1,0 +1,12 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export chooseEmpty = \emptyCollectionDict%1 ->
+  \section33%0 ->
+    case section33%0 of
+      true ->
+        empty
+      false ->
+        empty

--- a/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/Main.nbe.snap
@@ -7,6 +7,6 @@ expression: report
   \section33%0 ->
     case section33%0 of
       true ->
-        empty
+        emptyCollectionDict%1.empty
       false ->
-        empty
+        emptyCollectionDict%1.empty

--- a/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/Main.purs
+++ b/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+class Empty collection where
+  empty :: forall value. collection value
+
+chooseEmpty :: forall collection value. Empty collection => Boolean -> collection value
+chooseEmpty = case _ of
+  true -> empty
+  false -> empty

--- a/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/Main.snap
+++ b/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/Main.snap
@@ -1,0 +1,24 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 268
+expression: diagnostics_report
+---
+Terms
+empty ::
+  forall t0 (@collection :: t0 -> Prim.Type).
+    Main.Empty @t0 (collection :: t0 -> Prim.Type) =>
+    (forall (value :: t0). (collection :: t0 -> Prim.Type) (value :: t0))
+chooseEmpty ::
+  forall t0 (collection :: t0 -> Prim.Type) (value :: t0).
+    Main.Empty @t0 (collection :: t0 -> Prim.Type) =>
+    Prim.Boolean -> (collection :: t0 -> Prim.Type) (value :: t0)
+
+Types
+Empty :: forall t0. (t0 -> Prim.Type) -> Prim.Constraint
+
+Classes
+class forall (t0 :: Prim.Type) (collection :: t0 -> Prim.Type). Main.Empty @t0 (collection :: t0 -> Prim.Type)
+  empty ::
+  forall t0 (@collection :: t0 -> Prim.Type).
+    Main.Empty @t0 (collection :: t0 -> Prim.Type) =>
+    (forall (value :: t0). (collection :: t0 -> Prim.Type) (value :: t0))

--- a/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/Main.ssa.snap
@@ -1,0 +1,47 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 269
+expression: ssa_report
+---
+@export function chooseEmpty(emptyCollectionDict) {
+  entry() {
+    const closure = closure(chooseEmpty$closure);
+    return closure;
+  }
+}
+
+closure chooseEmpty$closure[](section33) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(section33, true);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const matches$1 = pattern.literal(section33, false);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$failure();
+    }
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const empty = global(empty);
+    case$join(empty);
+  }
+  match$success$1() {
+    const empty$1 = global(empty);
+    case$join(empty$1);
+  }
+}

--- a/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/Main.ssa.snap
@@ -5,12 +5,12 @@ expression: ssa_report
 ---
 @export function chooseEmpty(emptyCollectionDict) {
   entry() {
-    const closure = closure(chooseEmpty$closure);
+    const closure = closure(chooseEmpty$closure, emptyCollectionDict);
     return closure;
   }
 }
 
-closure chooseEmpty$closure[](section33) {
+closure chooseEmpty$closure[emptyCollectionDict](section33) {
   entry() {
     case$0();
   }
@@ -37,11 +37,11 @@ closure chooseEmpty$closure[](section33) {
     return result;
   }
   match$success() {
-    const empty = global(empty);
+    const empty = emptyCollectionDict.empty;
     case$join(empty);
   }
   match$success$1() {
-    const empty$1 = global(empty);
+    const empty$1 = emptyCollectionDict.empty;
     case$join(empty$1);
   }
 }

--- a/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/output/Main/index.js
@@ -1,0 +1,16 @@
+export function chooseEmpty(emptyCollectionDict) {
+  function chooseEmpty$closure(emptyCollectionDict) {
+    return section33 => {
+      if (section33 === true) {
+        return emptyCollectionDict.empty;
+      } else {
+        if (section33 === false) {
+          return emptyCollectionDict.empty;
+        } else {
+          throw new Error("Pattern match failure");
+        }
+      }
+    };
+  }
+  return chooseEmpty$closure(emptyCollectionDict);
+}

--- a/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/output/error.txt
+++ b/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/output/error.txt
@@ -1,0 +1,1 @@
+cannot convert SSA module Idx::<File>(42) to JavaScript: local global "empty" has no JavaScript declaration

--- a/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/output/error.txt
+++ b/tests-integration/fixtures/backend/1787415420_inferred_case_evidence/output/error.txt
@@ -1,1 +1,0 @@
-cannot convert SSA module Idx::<File>(42) to JavaScript: local global "empty" has no JavaScript declaration


### PR DESCRIPTION
## Problem

Inferred case alternatives related their guarded result to the fresh case result type with type-only subtyping. When a branch returned a constrained nullary class member, the checker pushed the wanted constraint but omitted the corresponding `EvidenceApplication`; NBE therefore retained a bare class-member reference that JavaScript could not resolve.

## Approach

- Add a guarded-expression subtyping mode that preserves the existing inference behavior while materializing implicit applications through `subtype_expression`.
- Use that mode for infer-mode case alternatives.
- Add a minimal backend fixture whose NBE, SSA, and JavaScript outputs all project the member from the evidence dictionary.

The fix remains at the checking/elaboration boundary; it does not synthesize class-member JavaScript declarations or change NBE.

## Verification

- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (34 passed)
- `just t backend 1787415420_inferred_case_evidence --verbose` (2 passed)
- `just t checking --verbose` (372 passed)
- `just t backend --verbose` (72 passed)
- Package-specific `these` compatibility comparison against `origin/main`: 0 introduced errors, 1 fixed error (`Data/Align.purs`: local global `nil` has no JavaScript declaration)

Closes #374.