### PR TITLE
[ssa] Lower recursive local values lazily

### DIFF
--- a/compiler-backend/javascript/src/convert/generator.rs
+++ b/compiler-backend/javascript/src/convert/generator.rs
@@ -21,8 +21,8 @@ use crate::tree::{ExpressionId, Tree};
 
 use self::analysis::{
     FunctionContext, InlineExpressionContext, VisitState, collect_module_references,
-    cyclic_instance_initializers, function_globals, identity_file, initializer_value_is_inlineable,
-    instruction_value_uses, visit_initializer,
+    cyclic_instance_initializers, function_globals, has_local_lazy_initializers, identity_file,
+    initializer_value_is_inlineable, instruction_value_uses, visit_initializer,
 };
 use self::names::NameAllocator;
 use self::syntax::constructor_expression;
@@ -68,7 +68,8 @@ impl<'m> Generator<'m> {
             .any(|declaration| matches!(declaration.kind, DeclarationKind::Foreign));
         let foreign_namespace = has_foreign.then(|| allocator.allocate("$foreign"));
         let lazy_globals = cyclic_instance_initializers(module);
-        let runtime_namespace = (!lazy_globals.is_empty()).then(|| allocator.allocate("$runtime"));
+        let requires_runtime = !lazy_globals.is_empty() || has_local_lazy_initializers(module);
+        let runtime_namespace = requires_runtime.then(|| allocator.allocate("$runtime"));
         let lazy_global_names = lazy_globals.into_iter().map(|identity| {
             let global_name = &global_names[&identity];
             let lazy_name = allocator.allocate(&format!("$lazy_{global_name}"));

--- a/compiler-backend/javascript/src/convert/generator/analysis.rs
+++ b/compiler-backend/javascript/src/convert/generator/analysis.rs
@@ -177,6 +177,9 @@ fn direct_closures(module: &ssa::tree::Module, function: &Function) -> Vec<Funct
                 Instruction::RecursiveClosures { bindings } => {
                     closures.extend(bindings.iter().map(|binding| binding.function));
                 }
+                Instruction::RecursiveLazyInitializers { bindings } => {
+                    closures.extend(bindings.iter().map(|binding| binding.initializer));
+                }
                 Instruction::Assign { .. } => {}
             }
         }
@@ -321,6 +324,12 @@ impl HelperRegions<'_, '_> {
                         definitions.insert(binding.result);
                     }
                 }
+                Instruction::RecursiveLazyInitializers { bindings } => {
+                    for binding in bindings.iter() {
+                        uses.extend(binding.captures.iter().copied());
+                        definitions.insert(binding.accessor);
+                    }
+                }
             }
         }
 
@@ -384,24 +393,55 @@ pub(super) fn collect_module_references(module: &ssa::tree::Module) -> Vec<&Glob
                     }
                     _ => {}
                 },
-                Instruction::RecursiveClosures { .. } => {}
+                Instruction::RecursiveClosures { .. }
+                | Instruction::RecursiveLazyInitializers { .. } => {}
             }
         }
     }
     external_globals
 }
 
+pub(super) fn has_local_lazy_initializers(module: &ssa::tree::Module) -> bool {
+    module.storage.blocks().any(|(_, block)| {
+        block
+            .instructions
+            .iter()
+            .any(|instruction| matches!(instruction, Instruction::RecursiveLazyInitializers { .. }))
+    })
+}
+
 pub(super) fn function_globals(
     module: &ssa::tree::Module,
     function: FunctionId,
 ) -> FxHashSet<GlobalIdentity> {
+    function_globals_eager(module, function, &mut FxHashSet::default())
+}
+
+fn function_globals_eager(
+    module: &ssa::tree::Module,
+    function: FunctionId,
+    visited: &mut FxHashSet<FunctionId>,
+) -> FxHashSet<GlobalIdentity> {
+    if !visited.insert(function) {
+        return FxHashSet::default();
+    }
     let mut globals = FxHashSet::default();
     for block in module.storage[function].blocks.iter().copied() {
         for instruction in &module.storage[block].instructions {
-            if let Instruction::Assign { value: InstructionValue::Global { global }, .. } =
-                instruction
-            {
-                globals.insert(global.identity);
+            match instruction {
+                Instruction::Assign { value: InstructionValue::Global { global }, .. } => {
+                    globals.insert(global.identity);
+                }
+                Instruction::RecursiveLazyInitializers { bindings } => {
+                    for binding in bindings.iter() {
+                        globals.extend(function_globals_eager(
+                            module,
+                            binding.initializer,
+                            visited,
+                        ));
+                    }
+                }
+                Instruction::Assign { .. } | Instruction::RecursiveClosures { .. } => {}
             }
         }
     }
@@ -493,6 +533,15 @@ fn function_globals_recursive(
                         globals.extend(function_globals_recursive(
                             module,
                             binding.function,
+                            visited,
+                        ));
+                    }
+                }
+                Instruction::RecursiveLazyInitializers { bindings } => {
+                    for binding in bindings.iter() {
+                        globals.extend(function_globals_recursive(
+                            module,
+                            binding.initializer,
                             visited,
                         ));
                     }
@@ -591,6 +640,9 @@ fn function_values(module: &ssa::tree::Module, function: &Function) -> Vec<Value
                 Instruction::RecursiveClosures { bindings } => {
                     values.extend(bindings.iter().map(|binding| binding.result));
                 }
+                Instruction::RecursiveLazyInitializers { bindings } => {
+                    values.extend(bindings.iter().map(|binding| binding.accessor));
+                }
             }
         }
     }
@@ -649,6 +701,7 @@ pub(super) fn instruction_value_uses(value: &InstructionValue) -> Vec<ValueId> {
             values
         }
         InstructionValue::Project { record, .. } => vec![*record],
+        InstructionValue::Force { accessor } => vec![*accessor],
         InstructionValue::Closure { captures, .. } => captures.to_vec(),
         InstructionValue::Call { function, arguments, .. } => {
             let mut values = vec![*function];
@@ -683,6 +736,13 @@ fn locally_inlineable_values(
                     }
                 }
                 Instruction::RecursiveClosures { bindings } => {
+                    for binding in bindings.iter() {
+                        for capture in binding.captures.iter().copied() {
+                            *function_uses.entry(capture).or_default() += 1;
+                        }
+                    }
+                }
+                Instruction::RecursiveLazyInitializers { bindings } => {
                     for binding in bindings.iter() {
                         for capture in binding.captures.iter().copied() {
                             *function_uses.entry(capture).or_default() += 1;
@@ -827,6 +887,10 @@ impl<'b> EvaluationTracer<'b> {
                 self.expression(*record, EvaluationContext::Eager);
                 self.operation(result, 0);
             }
+            InstructionValue::Force { accessor } => {
+                self.expression(*accessor, EvaluationContext::Eager);
+                self.operation(result, 0);
+            }
             InstructionValue::Closure { captures, .. } => {
                 for capture in captures.iter().copied() {
                     self.expression(capture, EvaluationContext::Eager);
@@ -911,6 +975,11 @@ fn block_evaluation_trace(
             Instruction::RecursiveClosures { bindings } => {
                 for binding in bindings.iter() {
                     tracer.operation(binding.result, 0);
+                }
+            }
+            Instruction::RecursiveLazyInitializers { bindings } => {
+                for binding in bindings.iter() {
+                    tracer.operation(binding.accessor, 0);
                 }
             }
         }

--- a/compiler-backend/javascript/src/convert/generator/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/render.rs
@@ -3,9 +3,9 @@ use std::iter;
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 use ssa::tree::{
-    BlockId, BlockTarget, Failure, Function, Instruction, InstructionValue, PatternTest,
-    RecordUpdate, RecursiveClosure, ReflectableEvidence, ReflectableOrdering, SynthesizedEvidence,
-    Terminator, ValueId,
+    BlockId, BlockTarget, Failure, Function, Instruction, InstructionValue, LazyInitializer,
+    PatternTest, RecordUpdate, RecursiveClosure, ReflectableEvidence, ReflectableOrdering,
+    SynthesizedEvidence, Terminator, ValueId,
 };
 
 use super::Generator;
@@ -428,6 +428,28 @@ impl Generator<'_> {
                     );
                 }
             }
+            Instruction::RecursiveLazyInitializers { bindings } => {
+                for binding in bindings.iter() {
+                    let name = context.closure(binding.initializer);
+                    let function = &self.module.storage[binding.initializer];
+                    self.render_function(tree, writer, name, function, false)?;
+                }
+                if declare {
+                    for binding in bindings.iter() {
+                        writer.line(format!("let {};", context.value(binding.accessor)));
+                    }
+                }
+                for binding in bindings.iter() {
+                    let expression =
+                        self.lazy_initializer_expression(tree, binding, context, expressions);
+                    writer.expression_line(
+                        format!("{} = ", context.value(binding.accessor)),
+                        tree,
+                        expression,
+                        ";",
+                    );
+                }
+            }
         }
         Ok(())
     }
@@ -480,6 +502,10 @@ impl Generator<'_> {
             }
             InstructionValue::Constructor { global } => self.global_expression(tree, global),
             InstructionValue::Global { global } => self.global_expression(tree, global),
+            InstructionValue::Force { accessor } => {
+                let accessor = context.expression(tree, *accessor);
+                Ok(tree.call(accessor, vec![]))
+            }
             InstructionValue::Closure { function, captures } => {
                 let name = tree.identifier(context.closure(*function));
                 if captures.is_empty() {
@@ -523,6 +549,29 @@ impl Generator<'_> {
             }
             InstructionValue::TrivialEvidence => Ok(tree.object(vec![])),
         }
+    }
+
+    fn lazy_initializer_expression(
+        &self,
+        tree: &mut Tree,
+        binding: &LazyInitializer,
+        context: &FunctionContext,
+        expressions: &dyn ValueExpressionContext,
+    ) -> ExpressionId {
+        let runtime = self
+            .runtime_namespace
+            .as_ref()
+            .expect("invariant violated: local lazy initializer has no runtime namespace");
+        let runtime = tree.identifier(runtime);
+        let runtime_binding = tree.member(runtime, "binding");
+        let name = tree.string(binding.name.as_str());
+        let initializer = tree.identifier(context.closure(binding.initializer));
+        let captures =
+            binding.captures.iter().map(|capture| expressions.expression(tree, *capture));
+        let captures = captures.collect_vec();
+        let initialize = tree.call(initializer, captures);
+        let initialize = tree.arrow(vec![], initialize);
+        tree.call(runtime_binding, vec![name, initialize])
     }
 
     fn recursive_closure_expression(

--- a/compiler-backend/nbe/src/convert.rs
+++ b/compiler-backend/nbe/src/convert.rs
@@ -624,7 +624,12 @@ fn let_bindings(
             checking_tree::LetBindingChunk::PatternError { source, .. } => {
                 return Err(context.unsupported(UnsupportedState::PatternBindingError(*source)));
             }
-            checking_tree::LetBindingChunk::Names { groups, .. } => {
+            checking_tree::LetBindingChunk::Names { declarations, groups } => {
+                let source_order = declarations
+                    .iter()
+                    .enumerate()
+                    .map(|(position, &declaration)| (declaration, position));
+                let source_order = source_order.collect::<FxHashMap<_, _>>();
                 for group in groups.iter().rev() {
                     let mut converted = Vec::new();
                     for &source in group.as_slice() {
@@ -635,7 +640,8 @@ fn let_bindings(
                         let declaration = &checked.tree[declaration_id];
                         let parameter = context.local_parameter(source)?;
                         let expression = value_declaration(context, &declaration.value)?;
-                        converted.push(Binding { parameter, expression });
+                        let source_order = source_order[&declaration_id];
+                        converted.push(Binding { parameter, expression, source_order });
                     }
                     body = context.expression(ExpressionKind::Let {
                         recursive: group.is_recursive(),
@@ -1132,7 +1138,11 @@ where
                     .insert(evidence.clone(), EvidenceConstruction::Shared(parameter.clone()));
                 scope.bindings.push(EvidenceBinding {
                     evidence: evidence.clone(),
-                    binding: Binding { parameter: parameter.clone(), expression: construction },
+                    binding: Binding {
+                        parameter: parameter.clone(),
+                        expression: construction,
+                        source_order: 0,
+                    },
                 });
                 parameter
             }

--- a/compiler-backend/nbe/src/tree.rs
+++ b/compiler-backend/nbe/src/tree.rs
@@ -210,6 +210,7 @@ pub enum RecordUpdate {
 pub struct Binding {
     pub parameter: Parameter,
     pub expression: ExpressionId,
+    pub source_order: usize,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/compiler-backend/ssa/src/convert.rs
+++ b/compiler-backend/ssa/src/convert.rs
@@ -12,10 +12,10 @@ use crate::error::{ModuleError, ModuleResult, UnsupportedState};
 use crate::tree::{
     Block, BlockId, BlockTarget, CallingConvention, Declaration, DeclarationKind, Failure, Field,
     FieldIdentity, Function, FunctionId, Global, GlobalIdentity, IndirectModuleExports,
-    InstanceIdentity, Instruction, InstructionValue, Literal, Module, ModuleDependency,
-    ModuleSurface, PatternTest, Projection, RecordField, RecordUpdate, RecursiveClosure,
-    RecursiveGroupId, ReflectableEvidence, ReflectableOrdering, Storage, SuperclassIdentity,
-    SynthesizedEvidence, Terminator, Value, ValueId,
+    InstanceIdentity, Instruction, InstructionValue, LazyInitializer, Literal, Module,
+    ModuleDependency, ModuleSurface, PatternTest, Projection, RecordField, RecordUpdate,
+    RecursiveClosure, RecursiveGroupId, ReflectableEvidence, ReflectableOrdering, Storage,
+    SuperclassIdentity, SynthesizedEvidence, Terminator, Value, ValueId,
 };
 
 type ConversionResult<T> = ModuleResult<T>;
@@ -66,10 +66,28 @@ struct Traversal {
     function_name: SmolStr,
     current_block: Option<BlockId>,
     blocks: Vec<BlockId>,
-    scope: FxHashMap<nbe::tree::LocalId, ValueId>,
+    scope: FxHashMap<nbe::tree::LocalId, ScopedValue>,
     value_names: FxHashMap<SmolStr, u32>,
     block_names: FxHashMap<SmolStr, u32>,
     unterminated: FxHashSet<BlockId>,
+}
+
+#[derive(Clone, Copy)]
+enum ScopedValue {
+    Direct(ValueId),
+    Lazy(ValueId),
+}
+
+impl ScopedValue {
+    fn value(self) -> ValueId {
+        match self {
+            ScopedValue::Direct(value) | ScopedValue::Lazy(value) => value,
+        }
+    }
+
+    fn is_lazy(self) -> bool {
+        matches!(self, ScopedValue::Lazy(_))
+    }
 }
 
 impl Traversal {
@@ -177,12 +195,15 @@ fn build_function(
     let function_name = state.fresh_function_name(preferred_name);
     let free_parameters = free_parameters(context, &parameters, body);
     let capture_sources =
-        free_parameters.iter().map(|parameter| state.lookup_local(context, parameter));
+        free_parameters.iter().map(|parameter| state.lookup_scoped(context, parameter));
     let capture_sources = capture_sources.collect::<ConversionResult<Vec<_>>>()?;
+    let lazy_captures = capture_sources.iter().map(|source| source.is_lazy());
+    let lazy_captures = lazy_captures.collect_vec();
 
     let parent = state.traversal.take();
     state.traversal = Some(Traversal::new(function_name.clone()));
-    let result = build_function_body(state, context, &free_parameters, &parameters, body);
+    let result =
+        build_function_body(state, context, &free_parameters, &lazy_captures, &parameters, body);
     let traversal =
         state.traversal.take().expect("invariant violated: function traversal is missing");
     state.traversal = parent;
@@ -202,6 +223,8 @@ fn build_function(
         blocks: traversal.blocks.into(),
     };
     let function = state.output.storage.allocate_function(function);
+    let capture_sources = capture_sources.into_iter().map(ScopedValue::value);
+    let capture_sources = capture_sources.collect_vec();
     Ok(BuiltFunction { function, captures: capture_sources.into() })
 }
 
@@ -209,6 +232,7 @@ fn build_function_body(
     state: &mut State,
     context: &Context<'_>,
     free_parameters: &[nbe::tree::Parameter],
+    lazy_captures: &[bool],
     parameters: &[FunctionParameter],
     body: nbe::tree::ExpressionId,
 ) -> ConversionResult<(Vec<ValueId>, Vec<ValueId>, BlockId)> {
@@ -216,9 +240,13 @@ fn build_function_body(
     state.switch_to(entry);
 
     let mut captures = vec![];
-    for parameter in free_parameters {
+    for (parameter, lazy) in free_parameters.iter().zip(lazy_captures.iter().copied()) {
         let value = state.fresh_value(parameter.name.clone());
-        state.bind_local(parameter, value);
+        if lazy {
+            state.bind_lazy(parameter, value);
+        } else {
+            state.bind_local(parameter, value);
+        }
         captures.push(value);
     }
 
@@ -296,7 +324,7 @@ fn lower_expression(
             let name = SmolStr::clone(&global.item_name);
             Ok(state.emit(name, InstructionValue::Global { global }))
         }
-        nbe::tree::ExpressionKind::Local { parameter } => state.lookup_local(context, parameter),
+        nbe::tree::ExpressionKind::Local { parameter } => state.lower_local(context, parameter),
         nbe::tree::ExpressionKind::Abstraction { parameters, body } => {
             let parameters =
                 parameters.iter().map(|&pattern| FunctionParameter::Pattern { pattern });
@@ -560,6 +588,22 @@ fn lower_recursive_bindings(
     context: &Context<'_>,
     bindings: &[nbe::tree::Binding],
 ) -> ConversionResult<()> {
+    let all_abstractions = bindings.iter().all(|binding| {
+        let expression = &context.functional.storage[binding.expression];
+        matches!(expression.kind, nbe::tree::ExpressionKind::Abstraction { .. })
+    });
+    if all_abstractions {
+        lower_recursive_closures(state, context, bindings)
+    } else {
+        lower_recursive_lazy_initializers(state, context, bindings)
+    }
+}
+
+fn lower_recursive_closures(
+    state: &mut State,
+    context: &Context<'_>,
+    bindings: &[nbe::tree::Binding],
+) -> ConversionResult<()> {
     let mut results = vec![];
     for binding in bindings {
         let result = state.fresh_value(binding.parameter.name.clone());
@@ -571,9 +615,7 @@ fn lower_recursive_bindings(
     for (binding, result) in bindings.iter().zip(results) {
         let expression = &context.functional.storage[binding.expression];
         let nbe::tree::ExpressionKind::Abstraction { parameters, body } = &expression.kind else {
-            return Err(context.unsupported(UnsupportedState::RecursiveValue {
-                local_name: binding.parameter.name.to_string(),
-            }));
+            unreachable!("invariant violated: recursive closure binding is not an abstraction")
         };
         let parameters = parameters.iter().map(|&pattern| FunctionParameter::Pattern { pattern });
         let parameters = parameters.collect_vec();
@@ -593,6 +635,50 @@ fn lower_recursive_bindings(
         });
     }
     state.append(Instruction::RecursiveClosures { bindings: closures.into() });
+    Ok(())
+}
+
+fn lower_recursive_lazy_initializers(
+    state: &mut State,
+    context: &Context<'_>,
+    bindings: &[nbe::tree::Binding],
+) -> ConversionResult<()> {
+    let mut bindings = bindings.iter().collect_vec();
+    bindings.sort_by_key(|binding| binding.source_order);
+
+    let mut accessors = vec![];
+    for binding in &bindings {
+        let name = format_smolstr!("{}$lazy", binding.parameter.name);
+        let accessor = state.fresh_value(name);
+        state.bind_lazy(&binding.parameter, accessor);
+        accessors.push(accessor);
+    }
+
+    let mut initializers = vec![];
+    for (binding, accessor) in bindings.iter().zip(accessors.iter().copied()) {
+        let name = format_smolstr!("{}$initialize", binding.parameter.name);
+        let built = build_function(
+            state,
+            context,
+            name,
+            CallingConvention::Initializer,
+            vec![],
+            binding.expression,
+        )?;
+        initializers.push(LazyInitializer {
+            name: binding.parameter.name.clone(),
+            accessor,
+            initializer: built.function,
+            captures: built.captures,
+        });
+    }
+    state.append(Instruction::RecursiveLazyInitializers { bindings: initializers.into() });
+
+    for (binding, accessor) in bindings.iter().zip(accessors) {
+        let value =
+            state.emit(binding.parameter.name.clone(), InstructionValue::Force { accessor });
+        state.bind_local(&binding.parameter, value);
+    }
     Ok(())
 }
 
@@ -1134,23 +1220,27 @@ impl State {
         BlockTarget { block, arguments: arguments.into() }
     }
 
-    fn scope(&self) -> &FxHashMap<nbe::tree::LocalId, ValueId> {
+    fn scope(&self) -> &FxHashMap<nbe::tree::LocalId, ScopedValue> {
         &self.traversal().scope
     }
 
-    fn set_scope(&mut self, scope: FxHashMap<nbe::tree::LocalId, ValueId>) {
+    fn set_scope(&mut self, scope: FxHashMap<nbe::tree::LocalId, ScopedValue>) {
         self.traversal_mut().scope = scope;
     }
 
     fn bind_local(&mut self, parameter: &nbe::tree::Parameter, value: ValueId) {
-        self.traversal_mut().scope.insert(parameter.id, value);
+        self.traversal_mut().scope.insert(parameter.id, ScopedValue::Direct(value));
     }
 
-    fn lookup_local(
+    fn bind_lazy(&mut self, parameter: &nbe::tree::Parameter, accessor: ValueId) {
+        self.traversal_mut().scope.insert(parameter.id, ScopedValue::Lazy(accessor));
+    }
+
+    fn lookup_scoped(
         &self,
         context: &Context<'_>,
         parameter: &nbe::tree::Parameter,
-    ) -> ConversionResult<ValueId> {
+    ) -> ConversionResult<ScopedValue> {
         let Some(traversal) = &self.traversal else {
             return Err(context.unsupported(UnsupportedState::MissingLocal {
                 local_name: parameter.name.to_string(),
@@ -1161,6 +1251,21 @@ impl State {
                 local_name: parameter.name.to_string(),
             })
         })
+    }
+
+    fn lower_local(
+        &mut self,
+        context: &Context<'_>,
+        parameter: &nbe::tree::Parameter,
+    ) -> ConversionResult<ValueId> {
+        let scoped = self.lookup_scoped(context, parameter)?;
+        match scoped {
+            ScopedValue::Direct(value) => Ok(value),
+            ScopedValue::Lazy(accessor) => {
+                let name = format_smolstr!("{}$forced", parameter.name);
+                Ok(self.emit(name, InstructionValue::Force { accessor }))
+            }
+        }
     }
 }
 

--- a/compiler-backend/ssa/src/error.rs
+++ b/compiler-backend/ssa/src/error.rs
@@ -15,8 +15,6 @@ pub enum ModuleError {
 pub enum UnsupportedState {
     #[error("local {local_name} is not available in the current lexical scope")]
     MissingLocal { local_name: String },
-    #[error("recursive local {local_name} is not a function")]
-    RecursiveValue { local_name: String },
     #[error("case expression has no alternatives")]
     MissingCaseAlternative,
     #[error("guarded expression has no alternatives")]

--- a/compiler-backend/ssa/src/pretty.rs
+++ b/compiler-backend/ssa/src/pretty.rs
@@ -6,8 +6,8 @@ use rustc_hash::FxHashSet;
 
 use crate::tree::{
     Block, BlockTarget, CallingConvention, Declaration, DeclarationKind, Failure, Field, Function,
-    Global, GlobalIdentity, IndirectModuleExports, Instruction, InstructionValue, Literal, Module,
-    PatternTest, Projection, RecordUpdate, RecursiveClosure, ReflectableEvidence,
+    Global, GlobalIdentity, IndirectModuleExports, Instruction, InstructionValue, LazyInitializer,
+    Literal, Module, PatternTest, Projection, RecordUpdate, RecursiveClosure, ReflectableEvidence,
     ReflectableOrdering, SynthesizedEvidence, Terminator, ValueId,
 };
 
@@ -165,6 +165,18 @@ impl<'a> Printer<'a, '_> {
                     .append(bindings)
                     .append(");")
             }
+            Instruction::RecursiveLazyInitializers { bindings } => {
+                let accessors = bindings.iter().map(|binding| self.value(binding.accessor));
+                let accessors = self.bracketed(accessors);
+                let bindings = bindings.iter().map(|binding| self.lazy_initializer(binding));
+                let bindings = self.braced(bindings);
+                self.arena
+                    .text("const ")
+                    .append(accessors)
+                    .append(" = lazy.recursive(")
+                    .append(bindings)
+                    .append(");")
+            }
         }
     }
 
@@ -174,6 +186,17 @@ impl<'a> Printer<'a, '_> {
         let captures = closure.captures.iter().map(|capture| self.value(*capture));
         let captures = self.arguments(captures);
         name.append(": closure(")
+            .append(self.arena.text(function.name.to_string()))
+            .append(captures)
+            .append(")")
+    }
+
+    fn lazy_initializer(&self, binding: &LazyInitializer) -> Doc<'a> {
+        let function = &self.module.storage[binding.initializer];
+        let captures = binding.captures.iter().map(|capture| self.value(*capture));
+        let captures = self.arguments(captures);
+        self.arena
+            .text(format!("{:?}: initializer(", binding.name))
             .append(self.arena.text(function.name.to_string()))
             .append(captures)
             .append(")")
@@ -214,6 +237,9 @@ impl<'a> Printer<'a, '_> {
             }
             InstructionValue::Global { global } => {
                 self.arena.text("global(").append(self.global(global)).append(")")
+            }
+            InstructionValue::Force { accessor } => {
+                self.arena.text("force(").append(self.value(*accessor)).append(")")
             }
             InstructionValue::Closure { function, captures } => {
                 let function = &self.module.storage[*function];

--- a/compiler-backend/ssa/src/tree.rs
+++ b/compiler-backend/ssa/src/tree.rs
@@ -178,12 +178,21 @@ pub struct Value {
 pub enum Instruction {
     Assign { result: ValueId, value: InstructionValue },
     RecursiveClosures { bindings: Arc<[RecursiveClosure]> },
+    RecursiveLazyInitializers { bindings: Arc<[LazyInitializer]> },
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct RecursiveClosure {
     pub result: ValueId,
     pub function: FunctionId,
+    pub captures: Arc<[ValueId]>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct LazyInitializer {
+    pub name: SmolStr,
+    pub accessor: ValueId,
+    pub initializer: FunctionId,
     pub captures: Arc<[ValueId]>,
 }
 
@@ -196,6 +205,7 @@ pub enum InstructionValue {
     Project { record: ValueId, field: Field },
     Constructor { global: Global },
     Global { global: Global },
+    Force { accessor: ValueId },
     Closure { function: FunctionId, captures: Arc<[ValueId]> },
     Call { calling_convention: CallingConvention, function: ValueId, arguments: Arc<[ValueId]> },
     Test { value: ValueId, test: PatternTest },

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/Main.js
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/Main.js
@@ -1,0 +1,14 @@
+let trace = [];
+
+export const same = first => second => first === second;
+
+export const observe = name => value => {
+  trace.push(name);
+  return value;
+};
+
+export const readTrace = () => trace.slice();
+
+export const resetTrace = () => {
+  trace = [];
+};

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/Main.nbe.snap
@@ -1,0 +1,51 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export foreign same
+
+@export foreign observe
+
+@export foreign readTrace
+
+@export applicationRecursive = \token%1 ->
+  let
+    rec second%2 = observe "second"
+      (\condition%3 ->
+        if condition%3 then first%0 false else 2)
+    rec first%0 = observe "first"
+      (\condition%4 ->
+        if condition%4 then second%2 false else 1)
+  in { result: first%0 true, trace: readTrace token%1 }
+
+@export recordRecursive = let
+  rec second%6 = \condition%7 ->
+    if condition%7 then first%5.value false else 20
+  rec first%5 = { value: second%6 }
+in same first%5.value second%6
+
+@export caseRecursive = \condition%9 ->
+  let
+    rec go%8 = case condition%9 of
+      true ->
+        \current%10 ->
+          if current%10 then go%8 false else 30
+      false ->
+        \$boolean%11@(_) -> 31
+  in go%8 true
+
+@export letRecursive = \condition%13 ->
+  let
+    rec go%12 = let
+      wrapped%14 = \current%15 ->
+        if current%15 then go%12 false else 40
+    in wrapped%14
+  in go%12 condition%13
+
+@export strictCycle = \$boolean%17@(_) ->
+  let
+    rec value%16 = wrap value%16
+  in value%16
+
+@export wrap = \value%18 -> value%18

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/Main.purs
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/Main.purs
@@ -1,0 +1,56 @@
+module Main where
+
+foreign import same :: forall value. value -> value -> Boolean
+
+foreign import observe :: forall value. String -> value -> value
+
+foreign import readTrace :: Boolean -> Array String
+
+applicationRecursive :: Boolean -> { result :: Int, trace :: Array String }
+applicationRecursive token =
+  let
+    first :: Boolean -> Int
+    first = observe "first" \condition -> if condition then second false else 1
+
+    second :: Boolean -> Int
+    second = observe "second" \condition -> if condition then first false else 2
+  in
+    { result: first true, trace: readTrace token }
+
+recordRecursive :: Boolean
+recordRecursive =
+  let
+    first :: { value :: Boolean -> Int }
+    first = { value: second }
+
+    second :: Boolean -> Int
+    second condition = if condition then first.value false else 20
+  in
+    same first.value second
+
+caseRecursive :: Boolean -> Int
+caseRecursive condition = go true
+  where
+  go :: Boolean -> Int
+  go = case condition of
+    true -> \current -> if current then go false else 30
+    false -> \_ -> 31
+
+letRecursive :: Boolean -> Int
+letRecursive condition = go condition
+  where
+  go :: Boolean -> Int
+  go =
+    let
+      wrapped = \current -> if current then go false else 40
+    in
+      wrapped
+
+strictCycle :: Boolean -> Int
+strictCycle _ = value
+  where
+  value :: Int
+  value = wrap value
+
+wrap :: forall value. value -> value
+wrap value = value

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/Main.snap
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/Main.snap
@@ -1,0 +1,17 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 268
+expression: diagnostics_report
+---
+Terms
+same :: forall value. value -> value -> Prim.Boolean
+observe :: forall value. Prim.String -> value -> value
+readTrace :: Prim.Boolean -> Prim.Array Prim.String
+applicationRecursive :: Prim.Boolean -> { result :: Prim.Int, trace :: Prim.Array Prim.String }
+recordRecursive :: Prim.Boolean
+caseRecursive :: Prim.Boolean -> Prim.Int
+letRecursive :: Prim.Boolean -> Prim.Int
+strictCycle :: Prim.Boolean -> Prim.Int
+wrap :: forall value. value -> value
+
+Types

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/Main.ssa.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 269
+expression: ssa_report
+---
+cannot convert functional module Idx::<File>(42) to SSA: recursive local second is not a function

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/Main.ssa.snap
@@ -3,4 +3,286 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 269
 expression: ssa_report
 ---
-cannot convert functional module Idx::<File>(42) to SSA: recursive local second is not a function
+@export foreign const same;
+
+@export foreign const observe;
+
+@export foreign const readTrace;
+
+@export function applicationRecursive(token) {
+  entry() {
+    const [first$lazy, second$lazy] = lazy.recursive({
+      "first": initializer(first$initialize, second$lazy),
+      "second": initializer(second$initialize, first$lazy)
+    });
+    const first = force(first$lazy);
+    const second = force(second$lazy);
+    const literal = true;
+    const call = source.call(first, literal);
+    const readTrace = global(readTrace);
+    const call$1 = source.call(readTrace, token);
+    const record = { result: call, trace: call$1 };
+    return record;
+  }
+}
+
+@export const recordRecursive = initialize {
+  entry() {
+    const [first$lazy, second$lazy] = lazy.recursive({
+      "first": initializer(first$initialize$1, second$lazy),
+      "second": initializer(second$initialize$1, first$lazy)
+    });
+    const first = force(first$lazy);
+    const second = force(second$lazy);
+    const same = global(same);
+    const value = first.value;
+    const call = source.call(same, value);
+    const call$1 = source.call(call, second);
+    return call$1;
+  }
+}
+
+@export function caseRecursive(condition) {
+  entry() {
+    const [go$lazy] = lazy.recursive({ "go": initializer(go$initialize, condition, go$lazy) });
+    const go = force(go$lazy);
+    const literal = true;
+    const call = source.call(go, literal);
+    return call;
+  }
+}
+
+@export function letRecursive(condition) {
+  entry() {
+    const [go$lazy] = lazy.recursive({ "go": initializer(go$initialize$1, go$lazy) });
+    const go = force(go$lazy);
+    const call = source.call(go, condition);
+    return call;
+  }
+}
+
+@export function strictCycle($boolean) {
+  entry() {
+    const [value$lazy] = lazy.recursive({ "value": initializer(value$initialize, value$lazy) });
+    const value = force(value$lazy);
+    return value;
+  }
+}
+
+@export function wrap(value) {
+  entry() {
+    return value;
+  }
+}
+
+closure first$initialize$closure[second](condition) {
+  entry() {
+    if (condition) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const second$forced = force(second);
+    const literal = false;
+    const call = source.call(second$forced, literal);
+    if$join(call);
+  }
+  else() {
+    const literal$1 = 1;
+    if$join(literal$1);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+initializer first$initialize[second]() {
+  entry() {
+    const observe = global(observe);
+    const literal = "first";
+    const call = source.call(observe, literal);
+    const closure = closure(first$initialize$closure, second);
+    const call$1 = source.call(call, closure);
+    return call$1;
+  }
+}
+
+closure second$initialize$closure[first](condition) {
+  entry() {
+    if (condition) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const first$forced = force(first);
+    const literal = false;
+    const call = source.call(first$forced, literal);
+    if$join(call);
+  }
+  else() {
+    const literal$1 = 2;
+    if$join(literal$1);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+initializer second$initialize[first]() {
+  entry() {
+    const observe = global(observe);
+    const literal = "second";
+    const call = source.call(observe, literal);
+    const closure = closure(second$initialize$closure, first);
+    const call$1 = source.call(call, closure);
+    return call$1;
+  }
+}
+
+initializer first$initialize$1[second]() {
+  entry() {
+    const second$forced = force(second);
+    const record = { value: second$forced };
+    return record;
+  }
+}
+
+closure second$initialize$1$closure[first](condition) {
+  entry() {
+    if (condition) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const first$forced = force(first);
+    const value = first$forced.value;
+    const literal = false;
+    const call = source.call(value, literal);
+    if$join(call);
+  }
+  else() {
+    const literal$1 = 20;
+    if$join(literal$1);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+initializer second$initialize$1[first]() {
+  entry() {
+    const closure = closure(second$initialize$1$closure, first);
+    return closure;
+  }
+}
+
+closure go$initialize$closure[go](current) {
+  entry() {
+    if (current) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const go$forced = force(go);
+    const literal = false;
+    const call = source.call(go$forced, literal);
+    if$join(call);
+  }
+  else() {
+    const literal$1 = 30;
+    if$join(literal$1);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+closure go$initialize$closure$1[]($boolean) {
+  entry() {
+    const literal = 31;
+    return literal;
+  }
+}
+
+initializer go$initialize[condition, go]() {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.literal(condition, true);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const matches$1 = pattern.literal(condition, false);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$failure();
+    }
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const closure = closure(go$initialize$closure, go);
+    case$join(closure);
+  }
+  match$success$1() {
+    const closure$1 = closure(go$initialize$closure$1);
+    case$join(closure$1);
+  }
+}
+
+closure go$initialize$1$closure[go](current) {
+  entry() {
+    if (current) {
+      then();
+    } else {
+      else();
+    }
+  }
+  then() {
+    const go$forced = force(go);
+    const literal = false;
+    const call = source.call(go$forced, literal);
+    if$join(call);
+  }
+  else() {
+    const literal$1 = 40;
+    if$join(literal$1);
+  }
+  if$join(result) {
+    return result;
+  }
+}
+
+initializer go$initialize$1[go]() {
+  entry() {
+    const closure = closure(go$initialize$1$closure, go);
+    return closure;
+  }
+}
+
+initializer value$initialize[value]() {
+  entry() {
+    const wrap = global(wrap);
+    const value$forced = force(value);
+    const call = source.call(wrap, value$forced);
+    return call;
+  }
+}

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/Main/foreign.js
@@ -1,0 +1,14 @@
+let trace = [];
+
+export const same = first => second => first === second;
+
+export const observe = name => value => {
+  trace.push(name);
+  return value;
+};
+
+export const readTrace = () => trace.slice();
+
+export const resetTrace = () => {
+  trace = [];
+};

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/Main/index.js
@@ -1,0 +1,125 @@
+import * as $foreign from "./foreign.js";
+import * as $runtime from "../runtime.js";
+
+export function applicationRecursive(token) {
+  function first$initialize(second) {
+    function first$initialize$closure(second) {
+      return condition => {
+        if (condition) {
+          return second()(false);
+        } else {
+          return 1 | 0;
+        }
+      };
+    }
+    return observe("first")(first$initialize$closure(second));
+  }
+  function second$initialize(first) {
+    function second$initialize$closure(first) {
+      return condition => {
+        if (condition) {
+          return first()(false);
+        } else {
+          return 2 | 0;
+        }
+      };
+    }
+    return observe("second")(second$initialize$closure(first));
+  }
+  let first$lazy;
+  let second$lazy;
+  first$lazy = $runtime.binding("first", () => first$initialize(second$lazy));
+  second$lazy = $runtime.binding("second", () => second$initialize(first$lazy));
+  const first = first$lazy();
+  const second = second$lazy();
+  return { result: first(true), trace: readTrace(token) };
+}
+
+export function caseRecursive(condition) {
+  function go$initialize(condition, go) {
+    if (condition === true) {
+      function go$initialize$closure(go) {
+        return current => {
+          if (current) {
+            return go()(false);
+          } else {
+            return 30 | 0;
+          }
+        };
+      }
+      return go$initialize$closure(go);
+    } else {
+      if (condition === false) {
+        function go$initialize$closure$1($boolean) {
+          return 31 | 0;
+        }
+        return go$initialize$closure$1;
+      } else {
+        throw new Error("Pattern match failure");
+      }
+    }
+  }
+  let go$lazy;
+  go$lazy = $runtime.binding("go", () => go$initialize(condition, go$lazy));
+  return go$lazy()(true);
+}
+
+export function letRecursive(condition) {
+  function go$initialize(go) {
+    function go$initialize$1$closure(go) {
+      return current => {
+        if (current) {
+          return go()(false);
+        } else {
+          return 40 | 0;
+        }
+      };
+    }
+    return go$initialize$1$closure(go);
+  }
+  let go$lazy;
+  go$lazy = $runtime.binding("go", () => go$initialize(go$lazy));
+  return go$lazy()(condition);
+}
+
+export function strictCycle($boolean) {
+  function value$initialize(value) {
+    return wrap(value());
+  }
+  let value$lazy;
+  value$lazy = $runtime.binding("value", () => value$initialize(value$lazy));
+  return value$lazy();
+}
+
+export function wrap(value) {
+  return value;
+}
+
+export const same = $foreign["same"];
+export const observe = $foreign["observe"];
+export const readTrace = $foreign["readTrace"];
+
+export const recordRecursive = (() => {
+  function first$initialize(second) {
+    return { value: second() };
+  }
+  function second$initialize(first) {
+    function second$initialize$1$closure(first) {
+      return condition => {
+        if (condition) {
+          return (first()).value(false);
+        } else {
+          return 20 | 0;
+        }
+      };
+    }
+    return second$initialize$1$closure(first);
+  }
+  let first$lazy;
+  let second$lazy;
+  first$lazy = $runtime.binding("first", () => first$initialize(second$lazy));
+  second$lazy = $runtime.binding("second", () => second$initialize(first$lazy));
+  const first = first$lazy();
+  const second = second$lazy();
+  return same(first.value)(second);
+})();

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/error.txt
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/error.txt
@@ -1,0 +1,1 @@
+cannot convert functional module Idx::<File>(42) to SSA: recursive local second is not a function

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/error.txt
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/error.txt
@@ -1,1 +1,0 @@
-cannot convert functional module Idx::<File>(42) to SSA: recursive local second is not a function

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/runtime.js
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/runtime.js
@@ -1,0 +1,14 @@
+export function binding(name, initialize) {
+  let state = 0;
+  let value;
+  return () => {
+    if (state === 2) return value;
+    if (state === 1) {
+      throw new ReferenceError(`${name} was needed before it finished initializing`);
+    }
+    state = 1;
+    value = initialize();
+    state = 2;
+    return value;
+  };
+}

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/verify.mjs
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/verify.mjs
@@ -1,0 +1,26 @@
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+import { resetTrace } from "./output/Main/foreign.js";
+
+resetTrace();
+deepStrictEqual(Main.applicationRecursive(false), {
+  result: 2,
+  trace: ["first", "second"],
+});
+strictEqual(Main.recordRecursive, true);
+strictEqual(Main.caseRecursive(true), 30);
+strictEqual(Main.caseRecursive(false), 31);
+strictEqual(Main.letRecursive(true), 40);
+
+let strictCycleError;
+try {
+  Main.strictCycle(false);
+} catch (error) {
+  strictCycleError = error;
+}
+if (
+  !(strictCycleError instanceof ReferenceError) ||
+  strictCycleError.message !== "value was needed before it finished initializing"
+) {
+  throw new Error(`unexpected strict-cycle result: ${strictCycleError}`);
+}


### PR DESCRIPTION
## Intent

SSA conversion only represented recursive local groups when every right-hand side was a direct abstraction. Valid recursive values produced by NBE therefore failed JavaScript generation even though dependency tracking had correctly identified their SCCs.

## Implementation

- Keep `RecursiveClosures` unchanged as the all-abstraction fast path.
- Represent mixed recursive SCCs with memoized local lazy initializers and explicit SSA force operations.
- Preserve lazy/direct status across lexical scopes and closure captures, while installing every accessor before forcing members in source order.
- Render local accessors through `runtime.binding`, including runtime import gating and eager global-dependency analysis through local initializers.
- Extend the recursive-local backend fixture with executable Application, Record, Case, Let, memoization/identity, source-order effect, delayed recursion, capture, and strict-cycle assertions.

## Verification

- `just t backend 1787021820_recursive_local_bindings`
- `just t backend`
- `cargo check -p nbe --tests`
- `cargo check -p ssa --tests`
- `cargo check -p javascript --tests`
- `cargo nextest run -p nbe -p ssa -p javascript --no-tests pass` (the crates currently contain no unit tests)
- `just compatibility` against `origin/main` at `8dfea67`: 0 introduced errors, 33 fixed errors, all recursive-local SSA diagnostics

Closes #375