### PR TITLE
[lowering] Normalize Number literal digit separators

### DIFF
--- a/compiler-core/lowering/src/algorithm/recursive.rs
+++ b/compiler-core/lowering/src/algorithm/recursive.rs
@@ -52,6 +52,10 @@ fn integer_literal(text: &str, negative: bool) -> Option<i32> {
     if negative { Some(-integer) } else { Some(integer) }
 }
 
+fn number_literal(text: &str) -> SmolStr {
+    text.replace_smolstr("_", "")
+}
+
 fn char_literal(text: &str) -> Option<char> {
     let inner = text.strip_prefix('\'')?.strip_suffix('\'')?;
     if let Some(escaped) = inner.strip_prefix('\\') {
@@ -121,7 +125,7 @@ fn lower_binder_kind(
         }
         cst::Binder::BinderNumber(cst) => {
             let negative = cst.minus_token().is_some();
-            let value = cst.number_token().map(|token| SmolStr::from(token.text(context.source)));
+            let value = cst.number_token().map(|token| number_literal(token.text(context.source)));
             BinderKind::Number { negative, value }
         }
         cst::Binder::BinderConstructor(cst) => {
@@ -521,7 +525,7 @@ fn lower_expression_kind(
         }
         cst::Expression::ExpressionNumber(cst) => {
             let value = child_token(cst.syntax(), SyntaxKind::NUMBER)
-                .map(|token| SmolStr::from(token.text(context.source)));
+                .map(|token| number_literal(token.text(context.source)));
             ExpressionKind::Number { value }
         }
         cst::Expression::ExpressionArray(cst) => {

--- a/tests-integration/fixtures/backend/1787415420_separated_number_literals/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787415420_separated_number_literals/Main.nbe.snap
@@ -3,27 +3,27 @@ source: tests-integration/tests/nbe.rs
 assertion_line: 14
 expression: report
 ---
-@export separatedNumber = 4_294_967_295.0
+@export separatedNumber = 4294967295.0
 
-@export separatedNumberParts = 1_2.3_4e+0_2
+@export separatedNumberParts = 12.34e+02
 
-@export separatedExponent = 1_2e0_2
+@export separatedExponent = 12e02
 
-@export separatedUpperExponent = 1_3E0_2
+@export separatedUpperExponent = 13E02
 
-@export separatedNegativeExponent = 1_400e-0_2
+@export separatedNegativeExponent = 1400e-02
 
 @export matchesSeparatedNumber = \$number%0 ->
   case $number%0 of
-    1_0.0_5e+0_2 ->
+    10.05e+02 ->
       true
-    1_2e0_2 ->
+    12e02 ->
       true
-    1_3E0_2 ->
+    13E02 ->
       true
-    1_400e-0_2 ->
+    1400e-02 ->
       true
-    -1_5.0 ->
+    -15.0 ->
       true
     _ ->
       false

--- a/tests-integration/fixtures/backend/1787415420_separated_number_literals/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787415420_separated_number_literals/Main.nbe.snap
@@ -1,0 +1,29 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export separatedNumber = 4_294_967_295.0
+
+@export separatedNumberParts = 1_2.3_4e+0_2
+
+@export separatedExponent = 1_2e0_2
+
+@export separatedUpperExponent = 1_3E0_2
+
+@export separatedNegativeExponent = 1_400e-0_2
+
+@export matchesSeparatedNumber = \$number%0 ->
+  case $number%0 of
+    1_0.0_5e+0_2 ->
+      true
+    1_2e0_2 ->
+      true
+    1_3E0_2 ->
+      true
+    1_400e-0_2 ->
+      true
+    -1_5.0 ->
+      true
+    _ ->
+      false

--- a/tests-integration/fixtures/backend/1787415420_separated_number_literals/Main.purs
+++ b/tests-integration/fixtures/backend/1787415420_separated_number_literals/Main.purs
@@ -1,0 +1,24 @@
+module Main where
+
+separatedNumber :: Number
+separatedNumber = 4_294_967_295.0
+
+separatedNumberParts :: Number
+separatedNumberParts = 1_2.3_4e+0_2
+
+separatedExponent :: Number
+separatedExponent = 1_2e0_2
+
+separatedUpperExponent :: Number
+separatedUpperExponent = 1_3E0_2
+
+separatedNegativeExponent :: Number
+separatedNegativeExponent = 1_400e-0_2
+
+matchesSeparatedNumber :: Number -> Boolean
+matchesSeparatedNumber 1_0.0_5e+0_2 = true
+matchesSeparatedNumber 1_2e0_2 = true
+matchesSeparatedNumber 1_3E0_2 = true
+matchesSeparatedNumber 1_400e-0_2 = true
+matchesSeparatedNumber (-1_5.0) = true
+matchesSeparatedNumber _ = false

--- a/tests-integration/fixtures/backend/1787415420_separated_number_literals/Main.snap
+++ b/tests-integration/fixtures/backend/1787415420_separated_number_literals/Main.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 268
+expression: diagnostics_report
+---
+Terms
+separatedNumber :: Prim.Number
+separatedNumberParts :: Prim.Number
+separatedExponent :: Prim.Number
+separatedUpperExponent :: Prim.Number
+separatedNegativeExponent :: Prim.Number
+matchesSeparatedNumber :: Prim.Number -> Prim.Boolean
+
+Types

--- a/tests-integration/fixtures/backend/1787415420_separated_number_literals/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787415420_separated_number_literals/Main.ssa.snap
@@ -1,0 +1,115 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 269
+expression: ssa_report
+---
+@export const separatedNumber = initialize {
+  entry() {
+    const literal = 4_294_967_295.0;
+    return literal;
+  }
+}
+
+@export const separatedNumberParts = initialize {
+  entry() {
+    const literal = 1_2.3_4e+0_2;
+    return literal;
+  }
+}
+
+@export const separatedExponent = initialize {
+  entry() {
+    const literal = 1_2e0_2;
+    return literal;
+  }
+}
+
+@export const separatedUpperExponent = initialize {
+  entry() {
+    const literal = 1_3E0_2;
+    return literal;
+  }
+}
+
+@export const separatedNegativeExponent = initialize {
+  entry() {
+    const literal = 1_400e-0_2;
+    return literal;
+  }
+}
+
+@export function matchesSeparatedNumber($number) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal($number, 1_0.0_5e+0_2);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const matches$1 = pattern.literal($number, 1_2e0_2);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$2();
+    }
+  }
+  case$2() {
+    const matches$2 = pattern.literal($number, 1_3E0_2);
+    if (matches$2) {
+      match$success$2();
+    } else {
+      case$3();
+    }
+  }
+  case$3() {
+    const matches$3 = pattern.literal($number, 1_400e-0_2);
+    if (matches$3) {
+      match$success$3();
+    } else {
+      case$4();
+    }
+  }
+  case$4() {
+    const matches$4 = pattern.literal($number, -1_5.0);
+    if (matches$4) {
+      match$success$4();
+    } else {
+      case$5();
+    }
+  }
+  case$5() {
+    const literal$5 = false;
+    case$join(literal$5);
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const literal = true;
+    case$join(literal);
+  }
+  match$success$1() {
+    const literal$1 = true;
+    case$join(literal$1);
+  }
+  match$success$2() {
+    const literal$2 = true;
+    case$join(literal$2);
+  }
+  match$success$3() {
+    const literal$3 = true;
+    case$join(literal$3);
+  }
+  match$success$4() {
+    const literal$4 = true;
+    case$join(literal$4);
+  }
+}

--- a/tests-integration/fixtures/backend/1787415420_separated_number_literals/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787415420_separated_number_literals/Main.ssa.snap
@@ -5,35 +5,35 @@ expression: ssa_report
 ---
 @export const separatedNumber = initialize {
   entry() {
-    const literal = 4_294_967_295.0;
+    const literal = 4294967295.0;
     return literal;
   }
 }
 
 @export const separatedNumberParts = initialize {
   entry() {
-    const literal = 1_2.3_4e+0_2;
+    const literal = 12.34e+02;
     return literal;
   }
 }
 
 @export const separatedExponent = initialize {
   entry() {
-    const literal = 1_2e0_2;
+    const literal = 12e02;
     return literal;
   }
 }
 
 @export const separatedUpperExponent = initialize {
   entry() {
-    const literal = 1_3E0_2;
+    const literal = 13E02;
     return literal;
   }
 }
 
 @export const separatedNegativeExponent = initialize {
   entry() {
-    const literal = 1_400e-0_2;
+    const literal = 1400e-02;
     return literal;
   }
 }
@@ -43,7 +43,7 @@ expression: ssa_report
     case$0();
   }
   case$0() {
-    const matches = pattern.literal($number, 1_0.0_5e+0_2);
+    const matches = pattern.literal($number, 10.05e+02);
     if (matches) {
       match$success();
     } else {
@@ -51,7 +51,7 @@ expression: ssa_report
     }
   }
   case$1() {
-    const matches$1 = pattern.literal($number, 1_2e0_2);
+    const matches$1 = pattern.literal($number, 12e02);
     if (matches$1) {
       match$success$1();
     } else {
@@ -59,7 +59,7 @@ expression: ssa_report
     }
   }
   case$2() {
-    const matches$2 = pattern.literal($number, 1_3E0_2);
+    const matches$2 = pattern.literal($number, 13E02);
     if (matches$2) {
       match$success$2();
     } else {
@@ -67,7 +67,7 @@ expression: ssa_report
     }
   }
   case$3() {
-    const matches$3 = pattern.literal($number, 1_400e-0_2);
+    const matches$3 = pattern.literal($number, 1400e-02);
     if (matches$3) {
       match$success$3();
     } else {
@@ -75,7 +75,7 @@ expression: ssa_report
     }
   }
   case$4() {
-    const matches$4 = pattern.literal($number, -1_5.0);
+    const matches$4 = pattern.literal($number, -15.0);
     if (matches$4) {
       match$success$4();
     } else {

--- a/tests-integration/fixtures/backend/1787415420_separated_number_literals/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787415420_separated_number_literals/output/Main/index.js
@@ -1,0 +1,33 @@
+export function matchesSeparatedNumber($number) {
+  if ($number === 1005) {
+    return true;
+  } else {
+    if ($number === 1200) {
+      return true;
+    } else {
+      if ($number === 1300) {
+        return true;
+      } else {
+        if ($number === 14) {
+          return true;
+        } else {
+          if ($number === -15) {
+            return true;
+          } else {
+            return false;
+          }
+        }
+      }
+    }
+  }
+}
+
+export const separatedNumber = 4294967295;
+
+export const separatedNumberParts = 1234;
+
+export const separatedExponent = 1200;
+
+export const separatedUpperExponent = 1300;
+
+export const separatedNegativeExponent = 14;

--- a/tests-integration/fixtures/backend/1787415420_separated_number_literals/output/error.txt
+++ b/tests-integration/fixtures/backend/1787415420_separated_number_literals/output/error.txt
@@ -1,0 +1,1 @@
+cannot convert SSA module Idx::<File>(42) to JavaScript: number literal "1_0.0_5e+0_2" is not a finite JavaScript number

--- a/tests-integration/fixtures/backend/1787415420_separated_number_literals/output/error.txt
+++ b/tests-integration/fixtures/backend/1787415420_separated_number_literals/output/error.txt
@@ -1,1 +1,0 @@
-cannot convert SSA module Idx::<File>(42) to JavaScript: number literal "1_0.0_5e+0_2" is not a finite JavaScript number

--- a/tests-integration/fixtures/backend/1787415420_separated_number_literals/package.json
+++ b/tests-integration/fixtures/backend/1787415420_separated_number_literals/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787415420_separated_number_literals/verify.mjs
+++ b/tests-integration/fixtures/backend/1787415420_separated_number_literals/verify.mjs
@@ -1,0 +1,31 @@
+import { deepStrictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+const actual = {
+  separatedNumber: Main.separatedNumber,
+  separatedNumberParts: Main.separatedNumberParts,
+  separatedExponent: Main.separatedExponent,
+  separatedUpperExponent: Main.separatedUpperExponent,
+  separatedNegativeExponent: Main.separatedNegativeExponent,
+  matchesSeparatedNumber: Main.matchesSeparatedNumber(1005),
+  matchesSeparatedExponent: Main.matchesSeparatedNumber(1200),
+  matchesSeparatedUpperExponent: Main.matchesSeparatedNumber(1300),
+  matchesSeparatedNegativeExponent: Main.matchesSeparatedNumber(14),
+  matchesNegativeSeparatedNumber: Main.matchesSeparatedNumber(-15),
+  rejectsDifferentNumber: Main.matchesSeparatedNumber(1006),
+};
+const expected = {
+  separatedNumber: 4294967295,
+  separatedNumberParts: 1234,
+  separatedExponent: 1200,
+  separatedUpperExponent: 1300,
+  separatedNegativeExponent: 14,
+  matchesSeparatedNumber: true,
+  matchesSeparatedExponent: true,
+  matchesSeparatedUpperExponent: true,
+  matchesSeparatedNegativeExponent: true,
+  matchesNegativeSeparatedNumber: true,
+  rejectsDifferentNumber: false,
+};
+
+deepStrictEqual(actual, expected, "unexpected separated Number behavior");

--- a/tests-integration/fixtures/lowering/1786810320_binder_and_guard_forms/Main.snap
+++ b/tests-integration/fixtures/lowering/1786810320_binder_and_guard_forms/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 85
+assertion_line: 323
 expression: report
 ---
 module Main
@@ -39,6 +39,11 @@ fallback@20:10
   -> equation@21:7
 4@14:14
   -> integer 4
+
+Number Binders:
+
+-1.5@12:10
+  -> number -1.5
 
 Types:
 

--- a/tests-integration/fixtures/lowering/1787415420_separated_number_literals/Main.purs
+++ b/tests-integration/fixtures/lowering/1787415420_separated_number_literals/Main.purs
@@ -1,0 +1,18 @@
+module Main where
+
+separatedNumber = 4_294_967_295.0
+
+separatedNumberParts = 1_2.3_4e+0_2
+
+separatedExponent = 1_2e0_2
+
+separatedUpperExponent = 1_3E0_2
+
+separatedNegativeExponent = 1_400e-0_2
+
+matchesSeparatedNumber 1_0.0_5e+0_2 = true
+matchesSeparatedNumber 1_2e0_2 = true
+matchesSeparatedNumber 1_3E0_2 = true
+matchesSeparatedNumber 1_400e-0_2 = true
+matchesSeparatedNumber (-1_5.0) = true
+matchesSeparatedNumber _ = false

--- a/tests-integration/fixtures/lowering/1787415420_separated_number_literals/Main.snap
+++ b/tests-integration/fixtures/lowering/1787415420_separated_number_literals/Main.snap
@@ -1,0 +1,34 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 323
+expression: report
+---
+module Main
+
+Expressions:
+
+1_400e-0_2@10:27
+  -> number 1_400e-0_2
+1_3E0_2@8:24
+  -> number 1_3E0_2
+1_2e0_2@6:19
+  -> number 1_2e0_2
+1_2.3_4e+0_2@4:22
+  -> number 1_2.3_4e+0_2
+4_294_967_295.0@2:17
+  -> number 4_294_967_295.0
+
+Number Binders:
+
+1_2e0_2@13:22
+  -> number 1_2e0_2
+1_0.0_5e+0_2@12:22
+  -> number 1_0.0_5e+0_2
+1_400e-0_2@15:22
+  -> number 1_400e-0_2
+1_3E0_2@14:22
+  -> number 1_3E0_2
+-1_5.0@16:24
+  -> number -1_5.0
+
+Types:

--- a/tests-integration/fixtures/lowering/1787415420_separated_number_literals/Main.snap
+++ b/tests-integration/fixtures/lowering/1787415420_separated_number_literals/Main.snap
@@ -8,27 +8,27 @@ module Main
 Expressions:
 
 1_400e-0_2@10:27
-  -> number 1_400e-0_2
+  -> number 1400e-02
 1_3E0_2@8:24
-  -> number 1_3E0_2
+  -> number 13E02
 1_2e0_2@6:19
-  -> number 1_2e0_2
+  -> number 12e02
 1_2.3_4e+0_2@4:22
-  -> number 1_2.3_4e+0_2
+  -> number 12.34e+02
 4_294_967_295.0@2:17
-  -> number 4_294_967_295.0
+  -> number 4294967295.0
 
 Number Binders:
 
 1_2e0_2@13:22
-  -> number 1_2e0_2
+  -> number 12e02
 1_0.0_5e+0_2@12:22
-  -> number 1_0.0_5e+0_2
+  -> number 10.05e+02
 1_400e-0_2@15:22
-  -> number 1_400e-0_2
+  -> number 1400e-02
 1_3E0_2@14:22
-  -> number 1_3E0_2
+  -> number 13E02
 -1_5.0@16:24
-  -> number -1_5.0
+  -> number -15.0
 
 Types:

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -9,7 +9,7 @@ use files::FileId;
 use indexing::{ImportKind, IndexedTermItem, IndexedTypeItem, IndexedTypeItemKind, TypeItemId};
 use itertools::Itertools;
 use lowering::{
-    ExpressionKind, GraphNode, ImplicitTypeVariable, TermVariableResolution, TypeKind,
+    BinderKind, ExpressionKind, GraphNode, ImplicitTypeVariable, TermVariableResolution, TypeKind,
     TypeVariableResolution,
 };
 use syntax::ast::AstNode;
@@ -172,6 +172,16 @@ pub fn report_lowered(engine: &QueryEngine, id: FileId, name: &str) -> String {
                 kind,
             ),
             _ => continue,
+        }
+    }
+
+    let number_binders =
+        tree.iter_binder().filter(|(_, kind)| matches!(kind, BinderKind::Number { .. }));
+    let mut number_binders = number_binders.peekable();
+    if number_binders.peek().is_some() {
+        writeln!(out, "\nNumber Binders:\n").unwrap();
+        for (binder_id, kind) in number_binders {
+            write_number_binder(&content, &stabilized, &module, &mut out, binder_id, kind);
         }
     }
 
@@ -411,6 +421,31 @@ fn write_literal_expression(
             None => writeln!(out, "  -> number (missing)").unwrap(),
         },
         _ => unreachable!("invariant violated: expected literal expression"),
+    }
+}
+
+fn write_number_binder(
+    content: &str,
+    stabilized: &stabilizing::StabilizedModule,
+    module: &cst::Module,
+    out: &mut String,
+    binder_id: lowering::BinderId,
+    kind: &BinderKind,
+) {
+    let cst = stabilized.ast_ptr(binder_id).unwrap();
+    let node = cst.syntax_node_ptr().to_node(module.syntax());
+    let text = node.text(content).to_string();
+    let position = position::offset_to_utf8_position(content, node.text_range().start()).unwrap();
+
+    writeln!(out, "{}@{}:{}", text.trim(), position.line, position.column).unwrap();
+
+    let BinderKind::Number { negative, value } = kind else {
+        unreachable!("invariant violated: expected number binder")
+    };
+    match (negative, value) {
+        (true, Some(value)) => writeln!(out, "  -> number -{value}").unwrap(),
+        (false, Some(value)) => writeln!(out, "  -> number {value}").unwrap(),
+        (_, None) => writeln!(out, "  -> number (missing)").unwrap(),
     }
 }
 


### PR DESCRIPTION
## Summary

PureScript permits digit separators in `Number` literals, but lowering previously preserved `_` in Number payloads while normalizing integer payloads. Those raw payloads reached JavaScript generation, where Rust's `f64` parser rejected finite values such as `4_294_967_295.0`.

This change:

- removes digit separators from Number payloads at the lowering boundary for expressions and binders;
- keeps JavaScript parsing and finite-number validation unchanged;
- exposes lowered Number binders in lowering reports;
- covers decimal, fractional, exponent-only, uppercase-`E`, positive/negative exponent, and negative binder forms;
- adds backend generated-output and Node execution coverage for separated expressions and numeric patterns.

## Regression history

The commits preserve the red/green transition:

1. the fixture commit records raw separated payloads and the JavaScript `InvalidNumber` output;
2. the fix commit updates the same snapshots to normalized payloads and replaces the error output with executable JavaScript.

## Verification

- `just t lowering 1787415420_separated_number_literals`
- `just t backend 1787415420_separated_number_literals`
- `just t lowering`
- `just t backend`
- `cargo nextest run -p tests-integration --test lowering --test backend` (67 passed)
- `cargo check -p lowering -p javascript -p tests-integration --tests`
- `just format --check`
- selected compatibility comparison for `node-http2` and `spec-node`: 0 introduced errors, 2 fixed JavaScript errors
  - `node-http2/src/Node/Http2/Settings.purs`
  - `spec-node/src/Node/Config.purs`

Closes #372.