### PR TITLE
[backend] Erase direct newtype constructor applications

### DIFF
--- a/compiler-backend/nbe/src/convert.rs
+++ b/compiler-backend/nbe/src/convert.rs
@@ -728,6 +728,14 @@ fn convert_expression(
             ExpressionKind::Local { parameter }
         }
         checking_tree::ExpressionKind::TermApplication { function, argument } => {
+            if let checking_tree::ExpressionKind::Constructor { resolution } =
+                &checked.tree[*function].kind
+            {
+                let &(file_id, term_id) = resolution;
+                if context.constructor_is_newtype(file_id, term_id)? {
+                    return convert_expression(context, *argument);
+                }
+            }
             let function = convert_expression(context, *function)?;
             let argument = convert_expression(context, *argument)?;
             return Ok(context.application(function, [argument]));

--- a/tests-integration/fixtures/backend/1787080920_derived_instance/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787080920_derived_instance/Main.nbe.snap
@@ -17,4 +17,4 @@ expression: report
 
 @export instance showIdentity = \showADict%2 -> showADict%2
 
-@export rendered = (showIdentity showInt).show ((\value%3 -> value%3) 42)
+@export rendered = (showIdentity showInt).show 42

--- a/tests-integration/fixtures/backend/1787080920_derived_instance/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787080920_derived_instance/Main.ssa.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 256
+assertion_line: 269
 expression: ssa_report
 ---
 @export constructor Box/0;
@@ -37,11 +37,9 @@ expression: ssa_report
     const showInt = global(showInt);
     const call = source.call(showIdentity, showInt);
     const show = call.show;
-    const closure = closure(rendered$initialize$closure);
     const literal = 42;
-    const call$1 = source.call(closure, literal);
-    const call$2 = source.call(show, call$1);
-    return call$2;
+    const call$1 = source.call(show, literal);
+    return call$1;
   }
 }
 
@@ -74,11 +72,5 @@ closure eqBox$initialize$closure[](left, right) {
   match$success$1() {
     const literal = true;
     case$join(literal);
-  }
-}
-
-closure rendered$initialize$closure[](value) {
-  entry() {
-    return value;
   }
 }

--- a/tests-integration/fixtures/backend/1787080920_derived_instance/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787080920_derived_instance/output/Main/index.js
@@ -25,9 +25,4 @@ export const eqBox = (() => {
 
 export const equal = eqBox.eq(Box)(Box);
 
-export const rendered = (() => {
-  function rendered$initialize$closure(value) {
-    return value;
-  }
-  return (showIdentity(Data_Show.showInt)).show(rendered$initialize$closure(42 | 0));
-})();
+export const rendered = (showIdentity(Data_Show.showInt)).show(42 | 0);

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.nbe.snap
@@ -5,7 +5,7 @@ expression: report
 ---
 @export instance newtypeTypeIdentifierInt = { "Coercible0": \unit%0 -> <trivial evidence> }
 
-@export wrapped = (\value%1 -> value%1) 42
+@export wrapped = 42
 
 @export unwrapped = unwrap newtypeTypeIdentifierInt wrapped
 
@@ -17,32 +17,29 @@ expression: report
 
 @export instance genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt = {
   to:
-    \representation%2 ->
-      case representation%2 of
+    \representation%1 ->
+      case representation%1 of
         Inl (Constructor NoArguments) ->
           Empty
-        Inr (Inl (Constructor field0%3)) ->
-          Single field0%3
-        Inr (Inr (Constructor (Product field0%4 field1%5))) ->
-          Pair field0%4 field1%5,
+        Inr (Inl (Constructor field0%2)) ->
+          Single field0%2
+        Inr (Inr (Constructor (Product field0%3 field1%4))) ->
+          Pair field0%3 field1%4,
   from:
-    \value%6 ->
-      case value%6 of
+    \value%5 ->
+      case value%5 of
         Empty ->
           Inl (Constructor NoArguments)
-        Single field0%7 ->
-          Inr (Inl (Constructor ((\value%8 -> value%8) field0%7)))
-        Pair field0%9 field1%10 ->
-          Inr
-            (Inr
-              (Constructor
-                (Product ((\value%11 -> value%11) field0%9) ((\value%12 -> value%12) field1%10))))
+        Single field0%6 ->
+          Inr (Inl (Constructor field0%6))
+        Pair field0%7 field1%8 ->
+          Inr (Inr (Constructor (Product field0%7 field1%8)))
 }
 
-@export roundTrip = \value%13 ->
+@export roundTrip = \value%9 ->
   genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt.to
     (genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt.from
-      value%13)
+      value%9)
 
 @export emptyRoundTrip = roundTrip Empty
 
@@ -52,13 +49,13 @@ expression: report
 
 @export instance genericVoidNoConstructors = {
   to:
-    \value%14 ->
-      case value%14 of
+    \value%10 ->
+      case value%10 of
         _ ->
-          genericVoidNoConstructors.to value%14,
+          genericVoidNoConstructors.to value%10,
   from:
-    \value%15 ->
-      case value%15 of
+    \value%11 ->
+      case value%11 of
         _ ->
-          genericVoidNoConstructors.from value%15
+          genericVoidNoConstructors.from value%11
 }

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.ssa.snap
@@ -13,10 +13,8 @@ expression: ssa_report
 
 @export const wrapped = initialize {
   entry() {
-    const closure = closure(wrapped$initialize$closure);
     const literal = 42;
-    const call = source.call(closure, literal);
-    return call;
+    return literal;
   }
 }
 
@@ -104,12 +102,6 @@ closure newtypeTypeIdentifierInt$initialize$closure[](unit) {
   entry() {
     const evidence = evidence.trivial;
     return evidence;
-  }
-}
-
-closure wrapped$initialize$closure[](value) {
-  entry() {
-    return value;
   }
 }
 
@@ -231,27 +223,6 @@ closure genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstruct
   }
 }
 
-closure genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure[
-](value) {
-  entry() {
-    return value;
-  }
-}
-
-closure genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$1[
-](value) {
-  entry() {
-    return value;
-  }
-}
-
-closure genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$2[
-](value) {
-  entry() {
-    return value;
-  }
-}
-
 closure genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1[
 ](value) {
   entry() {
@@ -300,12 +271,10 @@ closure genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstruct
     const Inr = constructor(Inr);
     const Inl$1 = constructor(Inl);
     const Constructor$1 = constructor(Constructor);
-    const closure = closure(genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure);
-    const call$2 = source.call(closure, field0);
-    const call$3 = source.call(Constructor$1, call$2);
-    const call$4 = source.call(Inl$1, call$3);
-    const call$5 = source.call(Inr, call$4);
-    case$join(call$5);
+    const call$2 = source.call(Constructor$1, field0);
+    const call$3 = source.call(Inl$1, call$2);
+    const call$4 = source.call(Inr, call$3);
+    case$join(call$4);
   }
   match$success$2() {
     const field0$1 = pattern.argument(value, Pair, 0);
@@ -314,16 +283,12 @@ closure genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstruct
     const Inr$2 = constructor(Inr);
     const Constructor$2 = constructor(Constructor);
     const Product = constructor(Product);
-    const closure$1 = closure(genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$1);
-    const call$6 = source.call(closure$1, field0$1);
-    const call$7 = source.call(Product, call$6);
-    const closure$2 = closure(genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$2);
-    const call$8 = source.call(closure$2, field1);
-    const call$9 = source.call(call$7, call$8);
-    const call$10 = source.call(Constructor$2, call$9);
-    const call$11 = source.call(Inr$2, call$10);
-    const call$12 = source.call(Inr$1, call$11);
-    case$join(call$12);
+    const call$5 = source.call(Product, field0$1);
+    const call$6 = source.call(call$5, field1);
+    const call$7 = source.call(Constructor$2, call$6);
+    const call$8 = source.call(Inr$2, call$7);
+    const call$9 = source.call(Inr$1, call$8);
+    case$join(call$9);
   }
 }
 

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
@@ -34,12 +34,7 @@ export const newtypeTypeIdentifierInt = (() => {
   return { Coercible0: newtypeTypeIdentifierInt$initialize$closure };
 })();
 
-export const wrapped = (() => {
-  function wrapped$initialize$closure(value) {
-    return value;
-  }
-  return wrapped$initialize$closure(42 | 0);
-})();
+export const wrapped = 42 | 0;
 
 export const unwrapped = Data_Newtype.unwrap(newtypeTypeIdentifierInt)(wrapped);
 
@@ -109,41 +104,14 @@ export const genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntCons
       return Data_Generic_Rep.Inl(Data_Generic_Rep.Constructor(Data_Generic_Rep.NoArguments));
     } else {
       if (Array.isArray(value) && value[0] === "Single") {
-        function genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure(value) {
-          return value;
-        }
-        return Data_Generic_Rep.Inr(
-          Data_Generic_Rep.Inl(
-            Data_Generic_Rep.Constructor(
-              genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure(
-                value[1]
-              )
-            )
-          )
-        );
+        return Data_Generic_Rep.Inr(Data_Generic_Rep.Inl(Data_Generic_Rep.Constructor(value[1])));
       } else {
         if (Array.isArray(value) && value[0] === "Pair") {
           const field0$1 = value[1];
           const field1 = value[2];
-          function genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$1(value) {
-            return value;
-          }
-          function genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$2(value) {
-            return value;
-          }
           return Data_Generic_Rep.Inr(
             Data_Generic_Rep.Inr(
-              Data_Generic_Rep.Constructor(
-                Data_Generic_Rep.Product(
-                  genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$1(
-                    field0$1
-                  )
-                )(
-                  genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt$initialize$closure$1$closure$2(
-                    field1
-                  )
-                )
-              )
+              Data_Generic_Rep.Constructor(Data_Generic_Rep.Product(field0$1)(field1))
             )
           );
         } else {

--- a/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/Main.nbe.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export direct = (\value%0 -> value%0) 42
+
+@export firstClass = \value%1 -> value%1
+
+@export indirect = firstClass 43

--- a/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/Main.nbe.snap
@@ -3,8 +3,8 @@ source: tests-integration/tests/nbe.rs
 assertion_line: 14
 expression: report
 ---
-@export direct = (\value%0 -> value%0) 42
+@export direct = 42
 
-@export firstClass = \value%1 -> value%1
+@export firstClass = \value%0 -> value%0
 
 @export indirect = firstClass 43

--- a/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/Main.purs
+++ b/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+newtype Identity a = Identity a
+
+direct :: Identity Int
+direct = Identity 42
+
+firstClass :: forall a. a -> Identity a
+firstClass = Identity
+
+indirect :: Identity Int
+indirect = firstClass 43

--- a/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/Main.snap
+++ b/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/Main.snap
@@ -1,0 +1,16 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 268
+expression: diagnostics_report
+---
+Terms
+Identity :: forall @a. a -> Main.Identity a
+direct :: Main.Identity Prim.Int
+firstClass :: forall a. a -> Main.Identity a
+indirect :: Main.Identity Prim.Int
+
+Types
+Identity :: Prim.Type -> Prim.Type
+
+Roles
+Identity = [Representational]

--- a/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/Main.ssa.snap
@@ -1,0 +1,34 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 269
+expression: ssa_report
+---
+@export const direct = initialize {
+  entry() {
+    const closure = closure(direct$initialize$closure);
+    const literal = 42;
+    const call = source.call(closure, literal);
+    return call;
+  }
+}
+
+@export function firstClass(value) {
+  entry() {
+    return value;
+  }
+}
+
+@export const indirect = initialize {
+  entry() {
+    const firstClass = global(firstClass);
+    const literal = 43;
+    const call = source.call(firstClass, literal);
+    return call;
+  }
+}
+
+closure direct$initialize$closure[](value) {
+  entry() {
+    return value;
+  }
+}

--- a/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/Main.ssa.snap
@@ -5,10 +5,8 @@ expression: ssa_report
 ---
 @export const direct = initialize {
   entry() {
-    const closure = closure(direct$initialize$closure);
     const literal = 42;
-    const call = source.call(closure, literal);
-    return call;
+    return literal;
   }
 }
 
@@ -24,11 +22,5 @@ expression: ssa_report
     const literal = 43;
     const call = source.call(firstClass, literal);
     return call;
-  }
-}
-
-closure direct$initialize$closure[](value) {
-  entry() {
-    return value;
   }
 }

--- a/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/output/Main/index.js
@@ -1,0 +1,12 @@
+export function firstClass(value) {
+  return value;
+}
+
+export const direct = (() => {
+  function direct$initialize$closure(value) {
+    return value;
+  }
+  return direct$initialize$closure(42 | 0);
+})();
+
+export const indirect = firstClass(43 | 0);

--- a/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/output/Main/index.js
@@ -2,11 +2,6 @@ export function firstClass(value) {
   return value;
 }
 
-export const direct = (() => {
-  function direct$initialize$closure(value) {
-    return value;
-  }
-  return direct$initialize$closure(42 | 0);
-})();
+export const direct = 42 | 0;
 
 export const indirect = firstClass(43 | 0);

--- a/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/package.json
+++ b/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/verify.mjs
+++ b/tests-integration/fixtures/backend/1787506320_direct_newtype_constructor_application/verify.mjs
@@ -1,0 +1,6 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.direct, 42);
+strictEqual(Main.firstClass(43), 43);
+strictEqual(Main.indirect, 43);


### PR DESCRIPTION
## Summary

Direct newtype-constructor applications are representationally the argument itself, but NBE conversion previously materialized the constructor as an identity lambda before converting the surrounding application. That introduced an avoidable closure and call in SSA and generated JavaScript.

This change recognizes a directly resolved newtype constructor at the `TermApplication` conversion boundary and converts only its argument. The argument is still converted and evaluated exactly once. A constructor used as a first-class value continues to convert to an identity function.

A focused backend fixture records both sides of the behavior, and the existing derived-instance and derived-Newtype/Generic fixtures are updated for the newly erased direct applications.

## Verification

- `cargo check -p nbe --tests`
- `just t backend 1787506320`
- `just t backend`