### PR TITLE
[checking] Clarify guarded expression subsumption

### DIFF
--- a/compiler-core/checking/src/source/terms/forms.rs
+++ b/compiler-core/checking/src/source/terms/forms.rs
@@ -295,7 +295,7 @@ where
         let guarded_expression = if let Some(guarded_source) = &branch.guarded_expression {
             match mode {
                 CaseOfMode::Infer => {
-                    guarded::subtype_guarded_expression(state, context, guarded_source, expected)?
+                    guarded::subsume_guarded_expression(state, context, guarded_source, expected)?
                         .guarded_expression
                 }
                 CaseOfMode::Check { .. } => {

--- a/compiler-core/checking/src/source/terms/guarded.rs
+++ b/compiler-core/checking/src/source/terms/guarded.rs
@@ -22,7 +22,7 @@ pub struct ElaboratedWhereExpression {
 #[derive(Copy, Clone, Debug)]
 enum GuardedExpressionMode {
     Infer,
-    Subtype { expected: TypeId },
+    Subsume { expected: TypeId },
     Check { expected: TypeId },
 }
 
@@ -55,9 +55,12 @@ where
     guarded_expression_core(state, context, guarded, GuardedExpressionMode::Check { expected })
 }
 
-/// Infers a guarded expression against a shared result type while retaining
-/// implicit applications introduced on the inferred side.
-pub fn subtype_guarded_expression<Q>(
+/// Infers an unconditional guarded result before subsuming it against the
+/// shared result type of an inferred case expression. Subsumption operates on
+/// the elaborated expression rather than its type alone so that implicit
+/// evidence applications introduced by the relation remain in the checked
+/// tree.
+pub fn subsume_guarded_expression<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     guarded: &lowering::GuardedExpression,
@@ -66,7 +69,7 @@ pub fn subtype_guarded_expression<Q>(
 where
     Q: ExternalQueries,
 {
-    guarded_expression_core(state, context, guarded, GuardedExpressionMode::Subtype { expected })
+    guarded_expression_core(state, context, guarded, GuardedExpressionMode::Subsume { expected })
 }
 
 fn guarded_expression_core<Q>(
@@ -83,7 +86,7 @@ where
             let Some(where_expression) = where_expression else {
                 let type_id = match mode {
                     GuardedExpressionMode::Infer => context.unknown("missing guarded expression"),
-                    GuardedExpressionMode::Subtype { expected }
+                    GuardedExpressionMode::Subsume { expected }
                     | GuardedExpressionMode::Check { expected } => expected,
                 };
                 let expression = state.allocate_error_expression(type_id);
@@ -96,10 +99,10 @@ where
                 GuardedExpressionMode::Infer => {
                     infer_where_expression(state, context, where_expression)?
                 }
-                GuardedExpressionMode::Subtype { expected } => {
+                GuardedExpressionMode::Subsume { expected } => {
                     let where_expression =
                         infer_where_expression(state, context, where_expression)?;
-                    subtype_where_expression(state, context, where_expression, expected)?
+                    subsume_where_expression(state, context, where_expression, expected)?
                 }
                 GuardedExpressionMode::Check { expected } => {
                     check_where_expression(state, context, where_expression, expected)?
@@ -115,7 +118,7 @@ where
                 GuardedExpressionMode::Infer => {
                     state.fresh_unification(context.queries, context.prim.t)
                 }
-                GuardedExpressionMode::Subtype { expected }
+                GuardedExpressionMode::Subsume { expected }
                 | GuardedExpressionMode::Check { expected } => expected,
             };
 
@@ -194,7 +197,7 @@ where
     where_expression_core(state, context, where_expression, WhereExpressionMode::Infer)
 }
 
-fn subtype_where_expression<Q>(
+fn subsume_where_expression<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     where_expression: ElaboratedWhereExpression,


### PR DESCRIPTION
## Summary

Inferred case alternatives first infer an unconditional guarded result, then relate the elaborated expression to the case's shared result type. Calling this operation a subtype checking mode obscures both the inference step and the expression elaboration it preserves.

Rename the guarded-expression mode and helpers from `Subtype` to `Subsume`, and document why the relation must operate on the elaborated expression: inferred-side evidence applications need to remain in the checked tree for later compiler stages.

This is a terminology and documentation change; checking behavior and integration snapshots remain unchanged.

## Verification

- `cargo check -p checking --tests`
- `cargo nextest run -p checking`
- `just t checking`
- `just t semantic`
- `just t backend`