### PR TITLE
[checking] Emit runtime declarations for derived Newtype and Generic instances

### DIFF
--- a/compiler-core/checking/src/context.rs
+++ b/compiler-core/checking/src/context.rs
@@ -772,6 +772,14 @@ pub struct KnownGeneric {
     pub product: TypeId,
     pub no_arguments: TypeId,
     pub argument: TypeId,
+    pub constructor_value: (FileId, TermItemId),
+    pub in_left: (FileId, TermItemId),
+    pub in_right: (FileId, TermItemId),
+    pub product_value: (FileId, TermItemId),
+    pub no_arguments_value: (FileId, TermItemId),
+    pub argument_value: (FileId, TermItemId),
+    pub to: (FileId, TermItemId),
+    pub from: (FileId, TermItemId),
 }
 
 impl KnownGeneric {
@@ -801,6 +809,34 @@ impl KnownGeneric {
         else {
             return Ok(None);
         };
+        let Some(constructor_value) = fetch_known_term(queries, "Data.Generic.Rep", "Constructor")?
+        else {
+            return Ok(None);
+        };
+        let Some(in_left) = fetch_known_term(queries, "Data.Generic.Rep", "Inl")? else {
+            return Ok(None);
+        };
+        let Some(in_right) = fetch_known_term(queries, "Data.Generic.Rep", "Inr")? else {
+            return Ok(None);
+        };
+        let Some(product_value) = fetch_known_term(queries, "Data.Generic.Rep", "Product")? else {
+            return Ok(None);
+        };
+        let Some(no_arguments_value) =
+            fetch_known_term(queries, "Data.Generic.Rep", "NoArguments")?
+        else {
+            return Ok(None);
+        };
+        let Some(argument_value) = fetch_known_term(queries, "Data.Generic.Rep", "Argument")?
+        else {
+            return Ok(None);
+        };
+        let Some(to) = fetch_known_term(queries, "Data.Generic.Rep", "to")? else {
+            return Ok(None);
+        };
+        let Some(from) = fetch_known_term(queries, "Data.Generic.Rep", "from")? else {
+            return Ok(None);
+        };
         Ok(Some(KnownGeneric {
             no_constructors,
             constructor,
@@ -808,6 +844,14 @@ impl KnownGeneric {
             product,
             no_arguments,
             argument,
+            constructor_value,
+            in_left,
+            in_right,
+            product_value,
+            no_arguments_value,
+            argument_value,
+            to,
+            from,
         }))
     }
 }

--- a/compiler-core/checking/src/source/derive.rs
+++ b/compiler-core/checking/src/source/derive.rs
@@ -59,7 +59,11 @@ pub(super) enum DeriveStrategy {
     NewtypeDeriveConstraint {
         delegate_constraint: TypeId,
     },
-    HeadOnly,
+    NewtypeClass,
+    Generic {
+        data_file: FileId,
+        data_id: TypeItemId,
+    },
     VarianceConstraints {
         data_file: FileId,
         data_id: TypeItemId,

--- a/compiler-core/checking/src/source/derive/generate.rs
+++ b/compiler-core/checking/src/source/derive/generate.rs
@@ -20,6 +20,7 @@ mod contravariant;
 mod eq_ord;
 mod foldable;
 mod functor;
+mod generic;
 mod traversable;
 
 pub(super) fn generate_instance<Q>(
@@ -48,10 +49,14 @@ where
         | DeriveDispatch::Foldable
         | DeriveDispatch::Bifoldable
         | DeriveDispatch::Traversable
-        | DeriveDispatch::Bitraversable => {
+        | DeriveDispatch::Bitraversable
+        | DeriveDispatch::Newtype
+        | DeriveDispatch::Generic => {
             generate_known_instance(state, context, result, dispatch, recipe)
         }
-        _ => Ok(None),
+        DeriveDispatch::Unsupported => {
+            unreachable!("invariant violated: successful derive has unsupported dispatch")
+        }
     }
 }
 
@@ -123,6 +128,10 @@ where
         (result.class_file, result.class_id),
     )?
     else {
+        if matches!(result.strategy, DeriveStrategy::NewtypeClass | DeriveStrategy::Generic { .. })
+        {
+            unreachable!("invariant violated: runtime derive has no instance signature");
+        }
         return Ok(None);
     };
 
@@ -147,8 +156,7 @@ where
         let members = match dispatch {
             DeriveDispatch::Eq => {
                 eq_ord::generate_eq_member(state, context, result, &freshened.arguments)?
-                    .into_iter()
-                    .collect()
+                    .map(|member| vec![member])
             }
             DeriveDispatch::Eq1 => generate_delegated_member(
                 state,
@@ -157,12 +165,10 @@ where
                 &freshened.arguments,
                 context.known_terms.eq,
             )?
-            .into_iter()
-            .collect(),
+            .map(|member| vec![member]),
             DeriveDispatch::Ord => {
                 eq_ord::generate_ord_member(state, context, result, &freshened.arguments)?
-                    .into_iter()
-                    .collect()
+                    .map(|member| vec![member])
             }
             DeriveDispatch::Ord1 => generate_delegated_member(
                 state,
@@ -171,8 +177,7 @@ where
                 &freshened.arguments,
                 context.known_terms.compare,
             )?
-            .into_iter()
-            .collect(),
+            .map(|member| vec![member]),
             DeriveDispatch::Functor | DeriveDispatch::Bifunctor => {
                 let Some(recipe) = recipe else {
                     return Ok(None);
@@ -190,8 +195,7 @@ where
                     recipe,
                     traversal,
                 )?
-                .into_iter()
-                .collect()
+                .map(|member| vec![member])
             }
             DeriveDispatch::Contravariant | DeriveDispatch::Profunctor => {
                 let Some(recipe) = recipe else {
@@ -210,8 +214,7 @@ where
                     recipe,
                     traversal,
                 )?
-                .into_iter()
-                .collect()
+                .map(|member| vec![member])
             }
             DeriveDispatch::Foldable | DeriveDispatch::Bifoldable => {
                 let Some(recipe) = recipe else {
@@ -222,7 +225,7 @@ where
                     DeriveDispatch::Bifoldable => foldable::TraversalKind::Bifoldable,
                     _ => unreachable!(),
                 };
-                let Some(members) = foldable::generate_fold_members(
+                foldable::generate_fold_members(
                     state,
                     context,
                     result,
@@ -230,10 +233,6 @@ where
                     recipe,
                     traversal,
                 )?
-                else {
-                    return Ok(None);
-                };
-                members
             }
             DeriveDispatch::Traversable | DeriveDispatch::Bitraversable => {
                 let Some(recipe) = recipe else {
@@ -244,7 +243,7 @@ where
                     DeriveDispatch::Bitraversable => traversable::TraversalKind::Bitraversable,
                     _ => unreachable!(),
                 };
-                let Some(members) = traversable::generate_traversal_members(
+                traversable::generate_traversal_members(
                     state,
                     context,
                     result,
@@ -252,17 +251,19 @@ where
                     recipe,
                     traversal,
                 )?
-                else {
-                    return Ok(None);
-                };
-                members
             }
-            _ => vec![],
+            DeriveDispatch::Newtype => Some(vec![]),
+            DeriveDispatch::Generic => {
+                generic::generate_generic_members(state, context, result, &freshened.arguments)?
+            }
+            DeriveDispatch::Unsupported => {
+                unreachable!("invariant violated: successful derive has unsupported dispatch")
+            }
         };
 
-        if members.is_empty() {
+        let Some(members) = members else {
             return Ok(None);
-        }
+        };
 
         let instance = tree::InstanceDeclaration {
             class: (result.class_file, result.class_id),

--- a/compiler-core/checking/src/source/derive/generate/generic.rs
+++ b/compiler-core/checking/src/source/derive/generate/generic.rs
@@ -1,0 +1,576 @@
+use building_types::QueryResult;
+use smol_str::format_smolstr;
+
+use crate::context::{CheckContext, KnownGeneric};
+use crate::core::{ApplicationArgument, TypeId, normalise, toolkit};
+use crate::source::derive::builder::DerivedTreeBuilder;
+use crate::source::derive::{field, tools};
+use crate::source::terms::ElaboratedExpression;
+use crate::state::CheckState;
+use crate::{ExternalQueries, tree};
+
+use super::{
+    DeriveHeadResult, DeriveStrategy, ResolvedMember, generated_member, resolve_known_member,
+};
+
+struct GenericMember {
+    member: ResolvedMember,
+    argument_type: TypeId,
+    result_type: TypeId,
+}
+
+struct GenericRepresentation {
+    derived_type: TypeId,
+    suffix_types: Vec<TypeId>,
+    constructors: Vec<GenericConstructor>,
+}
+
+struct GenericConstructor {
+    resolution: (files::FileId, indexing::TermItemId),
+    fields: Vec<TypeId>,
+    representation_type: TypeId,
+    fields_representation_type: TypeId,
+}
+
+pub(super) fn generate_generic_members<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    instance_arguments: &[ApplicationArgument],
+) -> QueryResult<Option<Vec<tree::InstanceMember>>>
+where
+    Q: ExternalQueries,
+{
+    let Some(known) = context.known_generic.as_ref() else {
+        return Ok(None);
+    };
+    let Some(representation) =
+        instantiate_representation(state, context, result, instance_arguments, known)?
+    else {
+        return Ok(None);
+    };
+    let Some(to) = resolve_generic_member(state, context, result, instance_arguments, known.to)?
+    else {
+        return Ok(None);
+    };
+    let Some(from) =
+        resolve_generic_member(state, context, result, instance_arguments, known.from)?
+    else {
+        return Ok(None);
+    };
+
+    let Some(to_body) = generate_to(state, context, result, known, &representation, &to)? else {
+        return Ok(None);
+    };
+    let Some(from_body) = generate_from(state, context, result, known, &representation, &from)?
+    else {
+        return Ok(None);
+    };
+
+    let to = generated_member(
+        result.derive_id,
+        (to.member.file_id, to.member.item_id),
+        to.member.implementation_type,
+        vec![],
+        to_body,
+    );
+    let from = generated_member(
+        result.derive_id,
+        (from.member.file_id, from.member.item_id),
+        from.member.implementation_type,
+        vec![],
+        from_body,
+    );
+    Ok(Some(vec![to, from]))
+}
+
+fn resolve_generic_member<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    instance_arguments: &[ApplicationArgument],
+    resolution: (files::FileId, indexing::TermItemId),
+) -> QueryResult<Option<GenericMember>>
+where
+    Q: ExternalQueries,
+{
+    let Some(member) =
+        resolve_known_member(state, context, result, instance_arguments, resolution)?
+    else {
+        return Ok(None);
+    };
+    let toolkit::InspectFunction { arguments, result: result_type } =
+        toolkit::inspect_function(state, context, member.implementation_type)?;
+    let [argument_type] = arguments.as_slice() else {
+        return Ok(None);
+    };
+    Ok(Some(GenericMember { member, argument_type: *argument_type, result_type }))
+}
+
+fn instantiate_representation<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    instance_arguments: &[ApplicationArgument],
+    known: &KnownGeneric,
+) -> QueryResult<Option<GenericRepresentation>>
+where
+    Q: ExternalQueries,
+{
+    let DeriveStrategy::Generic { data_file, data_id } = result.strategy else {
+        return Ok(None);
+    };
+    let [ApplicationArgument::Type(derived_type), ApplicationArgument::Type(representation_type)] =
+        instance_arguments
+    else {
+        return Ok(None);
+    };
+
+    let constructor_ids = tools::lookup_data_constructors(context, data_file, data_id)?;
+    if constructor_ids.is_empty() {
+        let representation_type = normalise::expand(state, context, *representation_type)?;
+        let no_constructors = normalise::expand(state, context, known.no_constructors)?;
+        if representation_type != no_constructors {
+            return Ok(None);
+        }
+        return Ok(Some(GenericRepresentation {
+            derived_type: *derived_type,
+            suffix_types: vec![],
+            constructors: vec![],
+        }));
+    }
+
+    let Some((suffix_types, constructor_representations)) = split_sum_representations(
+        state,
+        context,
+        known,
+        *representation_type,
+        constructor_ids.len(),
+    )?
+    else {
+        return Ok(None);
+    };
+    let (_, data_arguments) = toolkit::extract_all_applications(state, context, *derived_type)?;
+    let mut constructors = Vec::with_capacity(constructor_ids.len());
+    for (&constructor_id, &constructor_representation) in
+        std::iter::zip(&constructor_ids, &constructor_representations)
+    {
+        let constructor_type =
+            toolkit::lookup_file_term(state, context, data_file, constructor_id)?;
+        let fields = field::instantiate_constructor_fields(
+            state,
+            context,
+            constructor_type,
+            &data_arguments,
+        )?;
+        let Some(arguments) =
+            applied_arguments(state, context, known.constructor, constructor_representation)?
+        else {
+            return Ok(None);
+        };
+        let [_, fields_representation_type] = arguments.as_slice() else {
+            return Ok(None);
+        };
+        constructors.push(GenericConstructor {
+            resolution: (data_file, constructor_id),
+            fields,
+            representation_type: constructor_representation,
+            fields_representation_type: *fields_representation_type,
+        });
+    }
+
+    Ok(Some(GenericRepresentation { derived_type: *derived_type, suffix_types, constructors }))
+}
+
+fn split_sum_representations<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    known: &KnownGeneric,
+    representation_type: TypeId,
+    constructor_count: usize,
+) -> QueryResult<Option<(Vec<TypeId>, Vec<TypeId>)>>
+where
+    Q: ExternalQueries,
+{
+    let mut current = representation_type;
+    let mut suffix_types = Vec::with_capacity(constructor_count);
+    let mut constructors = Vec::with_capacity(constructor_count);
+    for position in 0..constructor_count {
+        suffix_types.push(current);
+        if position + 1 == constructor_count {
+            constructors.push(current);
+            continue;
+        }
+        let Some(arguments) = applied_arguments(state, context, known.sum, current)? else {
+            return Ok(None);
+        };
+        let [left, right] = arguments.as_slice() else {
+            return Ok(None);
+        };
+        constructors.push(*left);
+        current = *right;
+    }
+    Ok(Some((suffix_types, constructors)))
+}
+
+fn applied_arguments<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    constructor: TypeId,
+    application: TypeId,
+) -> QueryResult<Option<Vec<TypeId>>>
+where
+    Q: ExternalQueries,
+{
+    let (head, arguments) = toolkit::extract_type_application(state, context, application)?;
+    let head = normalise::expand(state, context, head)?;
+    let constructor = normalise::expand(state, context, constructor)?;
+    Ok((head == constructor).then_some(arguments))
+}
+
+fn generate_to<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    known: &KnownGeneric,
+    representation: &GenericRepresentation,
+    member: &GenericMember,
+) -> QueryResult<Option<ElaboratedExpression>>
+where
+    Q: ExternalQueries,
+{
+    if representation.constructors.is_empty() {
+        return generate_impossible_member(state, context, result, member, known.to);
+    }
+
+    let mut builder = DerivedTreeBuilder::new(state, context, result.derive_id);
+    let value = builder.variable_binder("representation", member.argument_type);
+    let value_expression = builder.variable(value);
+    let mut alternatives = Vec::with_capacity(representation.constructors.len());
+    for (position, constructor) in representation.constructors.iter().enumerate() {
+        let Some(alternative) = emit_to_alternative(
+            &mut builder,
+            known,
+            representation,
+            constructor,
+            position,
+            member.result_type,
+        )?
+        else {
+            return Ok(None);
+        };
+        alternatives.push(alternative);
+    }
+    let body = builder.case(member.result_type, vec![value_expression], alternatives);
+    Ok(Some(builder.lambda(member.member.implementation_type, vec![value], body)))
+}
+
+fn emit_to_alternative<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    known: &KnownGeneric,
+    representation: &GenericRepresentation,
+    constructor: &GenericConstructor,
+    position: usize,
+    result_type: TypeId,
+) -> QueryResult<Option<tree::CaseAlternative>>
+where
+    Q: ExternalQueries,
+{
+    let field_binders = allocate_field_binders(builder, &constructor.fields);
+    let Some(fields_pattern) = emit_fields_pattern(
+        builder,
+        known,
+        &constructor.fields,
+        &field_binders,
+        constructor.fields_representation_type,
+    )?
+    else {
+        return Ok(None);
+    };
+    let pattern = builder.constructor_pattern(
+        "constructor",
+        constructor.representation_type,
+        known.constructor_value,
+        vec![fields_pattern],
+    );
+    let pattern = wrap_sum_pattern(builder, known, representation, pattern, position);
+
+    let mut body = builder.term_reference(constructor.resolution)?;
+    for binder in field_binders {
+        let field = builder.variable(binder);
+        let Some(applied) = builder.apply(body, field)? else {
+            return Ok(None);
+        };
+        body = applied;
+    }
+    let body = builder.subtype(body, result_type)?;
+    Ok(Some(builder.alternative(vec![pattern], body)))
+}
+
+fn generate_from<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    known: &KnownGeneric,
+    representation: &GenericRepresentation,
+    member: &GenericMember,
+) -> QueryResult<Option<ElaboratedExpression>>
+where
+    Q: ExternalQueries,
+{
+    if representation.constructors.is_empty() {
+        return generate_impossible_member(state, context, result, member, known.from);
+    }
+
+    let mut builder = DerivedTreeBuilder::new(state, context, result.derive_id);
+    let value = builder.variable_binder("value", member.argument_type);
+    let value_expression = builder.variable(value);
+    let mut alternatives = Vec::with_capacity(representation.constructors.len());
+    for (position, constructor) in representation.constructors.iter().enumerate() {
+        let Some(alternative) = emit_from_alternative(
+            &mut builder,
+            known,
+            representation,
+            constructor,
+            position,
+            member.result_type,
+        )?
+        else {
+            return Ok(None);
+        };
+        alternatives.push(alternative);
+    }
+    let body = builder.case(member.result_type, vec![value_expression], alternatives);
+    Ok(Some(builder.lambda(member.member.implementation_type, vec![value], body)))
+}
+
+fn emit_from_alternative<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    known: &KnownGeneric,
+    representation: &GenericRepresentation,
+    constructor: &GenericConstructor,
+    position: usize,
+    result_type: TypeId,
+) -> QueryResult<Option<tree::CaseAlternative>>
+where
+    Q: ExternalQueries,
+{
+    let field_binders = allocate_field_binders(builder, &constructor.fields);
+    let pattern = builder.constructor_pattern(
+        "constructor",
+        representation.derived_type,
+        constructor.resolution,
+        field_binders.clone(),
+    );
+
+    let field_expressions = field_binders.into_iter().map(|binder| builder.variable(binder));
+    let field_expressions = field_expressions.collect();
+    let Some(fields) = emit_fields_expression(builder, known, field_expressions)? else {
+        return Ok(None);
+    };
+    let constructor_value = builder.term_reference(known.constructor_value)?;
+    let Some(mut body) = builder.apply(constructor_value, fields)? else {
+        return Ok(None);
+    };
+    body = builder.subtype(body, constructor.representation_type)?;
+    if position + 1 < representation.constructors.len() {
+        let in_left = builder.term_reference(known.in_left)?;
+        let Some(applied) = builder.apply(in_left, body)? else {
+            return Ok(None);
+        };
+        body = builder.subtype(applied, representation.suffix_types[position])?;
+    }
+    for outer in (0..position).rev() {
+        let in_right = builder.term_reference(known.in_right)?;
+        let Some(applied) = builder.apply(in_right, body)? else {
+            return Ok(None);
+        };
+        body = builder.subtype(applied, representation.suffix_types[outer])?;
+    }
+    let body = builder.subtype(body, result_type)?;
+    Ok(Some(builder.alternative(vec![pattern], body)))
+}
+
+fn allocate_field_binders<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    fields: &[TypeId],
+) -> Vec<tree::BinderId>
+where
+    Q: ExternalQueries,
+{
+    let binders = fields.iter().enumerate().map(|(position, &field)| {
+        builder.variable_binder(&format_smolstr!("field{position}"), field)
+    });
+    binders.collect()
+}
+
+fn emit_fields_pattern<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    known: &KnownGeneric,
+    fields: &[TypeId],
+    binders: &[tree::BinderId],
+    representation_type: TypeId,
+) -> QueryResult<Option<tree::BinderId>>
+where
+    Q: ExternalQueries,
+{
+    match (fields, binders) {
+        ([], []) => {
+            let representation_type =
+                normalise::expand(builder.state, builder.context, representation_type)?;
+            let no_arguments =
+                normalise::expand(builder.state, builder.context, known.no_arguments)?;
+            if representation_type != no_arguments {
+                return Ok(None);
+            }
+            Ok(Some(builder.constructor_pattern(
+                "noArguments",
+                representation_type,
+                known.no_arguments_value,
+                vec![],
+            )))
+        }
+        ([_], [binder]) => {
+            let Some(arguments) = applied_arguments(
+                builder.state,
+                builder.context,
+                known.argument,
+                representation_type,
+            )?
+            else {
+                return Ok(None);
+            };
+            let [_] = arguments.as_slice() else {
+                return Ok(None);
+            };
+            Ok(Some(builder.constructor_pattern(
+                "argument",
+                representation_type,
+                known.argument_value,
+                vec![*binder],
+            )))
+        }
+        ([_, remaining_fields @ ..], [binder, remaining_binders @ ..]) => {
+            let Some(arguments) = applied_arguments(
+                builder.state,
+                builder.context,
+                known.product,
+                representation_type,
+            )?
+            else {
+                return Ok(None);
+            };
+            let [left, right] = arguments.as_slice() else {
+                return Ok(None);
+            };
+            let Some(argument) =
+                applied_arguments(builder.state, builder.context, known.argument, *left)?
+            else {
+                return Ok(None);
+            };
+            let [_] = argument.as_slice() else {
+                return Ok(None);
+            };
+            let argument =
+                builder.constructor_pattern("argument", *left, known.argument_value, vec![*binder]);
+            let Some(remaining) =
+                emit_fields_pattern(builder, known, remaining_fields, remaining_binders, *right)?
+            else {
+                return Ok(None);
+            };
+            Ok(Some(builder.constructor_pattern(
+                "product",
+                representation_type,
+                known.product_value,
+                vec![argument, remaining],
+            )))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn wrap_sum_pattern<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    known: &KnownGeneric,
+    representation: &GenericRepresentation,
+    mut pattern: tree::BinderId,
+    position: usize,
+) -> tree::BinderId
+where
+    Q: ExternalQueries,
+{
+    if position + 1 < representation.constructors.len() {
+        pattern = builder.constructor_pattern(
+            "inLeft",
+            representation.suffix_types[position],
+            known.in_left,
+            vec![pattern],
+        );
+    }
+    for outer in (0..position).rev() {
+        pattern = builder.constructor_pattern(
+            "inRight",
+            representation.suffix_types[outer],
+            known.in_right,
+            vec![pattern],
+        );
+    }
+    pattern
+}
+
+fn emit_fields_expression<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    known: &KnownGeneric,
+    mut fields: Vec<ElaboratedExpression>,
+) -> QueryResult<Option<ElaboratedExpression>>
+where
+    Q: ExternalQueries,
+{
+    let Some(last) = fields.pop() else {
+        return builder.term_reference(known.no_arguments_value).map(Some);
+    };
+    let argument = builder.term_reference(known.argument_value)?;
+    let Some(mut result) = builder.apply(argument, last)? else {
+        return Ok(None);
+    };
+    for field in fields.into_iter().rev() {
+        let argument = builder.term_reference(known.argument_value)?;
+        let Some(argument) = builder.apply(argument, field)? else {
+            return Ok(None);
+        };
+        let product = builder.term_reference(known.product_value)?;
+        let Some(product) = builder.apply(product, argument)? else {
+            return Ok(None);
+        };
+        let Some(product) = builder.apply(product, result)? else {
+            return Ok(None);
+        };
+        result = product;
+    }
+    Ok(Some(result))
+}
+
+fn generate_impossible_member<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    member: &GenericMember,
+    operation: (files::FileId, indexing::TermItemId),
+) -> QueryResult<Option<ElaboratedExpression>>
+where
+    Q: ExternalQueries,
+{
+    let mut builder = DerivedTreeBuilder::new(state, context, result.derive_id);
+    let value = builder.variable_binder("value", member.argument_type);
+    let value_expression = builder.variable(value);
+    let operation = builder.term_reference(operation)?;
+    let Some(body) = builder.apply(operation, value_expression)? else {
+        return Ok(None);
+    };
+    let body = builder.subtype(body, member.result_type)?;
+    let pattern = builder.wildcard_pattern("impossible", member.argument_type);
+    let alternative = builder.alternative(vec![pattern], body);
+    let value_expression = builder.variable(value);
+    let body = builder.case(member.result_type, vec![value_expression], vec![alternative]);
+    Ok(Some(builder.lambda(member.member.implementation_type, vec![value], body)))
+}

--- a/compiler-core/checking/src/source/derive/generic.rs
+++ b/compiler-core/checking/src/source/derive/generic.rs
@@ -49,8 +49,10 @@ where
     let generic_rep =
         build_generic_rep(state, context, known_generic, data_file, *derived_type, &constructors)?;
 
-    let _ = unification::unify(state, context, *wildcard_type, generic_rep)?;
-    Ok(Some(DeriveStrategy::HeadOnly))
+    if !unification::unify(state, context, *wildcard_type, generic_rep)? {
+        return Ok(None);
+    }
+    Ok(Some(DeriveStrategy::Generic { data_file, data_id }))
 }
 
 fn build_generic_rep<Q>(

--- a/compiler-core/checking/src/source/derive/member.rs
+++ b/compiler-core/checking/src/source/derive/member.rs
@@ -68,7 +68,7 @@ where
         DeriveStrategy::NewtypeDeriveConstraint { delegate_constraint } => {
             state.push_wanted(delegate_constraint);
         }
-        DeriveStrategy::HeadOnly => {
+        DeriveStrategy::NewtypeClass | DeriveStrategy::Generic { .. } => {
             tools::emit_superclass_constraints(
                 state,
                 context,

--- a/compiler-core/checking/src/source/derive/newtype.rs
+++ b/compiler-core/checking/src/source/derive/newtype.rs
@@ -108,9 +108,11 @@ where
         return Ok(None);
     };
 
-    unification::unify(state, context, *inner_type, newtype_inner.inner)?;
+    if !unification::unify(state, context, *inner_type, newtype_inner.inner)? {
+        return Ok(None);
+    }
 
-    Ok(Some(DeriveStrategy::HeadOnly))
+    Ok(Some(DeriveStrategy::NewtypeClass))
 }
 
 fn try_peel_trailing_rigids<Q>(

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.nbe.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+cannot convert checked module Idx::<File>(42): checked instance declaration is missing

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.nbe.snap
@@ -3,4 +3,62 @@ source: tests-integration/tests/nbe.rs
 assertion_line: 14
 expression: report
 ---
-cannot convert checked module Idx::<File>(42): checked instance declaration is missing
+@export instance newtypeTypeIdentifierInt = { "Coercible0": \unit%0 -> <trivial evidence> }
+
+@export wrapped = (\value%1 -> value%1) 42
+
+@export unwrapped = unwrap newtypeTypeIdentifierInt wrapped
+
+@export constructor Empty/0
+
+@export constructor Single/1
+
+@export constructor Pair/2
+
+@export instance genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt = {
+  to:
+    \representation%2 ->
+      case representation%2 of
+        Inl (Constructor NoArguments) ->
+          Empty
+        Inr (Inl (Constructor field0%3)) ->
+          Single field0%3
+        Inr (Inr (Constructor (Product field0%4 field1%5))) ->
+          Pair field0%4 field1%5,
+  from:
+    \value%6 ->
+      case value%6 of
+        Empty ->
+          Inl (Constructor NoArguments)
+        Single field0%7 ->
+          Inr (Inl (Constructor ((\value%8 -> value%8) field0%7)))
+        Pair field0%9 field1%10 ->
+          Inr
+            (Inr
+              (Constructor
+                (Product ((\value%11 -> value%11) field0%9) ((\value%12 -> value%12) field1%10))))
+}
+
+@export roundTrip = \value%13 ->
+  genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt.to
+    (genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt.from
+      value%13)
+
+@export emptyRoundTrip = roundTrip Empty
+
+@export singleRoundTrip = roundTrip (Single 6)
+
+@export pairRoundTrip = roundTrip (Pair 7 8)
+
+@export instance genericVoidNoConstructors = {
+  to:
+    \value%14 ->
+      case value%14 of
+        _ ->
+          genericVoidNoConstructors.to value%14,
+  from:
+    \value%15 ->
+      case value%15 of
+        _ ->
+          genericVoidNoConstructors.from value%15
+}

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.purs
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.purs
@@ -1,0 +1,34 @@
+module Main where
+
+import Data.Generic.Rep (class Generic, from, to)
+import Data.Newtype (class Newtype, unwrap)
+
+newtype Identifier = Identifier Int
+
+derive instance Newtype Identifier _
+
+wrapped :: Identifier
+wrapped = Identifier 42
+
+unwrapped :: Int
+unwrapped = unwrap wrapped
+
+data Choice = Empty | Single Int | Pair Int Int
+
+derive instance Generic Choice _
+
+roundTrip :: Choice -> Choice
+roundTrip value = to (from value)
+
+emptyRoundTrip :: Choice
+emptyRoundTrip = roundTrip Empty
+
+singleRoundTrip :: Choice
+singleRoundTrip = roundTrip (Single 6)
+
+pairRoundTrip :: Choice
+pairRoundTrip = roundTrip (Pair 7 8)
+
+data Void
+
+derive instance Generic Void _

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.snap
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.snap
@@ -1,0 +1,41 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 268
+expression: diagnostics_report
+---
+Terms
+Identifier :: Prim.Int -> Main.Identifier
+wrapped :: Main.Identifier
+unwrapped :: Prim.Int
+Empty :: Main.Choice
+Single :: Prim.Int -> Main.Choice
+Pair :: Prim.Int -> Prim.Int -> Main.Choice
+roundTrip :: Main.Choice -> Main.Choice
+emptyRoundTrip :: Main.Choice
+singleRoundTrip :: Main.Choice
+pairRoundTrip :: Main.Choice
+
+Types
+Identifier :: Prim.Type
+Choice :: Prim.Type
+Void :: Prim.Type
+
+Derived
+derive Data.Newtype.Newtype @Prim.Type Main.Identifier Prim.Int
+derive Data.Generic.Rep.Generic
+  Main.Choice
+  (Data.Generic.Rep.Sum
+    (Data.Generic.Rep.Constructor "Empty" Data.Generic.Rep.NoArguments)
+    (Data.Generic.Rep.Sum
+      (Data.Generic.Rep.Constructor "Single" (Data.Generic.Rep.Argument Prim.Int))
+      (Data.Generic.Rep.Constructor
+        "Pair"
+        (Data.Generic.Rep.Product
+          (Data.Generic.Rep.Argument Prim.Int)
+          (Data.Generic.Rep.Argument Prim.Int)))))
+derive Data.Generic.Rep.Generic Main.Void Data.Generic.Rep.NoConstructors
+
+Roles
+Identifier = []
+Choice = []
+Void = []

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.ssa.snap
@@ -3,4 +3,362 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 269
 expression: ssa_report
 ---
-cannot convert checked module Idx::<File>(42): checked instance declaration is missing
+@export instance const newtypeTypeIdentifierInt = initialize {
+  entry() {
+    const closure = closure(newtypeTypeIdentifierInt$initialize$closure);
+    const record = { Coercible0: closure };
+    return record;
+  }
+}
+
+@export const wrapped = initialize {
+  entry() {
+    const closure = closure(wrapped$initialize$closure);
+    const literal = 42;
+    const call = source.call(closure, literal);
+    return call;
+  }
+}
+
+@export const unwrapped = initialize {
+  entry() {
+    const unwrap = global(unwrap);
+    const newtypeTypeIdentifierInt = global(newtypeTypeIdentifierInt);
+    const call = source.call(unwrap, newtypeTypeIdentifierInt);
+    const wrapped = global(wrapped);
+    const call$1 = source.call(call, wrapped);
+    return call$1;
+  }
+}
+
+@export constructor Empty/0;
+
+@export constructor Single/1;
+
+@export constructor Pair/2;
+
+@export instance const genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt = initialize {
+  entry() {
+    const closure = closure(genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure);
+    const closure$1 = closure(genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1);
+    const record = { to: closure, from: closure$1 };
+    return record;
+  }
+}
+
+@export function roundTrip(value) {
+  entry() {
+    const genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt = global(genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt);
+    const to = genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt.to;
+    const genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$1 = global(genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt);
+    const from = genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$1.from;
+    const call = source.call(from, value);
+    const call$1 = source.call(to, call);
+    return call$1;
+  }
+}
+
+@export const emptyRoundTrip = initialize {
+  entry() {
+    const roundTrip = global(roundTrip);
+    const Empty = constructor(Empty);
+    const call = source.call(roundTrip, Empty);
+    return call;
+  }
+}
+
+@export const singleRoundTrip = initialize {
+  entry() {
+    const roundTrip = global(roundTrip);
+    const Single = constructor(Single);
+    const literal = 6;
+    const call = source.call(Single, literal);
+    const call$1 = source.call(roundTrip, call);
+    return call$1;
+  }
+}
+
+@export const pairRoundTrip = initialize {
+  entry() {
+    const roundTrip = global(roundTrip);
+    const Pair = constructor(Pair);
+    const literal = 7;
+    const call = source.call(Pair, literal);
+    const literal$1 = 8;
+    const call$1 = source.call(call, literal$1);
+    const call$2 = source.call(roundTrip, call$1);
+    return call$2;
+  }
+}
+
+@export instance const genericVoidNoConstructors = initialize {
+  entry() {
+    const closure = closure(genericVoidNoConstructors$initialize$closure);
+    const closure$1 = closure(genericVoidNoConstructors$initialize$closure$1);
+    const record = { to: closure, from: closure$1 };
+    return record;
+  }
+}
+
+closure newtypeTypeIdentifierInt$initialize$closure[](unit) {
+  entry() {
+    const evidence = evidence.trivial;
+    return evidence;
+  }
+}
+
+closure wrapped$initialize$closure[](value) {
+  entry() {
+    return value;
+  }
+}
+
+closure genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure[
+](representation) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.constructor(representation, Inl);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const matches$3 = pattern.constructor(representation, Inr);
+    if (matches$3) {
+      match$success$3();
+    } else {
+      case$2();
+    }
+  }
+  case$2() {
+    const matches$6 = pattern.constructor(representation, Inr);
+    if (matches$6) {
+      match$success$6();
+    } else {
+      case$failure();
+    }
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const argument = pattern.argument(representation, Inl, 0);
+    const matches$1 = pattern.constructor(argument, Constructor);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$1();
+    }
+  }
+  match$success$1() {
+    const argument$1 = pattern.argument(argument, Constructor, 0);
+    const matches$2 = pattern.constructor(argument$1, NoArguments);
+    if (matches$2) {
+      match$success$2();
+    } else {
+      case$1();
+    }
+  }
+  match$success$2() {
+    const Empty = constructor(Empty);
+    case$join(Empty);
+  }
+  match$success$3() {
+    const argument$2 = pattern.argument(representation, Inr, 0);
+    const matches$4 = pattern.constructor(argument$2, Inl);
+    if (matches$4) {
+      match$success$4();
+    } else {
+      case$2();
+    }
+  }
+  match$success$4() {
+    const argument$3 = pattern.argument(argument$2, Inl, 0);
+    const matches$5 = pattern.constructor(argument$3, Constructor);
+    if (matches$5) {
+      match$success$5();
+    } else {
+      case$2();
+    }
+  }
+  match$success$5() {
+    const field0 = pattern.argument(argument$3, Constructor, 0);
+    const Single = constructor(Single);
+    const call = source.call(Single, field0);
+    case$join(call);
+  }
+  match$success$6() {
+    const argument$4 = pattern.argument(representation, Inr, 0);
+    const matches$7 = pattern.constructor(argument$4, Inr);
+    if (matches$7) {
+      match$success$7();
+    } else {
+      case$failure();
+    }
+  }
+  match$success$7() {
+    const argument$5 = pattern.argument(argument$4, Inr, 0);
+    const matches$8 = pattern.constructor(argument$5, Constructor);
+    if (matches$8) {
+      match$success$8();
+    } else {
+      case$failure();
+    }
+  }
+  match$success$8() {
+    const argument$6 = pattern.argument(argument$5, Constructor, 0);
+    const matches$9 = pattern.constructor(argument$6, Product);
+    if (matches$9) {
+      match$success$9();
+    } else {
+      case$failure();
+    }
+  }
+  match$success$9() {
+    const field0$1 = pattern.argument(argument$6, Product, 0);
+    const field1 = pattern.argument(argument$6, Product, 1);
+    const Pair = constructor(Pair);
+    const call$1 = source.call(Pair, field0$1);
+    const call$2 = source.call(call$1, field1);
+    case$join(call$2);
+  }
+}
+
+closure genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure[
+](value) {
+  entry() {
+    return value;
+  }
+}
+
+closure genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$1[
+](value) {
+  entry() {
+    return value;
+  }
+}
+
+closure genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$2[
+](value) {
+  entry() {
+    return value;
+  }
+}
+
+closure genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1[
+](value) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const matches = pattern.constructor(value, Empty);
+    if (matches) {
+      match$success();
+    } else {
+      case$1();
+    }
+  }
+  case$1() {
+    const matches$1 = pattern.constructor(value, Single);
+    if (matches$1) {
+      match$success$1();
+    } else {
+      case$2();
+    }
+  }
+  case$2() {
+    const matches$2 = pattern.constructor(value, Pair);
+    if (matches$2) {
+      match$success$2();
+    } else {
+      case$failure();
+    }
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+  match$success() {
+    const Inl = constructor(Inl);
+    const Constructor = constructor(Constructor);
+    const NoArguments = constructor(NoArguments);
+    const call = source.call(Constructor, NoArguments);
+    const call$1 = source.call(Inl, call);
+    case$join(call$1);
+  }
+  match$success$1() {
+    const field0 = pattern.argument(value, Single, 0);
+    const Inr = constructor(Inr);
+    const Inl$1 = constructor(Inl);
+    const Constructor$1 = constructor(Constructor);
+    const closure = closure(genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure);
+    const call$2 = source.call(closure, field0);
+    const call$3 = source.call(Constructor$1, call$2);
+    const call$4 = source.call(Inl$1, call$3);
+    const call$5 = source.call(Inr, call$4);
+    case$join(call$5);
+  }
+  match$success$2() {
+    const field0$1 = pattern.argument(value, Pair, 0);
+    const field1 = pattern.argument(value, Pair, 1);
+    const Inr$1 = constructor(Inr);
+    const Inr$2 = constructor(Inr);
+    const Constructor$2 = constructor(Constructor);
+    const Product = constructor(Product);
+    const closure$1 = closure(genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$1);
+    const call$6 = source.call(closure$1, field0$1);
+    const call$7 = source.call(Product, call$6);
+    const closure$2 = closure(genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$2);
+    const call$8 = source.call(closure$2, field1);
+    const call$9 = source.call(call$7, call$8);
+    const call$10 = source.call(Constructor$2, call$9);
+    const call$11 = source.call(Inr$2, call$10);
+    const call$12 = source.call(Inr$1, call$11);
+    case$join(call$12);
+  }
+}
+
+closure genericVoidNoConstructors$initialize$closure[](value) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const genericVoidNoConstructors = global(genericVoidNoConstructors);
+    const to = genericVoidNoConstructors.to;
+    const call = source.call(to, value);
+    case$join(call);
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+}
+
+closure genericVoidNoConstructors$initialize$closure$1[](value) {
+  entry() {
+    case$0();
+  }
+  case$0() {
+    const genericVoidNoConstructors = global(genericVoidNoConstructors);
+    const from = genericVoidNoConstructors.from;
+    const call = source.call(from, value);
+    case$join(call);
+  }
+  case$failure() {
+    throw patternMatchFailure();
+  }
+  case$join(result) {
+    return result;
+  }
+}

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.ssa.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 269
+expression: ssa_report
+---
+cannot convert checked module Idx::<File>(42): checked instance declaration is missing

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Data.Generic.Rep/index.js
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Data.Generic.Rep/index.js
@@ -1,0 +1,5 @@
+export const Constructor = $value0 => ["Constructor", $value0];
+export const Inl = $value0 => ["Inl", $value0];
+export const Inr = $value0 => ["Inr", $value0];
+export const Product = $value0 => $value1 => ["Product", $value0, $value1];
+export const NoArguments = ["NoArguments"];

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Data.Newtype/index.js
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Data.Newtype/index.js
@@ -1,0 +1,9 @@
+import * as Safe_Coerce from "../Safe.Coerce/index.js";
+
+export function wrap(newtypeTADict) {
+  return Safe_Coerce.coerce({});
+}
+
+export function unwrap(newtypeTADict) {
+  return Safe_Coerce.coerce(newtypeTADict.Coercible0({}));
+}

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
@@ -1,0 +1,167 @@
+import * as Data_Generic_Rep from "../Data.Generic.Rep/index.js";
+import * as Data_Newtype from "../Data.Newtype/index.js";
+import * as $runtime from "../runtime.js";
+
+export const Empty = ["Empty"];
+export const Single = $value0 => ["Single", $value0];
+export const Pair = $value0 => $value1 => ["Pair", $value0, $value1];
+
+export function roundTrip(value) {
+  return genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt.to(
+    genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt.from(
+      value
+    )
+  );
+}
+
+const $lazy_genericVoidNoConstructors = $runtime.binding("genericVoidNoConstructors", () => {
+  function genericVoidNoConstructors$initialize$closure(value) {
+    return ($lazy_genericVoidNoConstructors()).to(value);
+  }
+  function genericVoidNoConstructors$initialize$closure$1(value) {
+    return ($lazy_genericVoidNoConstructors()).from(value);
+  }
+  return {
+    to: genericVoidNoConstructors$initialize$closure,
+    from: genericVoidNoConstructors$initialize$closure$1
+  };
+});
+
+export const newtypeTypeIdentifierInt = (() => {
+  function newtypeTypeIdentifierInt$initialize$closure(unit) {
+    return {};
+  }
+  return { Coercible0: newtypeTypeIdentifierInt$initialize$closure };
+})();
+
+export const wrapped = (() => {
+  function wrapped$initialize$closure(value) {
+    return value;
+  }
+  return wrapped$initialize$closure(42 | 0);
+})();
+
+export const unwrapped = Data_Newtype.unwrap(newtypeTypeIdentifierInt)(wrapped);
+
+export const genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt = (() => {
+  function genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure(representation) {
+    function case$1(representation) {
+      if (Array.isArray(representation) && representation[0] === "Inr") {
+        const argument$2 = representation[1];
+        if (Array.isArray(argument$2) && argument$2[0] === "Inl") {
+          const argument$3 = argument$2[1];
+          if (Array.isArray(argument$3) && argument$3[0] === "Constructor") {
+            return Single(argument$3[1]);
+          } else {
+            return case$2(representation);
+          }
+        } else {
+          return case$2(representation);
+        }
+      } else {
+        return case$2(representation);
+      }
+    }
+
+    function case$2(representation) {
+      if (Array.isArray(representation) && representation[0] === "Inr") {
+        const argument$4 = representation[1];
+        if (Array.isArray(argument$4) && argument$4[0] === "Inr") {
+          const argument$5 = argument$4[1];
+          if (Array.isArray(argument$5) && argument$5[0] === "Constructor") {
+            const argument$6 = argument$5[1];
+            if (Array.isArray(argument$6) && argument$6[0] === "Product") {
+              const field0$1 = argument$6[1];
+              const field1 = argument$6[2];
+              return Pair(field0$1)(field1);
+            } else {
+              throw new Error("Pattern match failure");
+            }
+          } else {
+            throw new Error("Pattern match failure");
+          }
+        } else {
+          throw new Error("Pattern match failure");
+        }
+      } else {
+        throw new Error("Pattern match failure");
+      }
+    }
+
+    if (Array.isArray(representation) && representation[0] === "Inl") {
+      const argument = representation[1];
+      if (Array.isArray(argument) && argument[0] === "Constructor") {
+        const argument$1 = argument[1];
+        if (Array.isArray(argument$1) && argument$1[0] === "NoArguments") {
+          return Empty;
+        } else {
+          return case$1(representation);
+        }
+      } else {
+        return case$1(representation);
+      }
+    } else {
+      return case$1(representation);
+    }
+  }
+  function genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1(value) {
+    if (Array.isArray(value) && value[0] === "Empty") {
+      return Data_Generic_Rep.Inl(Data_Generic_Rep.Constructor(Data_Generic_Rep.NoArguments));
+    } else {
+      if (Array.isArray(value) && value[0] === "Single") {
+        function genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure(value) {
+          return value;
+        }
+        return Data_Generic_Rep.Inr(
+          Data_Generic_Rep.Inl(
+            Data_Generic_Rep.Constructor(
+              genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure(
+                value[1]
+              )
+            )
+          )
+        );
+      } else {
+        if (Array.isArray(value) && value[0] === "Pair") {
+          const field0$1 = value[1];
+          const field1 = value[2];
+          function genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$1(value) {
+            return value;
+          }
+          function genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$2(value) {
+            return value;
+          }
+          return Data_Generic_Rep.Inr(
+            Data_Generic_Rep.Inr(
+              Data_Generic_Rep.Constructor(
+                Data_Generic_Rep.Product(
+                  genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$1(
+                    field0$1
+                  )
+                )(
+                  genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$2(
+                    field1
+                  )
+                )
+              )
+            )
+          );
+        } else {
+          throw new Error("Pattern match failure");
+        }
+      }
+    }
+  }
+  return {
+    to: genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure,
+    from: genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1
+  };
+})();
+
+export const emptyRoundTrip = roundTrip(Empty);
+
+export const singleRoundTrip = roundTrip(Single(6 | 0));
+
+export const pairRoundTrip = roundTrip(Pair(7 | 0)(8 | 0));
+
+export const genericVoidNoConstructors = $lazy_genericVoidNoConstructors();

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Safe.Coerce/foreign.js
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Safe.Coerce/foreign.js
@@ -1,0 +1,1 @@
+export const unsafeCoerce = value => value;

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Safe.Coerce/index.js
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Safe.Coerce/index.js
@@ -1,0 +1,7 @@
+import * as $foreign from "./foreign.js";
+
+export function coerce(coercibleABDict) {
+  return unsafeCoerce;
+}
+
+const unsafeCoerce = $foreign["unsafeCoerce"];

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/error.txt
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/error.txt
@@ -1,0 +1,1 @@
+cannot convert checked module Idx::<File>(42): checked instance declaration is missing

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/error.txt
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/error.txt
@@ -1,1 +1,0 @@
-cannot convert checked module Idx::<File>(42): checked instance declaration is missing

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/runtime.js
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/runtime.js
@@ -1,0 +1,14 @@
+export function binding(name, initialize) {
+  let state = 0;
+  let value;
+  return () => {
+    if (state === 2) return value;
+    if (state === 1) {
+      throw new ReferenceError(`${name} was needed before it finished initializing`);
+    }
+    state = 1;
+    value = initialize();
+    state = 2;
+    return value;
+  };
+}

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/package.json
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/verify.mjs
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/verify.mjs
@@ -1,0 +1,15 @@
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.unwrapped, 42, "derived Newtype dictionary did not supply coercion evidence");
+deepStrictEqual(Main.emptyRoundTrip, Main.Empty, "Generic to/from failed for the left branch");
+deepStrictEqual(
+  Main.singleRoundTrip,
+  Main.Single(6),
+  "Generic to/from failed for the middle branch",
+);
+deepStrictEqual(
+  Main.pairRoundTrip,
+  Main.Pair(7)(8),
+  "Generic to/from failed for the right branch",
+);

--- a/tests-integration/fixtures/checking/prelude/Safe.Coerce.js
+++ b/tests-integration/fixtures/checking/prelude/Safe.Coerce.js
@@ -1,0 +1,1 @@
+export const unsafeCoerce = value => value;


### PR DESCRIPTION
Fixes #371.

## Summary

Ordinary `Newtype` and `Generic` derives previously stopped after registering their searchable instance heads. This made checking succeed while leaving `CheckedTree::derives` incomplete, so NBE could not lower any module containing those derives.

This change replaces the ambiguous head-only derive strategy with concrete runtime-producing strategies. Derived `Newtype` instances now emit a valid zero-member dictionary through normal instance elaboration, preserving solved `Coercible` superclass evidence. Derived `Generic` instances emit checked `to` and `from` members that construct and match the computed `NoArguments`/`Argument`/`Product`, `Constructor`, and `Sum` representation.

A successful ordinary runtime derive is now routed through declaration generation instead of being deferred to NBE. Explicit representation mismatches are rejected when checking the derive head, and generation uses `Option<Vec<InstanceMember>>` to distinguish failure from a valid zero-member dictionary without a user-reachable panic.

The backend regression fixture consumes Newtype coercion evidence at runtime and round-trips zero-, one-, and two-field Generic constructors across a three-way sum. It also initializes a zero-constructor Generic dictionary, covering NBE, SSA, generated JavaScript, and Node execution.

## Verification

- `cargo check -p checking --tests`
- `cargo clippy -p checking --tests -- -D warnings`
- `cargo nextest run -p checking` — 34 passed
- `just t checking`
- `just t backend`
- Full `core` + `acme` compatibility comparison against `origin/main` (`80bf2f7`)
  - 0 introduced compatibility errors
  - 442 fixed JavaScript errors
  - 39 remaining pre-existing backend errors
