### PR TITLE
[backend] Optimize known function applications

### DIFF
--- a/compiler-backend/javascript/src/convert/generator/analysis.rs
+++ b/compiler-backend/javascript/src/convert/generator/analysis.rs
@@ -732,6 +732,8 @@ pub(super) fn instruction_value_uses(value: &InstructionValue) -> Vec<ValueId> {
             values
         }
         InstructionValue::Project { record, .. } => vec![*record],
+        InstructionValue::Unary { value, .. } => vec![*value],
+        InstructionValue::Binary { left, right, .. } => vec![*left, *right],
         InstructionValue::Force { accessor } => vec![*accessor],
         InstructionValue::Closure { captures, .. } => captures.to_vec(),
         InstructionValue::Call { function, arguments, .. } => {
@@ -917,6 +919,13 @@ impl<'b> EvaluationTracer<'b> {
             InstructionValue::Project { record, .. } => {
                 self.expression(*record, EvaluationContext::Eager);
                 self.operation(result, 0);
+            }
+            InstructionValue::Unary { value, .. } => {
+                self.expression(*value, EvaluationContext::Eager);
+            }
+            InstructionValue::Binary { left, right, .. } => {
+                self.expression(*left, EvaluationContext::Eager);
+                self.expression(*right, EvaluationContext::Eager);
             }
             InstructionValue::Force { accessor } => {
                 self.expression(*accessor, EvaluationContext::Eager);

--- a/compiler-backend/javascript/src/convert/generator/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/render.rs
@@ -15,7 +15,8 @@ use super::analysis::{
 };
 use super::names::NameAllocator;
 use super::syntax::{
-    call_expression, integer_expression, literal_expression, project_field, projection_expression,
+    binary_expression, call_expression, integer_expression, literal_expression, project_field,
+    projection_expression, unary_expression,
 };
 use crate::error::ModuleResult;
 use crate::pretty::Writer;
@@ -604,6 +605,15 @@ impl Generator<'_> {
             InstructionValue::Project { record, field } => {
                 let record = context.expression(tree, *record);
                 Ok(project_field(tree, record, field))
+            }
+            InstructionValue::Unary { operator, value } => {
+                let value = context.expression(tree, *value);
+                Ok(unary_expression(tree, *operator, value))
+            }
+            InstructionValue::Binary { operator, left, right } => {
+                let left = context.expression(tree, *left);
+                let right = context.expression(tree, *right);
+                Ok(binary_expression(tree, *operator, left, right))
             }
             InstructionValue::Constructor { global } => self.global_expression(tree, global),
             InstructionValue::Global { global } => self.global_expression(tree, global),

--- a/compiler-backend/javascript/src/convert/generator/syntax.rs
+++ b/compiler-backend/javascript/src/convert/generator/syntax.rs
@@ -1,9 +1,12 @@
 use files::FileId;
 use itertools::Itertools;
-use ssa::tree::{CallingConvention, Field, Literal, Projection};
+use ssa::tree::{
+    BinaryOperator as SsaBinaryOperator, CallingConvention, Field, Literal, Projection,
+    UnaryOperator as SsaUnaryOperator,
+};
 
 use crate::error::{ModuleError, ModuleResult, UnsupportedState};
-use crate::tree::{BinaryOperator, ExpressionId, Tree};
+use crate::tree::{BinaryOperator, ExpressionId, Tree, UnaryOperator};
 
 pub(super) fn literal_expression(
     tree: &mut Tree,
@@ -33,6 +36,39 @@ pub(super) fn literal_expression(
 
 pub(super) fn integer_expression(tree: &mut Tree, value: i32) -> ExpressionId {
     let value = tree.number(value.to_string());
+    integer_coercion_expression(tree, value)
+}
+
+pub(super) fn unary_expression(
+    tree: &mut Tree,
+    operator: SsaUnaryOperator,
+    value: ExpressionId,
+) -> ExpressionId {
+    match operator {
+        SsaUnaryOperator::BooleanNot => tree.unary(UnaryOperator::LogicalNot, value),
+        SsaUnaryOperator::IntegerNegate => {
+            let value = tree.unary(UnaryOperator::Negate, value);
+            integer_coercion_expression(tree, value)
+        }
+    }
+}
+
+pub(super) fn binary_expression(
+    tree: &mut Tree,
+    operator: SsaBinaryOperator,
+    left: ExpressionId,
+    right: ExpressionId,
+) -> ExpressionId {
+    let operator = match operator {
+        SsaBinaryOperator::IntegerAdd => BinaryOperator::Add,
+        SsaBinaryOperator::IntegerSubtract => BinaryOperator::Subtract,
+        SsaBinaryOperator::IntegerMultiply => BinaryOperator::Multiply,
+    };
+    let value = tree.binary(operator, left, right);
+    integer_coercion_expression(tree, value)
+}
+
+fn integer_coercion_expression(tree: &mut Tree, value: ExpressionId) -> ExpressionId {
     let zero = tree.number("0");
     tree.binary(BinaryOperator::BitwiseOr, value, zero)
 }

--- a/compiler-backend/javascript/src/pretty.rs
+++ b/compiler-backend/javascript/src/pretty.rs
@@ -1,6 +1,6 @@
 use pretty::{Arena, DocAllocator, DocBuilder};
 
-use crate::tree::{BinaryOperator, Expression, ExpressionId, ObjectProperty, Tree};
+use crate::tree::{BinaryOperator, Expression, ExpressionId, ObjectProperty, Tree, UnaryOperator};
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
 
@@ -76,6 +76,10 @@ impl<'a> Printer<'a, '_> {
                 .append("[")
                 .append(self.expression(*index))
                 .append("]"),
+            Expression::Unary { operator, value } => self
+                .arena
+                .text(operator.source())
+                .append(self.expression_at(*value, Precedence::Unary)),
             Expression::Binary { operator, left, right } => {
                 let precedence = operator.precedence();
                 self.expression_at(*left, precedence)
@@ -109,6 +113,7 @@ impl<'a> Printer<'a, '_> {
     fn precedence(&self, expression: ExpressionId) -> Precedence {
         match &self.tree[expression] {
             Expression::Arrow { .. } => Precedence::Assignment,
+            Expression::Unary { .. } => Precedence::Unary,
             Expression::Binary { operator, .. } => operator.precedence(),
             Expression::Call { .. } => Precedence::Call,
             Expression::Member { .. } | Expression::Index { .. } => Precedence::Member,
@@ -150,12 +155,24 @@ impl<'a> Printer<'a, '_> {
     }
 }
 
+impl UnaryOperator {
+    fn source(self) -> &'static str {
+        match self {
+            UnaryOperator::LogicalNot => "!",
+            UnaryOperator::Negate => "-",
+        }
+    }
+}
+
 impl BinaryOperator {
     fn source(self) -> &'static str {
         match self {
             BinaryOperator::StrictEqual => "===",
             BinaryOperator::BitwiseOr => "|",
             BinaryOperator::LogicalAnd => "&&",
+            BinaryOperator::Add => "+",
+            BinaryOperator::Subtract => "-",
+            BinaryOperator::Multiply => "*",
         }
     }
 
@@ -164,6 +181,8 @@ impl BinaryOperator {
             BinaryOperator::LogicalAnd => Precedence::LogicalAnd,
             BinaryOperator::BitwiseOr => Precedence::BitwiseOr,
             BinaryOperator::StrictEqual => Precedence::Equality,
+            BinaryOperator::Add | BinaryOperator::Subtract => Precedence::Additive,
+            BinaryOperator::Multiply => Precedence::Multiplicative,
         }
     }
 }
@@ -175,6 +194,9 @@ enum Precedence {
     LogicalAnd,
     BitwiseOr,
     Equality,
+    Additive,
+    Multiplicative,
+    Unary,
     Call,
     Member,
     Primary,
@@ -187,7 +209,10 @@ impl Precedence {
             Precedence::Assignment => Precedence::LogicalAnd,
             Precedence::LogicalAnd => Precedence::BitwiseOr,
             Precedence::BitwiseOr => Precedence::Equality,
-            Precedence::Equality => Precedence::Call,
+            Precedence::Equality => Precedence::Additive,
+            Precedence::Additive => Precedence::Multiplicative,
+            Precedence::Multiplicative => Precedence::Unary,
+            Precedence::Unary => Precedence::Call,
             Precedence::Call => Precedence::Member,
             Precedence::Member | Precedence::Primary => Precedence::Primary,
         }

--- a/compiler-backend/javascript/src/tree.rs
+++ b/compiler-backend/javascript/src/tree.rs
@@ -18,6 +18,7 @@ pub(crate) enum Expression {
     Call { callee: ExpressionId, arguments: Vec<ExpressionId> },
     Member { object: ExpressionId, property: String },
     Index { object: ExpressionId, index: ExpressionId },
+    Unary { operator: UnaryOperator, value: ExpressionId },
     Binary { operator: BinaryOperator, left: ExpressionId, right: ExpressionId },
     Arrow { parameters: Vec<String>, body: ExpressionId },
 }
@@ -29,10 +30,19 @@ pub(crate) enum ObjectProperty {
 }
 
 #[derive(Debug, Clone, Copy)]
+pub(crate) enum UnaryOperator {
+    LogicalNot,
+    Negate,
+}
+
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum BinaryOperator {
     StrictEqual,
     BitwiseOr,
     LogicalAnd,
+    Add,
+    Subtract,
+    Multiply,
 }
 
 impl Tree {
@@ -82,6 +92,10 @@ impl Tree {
 
     pub(crate) fn index(&mut self, object: ExpressionId, index: ExpressionId) -> ExpressionId {
         self.allocate(Expression::Index { object, index })
+    }
+
+    pub(crate) fn unary(&mut self, operator: UnaryOperator, value: ExpressionId) -> ExpressionId {
+        self.allocate(Expression::Unary { operator, value })
     }
 
     pub(crate) fn binary(

--- a/compiler-backend/nbe/src/convert.rs
+++ b/compiler-backend/nbe/src/convert.rs
@@ -530,7 +530,7 @@ fn equations(
             }
             let expression = guarded_expression(context, &equation.guarded_expression)?;
             let remaining_arguments = scrutinees.iter().skip(supplied).copied();
-            let expression = context.application(expression, remaining_arguments);
+            let expression = context.application(expression, remaining_arguments)?;
             alternatives.push(CaseAlternative { patterns: patterns.into(), expression });
         }
         Ok(context.expression(ExpressionKind::Case {
@@ -740,7 +740,7 @@ fn convert_expression(
             }
             let function = convert_expression(context, *function)?;
             let argument = convert_expression(context, *argument)?;
-            return Ok(context.application(function, [argument]));
+            return context.application(function, [argument]);
         }
         checking_tree::ExpressionKind::EvidenceApplication { function, evidence, .. } => {
             let evidence = evidence_variable(context, *evidence)?;
@@ -749,7 +749,7 @@ fn convert_expression(
                 return Ok(context.expression(ExpressionKind::Project { record: evidence, field }));
             }
             let function = convert_expression(context, *function)?;
-            return Ok(context.application(function, [evidence]));
+            return context.application(function, [evidence]);
         }
         checking_tree::ExpressionKind::EvidenceAbstraction { binder, expression } => {
             let parameter = context.evidence_parameter(*binder)?;
@@ -1023,7 +1023,7 @@ fn convert_evidence(
             let function = context.expression(ExpressionKind::Global { global });
             let arguments = subgoals.iter().map(|&subgoal| evidence_variable(context, subgoal));
             let arguments = arguments.collect::<ConversionResult<Vec<_>>>()?;
-            let construction = context.application(function, arguments);
+            let construction = context.application(function, arguments)?;
             if subgoals.is_empty() {
                 Ok(construction)
             } else {
@@ -1436,14 +1436,133 @@ where
         &mut self,
         function: ExpressionId,
         arguments: impl IntoIterator<Item = ExpressionId>,
-    ) -> ExpressionId {
+    ) -> ConversionResult<ExpressionId> {
         let arguments = arguments.into_iter();
         let arguments = arguments.collect_vec();
         if arguments.is_empty() {
-            function
-        } else {
-            self.expression(ExpressionKind::Application { function, arguments: arguments.into() })
+            return Ok(function);
         }
+        let (known_function, known_arguments) = self.application_spine(function, &arguments);
+        if self.known_term(known_function, "Data.Function", "apply")?
+            && let [function, argument] = known_arguments.as_slice()
+        {
+            return self.application(*function, [*argument]);
+        }
+        if self.known_term(known_function, "Data.Function", "applyFlipped")?
+            && let [argument, function] = known_arguments.as_slice()
+        {
+            return self.flipped_application(*argument, *function);
+        }
+        if self.known_instance_member(
+            known_function,
+            "Control.Category",
+            "identity",
+            "categoryFn",
+        )? && let [argument] = known_arguments.as_slice()
+        {
+            return Ok(*argument);
+        }
+        if self.known_term(known_function, "Unsafe.Coerce", "unsafeCoerce")?
+            && let [argument] = known_arguments.as_slice()
+        {
+            return Ok(*argument);
+        }
+        Ok(self.expression(ExpressionKind::Application { function, arguments: arguments.into() }))
+    }
+
+    fn application_spine(
+        &self,
+        mut function: ExpressionId,
+        arguments: &[ExpressionId],
+    ) -> (ExpressionId, Vec<ExpressionId>) {
+        let mut groups = vec![arguments];
+        while let ExpressionKind::Application { function: inner, arguments } =
+            &self.storage[function].kind
+        {
+            function = *inner;
+            groups.push(arguments);
+        }
+        let arguments = groups.into_iter().rev().flatten().copied();
+        (function, arguments.collect())
+    }
+
+    fn flipped_application(
+        &mut self,
+        argument: ExpressionId,
+        function: ExpressionId,
+    ) -> ConversionResult<ExpressionId> {
+        if self.expression_is_stable(argument) || self.expression_is_stable(function) {
+            return self.application(function, [argument]);
+        }
+
+        let argument_parameter = self.fresh_parameter("applyArgument".into())?;
+        let function_parameter = self.fresh_parameter("applyFunction".into())?;
+        let argument_local =
+            self.expression(ExpressionKind::Local { parameter: argument_parameter.clone() });
+        let function_local =
+            self.expression(ExpressionKind::Local { parameter: function_parameter.clone() });
+        let body = self.application(function_local, [argument_local])?;
+        let bindings = [
+            Binding { parameter: argument_parameter, expression: argument, source_order: 0 },
+            Binding { parameter: function_parameter, expression: function, source_order: 1 },
+        ];
+        Ok(self.expression(ExpressionKind::Let {
+            recursive: false,
+            bindings: bindings.into(),
+            body,
+        }))
+    }
+
+    fn expression_is_stable(&self, expression: ExpressionId) -> bool {
+        matches!(
+            self.storage[expression].kind,
+            ExpressionKind::Literal { .. }
+                | ExpressionKind::Constructor { .. }
+                | ExpressionKind::Global { .. }
+                | ExpressionKind::Local { .. }
+        )
+    }
+
+    fn known_term(
+        &self,
+        expression: ExpressionId,
+        module_name: &str,
+        item_name: &str,
+    ) -> QueryResult<bool> {
+        let ExpressionKind::Global { global } = &self.storage[expression].kind else {
+            return Ok(false);
+        };
+        let GlobalId::Term(file_id, _) = global.id else { return Ok(false) };
+        Ok(global.item_name == item_name && self.source_module_name(file_id)? == module_name)
+    }
+
+    fn known_instance_member(
+        &self,
+        expression: ExpressionId,
+        module_name: &str,
+        member_name: &str,
+        instance_name: &str,
+    ) -> QueryResult<bool> {
+        let ExpressionKind::Project { record, field } = &self.storage[expression].kind else {
+            return Ok(false);
+        };
+        let FieldIdentity::Member(member_file, _) = field.identity else {
+            return Ok(false);
+        };
+        if field.name != member_name || self.source_module_name(member_file)? != module_name {
+            return Ok(false);
+        }
+        let ExpressionKind::Global { global } = &self.storage[*record].kind else {
+            return Ok(false);
+        };
+        let GlobalId::Instance(identity) = global.id else { return Ok(false) };
+        let instance_file = match identity {
+            InstanceIdentity::Declared(file_id, _) | InstanceIdentity::Derived(file_id, _) => {
+                file_id
+            }
+        };
+        Ok(global.item_name == instance_name
+            && self.source_module_name(instance_file)? == module_name)
     }
 
     fn expression(&mut self, kind: ExpressionKind) -> ExpressionId {

--- a/compiler-backend/nbe/src/convert.rs
+++ b/compiler-backend/nbe/src/convert.rs
@@ -19,12 +19,12 @@ use thiserror::Error;
 
 use crate::error::{ModuleError, ModuleResult, UnsupportedState};
 use crate::tree::{
-    Binding, CaseAlternative, Declaration, DeclarationKind, Expression, ExpressionId,
-    ExpressionKind, Field, FieldIdentity, Global, GlobalId, Guard, GuardedAlternative,
-    IndirectModuleExports, InstanceIdentity, Literal, LocalId, Module, ModuleDependency,
-    ModuleSurface, Parameter, Pattern, PatternId, PatternKind, RecordField, RecordPatternField,
-    RecordUpdate, RecursiveGroupId, ReflectableEvidence, ReflectableOrdering, Storage,
-    SuperclassIdentity, SynthesizedEvidence,
+    BinaryOperator, Binding, CaseAlternative, Declaration, DeclarationKind, Expression,
+    ExpressionId, ExpressionKind, Field, FieldIdentity, Global, GlobalId, Guard,
+    GuardedAlternative, IndirectModuleExports, InstanceIdentity, Literal, LocalId, Module,
+    ModuleDependency, ModuleSurface, Parameter, Pattern, PatternId, PatternKind, RecordField,
+    RecordPatternField, RecordUpdate, RecursiveGroupId, ReflectableEvidence, ReflectableOrdering,
+    Storage, SuperclassIdentity, SynthesizedEvidence, UnaryOperator,
 };
 
 const MAX_EVIDENCE_NAME_FRAGMENTS: usize = 4;
@@ -1466,6 +1466,48 @@ where
             && let [argument] = known_arguments.as_slice()
         {
             return Ok(*argument);
+        }
+        if self.known_instance_member(
+            known_function,
+            "Data.HeytingAlgebra",
+            "not",
+            "heytingAlgebraBoolean",
+        )? && let [value] = known_arguments.as_slice()
+        {
+            return Ok(self.expression(ExpressionKind::Unary {
+                operator: UnaryOperator::BooleanNot,
+                value: *value,
+            }));
+        }
+        if self.known_instance_member(known_function, "Data.Ring", "negate", "ringInt")?
+            && let [value] = known_arguments.as_slice()
+        {
+            return Ok(self.expression(ExpressionKind::Unary {
+                operator: UnaryOperator::IntegerNegate,
+                value: *value,
+            }));
+        }
+        let binary_operator =
+            if self.known_instance_member(known_function, "Data.Semiring", "add", "semiringInt")? {
+                Some(BinaryOperator::IntegerAdd)
+            } else if self.known_instance_member(known_function, "Data.Ring", "sub", "ringInt")? {
+                Some(BinaryOperator::IntegerSubtract)
+            } else if self.known_instance_member(
+                known_function,
+                "Data.Semiring",
+                "mul",
+                "semiringInt",
+            )? {
+                Some(BinaryOperator::IntegerMultiply)
+            } else {
+                None
+            };
+        if let (Some(operator), [left, right]) = (binary_operator, known_arguments.as_slice()) {
+            return Ok(self.expression(ExpressionKind::Binary {
+                operator,
+                left: *left,
+                right: *right,
+            }));
         }
         Ok(self.expression(ExpressionKind::Application { function, arguments: arguments.into() }))
     }

--- a/compiler-backend/nbe/src/pretty.rs
+++ b/compiler-backend/nbe/src/pretty.rs
@@ -3,9 +3,10 @@
 use pretty::{Arena, DocAllocator, DocBuilder};
 
 use crate::tree::{
-    Declaration, DeclarationKind, EffectExpression, ExpressionId, ExpressionKind, Field, GlobalId,
-    Guard, IndirectModuleExports, Literal, Module, Parameter, PatternId, PatternKind, RecordUpdate,
-    ReflectableEvidence, ReflectableOrdering, SynthesizedEvidence,
+    BinaryOperator, Declaration, DeclarationKind, EffectExpression, ExpressionId, ExpressionKind,
+    Field, GlobalId, Guard, IndirectModuleExports, Literal, Module, Parameter, PatternId,
+    PatternKind, RecordUpdate, ReflectableEvidence, ReflectableOrdering, SynthesizedEvidence,
+    UnaryOperator,
 };
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
@@ -91,7 +92,9 @@ impl<'a> Printer<'a, '_> {
             | ExpressionKind::Guarded { .. }
             | ExpressionKind::Let { .. }
             | ExpressionKind::LetPattern { .. } => ExpressionPrecedence::Abstraction,
-            ExpressionKind::Application { .. }
+            ExpressionKind::Unary { .. }
+            | ExpressionKind::Binary { .. }
+            | ExpressionKind::Application { .. }
             | ExpressionKind::Effect { .. }
             | ExpressionKind::SynthesizedEvidence { .. } => ExpressionPrecedence::Application,
             ExpressionKind::RecordUpdate { .. } => ExpressionPrecedence::RecordUpdate,
@@ -132,6 +135,24 @@ impl<'a> Printer<'a, '_> {
                 let record = self.expression_at(*record, ExpressionPrecedence::Atom);
                 let field = self.field(field);
                 record.append(self.arena.text(format!(".{field}")))
+            }
+            ExpressionKind::Unary { operator, value } => {
+                let operator = match operator {
+                    UnaryOperator::BooleanNot => "boolean.not",
+                    UnaryOperator::IntegerNegate => "integer.negate",
+                };
+                let value = self.expression_at(*value, ExpressionPrecedence::Atom);
+                self.arena.text(operator).append(" ").append(value)
+            }
+            ExpressionKind::Binary { operator, left, right } => {
+                let operator = match operator {
+                    BinaryOperator::IntegerAdd => "integer.add",
+                    BinaryOperator::IntegerSubtract => "integer.subtract",
+                    BinaryOperator::IntegerMultiply => "integer.multiply",
+                };
+                let left = self.expression_at(*left, ExpressionPrecedence::Atom);
+                let right = self.expression_at(*right, ExpressionPrecedence::Atom);
+                self.arena.text(operator).append(" ").append(left).append(" ").append(right)
             }
             ExpressionKind::Constructor { global } | ExpressionKind::Global { global } => {
                 self.arena.text(global.item_name.to_string())

--- a/compiler-backend/nbe/src/tree.rs
+++ b/compiler-backend/nbe/src/tree.rs
@@ -173,6 +173,8 @@ pub enum ExpressionKind {
     Record { fields: Arc<[RecordField]> },
     RecordUpdate { record: ExpressionId, updates: Arc<[RecordUpdate]> },
     Project { record: ExpressionId, field: Field },
+    Unary { operator: UnaryOperator, value: ExpressionId },
+    Binary { operator: BinaryOperator, left: ExpressionId, right: ExpressionId },
     Constructor { global: Global },
     Global { global: Global },
     Local { parameter: Parameter },
@@ -186,6 +188,19 @@ pub enum ExpressionKind {
     Effect { effect: EffectExpression },
     SynthesizedEvidence { evidence: SynthesizedEvidence },
     TrivialEvidence,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnaryOperator {
+    BooleanNot,
+    IntegerNegate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryOperator {
+    IntegerAdd,
+    IntegerSubtract,
+    IntegerMultiply,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/compiler-backend/ssa/src/convert.rs
+++ b/compiler-backend/ssa/src/convert.rs
@@ -10,12 +10,12 @@ use smol_str::{SmolStr, format_smolstr};
 
 use crate::error::{ModuleError, ModuleResult, UnsupportedState};
 use crate::tree::{
-    Block, BlockId, BlockTarget, CallingConvention, Declaration, DeclarationKind, Failure, Field,
-    FieldIdentity, Function, FunctionId, Global, GlobalIdentity, IndirectModuleExports,
-    InstanceIdentity, Instruction, InstructionValue, LazyInitializer, Literal, Module,
-    ModuleDependency, ModuleSurface, PatternTest, Projection, RecordField, RecordUpdate,
-    RecursiveClosure, RecursiveGroupId, ReflectableEvidence, ReflectableOrdering, Storage,
-    SuperclassIdentity, SynthesizedEvidence, Terminator, Value, ValueId,
+    BinaryOperator, Block, BlockId, BlockTarget, CallingConvention, Declaration, DeclarationKind,
+    Failure, Field, FieldIdentity, Function, FunctionId, Global, GlobalIdentity,
+    IndirectModuleExports, InstanceIdentity, Instruction, InstructionValue, LazyInitializer,
+    Literal, Module, ModuleDependency, ModuleSurface, PatternTest, Projection, RecordField,
+    RecordUpdate, RecursiveClosure, RecursiveGroupId, ReflectableEvidence, ReflectableOrdering,
+    Storage, SuperclassIdentity, SynthesizedEvidence, Terminator, UnaryOperator, Value, ValueId,
 };
 
 type ConversionResult<T> = ModuleResult<T>;
@@ -313,6 +313,30 @@ fn lower_expression(
             let field = convert_field(field);
             let name = field.name.clone();
             Ok(state.emit(name, InstructionValue::Project { record, field }))
+        }
+        nbe::tree::ExpressionKind::Unary { operator, value } => {
+            let value = lower_expression(state, context, *value)?;
+            let (name, operator) = match operator {
+                nbe::tree::UnaryOperator::BooleanNot => ("booleanNot", UnaryOperator::BooleanNot),
+                nbe::tree::UnaryOperator::IntegerNegate => {
+                    ("integerNegate", UnaryOperator::IntegerNegate)
+                }
+            };
+            Ok(state.emit(name, InstructionValue::Unary { operator, value }))
+        }
+        nbe::tree::ExpressionKind::Binary { operator, left, right } => {
+            let left = lower_expression(state, context, *left)?;
+            let right = lower_expression(state, context, *right)?;
+            let (name, operator) = match operator {
+                nbe::tree::BinaryOperator::IntegerAdd => ("integerAdd", BinaryOperator::IntegerAdd),
+                nbe::tree::BinaryOperator::IntegerSubtract => {
+                    ("integerSubtract", BinaryOperator::IntegerSubtract)
+                }
+                nbe::tree::BinaryOperator::IntegerMultiply => {
+                    ("integerMultiply", BinaryOperator::IntegerMultiply)
+                }
+            };
+            Ok(state.emit(name, InstructionValue::Binary { operator, left, right }))
         }
         nbe::tree::ExpressionKind::Constructor { global } => {
             let global = convert_global(global);
@@ -910,6 +934,13 @@ fn collect_free_expression(
         }
         nbe::tree::ExpressionKind::Project { record, .. } => {
             collect_free_expression(context, *record, bound, free);
+        }
+        nbe::tree::ExpressionKind::Unary { value, .. } => {
+            collect_free_expression(context, *value, bound, free);
+        }
+        nbe::tree::ExpressionKind::Binary { left, right, .. } => {
+            collect_free_expression(context, *left, bound, free);
+            collect_free_expression(context, *right, bound, free);
         }
         nbe::tree::ExpressionKind::Local { parameter } => {
             if !bound.contains(&parameter.id) {

--- a/compiler-backend/ssa/src/pretty.rs
+++ b/compiler-backend/ssa/src/pretty.rs
@@ -5,10 +5,11 @@ use pretty::{Arena, DocAllocator, DocBuilder};
 use rustc_hash::FxHashSet;
 
 use crate::tree::{
-    Block, BlockTarget, CallingConvention, Declaration, DeclarationKind, Failure, Field, Function,
-    Global, GlobalIdentity, IndirectModuleExports, Instruction, InstructionValue, LazyInitializer,
-    Literal, Module, PatternTest, Projection, RecordUpdate, RecursiveClosure, ReflectableEvidence,
-    ReflectableOrdering, SynthesizedEvidence, Terminator, ValueId,
+    BinaryOperator, Block, BlockTarget, CallingConvention, Declaration, DeclarationKind, Failure,
+    Field, Function, Global, GlobalIdentity, IndirectModuleExports, Instruction, InstructionValue,
+    LazyInitializer, Literal, Module, PatternTest, Projection, RecordUpdate, RecursiveClosure,
+    ReflectableEvidence, ReflectableOrdering, SynthesizedEvidence, Terminator, UnaryOperator,
+    ValueId,
 };
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
@@ -231,6 +232,27 @@ impl<'a> Printer<'a, '_> {
             InstructionValue::Project { record, field } => {
                 let record = self.value(*record);
                 self.project_field(record, field)
+            }
+            InstructionValue::Unary { operator, value } => {
+                let operator = match operator {
+                    UnaryOperator::BooleanNot => "boolean.not",
+                    UnaryOperator::IntegerNegate => "integer.negate",
+                };
+                self.arena.text(operator).append("(").append(self.value(*value)).append(")")
+            }
+            InstructionValue::Binary { operator, left, right } => {
+                let operator = match operator {
+                    BinaryOperator::IntegerAdd => "integer.add",
+                    BinaryOperator::IntegerSubtract => "integer.subtract",
+                    BinaryOperator::IntegerMultiply => "integer.multiply",
+                };
+                self.arena
+                    .text(operator)
+                    .append("(")
+                    .append(self.value(*left))
+                    .append(", ")
+                    .append(self.value(*right))
+                    .append(")")
             }
             InstructionValue::Constructor { global } => {
                 self.arena.text("constructor(").append(self.global(global)).append(")")

--- a/compiler-backend/ssa/src/tree.rs
+++ b/compiler-backend/ssa/src/tree.rs
@@ -203,6 +203,8 @@ pub enum InstructionValue {
     Record { fields: Arc<[RecordField]> },
     RecordUpdate { record: ValueId, updates: Arc<[RecordUpdate]> },
     Project { record: ValueId, field: Field },
+    Unary { operator: UnaryOperator, value: ValueId },
+    Binary { operator: BinaryOperator, left: ValueId, right: ValueId },
     Constructor { global: Global },
     Global { global: Global },
     Force { accessor: ValueId },
@@ -214,6 +216,19 @@ pub enum InstructionValue {
     EffectBind { action: ValueId, continuation: ValueId },
     SynthesizedEvidence { evidence: SynthesizedEvidence },
     TrivialEvidence,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnaryOperator {
+    BooleanNot,
+    IntegerNegate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryOperator {
+    IntegerAdd,
+    IntegerSubtract,
+    IntegerMultiply,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/Control.Category.purs
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/Control.Category.purs
@@ -1,0 +1,7 @@
+module Control.Category where
+
+class Category (category :: Type -> Type -> Type) where
+  identity :: forall value. category value value
+
+instance categoryFn :: Category Function where
+  identity value = value

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/Data.Function.purs
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/Data.Function.purs
@@ -1,0 +1,7 @@
+module Data.Function where
+
+apply :: forall argument result. (argument -> result) -> argument -> result
+apply function argument = function argument
+
+applyFlipped :: forall argument result. argument -> (argument -> result) -> result
+applyFlipped argument function = function argument

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/Lookalike.purs
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/Lookalike.purs
@@ -1,0 +1,13 @@
+module Lookalike where
+
+apply :: forall argument result. (argument -> result) -> argument -> result
+apply function argument = function argument
+
+class Identity (identity :: Type -> Type -> Type) where
+  identity :: forall value. identity value value
+
+instance categoryFn :: Identity Function where
+  identity value = value
+
+unsafeCoerce :: forall value. value -> value
+unsafeCoerce value = value

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/Main.js
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/Main.js
@@ -1,0 +1,12 @@
+let trace = [];
+
+export const observe = label => value => {
+  trace.push(label);
+  return value;
+};
+
+export const readTrace = reset => {
+  const result = trace;
+  if (reset) trace = [];
+  return result;
+};

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/Main.nbe.snap
@@ -7,21 +7,24 @@ expression: report
 
 @export foreign readTrace
 
-@export directApply = apply (\value%0 -> value%0) 42
+@export directApply = (\value%0 -> value%0) 42
 
 @export directApplyOrder = \$boolean%2@(_) ->
-  apply (observe "function" (\value%1 -> value%1)) (observe "argument" 42)
+  observe "function" (\value%1 -> value%1) (observe "argument" 42)
 
-@export flippedApply = applyFlipped 42 (\value%3 -> value%3)
+@export flippedApply = (\value%3 -> value%3) 42
 
-@export flippedApplyOrder = \$boolean%5@(_) ->
-  applyFlipped (observe "argument" 42) (observe "function" (\value%4 -> value%4))
+@export flippedApplyOrder = \$boolean%7@(_) ->
+  let
+    applyArgument%5 = observe "argument" 42
+    applyFunction%6 = observe "function" (\value%4 -> value%4)
+  in applyFunction%6 applyArgument%5
 
-@export functionIdentity = categoryFn.identity 42
+@export functionIdentity = 42
 
-@export coerced = unsafeCoerce 42
+@export coerced = 42
 
-@export lookalikeApply = apply (\value%6 -> value%6) 42
+@export lookalikeApply = apply (\value%8 -> value%8) 42
 
 @export lookalikeIdentity = categoryFn.identity 42
 

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/Main.nbe.snap
@@ -1,0 +1,28 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export foreign observe
+
+@export foreign readTrace
+
+@export directApply = apply (\value%0 -> value%0) 42
+
+@export directApplyOrder = \$boolean%2@(_) ->
+  apply (observe "function" (\value%1 -> value%1)) (observe "argument" 42)
+
+@export flippedApply = applyFlipped 42 (\value%3 -> value%3)
+
+@export flippedApplyOrder = \$boolean%5@(_) ->
+  applyFlipped (observe "argument" 42) (observe "function" (\value%4 -> value%4))
+
+@export functionIdentity = categoryFn.identity 42
+
+@export coerced = unsafeCoerce 42
+
+@export lookalikeApply = apply (\value%6 -> value%6) 42
+
+@export lookalikeIdentity = categoryFn.identity 42
+
+@export lookalikeCoerce = unsafeCoerce 42

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/Main.purs
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/Main.purs
@@ -1,0 +1,42 @@
+module Main where
+
+import Control.Category as Category
+import Data.Function as Function
+import Lookalike as Lookalike
+import Unsafe.Coerce as UnsafeCoerce
+
+foreign import observe :: forall value. String -> value -> value
+foreign import readTrace :: Boolean -> Array String
+
+directApply :: Int
+directApply = Function.apply (\value -> value) 42
+
+directApplyOrder :: Boolean -> Int
+directApplyOrder _ =
+  Function.apply
+    (observe "function" (\value -> value))
+    (observe "argument" 42)
+
+flippedApply :: Int
+flippedApply = Function.applyFlipped 42 (\value -> value)
+
+flippedApplyOrder :: Boolean -> Int
+flippedApplyOrder _ =
+  Function.applyFlipped
+    (observe "argument" 42)
+    (observe "function" (\value -> value))
+
+functionIdentity :: Int
+functionIdentity = Category.identity 42
+
+coerced :: Int
+coerced = UnsafeCoerce.unsafeCoerce 42
+
+lookalikeApply :: Int
+lookalikeApply = Lookalike.apply (\value -> value) 42
+
+lookalikeIdentity :: Int
+lookalikeIdentity = Lookalike.identity 42
+
+lookalikeCoerce :: Int
+lookalikeCoerce = Lookalike.unsafeCoerce 42

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/Main.snap
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 268
+expression: diagnostics_report
+---
+Terms
+observe :: forall value. Prim.String -> value -> value
+readTrace :: Prim.Boolean -> Prim.Array Prim.String
+directApply :: Prim.Int
+directApplyOrder :: Prim.Boolean -> Prim.Int
+flippedApply :: Prim.Int
+flippedApplyOrder :: Prim.Boolean -> Prim.Int
+functionIdentity :: Prim.Int
+coerced :: Prim.Int
+lookalikeApply :: Prim.Int
+lookalikeIdentity :: Prim.Int
+lookalikeCoerce :: Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/Main.ssa.snap
@@ -1,0 +1,147 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 269
+expression: ssa_report
+---
+@export foreign const observe;
+
+@export foreign const readTrace;
+
+@export const directApply = initialize {
+  entry() {
+    const apply = global(apply);
+    const closure = closure(directApply$initialize$closure);
+    const call = source.call(apply, closure);
+    const literal = 42;
+    const call$1 = source.call(call, literal);
+    return call$1;
+  }
+}
+
+@export function directApplyOrder($boolean) {
+  entry() {
+    const apply = global(apply);
+    const observe = global(observe);
+    const literal = "function";
+    const call = source.call(observe, literal);
+    const closure = closure(directApplyOrder$closure);
+    const call$1 = source.call(call, closure);
+    const call$2 = source.call(apply, call$1);
+    const observe$1 = global(observe);
+    const literal$1 = "argument";
+    const call$3 = source.call(observe$1, literal$1);
+    const literal$2 = 42;
+    const call$4 = source.call(call$3, literal$2);
+    const call$5 = source.call(call$2, call$4);
+    return call$5;
+  }
+}
+
+@export const flippedApply = initialize {
+  entry() {
+    const applyFlipped = global(applyFlipped);
+    const literal = 42;
+    const call = source.call(applyFlipped, literal);
+    const closure = closure(flippedApply$initialize$closure);
+    const call$1 = source.call(call, closure);
+    return call$1;
+  }
+}
+
+@export function flippedApplyOrder($boolean) {
+  entry() {
+    const applyFlipped = global(applyFlipped);
+    const observe = global(observe);
+    const literal = "argument";
+    const call = source.call(observe, literal);
+    const literal$1 = 42;
+    const call$1 = source.call(call, literal$1);
+    const call$2 = source.call(applyFlipped, call$1);
+    const observe$1 = global(observe);
+    const literal$2 = "function";
+    const call$3 = source.call(observe$1, literal$2);
+    const closure = closure(flippedApplyOrder$closure);
+    const call$4 = source.call(call$3, closure);
+    const call$5 = source.call(call$2, call$4);
+    return call$5;
+  }
+}
+
+@export const functionIdentity = initialize {
+  entry() {
+    const categoryFn = global(categoryFn);
+    const identity = categoryFn.identity;
+    const literal = 42;
+    const call = source.call(identity, literal);
+    return call;
+  }
+}
+
+@export const coerced = initialize {
+  entry() {
+    const unsafeCoerce = global(unsafeCoerce);
+    const literal = 42;
+    const call = source.call(unsafeCoerce, literal);
+    return call;
+  }
+}
+
+@export const lookalikeApply = initialize {
+  entry() {
+    const apply = global(apply);
+    const closure = closure(lookalikeApply$initialize$closure);
+    const call = source.call(apply, closure);
+    const literal = 42;
+    const call$1 = source.call(call, literal);
+    return call$1;
+  }
+}
+
+@export const lookalikeIdentity = initialize {
+  entry() {
+    const categoryFn = global(categoryFn);
+    const identity = categoryFn.identity;
+    const literal = 42;
+    const call = source.call(identity, literal);
+    return call;
+  }
+}
+
+@export const lookalikeCoerce = initialize {
+  entry() {
+    const unsafeCoerce = global(unsafeCoerce);
+    const literal = 42;
+    const call = source.call(unsafeCoerce, literal);
+    return call;
+  }
+}
+
+closure directApply$initialize$closure[](value) {
+  entry() {
+    return value;
+  }
+}
+
+closure directApplyOrder$closure[](value) {
+  entry() {
+    return value;
+  }
+}
+
+closure flippedApply$initialize$closure[](value) {
+  entry() {
+    return value;
+  }
+}
+
+closure flippedApplyOrder$closure[](value) {
+  entry() {
+    return value;
+  }
+}
+
+closure lookalikeApply$initialize$closure[](value) {
+  entry() {
+    return value;
+  }
+}

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/Main.ssa.snap
@@ -9,80 +9,67 @@ expression: ssa_report
 
 @export const directApply = initialize {
   entry() {
-    const apply = global(apply);
     const closure = closure(directApply$initialize$closure);
-    const call = source.call(apply, closure);
     const literal = 42;
-    const call$1 = source.call(call, literal);
-    return call$1;
+    const call = source.call(closure, literal);
+    return call;
   }
 }
 
 @export function directApplyOrder($boolean) {
   entry() {
-    const apply = global(apply);
     const observe = global(observe);
     const literal = "function";
     const call = source.call(observe, literal);
     const closure = closure(directApplyOrder$closure);
     const call$1 = source.call(call, closure);
-    const call$2 = source.call(apply, call$1);
     const observe$1 = global(observe);
     const literal$1 = "argument";
-    const call$3 = source.call(observe$1, literal$1);
+    const call$2 = source.call(observe$1, literal$1);
     const literal$2 = 42;
-    const call$4 = source.call(call$3, literal$2);
-    const call$5 = source.call(call$2, call$4);
-    return call$5;
+    const call$3 = source.call(call$2, literal$2);
+    const call$4 = source.call(call$1, call$3);
+    return call$4;
   }
 }
 
 @export const flippedApply = initialize {
   entry() {
-    const applyFlipped = global(applyFlipped);
-    const literal = 42;
-    const call = source.call(applyFlipped, literal);
     const closure = closure(flippedApply$initialize$closure);
-    const call$1 = source.call(call, closure);
-    return call$1;
+    const literal = 42;
+    const call = source.call(closure, literal);
+    return call;
   }
 }
 
 @export function flippedApplyOrder($boolean) {
   entry() {
-    const applyFlipped = global(applyFlipped);
     const observe = global(observe);
     const literal = "argument";
     const call = source.call(observe, literal);
     const literal$1 = 42;
     const call$1 = source.call(call, literal$1);
-    const call$2 = source.call(applyFlipped, call$1);
     const observe$1 = global(observe);
     const literal$2 = "function";
-    const call$3 = source.call(observe$1, literal$2);
+    const call$2 = source.call(observe$1, literal$2);
     const closure = closure(flippedApplyOrder$closure);
-    const call$4 = source.call(call$3, closure);
-    const call$5 = source.call(call$2, call$4);
-    return call$5;
+    const call$3 = source.call(call$2, closure);
+    const call$4 = source.call(call$3, call$1);
+    return call$4;
   }
 }
 
 @export const functionIdentity = initialize {
   entry() {
-    const categoryFn = global(categoryFn);
-    const identity = categoryFn.identity;
     const literal = 42;
-    const call = source.call(identity, literal);
-    return call;
+    return literal;
   }
 }
 
 @export const coerced = initialize {
   entry() {
-    const unsafeCoerce = global(unsafeCoerce);
     const literal = 42;
-    const call = source.call(unsafeCoerce, literal);
-    return call;
+    return literal;
   }
 }
 

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/Unsafe.Coerce.js
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/Unsafe.Coerce.js
@@ -1,0 +1,1 @@
+export const unsafeCoerce = value => value;

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/Unsafe.Coerce.purs
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/Unsafe.Coerce.purs
@@ -1,0 +1,3 @@
+module Unsafe.Coerce where
+
+foreign import unsafeCoerce :: forall source target. source -> target

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Control.Category/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Control.Category/index.js
@@ -1,0 +1,3 @@
+export const categoryFn = (() => {
+  return { identity: value => value };
+})();

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Data.Function/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Data.Function/index.js
@@ -1,0 +1,11 @@
+export function apply($function) {
+  return argument => {
+    return $function(argument);
+  };
+}
+
+export function applyFlipped(argument) {
+  return $function => {
+    return $function(argument);
+  };
+}

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Lookalike/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Lookalike/index.js
@@ -1,0 +1,13 @@
+export function apply($function) {
+  return argument => {
+    return $function(argument);
+  };
+}
+
+export function unsafeCoerce(value) {
+  return value;
+}
+
+export const categoryFn = (() => {
+  return { identity: value => value };
+})();

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Main/foreign.js
@@ -1,0 +1,12 @@
+let trace = [];
+
+export const observe = label => value => {
+  trace.push(label);
+  return value;
+};
+
+export const readTrace = reset => {
+  const result = trace;
+  if (reset) trace = [];
+  return result;
+};

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Main/index.js
@@ -1,33 +1,29 @@
-import * as Control_Category from "../Control.Category/index.js";
-import * as Data_Function from "../Data.Function/index.js";
 import * as Lookalike from "../Lookalike/index.js";
-import * as Unsafe_Coerce from "../Unsafe.Coerce/index.js";
 import * as $foreign from "./foreign.js";
 
 export function directApplyOrder($boolean) {
-  return Data_Function.apply(observe("function")(value => value))(observe("argument")(42 | 0));
+  return observe("function")(value => value)(observe("argument")(42 | 0));
 }
 
 export function flippedApplyOrder($boolean) {
-  return Data_Function.applyFlipped(observe("argument")(42 | 0))(
-    observe("function")(value => value)
-  );
+  const call$1 = observe("argument")(42 | 0);
+  return observe("function")(value => value)(call$1);
 }
 
 export const observe = $foreign["observe"];
 export const readTrace = $foreign["readTrace"];
 
 export const directApply = (() => {
-  return Data_Function.apply(value => value)(42 | 0);
+  return (value => value)(42 | 0);
 })();
 
 export const flippedApply = (() => {
-  return Data_Function.applyFlipped(42 | 0)(value => value);
+  return (value => value)(42 | 0);
 })();
 
-export const functionIdentity = Control_Category.categoryFn.identity(42 | 0);
+export const functionIdentity = 42 | 0;
 
-export const coerced = Unsafe_Coerce.unsafeCoerce(42 | 0);
+export const coerced = 42 | 0;
 
 export const lookalikeApply = (() => {
   return Lookalike.apply(value => value)(42 | 0);

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Main/index.js
@@ -1,0 +1,38 @@
+import * as Control_Category from "../Control.Category/index.js";
+import * as Data_Function from "../Data.Function/index.js";
+import * as Lookalike from "../Lookalike/index.js";
+import * as Unsafe_Coerce from "../Unsafe.Coerce/index.js";
+import * as $foreign from "./foreign.js";
+
+export function directApplyOrder($boolean) {
+  return Data_Function.apply(observe("function")(value => value))(observe("argument")(42 | 0));
+}
+
+export function flippedApplyOrder($boolean) {
+  return Data_Function.applyFlipped(observe("argument")(42 | 0))(
+    observe("function")(value => value)
+  );
+}
+
+export const observe = $foreign["observe"];
+export const readTrace = $foreign["readTrace"];
+
+export const directApply = (() => {
+  return Data_Function.apply(value => value)(42 | 0);
+})();
+
+export const flippedApply = (() => {
+  return Data_Function.applyFlipped(42 | 0)(value => value);
+})();
+
+export const functionIdentity = Control_Category.categoryFn.identity(42 | 0);
+
+export const coerced = Unsafe_Coerce.unsafeCoerce(42 | 0);
+
+export const lookalikeApply = (() => {
+  return Lookalike.apply(value => value)(42 | 0);
+})();
+
+export const lookalikeIdentity = Lookalike.categoryFn.identity(42 | 0);
+
+export const lookalikeCoerce = Lookalike.unsafeCoerce(42 | 0);

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Unsafe.Coerce/foreign.js
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Unsafe.Coerce/foreign.js
@@ -1,0 +1,1 @@
+export const unsafeCoerce = value => value;

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Unsafe.Coerce/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/output/Unsafe.Coerce/index.js
@@ -1,0 +1,3 @@
+import * as $foreign from "./foreign.js";
+
+export const unsafeCoerce = $foreign["unsafeCoerce"];

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/verify.mjs
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/verify.mjs
@@ -1,0 +1,17 @@
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.directApply, 42);
+strictEqual(Main.flippedApply, 42);
+strictEqual(Main.functionIdentity, 42);
+strictEqual(Main.coerced, 42);
+strictEqual(Main.lookalikeApply, 42);
+strictEqual(Main.lookalikeIdentity, 42);
+strictEqual(Main.lookalikeCoerce, 42);
+
+Main.readTrace(true);
+strictEqual(Main.directApplyOrder(false), 42);
+deepStrictEqual(Main.readTrace(true), ["function", "argument"]);
+
+strictEqual(Main.flippedApplyOrder(false), 42);
+deepStrictEqual(Main.readTrace(true), ["argument", "function"]);

--- a/tests-integration/fixtures/backend/1787547540_known_function_reductions/verify.mjs
+++ b/tests-integration/fixtures/backend/1787547540_known_function_reductions/verify.mjs
@@ -1,5 +1,16 @@
 import { deepStrictEqual, strictEqual } from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import * as Main from "./output/Main/index.js";
+
+const source = await readFile(new URL("./output/Main/index.js", import.meta.url), "utf8");
+if (/Data_Function|Control_Category|Unsafe_Coerce/.test(source)) {
+  throw new Error("known function reduction left a canonical runtime reference");
+}
+for (const expected of ["Lookalike.apply", "Lookalike.categoryFn", "Lookalike.unsafeCoerce"]) {
+  if (!source.includes(expected)) {
+    throw new Error(`same-named non-canonical function was reduced: ${expected}`);
+  }
+}
 
 strictEqual(Main.directApply, 42);
 strictEqual(Main.flippedApply, 42);

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Data.HeytingAlgebra.purs
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Data.HeytingAlgebra.purs
@@ -1,0 +1,7 @@
+module Data.HeytingAlgebra where
+
+class HeytingAlgebra value where
+  not :: value -> value
+
+instance heytingAlgebraBoolean :: HeytingAlgebra Boolean where
+  not value = if value then false else true

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Data.Ring.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Data.Ring.js
@@ -1,0 +1,2 @@
+export const intSubtract = left => right => (left - right) | 0;
+export const intNegate = value => -value | 0;

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Data.Ring.purs
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Data.Ring.purs
@@ -1,0 +1,12 @@
+module Data.Ring where
+
+class Ring value where
+  sub :: value -> value -> value
+  negate :: value -> value
+
+foreign import intSubtract :: Int -> Int -> Int
+foreign import intNegate :: Int -> Int
+
+instance ringInt :: Ring Int where
+  sub = intSubtract
+  negate = intNegate

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Data.Semiring.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Data.Semiring.js
@@ -1,0 +1,2 @@
+export const intAdd = left => right => (left + right) | 0;
+export const intMultiply = left => right => (left * right) | 0;

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Data.Semiring.purs
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Data.Semiring.purs
@@ -1,0 +1,12 @@
+module Data.Semiring where
+
+class Semiring value where
+  add :: value -> value -> value
+  mul :: value -> value -> value
+
+foreign import intAdd :: Int -> Int -> Int
+foreign import intMultiply :: Int -> Int -> Int
+
+instance semiringInt :: Semiring Int where
+  add = intAdd
+  mul = intMultiply

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Lookalike.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Lookalike.js
@@ -1,0 +1,1 @@
+export const intAdd = left => right => (left + right) | 0;

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Lookalike.purs
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Lookalike.purs
@@ -1,0 +1,9 @@
+module Lookalike where
+
+class Semiring value where
+  add :: value -> value -> value
+
+foreign import intAdd :: Int -> Int -> Int
+
+instance semiringInt :: Semiring Int where
+  add = intAdd

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.js
@@ -1,0 +1,12 @@
+let trace = [];
+
+export const observe = label => value => {
+  trace.push(label);
+  return value;
+};
+
+export const readTrace = reset => {
+  const result = trace;
+  if (reset) trace = [];
+  return result;
+};

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.nbe.snap
@@ -7,18 +7,17 @@ expression: report
 
 @export foreign readTrace
 
-@export booleanNot = \value%0 -> heytingAlgebraBoolean.not value%0
+@export booleanNot = \value%0 -> boolean.not value%0
 
-@export integerAdd = \left%1 right%2 -> semiringInt.add left%1 right%2
+@export integerAdd = \left%1 right%2 -> integer.add left%1 right%2
 
-@export integerSubtract = \left%3 right%4 -> ringInt.sub left%3 right%4
+@export integerSubtract = \left%3 right%4 -> integer.subtract left%3 right%4
 
-@export integerMultiply = \left%5 right%6 -> semiringInt.mul left%5 right%6
+@export integerMultiply = \left%5 right%6 -> integer.multiply left%5 right%6
 
-@export integerNegate = \value%7 -> ringInt.negate value%7
+@export integerNegate = \value%7 -> integer.negate value%7
 
-@export integerAddOrder = \$boolean%8@(_) ->
-  semiringInt.add (observe "left" 20) (observe "right" 22)
+@export integerAddOrder = \$boolean%8@(_) -> integer.add (observe "left" 20) (observe "right" 22)
 
 @export partiallyAppliedAdd = semiringInt.add 1
 

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.nbe.snap
@@ -1,0 +1,25 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export foreign observe
+
+@export foreign readTrace
+
+@export booleanNot = \value%0 -> heytingAlgebraBoolean.not value%0
+
+@export integerAdd = \left%1 right%2 -> semiringInt.add left%1 right%2
+
+@export integerSubtract = \left%3 right%4 -> ringInt.sub left%3 right%4
+
+@export integerMultiply = \left%5 right%6 -> semiringInt.mul left%5 right%6
+
+@export integerNegate = \value%7 -> ringInt.negate value%7
+
+@export integerAddOrder = \$boolean%8@(_) ->
+  semiringInt.add (observe "left" 20) (observe "right" 22)
+
+@export partiallyAppliedAdd = semiringInt.add 1
+
+@export lookalikeAdd = \left%9 right%10 -> semiringInt.add left%9 right%10

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.purs
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.purs
@@ -1,0 +1,36 @@
+module Main where
+
+import Data.HeytingAlgebra as HeytingAlgebra
+import Data.Ring as Ring
+import Data.Semiring as Semiring
+import Lookalike as Lookalike
+
+foreign import observe :: forall value. String -> value -> value
+foreign import readTrace :: Boolean -> Array String
+
+booleanNot :: Boolean -> Boolean
+booleanNot value = HeytingAlgebra.not value
+
+integerAdd :: Int -> Int -> Int
+integerAdd left right = Semiring.add left right
+
+integerSubtract :: Int -> Int -> Int
+integerSubtract left right = Ring.sub left right
+
+integerMultiply :: Int -> Int -> Int
+integerMultiply left right = Semiring.mul left right
+
+integerNegate :: Int -> Int
+integerNegate value = Ring.negate value
+
+integerAddOrder :: Boolean -> Int
+integerAddOrder _ =
+  Semiring.add
+    (observe "left" 20)
+    (observe "right" 22)
+
+partiallyAppliedAdd :: Int -> Int
+partiallyAppliedAdd = Semiring.add 1
+
+lookalikeAdd :: Int -> Int -> Int
+lookalikeAdd left right = Lookalike.add left right

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.snap
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 268
+expression: diagnostics_report
+---
+Terms
+observe :: forall value. Prim.String -> value -> value
+readTrace :: Prim.Boolean -> Prim.Array Prim.String
+booleanNot :: Prim.Boolean -> Prim.Boolean
+integerAdd :: Prim.Int -> Prim.Int -> Prim.Int
+integerSubtract :: Prim.Int -> Prim.Int -> Prim.Int
+integerMultiply :: Prim.Int -> Prim.Int -> Prim.Int
+integerNegate :: Prim.Int -> Prim.Int
+integerAddOrder :: Prim.Boolean -> Prim.Int
+partiallyAppliedAdd :: Prim.Int -> Prim.Int
+lookalikeAdd :: Prim.Int -> Prim.Int -> Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.ssa.snap
@@ -1,0 +1,96 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 269
+expression: ssa_report
+---
+@export foreign const observe;
+
+@export foreign const readTrace;
+
+@export function booleanNot(value) {
+  entry() {
+    const heytingAlgebraBoolean = global(heytingAlgebraBoolean);
+    const not = heytingAlgebraBoolean.not;
+    const call = source.call(not, value);
+    return call;
+  }
+}
+
+@export function integerAdd(left, right) {
+  entry() {
+    const semiringInt = global(semiringInt);
+    const add = semiringInt.add;
+    const call = source.call(add, left);
+    const call$1 = source.call(call, right);
+    return call$1;
+  }
+}
+
+@export function integerSubtract(left, right) {
+  entry() {
+    const ringInt = global(ringInt);
+    const sub = ringInt.sub;
+    const call = source.call(sub, left);
+    const call$1 = source.call(call, right);
+    return call$1;
+  }
+}
+
+@export function integerMultiply(left, right) {
+  entry() {
+    const semiringInt = global(semiringInt);
+    const mul = semiringInt.mul;
+    const call = source.call(mul, left);
+    const call$1 = source.call(call, right);
+    return call$1;
+  }
+}
+
+@export function integerNegate(value) {
+  entry() {
+    const ringInt = global(ringInt);
+    const negate = ringInt.negate;
+    const call = source.call(negate, value);
+    return call;
+  }
+}
+
+@export function integerAddOrder($boolean) {
+  entry() {
+    const semiringInt = global(semiringInt);
+    const add = semiringInt.add;
+    const observe = global(observe);
+    const literal = "left";
+    const call = source.call(observe, literal);
+    const literal$1 = 20;
+    const call$1 = source.call(call, literal$1);
+    const call$2 = source.call(add, call$1);
+    const observe$1 = global(observe);
+    const literal$2 = "right";
+    const call$3 = source.call(observe$1, literal$2);
+    const literal$3 = 22;
+    const call$4 = source.call(call$3, literal$3);
+    const call$5 = source.call(call$2, call$4);
+    return call$5;
+  }
+}
+
+@export const partiallyAppliedAdd = initialize {
+  entry() {
+    const semiringInt = global(semiringInt);
+    const add = semiringInt.add;
+    const literal = 1;
+    const call = source.call(add, literal);
+    return call;
+  }
+}
+
+@export function lookalikeAdd(left, right) {
+  entry() {
+    const semiringInt = global(semiringInt);
+    const add = semiringInt.add;
+    const call = source.call(add, left);
+    const call$1 = source.call(call, right);
+    return call$1;
+  }
+}

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.ssa.snap
@@ -9,69 +9,53 @@ expression: ssa_report
 
 @export function booleanNot(value) {
   entry() {
-    const heytingAlgebraBoolean = global(heytingAlgebraBoolean);
-    const not = heytingAlgebraBoolean.not;
-    const call = source.call(not, value);
-    return call;
+    const booleanNot = boolean.not(value);
+    return booleanNot;
   }
 }
 
 @export function integerAdd(left, right) {
   entry() {
-    const semiringInt = global(semiringInt);
-    const add = semiringInt.add;
-    const call = source.call(add, left);
-    const call$1 = source.call(call, right);
-    return call$1;
+    const integerAdd = integer.add(left, right);
+    return integerAdd;
   }
 }
 
 @export function integerSubtract(left, right) {
   entry() {
-    const ringInt = global(ringInt);
-    const sub = ringInt.sub;
-    const call = source.call(sub, left);
-    const call$1 = source.call(call, right);
-    return call$1;
+    const integerSubtract = integer.subtract(left, right);
+    return integerSubtract;
   }
 }
 
 @export function integerMultiply(left, right) {
   entry() {
-    const semiringInt = global(semiringInt);
-    const mul = semiringInt.mul;
-    const call = source.call(mul, left);
-    const call$1 = source.call(call, right);
-    return call$1;
+    const integerMultiply = integer.multiply(left, right);
+    return integerMultiply;
   }
 }
 
 @export function integerNegate(value) {
   entry() {
-    const ringInt = global(ringInt);
-    const negate = ringInt.negate;
-    const call = source.call(negate, value);
-    return call;
+    const integerNegate = integer.negate(value);
+    return integerNegate;
   }
 }
 
 @export function integerAddOrder($boolean) {
   entry() {
-    const semiringInt = global(semiringInt);
-    const add = semiringInt.add;
     const observe = global(observe);
     const literal = "left";
     const call = source.call(observe, literal);
     const literal$1 = 20;
     const call$1 = source.call(call, literal$1);
-    const call$2 = source.call(add, call$1);
     const observe$1 = global(observe);
     const literal$2 = "right";
-    const call$3 = source.call(observe$1, literal$2);
+    const call$2 = source.call(observe$1, literal$2);
     const literal$3 = 22;
-    const call$4 = source.call(call$3, literal$3);
-    const call$5 = source.call(call$2, call$4);
-    return call$5;
+    const call$3 = source.call(call$2, literal$3);
+    const integerAdd = integer.add(call$1, call$3);
+    return integerAdd;
   }
 }
 

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.HeytingAlgebra/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.HeytingAlgebra/index.js
@@ -1,0 +1,10 @@
+export const heytingAlgebraBoolean = (() => {
+  function heytingAlgebraBoolean$initialize$closure(value) {
+    if (value) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+  return { not: heytingAlgebraBoolean$initialize$closure };
+})();

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.Ring/foreign.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.Ring/foreign.js
@@ -1,0 +1,2 @@
+export const intSubtract = left => right => (left - right) | 0;
+export const intNegate = value => -value | 0;

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.Ring/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.Ring/index.js
@@ -1,0 +1,6 @@
+import * as $foreign from "./foreign.js";
+
+export const intSubtract = $foreign["intSubtract"];
+export const intNegate = $foreign["intNegate"];
+
+export const ringInt = { sub: intSubtract, negate: intNegate };

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.Semiring/foreign.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.Semiring/foreign.js
@@ -1,0 +1,2 @@
+export const intAdd = left => right => (left + right) | 0;
+export const intMultiply = left => right => (left * right) | 0;

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.Semiring/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.Semiring/index.js
@@ -1,0 +1,6 @@
+import * as $foreign from "./foreign.js";
+
+export const intAdd = $foreign["intAdd"];
+export const intMultiply = $foreign["intMultiply"];
+
+export const semiringInt = { add: intAdd, mul: intMultiply };

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Lookalike/foreign.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Lookalike/foreign.js
@@ -1,0 +1,1 @@
+export const intAdd = left => right => (left + right) | 0;

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Lookalike/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Lookalike/index.js
@@ -1,0 +1,5 @@
+import * as $foreign from "./foreign.js";
+
+export const intAdd = $foreign["intAdd"];
+
+export const semiringInt = { add: intAdd };

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Main/foreign.js
@@ -1,0 +1,12 @@
+let trace = [];
+
+export const observe = label => value => {
+  trace.push(label);
+  return value;
+};
+
+export const readTrace = reset => {
+  const result = trace;
+  if (reset) trace = [];
+  return result;
+};

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Main/index.js
@@ -1,0 +1,46 @@
+import * as Data_HeytingAlgebra from "../Data.HeytingAlgebra/index.js";
+import * as Data_Ring from "../Data.Ring/index.js";
+import * as Data_Semiring from "../Data.Semiring/index.js";
+import * as Lookalike from "../Lookalike/index.js";
+import * as $foreign from "./foreign.js";
+
+export function booleanNot(value) {
+  return Data_HeytingAlgebra.heytingAlgebraBoolean.not(value);
+}
+
+export function integerAdd(left) {
+  return right => {
+    return Data_Semiring.semiringInt.add(left)(right);
+  };
+}
+
+export function integerSubtract(left) {
+  return right => {
+    return Data_Ring.ringInt.sub(left)(right);
+  };
+}
+
+export function integerMultiply(left) {
+  return right => {
+    return Data_Semiring.semiringInt.mul(left)(right);
+  };
+}
+
+export function integerNegate(value) {
+  return Data_Ring.ringInt.negate(value);
+}
+
+export function integerAddOrder($boolean) {
+  return Data_Semiring.semiringInt.add(observe("left")(20 | 0))(observe("right")(22 | 0));
+}
+
+export function lookalikeAdd(left) {
+  return right => {
+    return Lookalike.semiringInt.add(left)(right);
+  };
+}
+
+export const observe = $foreign["observe"];
+export const readTrace = $foreign["readTrace"];
+
+export const partiallyAppliedAdd = Data_Semiring.semiringInt.add(1 | 0);

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Main/index.js
@@ -1,37 +1,35 @@
-import * as Data_HeytingAlgebra from "../Data.HeytingAlgebra/index.js";
-import * as Data_Ring from "../Data.Ring/index.js";
 import * as Data_Semiring from "../Data.Semiring/index.js";
 import * as Lookalike from "../Lookalike/index.js";
 import * as $foreign from "./foreign.js";
 
 export function booleanNot(value) {
-  return Data_HeytingAlgebra.heytingAlgebraBoolean.not(value);
+  return !value;
 }
 
 export function integerAdd(left) {
   return right => {
-    return Data_Semiring.semiringInt.add(left)(right);
+    return left + right | 0;
   };
 }
 
 export function integerSubtract(left) {
   return right => {
-    return Data_Ring.ringInt.sub(left)(right);
+    return left - right | 0;
   };
 }
 
 export function integerMultiply(left) {
   return right => {
-    return Data_Semiring.semiringInt.mul(left)(right);
+    return left * right | 0;
   };
 }
 
 export function integerNegate(value) {
-  return Data_Ring.ringInt.negate(value);
+  return -value | 0;
 }
 
 export function integerAddOrder($boolean) {
-  return Data_Semiring.semiringInt.add(observe("left")(20 | 0))(observe("right")(22 | 0));
+  return observe("left")(20 | 0) + observe("right")(22 | 0) | 0;
 }
 
 export function lookalikeAdd(left) {

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/verify.mjs
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/verify.mjs
@@ -1,0 +1,14 @@
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.booleanNot(true), false);
+strictEqual(Main.integerAdd(2147483647)(1), -2147483648);
+strictEqual(Main.integerSubtract(-2147483647)(2), 2147483647);
+strictEqual(Main.integerMultiply(65536)(65536), 0);
+strictEqual(Main.integerNegate(-2147483648), -2147483648);
+strictEqual(Main.partiallyAppliedAdd(41), 42);
+strictEqual(Main.lookalikeAdd(20)(22), 42);
+
+Main.readTrace(true);
+strictEqual(Main.integerAddOrder(false), 42);
+deepStrictEqual(Main.readTrace(true), ["left", "right"]);

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/verify.mjs
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/verify.mjs
@@ -1,5 +1,23 @@
 import { deepStrictEqual, strictEqual } from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import * as Main from "./output/Main/index.js";
+
+const source = await readFile(new URL("./output/Main/index.js", import.meta.url), "utf8");
+const expectedPrimitives = [
+  "!value",
+  "left + right | 0",
+  "left - right | 0",
+  "left * right | 0",
+  "-value | 0",
+];
+for (const expected of expectedPrimitives) {
+  if (!source.includes(expected)) {
+    throw new Error(`missing known primitive output: ${expected}`);
+  }
+}
+if (!source.includes("Lookalike.semiringInt.add")) {
+  throw new Error("same-named non-canonical member was reduced");
+}
 
 strictEqual(Main.booleanNot(true), false);
 strictEqual(Main.integerAdd(2147483647)(1), -2147483648);


### PR DESCRIPTION
## Why

Halogen-style code frequently uses core-library function combinators and specialized Boolean and Int dictionaries. Alexandrite currently preserves those generic calls through NBE and SSA, leaving generated JavaScript behind PureScript 0.15.16 for these common operations.

## What changed

- recognize fully saturated `Data.Function.apply`, `Data.Function.applyFlipped`, `Control.Category.identity categoryFn`, and `Unsafe.Coerce.unsafeCoerce` applications at the NBE boundary
- recognize `heytingAlgebraBoolean` `not`, plus `semiringInt`/`ringInt` add, subtract, multiply, and negate
- carry Boolean and Int operations explicitly through NBE and SSA before rendering direct JavaScript operators with Int32 `| 0` coercions
- preserve operand evaluation order, leave partial applications intact, and require resolved canonical module/member/instance provenance so same-named lookalikes are not rewritten
- add executable backend fixtures that record the unoptimized output before updating NBE, SSA, and JavaScript expectations with the implementation

This intentionally remains a closed set of semantic rewrites rather than a general inliner. Function-specialized semigroupoid composition remains separate because its partially applied form requires capture-time evaluation handling.

## Verification

- `cargo check -p nbe --tests`
- `cargo check -p ssa --tests`
- `cargo check -p javascript --tests`
- `just t backend`