### PR TITLE
[checking] Materialize evidence for infix operands

### DIFF
--- a/compiler-core/checking/src/source/terms/application.rs
+++ b/compiler-core/checking/src/source/terms/application.rs
@@ -444,7 +444,7 @@ where
             let unknown = context.unknown("invalid function application");
             return Ok(super::allocate_error_expression(state, unknown));
         };
-        unification::subtype(state, context, infix.type_id, argument)?;
+        infix = subtype_expression(state, context, infix, argument)?;
         let applied_tick = materialize_application(state, tick, implicit, result, infix);
 
         let Some(UnanchoredApplication { implicit, argument, result }) =

--- a/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Data.Eq.purs
+++ b/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Data.Eq.purs
@@ -1,0 +1,7 @@
+module Data.Eq (class Eq, eq, eqInt) where
+
+class Eq a where
+  eq :: a -> a -> Boolean
+
+instance eqInt :: Eq Int where
+  eq _ _ = true

--- a/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Data.Function.purs
+++ b/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Data.Function.purs
@@ -1,0 +1,4 @@
+module Data.Function (on) where
+
+on :: forall a b c. (b -> b -> c) -> (a -> b) -> a -> a -> c
+on operation projection left right = operation (projection left) (projection right)

--- a/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Main.nbe.snap
@@ -1,0 +1,8 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export unwrap = \value%0 -> value%0
+
+@export instance eqWrapper = \eqADict%1 -> { eq: on eq unwrap }

--- a/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Main.nbe.snap
@@ -5,4 +5,4 @@ expression: report
 ---
 @export unwrap = \value%0 -> value%0
 
-@export instance eqWrapper = \eqADict%1 -> { eq: on eq unwrap }
+@export instance eqWrapper = \eqADict%1 -> { eq: on eqADict%1.eq unwrap }

--- a/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Main.purs
+++ b/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+import Data.Eq (class Eq, eq)
+import Data.Function (on)
+
+newtype Wrapper a = Wrapper a
+
+unwrap :: forall a. Wrapper a -> a
+unwrap (Wrapper value) = value
+
+instance eqWrapper :: Eq a => Eq (Wrapper a) where
+  eq = eq `on` unwrap

--- a/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Main.snap
+++ b/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Main.snap
@@ -1,0 +1,17 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 268
+expression: diagnostics_report
+---
+Terms
+Wrapper :: forall @a. a -> Main.Wrapper a
+unwrap :: forall a. Main.Wrapper a -> a
+
+Types
+Wrapper :: Prim.Type -> Prim.Type
+
+Instances
+instance forall a. Data.Eq.Eq a => Data.Eq.Eq (Main.Wrapper a)
+
+Roles
+Wrapper = [Representational]

--- a/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Main.ssa.snap
@@ -1,0 +1,22 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 269
+expression: ssa_report
+---
+@export function unwrap(value) {
+  entry() {
+    return value;
+  }
+}
+
+@export instance function eqWrapper(eqADict) {
+  entry() {
+    const on = global(on);
+    const eq = global(eq);
+    const call = source.call(on, eq);
+    const unwrap = global(unwrap);
+    const call$1 = source.call(call, unwrap);
+    const record = { eq: call$1 };
+    return record;
+  }
+}

--- a/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/Main.ssa.snap
@@ -12,7 +12,7 @@ expression: ssa_report
 @export instance function eqWrapper(eqADict) {
   entry() {
     const on = global(on);
-    const eq = global(eq);
+    const eq = eqADict.eq;
     const call = source.call(on, eq);
     const unwrap = global(unwrap);
     const call$1 = source.call(call, unwrap);

--- a/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/output/Data.Eq/index.js
+++ b/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/output/Data.Eq/index.js
@@ -1,0 +1,8 @@
+export const eqInt = (() => {
+  function eqInt$initialize$closure($int) {
+    return $int$1 => {
+      return true;
+    };
+  }
+  return { eq: eqInt$initialize$closure };
+})();

--- a/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/output/Data.Eq/index.js
+++ b/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/output/Data.Eq/index.js
@@ -1,8 +1,0 @@
-export const eqInt = (() => {
-  function eqInt$initialize$closure($int) {
-    return $int$1 => {
-      return true;
-    };
-  }
-  return { eq: eqInt$initialize$closure };
-})();

--- a/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/output/Data.Function/index.js
+++ b/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/output/Data.Function/index.js
@@ -1,0 +1,9 @@
+export function on(operation) {
+  return projection => {
+    return left => {
+      return right => {
+        return operation(projection(left))(projection(right));
+      };
+    };
+  };
+}

--- a/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/output/Main/index.js
@@ -1,4 +1,3 @@
-import * as Data_Eq from "../Data.Eq/index.js";
 import * as Data_Function from "../Data.Function/index.js";
 
 export function unwrap(value) {
@@ -6,5 +5,5 @@ export function unwrap(value) {
 }
 
 export function eqWrapper(eqADict) {
-  return { eq: Data_Function.on(Data_Eq.eq)(unwrap) };
+  return { eq: Data_Function.on(eqADict.eq)(unwrap) };
 }

--- a/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/output/Main/index.js
@@ -1,0 +1,10 @@
+import * as Data_Eq from "../Data.Eq/index.js";
+import * as Data_Function from "../Data.Function/index.js";
+
+export function unwrap(value) {
+  return value;
+}
+
+export function eqWrapper(eqADict) {
+  return { eq: Data_Function.on(Data_Eq.eq)(unwrap) };
+}

--- a/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/verify.mjs
+++ b/tests-integration/fixtures/backend/1787449440_instance_member_constraint_reference/verify.mjs
@@ -1,0 +1,8 @@
+import * as Main from "./output/Main/index.js";
+
+const eqInt = { eq: left => right => left === right };
+const eqWrapper = Main.eqWrapper(eqInt);
+
+if (!eqWrapper.eq(1)(1)) {
+  throw new Error("expected wrapped equal values to compare equal");
+}


### PR DESCRIPTION
## Problem

Constrained expressions used as the left operand of a backtick infix chain were subtype-checked without retaining the implicit applications introduced by subtyping.

For example, the standard `Data.Nullable` instance contains:

```purescript
instance eqNullable :: Eq a => Eq (Nullable a) where
  eq = eq `on` toMaybe
```

The checker solved the inner `eq` expression's `Eq a` constraint, but the checked tree did not contain an evidence application. The backend therefore treated `eq` as an ordinary global and generated `Data_Eq.eq`, even though class members intentionally have no standalone JavaScript export. The instance's `eqADict` prerequisite was left unused.

This is not an export-visibility bug: class-member calls must project their implementation from the selected dictionary.

## Fix

Use `subtype_expression` when checking the accumulated left operand in `infer_infix_chain`. Unlike raw `unification::subtype`, this helper materializes inferred type and evidence applications in the checked expression tree.

The generated dictionary now contains:

```javascript
export function eqWrapper(eqADict) {
  return { eq: Data_Function.on(eqADict.eq)(unwrap) };
}
```

## Regression coverage

Add a focused multi-module backend fixture matching the relevant `Data.Nullable` shape. It verifies:

- NBE and SSA project `eq` from `eqADict`
- generated JavaScript has no dependency on a nonexistent `Data.Eq.eq` export
- Node can construct and execute the resulting dictionary member

## Verification

- `cargo check -p checking --tests`
- `cargo nextest run -p checking`
- `just t backend`
- `just t checking`
- `just t semantic`
