### PR TITLE
[backend] Inline single-use closures and use zero-arity thunks

### DIFF
--- a/compiler-backend/javascript/src/convert/generator/analysis.rs
+++ b/compiler-backend/javascript/src/convert/generator/analysis.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::iter;
 
 use files::FileId;
 use itertools::Itertools;
@@ -19,6 +20,7 @@ pub(super) struct FunctionContext {
     closure_names: FxHashMap<FunctionId, String>,
     block_names: FxHashMap<BlockId, String>,
     inlineable_values: FxHashMap<BlockId, FxHashSet<ValueId>>,
+    lexically_stable_values: FxHashSet<ValueId>,
     pub(super) dispatch_block: String,
     pub(super) dispatch_arguments: String,
 }
@@ -92,14 +94,28 @@ impl ValueExpressionContext for BlockExpressionContext<'_> {
 
 impl FunctionContext {
     pub(super) fn new(generator: &Generator<'_>, function: &Function) -> FunctionContext {
-        let mut allocator =
-            NameAllocator::with_reserved(generator.reserved_module_names.iter().cloned());
-        let mut names = FxHashMap::default();
+        FunctionContext::with_capture_names(generator, function, FxHashMap::default())
+    }
+
+    pub(super) fn with_capture_names(
+        generator: &Generator<'_>,
+        function: &Function,
+        capture_names: FxHashMap<ValueId, String>,
+    ) -> FunctionContext {
+        let reserved = {
+            let reserved_module_names = generator.reserved_module_names.iter().cloned();
+            let reserved_capture_names = capture_names.values().cloned();
+            iter::chain(reserved_module_names, reserved_capture_names)
+        };
+
+        let mut allocator = NameAllocator::with_reserved(reserved);
+        let mut names = capture_names;
         for value in function_values(generator.module, function) {
             names
                 .entry(value)
                 .or_insert_with(|| allocator.allocate(&generator.module.storage[value].name));
         }
+
         let mut closure_names = FxHashMap::default();
         for function_id in direct_closures(generator.module, function) {
             let function_name = &generator.module.storage[function_id].name;
@@ -107,19 +123,30 @@ impl FunctionContext {
             let name = allocator.allocate(preferred_name);
             closure_names.insert(function_id, name);
         }
+
         let mut block_names = FxHashMap::default();
         for block in function.blocks.iter().copied() {
             let name = allocator.allocate(&generator.module.storage[block].name);
             block_names.insert(block, name);
         }
-        let inlineable_values = locally_inlineable_values(generator.module, function);
+
         let dispatch_block = allocator.allocate("$block");
         let dispatch_arguments = allocator.allocate("$arguments");
+
+        let inlineable_values = locally_inlineable_values(generator.module, function);
+        let lexically_stable_values = {
+            let captures = function.captures.iter();
+            let parameters = function.parameters.iter();
+            iter::chain(captures, parameters).copied()
+        };
+        let lexically_stable_values = lexically_stable_values.collect();
+
         FunctionContext {
             names,
             closure_names,
             block_names,
             inlineable_values,
+            lexically_stable_values,
             dispatch_block,
             dispatch_arguments,
         }
@@ -150,6 +177,10 @@ impl FunctionContext {
         self.inlineable_values
             .get(&block)
             .expect("invariant violated: JavaScript SSA block has no inlining analysis")
+    }
+
+    pub(super) fn value_is_lexically_stable(&self, value: ValueId) -> bool {
+        self.lexically_stable_values.contains(&value)
     }
 
     pub(super) fn mutable_values(&self, function: &Function) -> Vec<&str> {

--- a/compiler-backend/javascript/src/convert/generator/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/render.rs
@@ -3,9 +3,9 @@ use std::iter;
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 use ssa::tree::{
-    BlockId, BlockTarget, Failure, Function, Instruction, InstructionValue, LazyInitializer,
-    PatternTest, RecordUpdate, RecursiveClosure, ReflectableEvidence, ReflectableOrdering,
-    SynthesizedEvidence, Terminator, ValueId,
+    BlockId, BlockTarget, Failure, Function, FunctionId, Instruction, InstructionValue,
+    LazyInitializer, PatternTest, RecordUpdate, RecursiveClosure, ReflectableEvidence,
+    ReflectableOrdering, SynthesizedEvidence, Terminator, ValueId,
 };
 
 use super::Generator;
@@ -149,6 +149,13 @@ impl Generator<'_> {
             if let Instruction::Assign { result, value } = instruction
                 && inlineable.contains(result)
             {
+                if let InstructionValue::Closure { function, captures } = value
+                    && let Some(expression) =
+                        self.inline_closure_expression(output.tree, *function, captures, context)?
+                {
+                    expressions.insert(*result, expression);
+                    continue;
+                }
                 self.render_closure_function(output.tree, output.writer, value, context)?;
                 let expression = self.instruction_expression(output.tree, value, &expressions)?;
                 expressions.insert(*result, expression);
@@ -217,6 +224,86 @@ impl Generator<'_> {
             "invariant violated: inline JavaScript block expression was not consumed"
         );
         Ok(())
+    }
+
+    fn inline_closure_expression(
+        &self,
+        tree: &mut Tree,
+        function_id: FunctionId,
+        captures: &[ValueId],
+        parent_context: &FunctionContext,
+    ) -> ModuleResult<Option<ExpressionId>> {
+        // Factory calls snapshot captured values, whereas lexical closures capture bindings. They
+        // are equivalent only when the generated JavaScript never reassigns those bindings.
+        if captures.iter().any(|capture| !parent_context.value_is_lexically_stable(*capture)) {
+            return Ok(None);
+        }
+
+        let function = &self.module.storage[function_id];
+        assert!(
+            !function.parameters.is_empty(),
+            "invariant violated: SSA closure has no source parameters"
+        );
+        assert_eq!(
+            function.blocks.first(),
+            Some(&function.entry),
+            "invariant violated: SSA closure does not begin with its entry block"
+        );
+        assert_eq!(
+            function.captures.len(),
+            captures.len(),
+            "invariant violated: SSA closure capture arity does not match its function"
+        );
+
+        if function.blocks.len() != 1 {
+            return Ok(None);
+        }
+
+        let capture_names = {
+            let function_captures = function.captures.iter().copied();
+            let parent_capture_names =
+                captures.iter().map(|capture| parent_context.value(*capture).to_owned());
+            iter::zip(function_captures, parent_capture_names)
+        };
+        let capture_names = capture_names.collect::<FxHashMap<_, _>>();
+
+        let context = FunctionContext::with_capture_names(self, function, capture_names);
+        let block = &self.module.storage[function.entry];
+
+        let Terminator::Return { value } = block.terminator else {
+            return Ok(None);
+        };
+        let inlineable = context.inlineable_values(function.entry);
+        let instructions_are_inlineable = block.instructions.iter().all(|instruction| {
+            if let Instruction::Assign { result, value } = instruction {
+                inlineable.contains(result) && !matches!(value, InstructionValue::Closure { .. })
+            } else {
+                false
+            }
+        });
+        if !instructions_are_inlineable {
+            return Ok(None);
+        }
+
+        let expressions = BlockExpressionContext::new(&context);
+        for instruction in &block.instructions {
+            let Instruction::Assign { result, value } = instruction else {
+                unreachable!("invariant violated: inline closure contains a non-assignment")
+            };
+            let expression = self.instruction_expression(tree, value, &expressions)?;
+            expressions.insert(*result, expression);
+        }
+        let mut expression = expressions.expression(tree, value);
+        assert!(
+            expressions.is_empty(),
+            "invariant violated: inline JavaScript closure expression was not consumed"
+        );
+
+        for parameter in function.parameters.iter().rev() {
+            let parameter = context.value(*parameter).to_owned();
+            expression = tree.arrow(vec![parameter], expression);
+        }
+        Ok(Some(expression))
     }
 
     fn render_acyclic_target(

--- a/compiler-backend/javascript/src/convert/generator/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/render.rs
@@ -3,9 +3,9 @@ use std::iter;
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 use ssa::tree::{
-    BlockId, BlockTarget, Failure, Function, FunctionId, Instruction, InstructionValue,
-    LazyInitializer, PatternTest, RecordUpdate, RecursiveClosure, ReflectableEvidence,
-    ReflectableOrdering, SynthesizedEvidence, Terminator, ValueId,
+    BlockId, BlockTarget, CallingConvention, Failure, Function, FunctionId, Instruction,
+    InstructionValue, LazyInitializer, PatternTest, RecordUpdate, RecursiveClosure,
+    ReflectableEvidence, ReflectableOrdering, SynthesizedEvidence, Terminator, ValueId,
 };
 
 use super::Generator;
@@ -46,6 +46,12 @@ impl Generator<'_> {
         let parameters =
             function.parameters.iter().map(|parameter| context.value(*parameter).to_owned());
         let parameters = parameters.collect_vec();
+        let returns_zero_parameter_closure = !captures.is_empty()
+            && parameters.is_empty()
+            && matches!(
+                function.calling_convention,
+                CallingConvention::Source | CallingConvention::Effect
+            );
         let (function_parameters, arrow_parameters) = if captures.is_empty() {
             match parameters.split_first() {
                 Some((first, rest)) => (vec![first.clone()], rest.to_vec()),
@@ -58,7 +64,19 @@ impl Generator<'_> {
         let export = if exported { "export " } else { "" };
         let header = format!("{export}function {name}({}) {{", function_parameters.join(", "));
         writer.block(header, "}", |writer| {
-            self.render_curried_function_body(tree, writer, function, &context, &arrow_parameters)
+            if returns_zero_parameter_closure {
+                writer.block("return () => {", "};", |writer| {
+                    self.render_function_body(tree, writer, function, &context)
+                })
+            } else {
+                self.render_curried_function_body(
+                    tree,
+                    writer,
+                    function,
+                    &context,
+                    &arrow_parameters,
+                )
+            }
         })
     }
 
@@ -240,10 +258,6 @@ impl Generator<'_> {
         }
 
         let function = &self.module.storage[function_id];
-        assert!(
-            !function.parameters.is_empty(),
-            "invariant violated: SSA closure has no source parameters"
-        );
         assert_eq!(
             function.blocks.first(),
             Some(&function.entry),
@@ -299,9 +313,13 @@ impl Generator<'_> {
             "invariant violated: inline JavaScript closure expression was not consumed"
         );
 
-        for parameter in function.parameters.iter().rev() {
-            let parameter = context.value(*parameter).to_owned();
-            expression = tree.arrow(vec![parameter], expression);
+        if function.parameters.is_empty() {
+            expression = tree.arrow(vec![], expression);
+        } else {
+            for parameter in function.parameters.iter().rev() {
+                let parameter = context.value(*parameter).to_owned();
+                expression = tree.arrow(vec![parameter], expression);
+            }
         }
         Ok(Some(expression))
     }

--- a/compiler-backend/javascript/src/convert/generator/syntax.rs
+++ b/compiler-backend/javascript/src/convert/generator/syntax.rs
@@ -46,7 +46,11 @@ pub(super) fn call_expression(
     match convention {
         CallingConvention::Initializer => tree.call(function, arguments),
         CallingConvention::Source | CallingConvention::Effect => {
-            let arguments = arguments.into_iter();
+            let mut arguments = arguments.into_iter();
+            let Some(argument) = arguments.next() else {
+                return tree.call(function, vec![]);
+            };
+            let function = tree.call(function, vec![argument]);
             arguments.fold(function, |function, argument| tree.call(function, vec![argument]))
         }
     }

--- a/compiler-backend/nbe/src/convert.rs
+++ b/compiler-backend/nbe/src/convert.rs
@@ -436,8 +436,10 @@ fn convert_instance_declaration(
             let mut fields = Vec::new();
             for superclass in instance.superclasses.iter() {
                 let expression = evidence_variable(context, superclass.evidence)?;
-                let parameter = context.fresh_parameter(SmolStr::new("unit"))?;
-                let expression = context.parameter_abstraction([parameter], expression);
+                let expression = context.expression(ExpressionKind::Abstraction {
+                    parameters: Arc::from([]),
+                    body: expression,
+                });
                 let field = context.superclass_field(superclass.id)?;
                 fields.push(RecordField { field, expression });
             }
@@ -1037,8 +1039,10 @@ fn convert_evidence(
             let field = context.superclass_field(*superclass)?;
             let name = format_smolstr!("{}Dict", field.name);
             let accessor = context.expression(ExpressionKind::Project { record, field });
-            let unit = context.expression(ExpressionKind::TrivialEvidence);
-            let construction = context.application(accessor, [unit]);
+            let construction = context.expression(ExpressionKind::Application {
+                function: accessor,
+                arguments: Arc::from([]),
+            });
             context.record_evidence(evidence, construction, name)
         }
         Evidence::Trivial => Ok(context.expression(ExpressionKind::TrivialEvidence)),

--- a/compiler-backend/nbe/src/pretty.rs
+++ b/compiler-backend/nbe/src/pretty.rs
@@ -138,10 +138,14 @@ impl<'a> Printer<'a, '_> {
             }
             ExpressionKind::Local { parameter } => self.parameter(parameter),
             ExpressionKind::Abstraction { parameters, body } => {
-                let parameters = parameters
-                    .iter()
-                    .map(|pattern| self.pattern_at(*pattern, PatternPrecedence::Atom));
-                let parameters = self.arena.intersperse(parameters, self.arena.space());
+                let parameters = if parameters.is_empty() {
+                    self.arena.text("()")
+                } else {
+                    let parameters = parameters
+                        .iter()
+                        .map(|pattern| self.pattern_at(*pattern, PatternPrecedence::Atom));
+                    self.arena.intersperse(parameters, self.arena.space())
+                };
                 let abstraction = self.arena.text("\\").append(parameters).append(" ->");
                 let body_document = self.expression(*body);
                 if self.expression_requires_body_break(*body) {
@@ -154,12 +158,16 @@ impl<'a> Printer<'a, '_> {
             }
             ExpressionKind::Application { function, arguments } => {
                 let function = self.expression_at(*function, ExpressionPrecedence::Application);
-                let arguments = arguments
-                    .iter()
-                    .map(|argument| self.expression_at(*argument, ExpressionPrecedence::Atom));
-                let arguments = self.arena.intersperse(arguments, self.arena.line());
-                let arguments = self.arena.line().append(arguments).nest(2);
-                function.append(arguments).group()
+                if arguments.is_empty() {
+                    function.append("()")
+                } else {
+                    let arguments = arguments
+                        .iter()
+                        .map(|argument| self.expression_at(*argument, ExpressionPrecedence::Atom));
+                    let arguments = self.arena.intersperse(arguments, self.arena.line());
+                    let arguments = self.arena.line().append(arguments).nest(2);
+                    function.append(arguments).group()
+                }
             }
             ExpressionKind::IfThenElse { condition, then, else_ } => {
                 let condition = self.expression(*condition);

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/output/Main/index.js
@@ -59,8 +59,5 @@ export function bind(value) {
 }
 
 export function ordinaryBind(identity) {
-  function ordinaryBind$closure(value) {
-    return value;
-  }
-  return bind(identity)(ordinaryBind$closure);
+  return bind(identity)(value => value);
 }

--- a/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.nbe.snap
@@ -9,13 +9,13 @@ expression: report
 
 @export instance equalInt1 = { equal: equalInt }
 
-@export instance orderedInt = { "Equal0": \unit%0 -> equalInt1, lessThan: lessThanInt }
+@export instance orderedInt = { "Equal0": \() -> equalInt1, lessThan: lessThanInt }
 
-@export genericEqual = \equalADict%1 -> \left%2 right%3 -> equalADict%1.equal left%2 right%3
+@export genericEqual = \equalADict%0 -> \left%1 right%2 -> equalADict%0.equal left%1 right%2
 
 @export concreteEqual = equalInt1.equal 1 2
 
 @export concreteLessThan = orderedInt.lessThan 1 2
 
-@export superclassEqual = \orderedADict%4 ->
-  \left%5 right%6 -> (orderedADict%4."Equal0" <trivial evidence>).equal left%5 right%6
+@export superclassEqual = \orderedADict%3 ->
+  \left%4 right%5 -> (orderedADict%3."Equal0"()).equal left%4 right%5

--- a/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787021940_type_class_evidence/Main.ssa.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 265
+assertion_line: 269
 expression: ssa_report
 ---
 @export foreign const equalInt;
@@ -62,7 +62,7 @@ expression: ssa_report
   }
 }
 
-closure orderedInt$initialize$closure[](unit) {
+closure orderedInt$initialize$closure[]() {
   entry() {
     const equalInt1 = global(equalInt1);
     return equalInt1;
@@ -81,8 +81,7 @@ closure genericEqual$closure[equalADict](left, right) {
 closure superclassEqual$closure[orderedADict](left, right) {
   entry() {
     const Equal0 = orderedADict.Equal0;
-    const evidence = evidence.trivial;
-    const call = source.call(Equal0, evidence);
+    const call = source.call(Equal0);
     const equal = call.equal;
     const call$1 = source.call(equal, left);
     const call$2 = source.call(call$1, right);

--- a/tests-integration/fixtures/backend/1787021940_type_class_evidence/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021940_type_class_evidence/output/Main/index.js
@@ -1,25 +1,11 @@
 import * as $foreign from "./foreign.js";
 
 export function genericEqual(equalADict) {
-  function genericEqual$closure(equalADict) {
-    return left => {
-      return right => {
-        return equalADict.equal(left)(right);
-      };
-    };
-  }
-  return genericEqual$closure(equalADict);
+  return left => right => equalADict.equal(left)(right);
 }
 
 export function superclassEqual(orderedADict) {
-  function superclassEqual$closure(orderedADict) {
-    return left => {
-      return right => {
-        return (orderedADict.Equal0({})).equal(left)(right);
-      };
-    };
-  }
-  return superclassEqual$closure(orderedADict);
+  return left => right => (orderedADict.Equal0({})).equal(left)(right);
 }
 
 export const equalInt = $foreign["equalInt"];
@@ -28,10 +14,7 @@ export const lessThanInt = $foreign["lessThanInt"];
 export const equalInt1 = { equal: equalInt };
 
 export const orderedInt = (() => {
-  function orderedInt$initialize$closure(unit) {
-    return equalInt1;
-  }
-  return { Equal0: orderedInt$initialize$closure, lessThan: lessThanInt };
+  return { Equal0: unit => equalInt1, lessThan: lessThanInt };
 })();
 
 export const concreteEqual = equalInt1.equal(1 | 0)(2 | 0);

--- a/tests-integration/fixtures/backend/1787021940_type_class_evidence/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021940_type_class_evidence/output/Main/index.js
@@ -5,7 +5,7 @@ export function genericEqual(equalADict) {
 }
 
 export function superclassEqual(orderedADict) {
-  return left => right => (orderedADict.Equal0({})).equal(left)(right);
+  return left => right => (orderedADict.Equal0()).equal(left)(right);
 }
 
 export const equalInt = $foreign["equalInt"];
@@ -14,7 +14,7 @@ export const lessThanInt = $foreign["lessThanInt"];
 export const equalInt1 = { equal: equalInt };
 
 export const orderedInt = (() => {
-  return { Equal0: unit => equalInt1, lessThan: lessThanInt };
+  return { Equal0: () => equalInt1, lessThan: lessThanInt };
 })();
 
 export const concreteEqual = equalInt1.equal(1 | 0)(2 | 0);

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Effect/index.js
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Effect/index.js
@@ -8,32 +8,17 @@ export const bindEffect = $foreign["bindEffect"];
 export const functorEffect = { map: mapEffect };
 
 export const applyEffect1 = (() => {
-  function applyEffect1$initialize$closure(unit) {
-    return functorEffect;
-  }
-  return { Functor0: applyEffect1$initialize$closure, apply: applyEffect };
+  return { Functor0: unit => functorEffect, apply: applyEffect };
 })();
 
 export const applicativeEffect = (() => {
-  function applicativeEffect$initialize$closure(unit) {
-    return applyEffect1;
-  }
-  return { Apply0: applicativeEffect$initialize$closure, pure: pureEffect };
+  return { Apply0: unit => applyEffect1, pure: pureEffect };
 })();
 
 export const bindEffect1 = (() => {
-  function bindEffect1$initialize$closure(unit) {
-    return applyEffect1;
-  }
-  return { Apply0: bindEffect1$initialize$closure, bind: bindEffect };
+  return { Apply0: unit => applyEffect1, bind: bindEffect };
 })();
 
 export const monadEffect = (() => {
-  function monadEffect$initialize$closure(unit) {
-    return applicativeEffect;
-  }
-  function monadEffect$initialize$closure$1(unit) {
-    return bindEffect1;
-  }
-  return { Applicative0: monadEffect$initialize$closure, Bind1: monadEffect$initialize$closure$1 };
+  return { Applicative0: unit => applicativeEffect, Bind1: unit => bindEffect1 };
 })();

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Effect/index.js
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Effect/index.js
@@ -8,17 +8,17 @@ export const bindEffect = $foreign["bindEffect"];
 export const functorEffect = { map: mapEffect };
 
 export const applyEffect1 = (() => {
-  return { Functor0: unit => functorEffect, apply: applyEffect };
+  return { Functor0: () => functorEffect, apply: applyEffect };
 })();
 
 export const applicativeEffect = (() => {
-  return { Apply0: unit => applyEffect1, pure: pureEffect };
+  return { Apply0: () => applyEffect1, pure: pureEffect };
 })();
 
 export const bindEffect1 = (() => {
-  return { Apply0: unit => applyEffect1, bind: bindEffect };
+  return { Apply0: () => applyEffect1, bind: bindEffect };
 })();
 
 export const monadEffect = (() => {
-  return { Applicative0: unit => applicativeEffect, Bind1: unit => bindEffect1 };
+  return { Applicative0: () => applicativeEffect, Bind1: () => bindEffect1 };
 })();

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Main/index.js
@@ -6,20 +6,12 @@ export const secondAction = $foreign["secondAction"];
 export const independentAction = $foreign["independentAction"];
 
 export const sequential = (() => {
-  function sequential$initialize$closure(first) {
-    return secondAction(first);
-  }
-  return Effect.bindEffect1.bind(firstAction)(sequential$initialize$closure);
+  return Effect.bindEffect1.bind(firstAction)(first => secondAction(first));
 })();
 
 export const independent = (() => {
-  function independent$initialize$closure(first) {
-    return second => {
-      return { first: first, second: second };
-    };
-  }
   return Effect.applyEffect1.apply(
-    Effect.functorEffect.map(independent$initialize$closure)(firstAction)
+    Effect.functorEffect.map(first => second => ({ first: first, second: second }))(firstAction)
   )(independentAction);
 })();
 

--- a/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787022240_functions_closures_and_control_flow/output/Main/index.js
@@ -5,12 +5,7 @@ export function apply($function) {
 }
 
 export function capture(captured) {
-  function capture$closure(captured) {
-    return $int => {
-      return captured;
-    };
-  }
-  return capture$closure(captured);
+  return $int => captured;
 }
 
 export function choose(condition) {

--- a/tests-integration/fixtures/backend/1787080920_derived_instance/output/Data.Show/index.js
+++ b/tests-integration/fixtures/backend/1787080920_derived_instance/output/Data.Show/index.js
@@ -1,13 +1,7 @@
 export function showArray(showADict) {
-  function showArray$closure($array) {
-    return "";
-  }
-  return { show: showArray$closure };
+  return { show: $array => "" };
 }
 
 export const showInt = (() => {
-  function showInt$initialize$closure($int) {
-    return "";
-  }
-  return { show: showInt$initialize$closure };
+  return { show: $int => "" };
 })();

--- a/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
@@ -13,12 +13,7 @@ export function readProto(value) {
 }
 
 export function capture(captured) {
-  function capture$closure(captured) {
-    return $int => {
-      return captured;
-    };
-  }
-  return capture$closure(captured);
+  return $int => captured;
 }
 
 export function apply($function) {
@@ -28,12 +23,7 @@ export function apply($function) {
 }
 
 export function addCaptured(amount) {
-  function addCaptured$closure(amount) {
-    return value => {
-      return addInt(amount)(value);
-    };
-  }
-  return addCaptured$closure(amount);
+  return value => addInt(amount)(value);
 }
 
 export function nestedJoin(outer) {

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Data.Eq/index.js
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Data.Eq/index.js
@@ -1,11 +1,6 @@
 export function eqRec(rowToListRowListDict) {
   return eqRecordListRowDict => {
-    function eqRec$closure($record) {
-      return $record$1 => {
-        return true;
-      };
-    }
-    return { eq: eqRec$closure };
+    return { eq: $record => $record$1 => true };
   };
 }
 
@@ -13,44 +8,20 @@ export function eqRecordConsType(eqRecordRowlistTailRowDict) {
   return consKeyFocusRowTailRowDict => {
     return isSymbolKeyDict => {
       return eqFocusDict => {
-        function eqRecordConsType$closure($cons) {
-          return $record => {
-            return $record$1 => {
-              return true;
-            };
-          };
-        }
-        return { eqRecord: eqRecordConsType$closure };
+        return { eqRecord: $cons => $record => $record$1 => true };
       };
     };
   };
 }
 
 export const eqInt = (() => {
-  function eqInt$initialize$closure($int) {
-    return $int$1 => {
-      return true;
-    };
-  }
-  return { eq: eqInt$initialize$closure };
+  return { eq: $int => $int$1 => true };
 })();
 
 export const eqBoolean = (() => {
-  function eqBoolean$initialize$closure($boolean) {
-    return $boolean$1 => {
-      return true;
-    };
-  }
-  return { eq: eqBoolean$initialize$closure };
+  return { eq: $boolean => $boolean$1 => true };
 })();
 
 export const eqRecordNilType = (() => {
-  function eqRecordNilType$initialize$closure($nil) {
-    return $record => {
-      return $record$1 => {
-        return true;
-      };
-    };
-  }
-  return { eqRecord: eqRecordNilType$initialize$closure };
+  return { eqRecord: $nil => $record => $record$1 => true };
 })();

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Origin/index.js
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Origin/index.js
@@ -64,10 +64,7 @@ export const eqOption = (() => {
 })();
 
 export const measureInt = (() => {
-  function measureInt$initialize$closure(value) {
-    return value;
-  }
-  return { measure: measureInt$initialize$closure };
+  return { measure: value => value };
 })();
 
 export { $await as "await" };

--- a/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787157000_mixed_equation_arities/output/Main/index.js
@@ -1,10 +1,7 @@
 export function choose($int) {
   return $int$1 => {
     if ($int === (0 | 0)) {
-      function choose$closure(value) {
-        return value;
-      }
-      return choose$closure($int$1);
+      return (value => value)($int$1);
     } else {
       return $int;
     }

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.nbe.snap
@@ -67,13 +67,13 @@ expression: report
 @export compareSuperclassArraysTwice = \orderedADict%40 ->
   \left%41 right%42 ->
     let
-      eqArrayDict%43 = eqArray (orderedADict%40."Eq0" <trivial evidence>)
+      eqArrayDict%43 = eqArray (orderedADict%40."Eq0"())
     in if eqArrayDict%43.eq left%41 right%42 then eqArrayDict%43.eq right%42 left%41 else false
 
 @export compareSuperclassTwice = \orderedADict%44 ->
   \left%45 right%46 ->
     let
-      Eq0Dict%47 = orderedADict%44."Eq0" <trivial evidence>
+      Eq0Dict%47 = orderedADict%44."Eq0"()
     in if Eq0Dict%47.eq left%45 right%46 then Eq0Dict%47.eq right%46 left%45 else false
 
 @export lambdaScope = \left%48 right%49 ->

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.ssa.snap
@@ -500,8 +500,7 @@ closure compareSuperclassArraysTwice$closure[orderedADict](left, right) {
   entry() {
     const eqArray = global(eqArray);
     const Eq0 = orderedADict.Eq0;
-    const evidence = evidence.trivial;
-    const call = source.call(Eq0, evidence);
+    const call = source.call(Eq0);
     const call$1 = source.call(eqArray, call);
     const eq = call$1.eq;
     const call$2 = source.call(eq, left);
@@ -530,8 +529,7 @@ closure compareSuperclassArraysTwice$closure[orderedADict](left, right) {
 closure compareSuperclassTwice$closure[orderedADict](left, right) {
   entry() {
     const Eq0 = orderedADict.Eq0;
-    const evidence = evidence.trivial;
-    const call = source.call(Eq0, evidence);
+    const call = source.call(Eq0);
     const eq = call.eq;
     const call$1 = source.call(eq, left);
     const call$2 = source.call(call$1, right);

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Data.Eq/index.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Data.Eq/index.js
@@ -11,5 +11,5 @@ export const eqBoolean = (() => {
 })();
 
 export const orderedInt = (() => {
-  return { Eq0: unit => eqInt, lessThanOrEqual: $int => $int$1 => true };
+  return { Eq0: () => eqInt, lessThanOrEqual: $int => $int$1 => true };
 })();

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Data.Eq/index.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Data.Eq/index.js
@@ -1,38 +1,15 @@
 export function eqArray(eqADict) {
-  function eqArray$closure($array) {
-    return $array$1 => {
-      return true;
-    };
-  }
-  return { eq: eqArray$closure };
+  return { eq: $array => $array$1 => true };
 }
 
 export const eqInt = (() => {
-  function eqInt$initialize$closure($int) {
-    return $int$1 => {
-      return true;
-    };
-  }
-  return { eq: eqInt$initialize$closure };
+  return { eq: $int => $int$1 => true };
 })();
 
 export const eqBoolean = (() => {
-  function eqBoolean$initialize$closure($boolean) {
-    return $boolean$1 => {
-      return true;
-    };
-  }
-  return { eq: eqBoolean$initialize$closure };
+  return { eq: $boolean => $boolean$1 => true };
 })();
 
 export const orderedInt = (() => {
-  function orderedInt$initialize$closure(unit) {
-    return eqInt;
-  }
-  function orderedInt$initialize$closure$1($int) {
-    return $int$1 => {
-      return true;
-    };
-  }
-  return { Eq0: orderedInt$initialize$closure, lessThanOrEqual: orderedInt$initialize$closure$1 };
+  return { Eq0: unit => eqInt, lessThanOrEqual: $int => $int$1 => true };
 })();

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
@@ -163,7 +163,7 @@ export function compareSuperclassArraysTwice(orderedADict) {
   function compareSuperclassArraysTwice$closure(orderedADict) {
     return left => {
       return right => {
-        const call$1 = Data_Eq.eqArray(orderedADict.Eq0({}));
+        const call$1 = Data_Eq.eqArray(orderedADict.Eq0());
         if (call$1.eq(left)(right)) {
           return call$1.eq(right)(left);
         } else {
@@ -179,7 +179,7 @@ export function compareSuperclassTwice(orderedADict) {
   function compareSuperclassTwice$closure(orderedADict) {
     return left => {
       return right => {
-        const call = orderedADict.Eq0({});
+        const call = orderedADict.Eq0();
         if (call.eq(left)(right)) {
           return call.eq(right)(left);
         } else {

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
@@ -213,12 +213,9 @@ export function lambdaScope(left) {
 
 export function whereIsolation(left) {
   return right => {
-    function whereIsolation$closure(helperLeft) {
-      return helperRight => {
-        return (Data_Eq.eqArray(Data_Eq.eqInt)).eq(helperLeft)(helperRight);
-      };
-    }
-    if (whereIsolation$closure(left)(right)) {
+    if ((helperLeft => helperRight => (Data_Eq.eqArray(Data_Eq.eqInt)).eq(helperLeft)(helperRight))(
+      left
+    )(right)) {
       return (Data_Eq.eqArray(Data_Eq.eqInt)).eq(left)(right);
     } else {
       return false;

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.nbe.snap
@@ -22,36 +22,41 @@ expression: report
 
 @export inlineCapturedClosure = \captured%11 -> \$boolean%10@(_) -> captured%11
 
-@export keepMultiUse = \record%13 ->
+@export keepMultiUseClosure = \captured%14 ->
   let
-    value%12 = record%13.value
-  in { first: value%12, second: value%12 }
+    closure%12 = \$boolean%13@(_) -> captured%14
+  in { first: closure%12, second: closure%12 }
 
-@export inlineAcrossCall = \record%14 function%15 ->
-  { projected: record%14.value, called: function%15 true }
-
-@export inlineOrderedCalls = \first%16 second%17 ->
-  { first: first%16 true, second: second%17 false }
-
-@export keepReorderedCalls = \first%21 second%20 ->
+@export keepMultiUse = \record%16 ->
   let
-    firstResult%19 = first%21 true
+    value%15 = record%16.value
+  in { first: value%15, second: value%15 }
+
+@export inlineAcrossCall = \record%17 function%18 ->
+  { projected: record%17.value, called: function%18 true }
+
+@export inlineOrderedCalls = \first%19 second%20 ->
+  { first: first%19 true, second: second%20 false }
+
+@export keepReorderedCalls = \first%24 second%23 ->
+  let
+    firstResult%22 = first%24 true
   in let
-    secondResult%18 = second%20 false
-  in { first: secondResult%18, second: firstResult%19 }
+    secondResult%21 = second%23 false
+  in { first: secondResult%21, second: firstResult%22 }
 
-@export keepMultiUseCall = \function%23 value%24 ->
+@export keepMultiUseCall = \function%26 value%27 ->
   let
-    result%22 = function%23 value%24
-  in { first: result%22, second: result%22 }
+    result%25 = function%26 value%27
+  in { first: result%25, second: result%25 }
 
-@export keepCallBeforeBranch = \condition%25 function%28 value%27 ->
+@export keepCallBeforeBranch = \condition%28 function%31 value%30 ->
   let
-    result%26 = function%28 value%27
-  in if condition%25 then result%26 else value%27
+    result%29 = function%31 value%30
+  in if condition%28 then result%29 else value%30
 
-@export keepTestCall = \function%29 value%30 ->
-  case function%29 value%30 of
+@export keepTestCall = \function%32 value%33 ->
+  case function%32 value%33 of
     [] ->
       true
     _ ->

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.purs
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.purs
@@ -27,6 +27,13 @@ inlineRecord value = { value }
 inlineCapturedClosure :: Boolean -> Boolean -> Boolean
 inlineCapturedClosure captured = \_ -> captured
 
+keepMultiUseClosure
+  :: Boolean
+  -> { first :: Boolean -> Boolean, second :: Boolean -> Boolean }
+keepMultiUseClosure captured =
+  let closure = \_ -> captured
+  in { first: closure, second: closure }
+
 keepMultiUse :: { value :: Boolean } -> { first :: Boolean, second :: Boolean }
 keepMultiUse record =
   let value = record.value

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.snap
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.snap
@@ -1,5 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
+assertion_line: 268
 expression: diagnostics_report
 ---
 Terms
@@ -12,6 +13,8 @@ inlineCall :: (Prim.Boolean -> Prim.Boolean) -> Prim.Boolean -> Prim.Boolean
 inlineArray :: Prim.Boolean -> Prim.Array Prim.Boolean
 inlineRecord :: Prim.Boolean -> { value :: Prim.Boolean }
 inlineCapturedClosure :: Prim.Boolean -> Prim.Boolean -> Prim.Boolean
+keepMultiUseClosure ::
+  Prim.Boolean -> { first :: Prim.Boolean -> Prim.Boolean, second :: Prim.Boolean -> Prim.Boolean }
 keepMultiUse :: { value :: Prim.Boolean } -> { first :: Prim.Boolean, second :: Prim.Boolean }
 inlineAcrossCall ::
   { value :: Prim.Boolean } ->

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.ssa.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 256
+assertion_line: 269
 expression: ssa_report
 ---
 @export function identity(value) {
@@ -80,6 +80,14 @@ expression: ssa_report
   entry() {
     const closure = closure(inlineCapturedClosure$closure, captured);
     return closure;
+  }
+}
+
+@export function keepMultiUseClosure(captured) {
+  entry() {
+    const closure = closure(keepMultiUseClosure$closure, captured);
+    const record = { first: closure, second: closure };
+    return record;
   }
 }
 
@@ -187,6 +195,12 @@ closure inlineClosure$closure[](item) {
 }
 
 closure inlineCapturedClosure$closure[captured]($boolean) {
+  entry() {
+    return captured;
+  }
+}
+
+closure keepMultiUseClosure$closure[captured]($boolean) {
   entry() {
     return captured;
   }

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/output/Main/index.js
@@ -19,10 +19,7 @@ export function inlineLiteral(condition) {
 }
 
 export function inlineClosure(value) {
-  function inlineClosure$closure(item) {
-    return item;
-  }
-  return inlineClosure$closure(value);
+  return (item => item)(value);
 }
 
 export function inlineCall($function) {
@@ -40,12 +37,17 @@ export function inlineRecord(value) {
 }
 
 export function inlineCapturedClosure(captured) {
-  function inlineCapturedClosure$closure(captured) {
+  return $boolean => captured;
+}
+
+export function keepMultiUseClosure(captured) {
+  function keepMultiUseClosure$closure(captured) {
     return $boolean => {
       return captured;
     };
   }
-  return inlineCapturedClosure$closure(captured);
+  const closure = keepMultiUseClosure$closure(captured);
+  return { first: closure, second: closure };
 }
 
 export function keepMultiUse(record) {

--- a/tests-integration/fixtures/backend/1787315820_descriptive_dictionary_parameter_names/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787315820_descriptive_dictionary_parameter_names/output/Main/index.js
@@ -1,88 +1,37 @@
 export const Wrapper = $value0 => ["Wrapper", $value0];
 
 export function genericEqual(equalValueDict) {
-  function genericEqual$closure(equalValueDict) {
-    return left => {
-      return right => {
-        return equalValueDict.equal(left)(right);
-      };
-    };
-  }
-  return genericEqual$closure(equalValueDict);
+  return left => right => equalValueDict.equal(left)(right);
 }
 
 export function arrayEqual(equalArrayValueDict) {
-  function arrayEqual$closure(equalArrayValueDict) {
-    return left => {
-      return right => {
-        return equalArrayValueDict.equal(left)(right);
-      };
-    };
-  }
-  return arrayEqual$closure(equalArrayValueDict);
+  return left => right => equalArrayValueDict.equal(left)(right);
 }
 
 export function wrapperEqual(equalWrapperValueDict) {
-  function wrapperEqual$closure(equalWrapperValueDict) {
-    return left => {
-      return right => {
-        return equalWrapperValueDict.equal(left)(right);
-      };
-    };
-  }
-  return wrapperEqual$closure(equalWrapperValueDict);
+  return left => right => equalWrapperValueDict.equal(left)(right);
 }
 
 export function concreteEqual(equalIntDict) {
-  function concreteEqual$closure(equalIntDict) {
-    return left => {
-      return right => {
-        return equalIntDict.equal(left)(right);
-      };
-    };
-  }
-  return concreteEqual$closure(equalIntDict);
+  return left => right => equalIntDict.equal(left)(right);
 }
 
 export function convertToInt(convertValueIntDict) {
-  function convertToInt$closure(convertValueIntDict) {
-    return value => {
-      return convertValueIntDict.convert(value);
-    };
-  }
-  return convertToInt$closure(convertValueIntDict);
+  return value => convertValueIntDict.convert(value);
 }
 
 export function distinctEqual(equalLeftDict) {
   return equalRightDict => {
-    function distinctEqual$closure(equalLeftDict, equalRightDict) {
-      return left1 => {
-        return left2 => {
-          return right1 => {
-            return right2 => {
-              return {
-                left: equalLeftDict.equal(left1)(left2),
-                right: equalRightDict.equal(right1)(right2)
-              };
-            };
-          };
-        };
-      };
-    }
-    return distinctEqual$closure(equalLeftDict, equalRightDict);
+    return left1 => left2 => right1 => right2 => ({
+      left: equalLeftDict.equal(left1)(left2),
+      right: equalRightDict.equal(right1)(right2)
+    });
   };
 }
 
 export function duplicateEqual(equalValueDict) {
   return equalValueDict$1 => {
-    function duplicateEqual$closure(equalValueDict) {
-      return left => {
-        return right => {
-          return equalValueDict.equal(left)(right);
-        };
-      };
-    }
-    return duplicateEqual$closure(equalValueDict$1);
+    return left => right => equalValueDict$1.equal(left)(right);
   };
 }
 

--- a/tests-integration/fixtures/backend/1787317740_descriptive_closure_argument_names/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787317740_descriptive_closure_argument_names/output/Main/index.js
@@ -17,10 +17,7 @@ export function multiEquation($choice) {
 export function mixedArity($boolean) {
   return $int => {
     if ($boolean === true) {
-      function mixedArity$closure(value) {
-        return value;
-      }
-      return mixedArity$closure($int);
+      return (value => value)($int);
     } else {
       if ($boolean === false) {
         return $int;

--- a/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/Main.nbe.snap
@@ -7,34 +7,28 @@ expression: report
 
 @export liftApplicative = \applicativeFunctorDict%0 ->
   \function%1 value%2 ->
-    (applicativeFunctorDict%0."Apply0" <trivial evidence>).apply
-      (applicativeFunctorDict%0.pure function%1)
-      value%2
+    (applicativeFunctorDict%0."Apply0"()).apply (applicativeFunctorDict%0.pure function%1) value%2
 
 @export applyMonad = \monadMonadDict%3 ->
   \functions%4 values%6 ->
-    (monadMonadDict%3."Bind1" <trivial evidence>).bind functions%4
+    (monadMonadDict%3."Bind1"()).bind functions%4
       (\function%5 ->
-        (monadMonadDict%3."Bind1" <trivial evidence>).bind values%6
-          (\value%7 ->
-            (monadMonadDict%3."Applicative0" <trivial evidence>).pure (function%5 value%7)))
+        (monadMonadDict%3."Bind1"()).bind values%6
+          (\value%7 -> (monadMonadDict%3."Applicative0"()).pure (function%5 value%7)))
 
 @export instance functorBox = { map: liftApplicative applicativeBox }
 
-@export instance applyBox = { "Functor0": \unit%8 -> functorBox, apply: applyMonad monadBox }
+@export instance applyBox = { "Functor0": \() -> functorBox, apply: applyMonad monadBox }
 
-@export instance applicativeBox = { "Apply0": \unit%9 -> applyBox, pure: Box }
+@export instance applicativeBox = { "Apply0": \() -> applyBox, pure: Box }
 
 @export instance bindBox = {
-  "Apply0": \unit%10 -> applyBox,
-  bind: \$box%13@(Box value%12) continuation%11 -> continuation%11 value%12
+  "Apply0": \() -> applyBox,
+  bind: \$box%10@(Box value%9) continuation%8 -> continuation%8 value%9
 }
 
-@export instance monadBox = {
-  "Applicative0": \unit%14 -> applicativeBox,
-  "Bind1": \unit%15 -> bindBox
-}
+@export instance monadBox = { "Applicative0": \() -> applicativeBox, "Bind1": \() -> bindBox }
 
-@export result = case functorBox.map (\value%16 -> value%16) (Box 42) of
-  Box value%17 ->
-    value%17
+@export result = case functorBox.map (\value%11 -> value%11) (Box 42) of
+  Box value%12 ->
+    value%12

--- a/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/Main.ssa.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 265
+assertion_line: 269
 expression: ssa_report
 ---
 @export constructor Box/1;
@@ -102,8 +102,7 @@ expression: ssa_report
 closure liftApplicative$closure[applicativeFunctorDict](function, value) {
   entry() {
     const Apply0 = applicativeFunctorDict.Apply0;
-    const evidence = evidence.trivial;
-    const call = source.call(Apply0, evidence);
+    const call = source.call(Apply0);
     const apply = call.apply;
     const pure = applicativeFunctorDict.pure;
     const call$1 = source.call(pure, function);
@@ -116,8 +115,7 @@ closure liftApplicative$closure[applicativeFunctorDict](function, value) {
 closure applyMonad$closure$closure$closure[monadMonadDict, function](value) {
   entry() {
     const Applicative0 = monadMonadDict.Applicative0;
-    const evidence = evidence.trivial;
-    const call = source.call(Applicative0, evidence);
+    const call = source.call(Applicative0);
     const pure = call.pure;
     const call$1 = source.call(function, value);
     const call$2 = source.call(pure, call$1);
@@ -128,8 +126,7 @@ closure applyMonad$closure$closure$closure[monadMonadDict, function](value) {
 closure applyMonad$closure$closure[monadMonadDict, values](function) {
   entry() {
     const Bind1 = monadMonadDict.Bind1;
-    const evidence = evidence.trivial;
-    const call = source.call(Bind1, evidence);
+    const call = source.call(Bind1);
     const bind = call.bind;
     const call$1 = source.call(bind, values);
     const closure = closure(applyMonad$closure$closure$closure, monadMonadDict, function);
@@ -141,8 +138,7 @@ closure applyMonad$closure$closure[monadMonadDict, values](function) {
 closure applyMonad$closure[monadMonadDict](functions, values) {
   entry() {
     const Bind1 = monadMonadDict.Bind1;
-    const evidence = evidence.trivial;
-    const call = source.call(Bind1, evidence);
+    const call = source.call(Bind1);
     const bind = call.bind;
     const call$1 = source.call(bind, functions);
     const closure = closure(applyMonad$closure$closure, monadMonadDict, values);
@@ -151,21 +147,21 @@ closure applyMonad$closure[monadMonadDict](functions, values) {
   }
 }
 
-closure applyBox$initialize$closure[](unit) {
+closure applyBox$initialize$closure[]() {
   entry() {
     const functorBox = global(functorBox);
     return functorBox;
   }
 }
 
-closure applicativeBox$initialize$closure[](unit) {
+closure applicativeBox$initialize$closure[]() {
   entry() {
     const applyBox = global(applyBox);
     return applyBox;
   }
 }
 
-closure bindBox$initialize$closure[](unit) {
+closure bindBox$initialize$closure[]() {
   entry() {
     const applyBox = global(applyBox);
     return applyBox;
@@ -191,14 +187,14 @@ closure bindBox$initialize$closure$1[]($box, continuation) {
   }
 }
 
-closure monadBox$initialize$closure[](unit) {
+closure monadBox$initialize$closure[]() {
   entry() {
     const applicativeBox = global(applicativeBox);
     return applicativeBox;
   }
 }
 
-closure monadBox$initialize$closure$1[](unit) {
+closure monadBox$initialize$closure$1[]() {
   entry() {
     const bindBox = global(bindBox);
     return bindBox;

--- a/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/output/Main/index.js
@@ -3,7 +3,7 @@ import * as $runtime from "../runtime.js";
 export const Box = $value0 => ["Box", $value0];
 
 export function liftApplicative(applicativeFunctorDict) {
-  return $function => value => (applicativeFunctorDict.Apply0({})).apply(
+  return $function => value => (applicativeFunctorDict.Apply0()).apply(
     applicativeFunctorDict.pure($function)
   )(value);
 }
@@ -14,12 +14,12 @@ export function applyMonad(monadMonadDict) {
       return values => {
         function applyMonad$closure$closure(monadMonadDict, values) {
           return $function => {
-            return (monadMonadDict.Bind1({})).bind(values)(
-              value => (monadMonadDict.Applicative0({})).pure($function(value))
+            return (monadMonadDict.Bind1()).bind(values)(
+              value => (monadMonadDict.Applicative0()).pure($function(value))
             );
           };
         }
-        return (monadMonadDict.Bind1({})).bind(functions)(
+        return (monadMonadDict.Bind1()).bind(functions)(
           applyMonad$closure$closure(monadMonadDict, values)
         );
       };
@@ -33,11 +33,11 @@ const $lazy_functorBox = $runtime.binding("functorBox", () => {
 });
 
 const $lazy_applyBox = $runtime.binding("applyBox", () => {
-  return { Functor0: unit => $lazy_functorBox(), apply: applyMonad($lazy_monadBox()) };
+  return { Functor0: () => $lazy_functorBox(), apply: applyMonad($lazy_monadBox()) };
 });
 
 const $lazy_applicativeBox = $runtime.binding("applicativeBox", () => {
-  return { Apply0: unit => $lazy_applyBox(), pure: Box };
+  return { Apply0: () => $lazy_applyBox(), pure: Box };
 });
 
 const $lazy_bindBox = $runtime.binding("bindBox", () => {
@@ -50,11 +50,11 @@ const $lazy_bindBox = $runtime.binding("bindBox", () => {
       }
     };
   }
-  return { Apply0: unit => $lazy_applyBox(), bind: bindBox$initialize$closure$1 };
+  return { Apply0: () => $lazy_applyBox(), bind: bindBox$initialize$closure$1 };
 });
 
 const $lazy_monadBox = $runtime.binding("monadBox", () => {
-  return { Applicative0: unit => $lazy_applicativeBox(), Bind1: unit => $lazy_bindBox() };
+  return { Applicative0: () => $lazy_applicativeBox(), Bind1: () => $lazy_bindBox() };
 });
 
 export const functorBox = $lazy_functorBox();

--- a/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/output/Main/index.js
@@ -3,16 +3,9 @@ import * as $runtime from "../runtime.js";
 export const Box = $value0 => ["Box", $value0];
 
 export function liftApplicative(applicativeFunctorDict) {
-  function liftApplicative$closure(applicativeFunctorDict) {
-    return $function => {
-      return value => {
-        return (applicativeFunctorDict.Apply0({})).apply(applicativeFunctorDict.pure($function))(
-          value
-        );
-      };
-    };
-  }
-  return liftApplicative$closure(applicativeFunctorDict);
+  return $function => value => (applicativeFunctorDict.Apply0({})).apply(
+    applicativeFunctorDict.pure($function)
+  )(value);
 }
 
 export function applyMonad(monadMonadDict) {
@@ -21,13 +14,8 @@ export function applyMonad(monadMonadDict) {
       return values => {
         function applyMonad$closure$closure(monadMonadDict, values) {
           return $function => {
-            function applyMonad$closure$closure$closure(monadMonadDict, $function) {
-              return value => {
-                return (monadMonadDict.Applicative0({})).pure($function(value));
-              };
-            }
             return (monadMonadDict.Bind1({})).bind(values)(
-              applyMonad$closure$closure$closure(monadMonadDict, $function)
+              value => (monadMonadDict.Applicative0({})).pure($function(value))
             );
           };
         }
@@ -45,23 +33,14 @@ const $lazy_functorBox = $runtime.binding("functorBox", () => {
 });
 
 const $lazy_applyBox = $runtime.binding("applyBox", () => {
-  function applyBox$initialize$closure(unit) {
-    return $lazy_functorBox();
-  }
-  return { Functor0: applyBox$initialize$closure, apply: applyMonad($lazy_monadBox()) };
+  return { Functor0: unit => $lazy_functorBox(), apply: applyMonad($lazy_monadBox()) };
 });
 
 const $lazy_applicativeBox = $runtime.binding("applicativeBox", () => {
-  function applicativeBox$initialize$closure(unit) {
-    return $lazy_applyBox();
-  }
-  return { Apply0: applicativeBox$initialize$closure, pure: Box };
+  return { Apply0: unit => $lazy_applyBox(), pure: Box };
 });
 
 const $lazy_bindBox = $runtime.binding("bindBox", () => {
-  function bindBox$initialize$closure(unit) {
-    return $lazy_applyBox();
-  }
   function bindBox$initialize$closure$1($box) {
     return continuation => {
       if (Array.isArray($box) && $box[0] === "Box") {
@@ -71,17 +50,11 @@ const $lazy_bindBox = $runtime.binding("bindBox", () => {
       }
     };
   }
-  return { Apply0: bindBox$initialize$closure, bind: bindBox$initialize$closure$1 };
+  return { Apply0: unit => $lazy_applyBox(), bind: bindBox$initialize$closure$1 };
 });
 
 const $lazy_monadBox = $runtime.binding("monadBox", () => {
-  function monadBox$initialize$closure(unit) {
-    return $lazy_applicativeBox();
-  }
-  function monadBox$initialize$closure$1(unit) {
-    return $lazy_bindBox();
-  }
-  return { Applicative0: monadBox$initialize$closure, Bind1: monadBox$initialize$closure$1 };
+  return { Applicative0: unit => $lazy_applicativeBox(), Bind1: unit => $lazy_bindBox() };
 });
 
 export const functorBox = $lazy_functorBox();
@@ -95,10 +68,7 @@ export const bindBox = $lazy_bindBox();
 export const monadBox = $lazy_monadBox();
 
 export const result = (() => {
-  function result$initialize$closure(value) {
-    return value;
-  }
-  const call$2 = ($lazy_functorBox()).map(result$initialize$closure)(Box(42 | 0));
+  const call$2 = ($lazy_functorBox()).map(value => value)(Box(42 | 0));
   if (Array.isArray(call$2) && call$2[0] === "Box") {
     return call$2[1];
   } else {

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.nbe.snap
@@ -3,7 +3,7 @@ source: tests-integration/tests/nbe.rs
 assertion_line: 14
 expression: report
 ---
-@export instance newtypeTypeIdentifierInt = { "Coercible0": \unit%0 -> <trivial evidence> }
+@export instance newtypeTypeIdentifierInt = { "Coercible0": \() -> <trivial evidence> }
 
 @export wrapped = 42
 
@@ -17,29 +17,29 @@ expression: report
 
 @export instance genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt = {
   to:
-    \representation%1 ->
-      case representation%1 of
+    \representation%0 ->
+      case representation%0 of
         Inl (Constructor NoArguments) ->
           Empty
-        Inr (Inl (Constructor field0%2)) ->
-          Single field0%2
-        Inr (Inr (Constructor (Product field0%3 field1%4))) ->
-          Pair field0%3 field1%4,
+        Inr (Inl (Constructor field0%1)) ->
+          Single field0%1
+        Inr (Inr (Constructor (Product field0%2 field1%3))) ->
+          Pair field0%2 field1%3,
   from:
-    \value%5 ->
-      case value%5 of
+    \value%4 ->
+      case value%4 of
         Empty ->
           Inl (Constructor NoArguments)
-        Single field0%6 ->
-          Inr (Inl (Constructor field0%6))
-        Pair field0%7 field1%8 ->
-          Inr (Inr (Constructor (Product field0%7 field1%8)))
+        Single field0%5 ->
+          Inr (Inl (Constructor field0%5))
+        Pair field0%6 field1%7 ->
+          Inr (Inr (Constructor (Product field0%6 field1%7)))
 }
 
-@export roundTrip = \value%9 ->
+@export roundTrip = \value%8 ->
   genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt.to
     (genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt.from
-      value%9)
+      value%8)
 
 @export emptyRoundTrip = roundTrip Empty
 
@@ -49,13 +49,13 @@ expression: report
 
 @export instance genericVoidNoConstructors = {
   to:
+    \value%9 ->
+      case value%9 of
+        _ ->
+          genericVoidNoConstructors.to value%9,
+  from:
     \value%10 ->
       case value%10 of
         _ ->
-          genericVoidNoConstructors.to value%10,
-  from:
-    \value%11 ->
-      case value%11 of
-        _ ->
-          genericVoidNoConstructors.from value%11
+          genericVoidNoConstructors.from value%10
 }

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/Main.ssa.snap
@@ -98,7 +98,7 @@ expression: ssa_report
   }
 }
 
-closure newtypeTypeIdentifierInt$initialize$closure[](unit) {
+closure newtypeTypeIdentifierInt$initialize$closure[]() {
   entry() {
     const evidence = evidence.trivial;
     return evidence;

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Data.Newtype/index.js
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Data.Newtype/index.js
@@ -5,5 +5,5 @@ export function wrap(newtypeTADict) {
 }
 
 export function unwrap(newtypeTADict) {
-  return Safe_Coerce.coerce(newtypeTADict.Coercible0({}));
+  return Safe_Coerce.coerce(newtypeTADict.Coercible0());
 }

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
@@ -28,7 +28,7 @@ const $lazy_genericVoidNoConstructors = $runtime.binding("genericVoidNoConstruct
 });
 
 export const newtypeTypeIdentifierInt = (() => {
-  return { Coercible0: unit => ({}) };
+  return { Coercible0: () => ({}) };
 })();
 
 export const wrapped = 42 | 0;

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
@@ -28,10 +28,7 @@ const $lazy_genericVoidNoConstructors = $runtime.binding("genericVoidNoConstruct
 });
 
 export const newtypeTypeIdentifierInt = (() => {
-  function newtypeTypeIdentifierInt$initialize$closure(unit) {
-    return {};
-  }
-  return { Coercible0: newtypeTypeIdentifierInt$initialize$closure };
+  return { Coercible0: unit => ({}) };
 })();
 
 export const wrapped = 42 | 0;

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/Main/index.js
@@ -50,10 +50,7 @@ export function caseRecursive(condition) {
       return go$initialize$closure(go);
     } else {
       if (condition === false) {
-        function go$initialize$closure$1($boolean) {
-          return 31 | 0;
-        }
-        return go$initialize$closure$1;
+        return $boolean => 31 | 0;
       } else {
         throw new Error("Pattern match failure");
       }

--- a/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/Main.nbe.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export constructor Unit/0
+
+@export ordinaryUnit = \value%0 -> value%0
+
+@export ordinaryUnitCall = ordinaryUnit Unit
+
+@export instance parentInt = { parent: \value%1 -> value%1 }
+
+@export instance childArray = \parentArrayADict%2 ->
+  { "Parent0": \unit%3 -> parentArrayADict%2, child: \value%4 -> value%4 }
+
+@export useSuperclass = \childADict%5 ->
+  \value%6 -> (childADict%5."Parent0" <trivial evidence>).parent value%6

--- a/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/Main.nbe.snap
@@ -12,7 +12,6 @@ expression: report
 @export instance parentInt = { parent: \value%1 -> value%1 }
 
 @export instance childArray = \parentArrayADict%2 ->
-  { "Parent0": \unit%3 -> parentArrayADict%2, child: \value%4 -> value%4 }
+  { "Parent0": \() -> parentArrayADict%2, child: \value%3 -> value%3 }
 
-@export useSuperclass = \childADict%5 ->
-  \value%6 -> (childADict%5."Parent0" <trivial evidence>).parent value%6
+@export useSuperclass = \childADict%4 -> \value%5 -> (childADict%4."Parent0"()).parent value%5

--- a/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/Main.purs
+++ b/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/Main.purs
@@ -1,0 +1,24 @@
+module Main where
+
+data Unit = Unit
+
+ordinaryUnit :: Unit -> Unit
+ordinaryUnit value = value
+
+ordinaryUnitCall :: Unit
+ordinaryUnitCall = ordinaryUnit Unit
+
+class Parent a where
+  parent :: a -> a
+
+class Parent a <= Child a where
+  child :: a -> a
+
+instance Parent Int where
+  parent value = value
+
+instance childArray :: Parent (Array a) => Child (Array a) where
+  child value = value
+
+useSuperclass :: forall a. Child a => a -> a
+useSuperclass value = parent value

--- a/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/Main.snap
+++ b/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/Main.snap
@@ -1,0 +1,30 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 268
+expression: diagnostics_report
+---
+Terms
+Unit :: Main.Unit
+ordinaryUnit :: Main.Unit -> Main.Unit
+ordinaryUnitCall :: Main.Unit
+parent :: forall @a. Main.Parent a => a -> a
+child :: forall @a. Main.Child a => a -> a
+useSuperclass :: forall a. Main.Child a => a -> a
+
+Types
+Unit :: Prim.Type
+Parent :: Prim.Type -> Prim.Constraint
+Child :: Prim.Type -> Prim.Constraint
+
+Classes
+class forall (a :: Prim.Type). Main.Parent a
+  parent :: forall @a. Main.Parent a => a -> a
+class forall (a :: Prim.Type). Main.Parent a <= Main.Child a
+  child :: forall @a. Main.Child a => a -> a
+
+Instances
+instance Main.Parent Prim.Int
+instance forall a. Main.Parent (Prim.Array a) => Main.Child (Prim.Array a)
+
+Roles
+Unit = []

--- a/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/Main.ssa.snap
@@ -50,7 +50,7 @@ closure parentInt$initialize$closure[](value) {
   }
 }
 
-closure childArray$closure[parentArrayADict](unit) {
+closure childArray$closure[parentArrayADict]() {
   entry() {
     return parentArrayADict;
   }
@@ -65,8 +65,7 @@ closure childArray$closure$1[](value) {
 closure useSuperclass$closure[childADict](value) {
   entry() {
     const Parent0 = childADict.Parent0;
-    const evidence = evidence.trivial;
-    const call = source.call(Parent0, evidence);
+    const call = source.call(Parent0);
     const parent = call.parent;
     const call$1 = source.call(parent, value);
     return call$1;

--- a/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/Main.ssa.snap
@@ -1,0 +1,74 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 269
+expression: ssa_report
+---
+@export constructor Unit/0;
+
+@export function ordinaryUnit(value) {
+  entry() {
+    return value;
+  }
+}
+
+@export const ordinaryUnitCall = initialize {
+  entry() {
+    const ordinaryUnit = global(ordinaryUnit);
+    const Unit = constructor(Unit);
+    const call = source.call(ordinaryUnit, Unit);
+    return call;
+  }
+}
+
+@export instance const parentInt = initialize {
+  entry() {
+    const closure = closure(parentInt$initialize$closure);
+    const record = { parent: closure };
+    return record;
+  }
+}
+
+@export instance function childArray(parentArrayADict) {
+  entry() {
+    const closure = closure(childArray$closure, parentArrayADict);
+    const closure$1 = closure(childArray$closure$1);
+    const record = { Parent0: closure, child: closure$1 };
+    return record;
+  }
+}
+
+@export function useSuperclass(childADict) {
+  entry() {
+    const closure = closure(useSuperclass$closure, childADict);
+    return closure;
+  }
+}
+
+closure parentInt$initialize$closure[](value) {
+  entry() {
+    return value;
+  }
+}
+
+closure childArray$closure[parentArrayADict](unit) {
+  entry() {
+    return parentArrayADict;
+  }
+}
+
+closure childArray$closure$1[](value) {
+  entry() {
+    return value;
+  }
+}
+
+closure useSuperclass$closure[childADict](value) {
+  entry() {
+    const Parent0 = childADict.Parent0;
+    const evidence = evidence.trivial;
+    const call = source.call(Parent0, evidence);
+    const parent = call.parent;
+    const call$1 = source.call(parent, value);
+    return call$1;
+  }
+}

--- a/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/output/Main/index.js
@@ -1,0 +1,19 @@
+export const Unit = ["Unit"];
+
+export function ordinaryUnit(value) {
+  return value;
+}
+
+export function childArray(parentArrayADict) {
+  return { Parent0: unit => parentArrayADict, child: value => value };
+}
+
+export function useSuperclass(childADict) {
+  return value => (childADict.Parent0({})).parent(value);
+}
+
+export const ordinaryUnitCall = ordinaryUnit(Unit);
+
+export const parentInt = (() => {
+  return { parent: value => value };
+})();

--- a/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787515380_semantic_thunk_arity/output/Main/index.js
@@ -5,11 +5,11 @@ export function ordinaryUnit(value) {
 }
 
 export function childArray(parentArrayADict) {
-  return { Parent0: unit => parentArrayADict, child: value => value };
+  return { Parent0: () => parentArrayADict, child: value => value };
 }
 
 export function useSuperclass(childADict) {
-  return value => (childADict.Parent0({})).parent(value);
+  return value => (childADict.Parent0()).parent(value);
 }
 
 export const ordinaryUnitCall = ordinaryUnit(Unit);


### PR DESCRIPTION
## Summary

Generated JavaScript currently materializes every SSA closure as a named factory function, even when the resulting closure value is consumed only once. Compiler-created superclass thunks are also represented as one-argument functions taking a synthetic `unit` value and forced by passing trivial evidence, producing avoidable `$closure` helpers, `unit => value`, and `thunk({})` calls.

This PR addresses both sources of noise at their appropriate backend boundaries.

### Inline single-use closures

Render eligible single-use SSA closures directly as lexical arrow functions instead of named factory helpers. Inlining is limited to one-block closures whose assignments can all be rendered as expressions, and only when captured values are parent captures or parameters. This preserves the snapshot semantics of the former factory call when mutable SSA locals are present.

Nested and multi-use closures continue to use named helpers. Child function contexts inherit captured names so alpha-renaming remains stable and does not introduce shadowing. The JavaScript inlining fixture includes a multi-use closure assertion to preserve shared function identity.

### Represent compiler thunks with zero arity

Construct compiler-created superclass thunks as zero-parameter NBE abstractions and force them with zero-argument NBE applications. SSA already preserves those structural arities, and the generic JavaScript closure and call rendering paths now emit them as `() => value` and `thunk()`.

This is deliberately structural: there is no parameter-name matching, `{}` rendering special case, or nominal trivial-evidence erasure. Ordinary source-level Unit functions retain their declared parameter and call arity. A focused backend fixture covers both compiler-created thunks and an ordinary Unit function.

## Verification

- `cargo check -p nbe --tests`
- `cargo check -p javascript --tests`
- `cargo check -p tests-integration --tests`
- `just t backend`
- `just format --check`
- `git diff --check`
