### PR TITLE
[checking] Preserve evidence for local class member aliases

### DIFF
--- a/compiler-backend/javascript/src/convert/generator/analysis.rs
+++ b/compiler-backend/javascript/src/convert/generator/analysis.rs
@@ -74,6 +74,14 @@ impl<'c> BlockExpressionContext<'c> {
         self.expressions.borrow_mut().insert(value, expression);
     }
 
+    pub(super) fn get(&self, value: ValueId) -> Option<ExpressionId> {
+        self.expressions.borrow().get(&value).copied()
+    }
+
+    pub(super) fn remove(&self, value: ValueId) {
+        self.expressions.borrow_mut().remove(&value);
+    }
+
     pub(super) fn is_empty(&self) -> bool {
         self.expressions.borrow().is_empty()
     }

--- a/compiler-backend/javascript/src/convert/generator/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/render.rs
@@ -299,8 +299,8 @@ impl Generator<'_> {
         };
         let inlineable = context.inlineable_values(function.entry);
         let instructions_are_inlineable = block.instructions.iter().all(|instruction| {
-            if let Instruction::Assign { result, value } = instruction {
-                inlineable.contains(result) && !matches!(value, InstructionValue::Closure { .. })
+            if let Instruction::Assign { result, .. } = instruction {
+                inlineable.contains(result)
             } else {
                 false
             }
@@ -314,7 +314,16 @@ impl Generator<'_> {
             let Instruction::Assign { result, value } = instruction else {
                 unreachable!("invariant violated: inline closure contains a non-assignment")
             };
-            let expression = self.instruction_expression(tree, value, &expressions)?;
+            let expression = if let InstructionValue::Closure { function, captures } = value {
+                let Some(expression) =
+                    self.inline_closure_expression(tree, *function, captures, &context)?
+                else {
+                    return Ok(None);
+                };
+                expression
+            } else {
+                self.instruction_expression(tree, value, &expressions)?
+            };
             expressions.insert(*result, expression);
         }
         let mut expression = expressions.expression(tree, value);

--- a/compiler-backend/javascript/src/convert/generator/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/render.rs
@@ -178,9 +178,17 @@ impl Generator<'_> {
                 && inlineable.contains(result)
             {
                 if let InstructionValue::Closure { function, captures } = value
-                    && let Some(expression) =
-                        self.inline_closure_expression(output.tree, *function, captures, context)?
+                    && let Some(expression) = self.inline_closure_expression(
+                        output.tree,
+                        *function,
+                        captures,
+                        context,
+                        &expressions,
+                    )?
                 {
+                    for capture in captures.iter().copied() {
+                        expressions.remove(capture);
+                    }
                     expressions.insert(*result, expression);
                     continue;
                 }
@@ -260,10 +268,15 @@ impl Generator<'_> {
         function_id: FunctionId,
         captures: &[ValueId],
         parent_context: &FunctionContext,
+        parent_expressions: &BlockExpressionContext<'_>,
     ) -> ModuleResult<Option<ExpressionId>> {
         // Factory calls snapshot captured values, whereas lexical closures capture bindings. They
         // are equivalent only when the generated JavaScript never reassigns those bindings.
-        if captures.iter().any(|capture| !parent_context.value_is_lexically_stable(*capture)) {
+        let capture_is_unstable = captures.iter().any(|capture| {
+            parent_expressions.get(*capture).is_none()
+                && !parent_context.value_is_lexically_stable(*capture)
+        });
+        if capture_is_unstable {
             return Ok(None);
         }
 
@@ -285,9 +298,12 @@ impl Generator<'_> {
 
         let capture_names = {
             let function_captures = function.captures.iter().copied();
-            let parent_capture_names =
-                captures.iter().map(|capture| parent_context.value(*capture).to_owned());
-            iter::zip(function_captures, parent_capture_names)
+            let captures = iter::zip(function_captures, captures.iter().copied());
+            let captures = captures
+                .filter(|(_, parent_capture)| parent_expressions.get(*parent_capture).is_none());
+            captures.map(|(function_capture, parent_capture)| {
+                (function_capture, parent_context.value(parent_capture).to_owned())
+            })
         };
         let capture_names = capture_names.collect::<FxHashMap<_, _>>();
 
@@ -315,11 +331,19 @@ impl Generator<'_> {
                 unreachable!("invariant violated: inline closure contains a non-assignment")
             };
             let expression = if let InstructionValue::Closure { function, captures } = value {
-                let Some(expression) =
-                    self.inline_closure_expression(tree, *function, captures, &context)?
+                let Some(expression) = self.inline_closure_expression(
+                    tree,
+                    *function,
+                    captures,
+                    &context,
+                    &expressions,
+                )?
                 else {
                     return Ok(None);
                 };
+                for capture in captures.iter().copied() {
+                    expressions.remove(capture);
+                }
                 expression
             } else {
                 self.instruction_expression(tree, value, &expressions)?
@@ -344,6 +368,18 @@ impl Generator<'_> {
                 let parameter = context.value(*parameter).to_owned();
                 expression = tree.arrow(vec![parameter], expression);
             }
+        }
+
+        let pending_captures = iter::zip(function.captures.iter(), captures.iter());
+        let pending_captures = pending_captures.filter_map(|(function_capture, parent_capture)| {
+            parent_expressions
+                .get(*parent_capture)
+                .map(|expression| (context.value(*function_capture).to_owned(), expression))
+        });
+        let (parameters, arguments): (Vec<_>, Vec<_>) = pending_captures.unzip();
+        if !parameters.is_empty() {
+            expression = tree.arrow(parameters, expression);
+            expression = tree.call(expression, arguments);
         }
         Ok(Some(expression))
     }

--- a/compiler-frontend/checking/src/source/terms/form_let.rs
+++ b/compiler-frontend/checking/src/source/terms/form_let.rs
@@ -270,15 +270,26 @@ where
                     equation.binders.len(),
                 )?;
 
-            let abstractions = equations::bind_signature_abstractions(state, &abstractions);
+            let declaration_abstractions =
+                equations::bind_signature_abstractions(state, &abstractions);
             let inferred = state.with_source_type_renaming(&renaming, |state| {
-                guarded::subsume_elaborated_guarded_expression(state, context, inferred, result)
+                guarded::subsume_elaborated_guarded_expression(
+                    state,
+                    context,
+                    inferred,
+                    &abstractions,
+                    result,
+                )
             })?;
 
             let equation =
                 tree::Equation::local(*equation_source, [].into(), inferred.guarded_expression);
-            let declaration =
-                tree::LocalDeclaration::new(id, name_type, abstractions.into(), [equation].into());
+            let declaration = tree::LocalDeclaration::new(
+                id,
+                name_type,
+                declaration_abstractions.into(),
+                [equation].into(),
+            );
 
             return Ok(declaration);
         } else {

--- a/compiler-frontend/checking/src/source/terms/form_let.rs
+++ b/compiler-frontend/checking/src/source/terms/form_let.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use building_types::QueryResult;
 
 use crate::context::CheckContext;
-use crate::core::{Type, TypeId, exhaustive, normalise, skolem, unification};
+use crate::core::{Type, TypeId, exhaustive, normalise, signature, skolem, unification};
 use crate::error::ErrorCrumb;
 use crate::source::terms::{ElaboratedExpression, application, equations, guarded};
 use crate::source::{binder, types};
@@ -262,12 +262,24 @@ where
                 unification::subtype(state, context, inferred_type, expanded_name_type)?;
             }
 
-            let declaration = tree::LocalDeclaration::nullary(
-                id,
-                name_type,
-                *equation_source,
-                inferred.guarded_expression,
-            );
+            let signature::SkolemisedSignature { renaming, abstractions, result, .. } =
+                signature::expect_term_signature(
+                    state,
+                    context,
+                    inferred_type,
+                    equation.binders.len(),
+                )?;
+
+            let abstractions = equations::bind_signature_abstractions(state, &abstractions);
+            let inferred = state.with_source_type_renaming(&renaming, |state| {
+                guarded::subsume_elaborated_guarded_expression(state, context, inferred, result)
+            })?;
+
+            let equation =
+                tree::Equation::local(*equation_source, [].into(), inferred.guarded_expression);
+            let declaration =
+                tree::LocalDeclaration::new(id, name_type, abstractions.into(), [equation].into());
+
             return Ok(declaration);
         } else {
             equations::infer_value_equations(state, context, name_type, &name.equations)?

--- a/compiler-frontend/checking/src/source/terms/guarded.rs
+++ b/compiler-frontend/checking/src/source/terms/guarded.rs
@@ -1,5 +1,7 @@
 //! Implements checking and inference rules for guarded and where expressions.
 
+use std::sync::Arc;
+
 use building_types::QueryResult;
 
 use crate::context::CheckContext;
@@ -70,6 +72,30 @@ where
     Q: ExternalQueries,
 {
     guarded_expression_core(state, context, guarded, GuardedExpressionMode::Subsume { expected })
+}
+
+pub fn subsume_elaborated_guarded_expression<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    mut guarded: ElaboratedGuardedExpression,
+    expected: TypeId,
+) -> QueryResult<ElaboratedGuardedExpression>
+where
+    Q: ExternalQueries,
+{
+    let alternatives = Arc::get_mut(&mut guarded.guarded_expression.alternatives)
+        .expect("invariant violated: inferred guarded alternatives are shared");
+    for alternative in alternatives {
+        let expression = terms::ElaboratedExpression {
+            type_id: guarded.type_id,
+            expression: alternative.where_expression.expression,
+        };
+        let expression =
+            terms::application::subtype_expression(state, context, expression, expected)?;
+        alternative.where_expression.expression = expression.expression;
+    }
+    guarded.type_id = expected;
+    Ok(guarded)
 }
 
 fn guarded_expression_core<Q>(

--- a/compiler-frontend/checking/src/source/terms/guarded.rs
+++ b/compiler-frontend/checking/src/source/terms/guarded.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use building_types::QueryResult;
 
 use crate::context::CheckContext;
-use crate::core::TypeId;
+use crate::core::substitute::SubstituteName;
+use crate::core::{Type, TypeId, normalise, signature, unification};
 use crate::source::terms::form_let;
 use crate::source::{binder, terms};
 use crate::state::CheckState;
@@ -78,6 +79,7 @@ pub fn subsume_elaborated_guarded_expression<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     mut guarded: ElaboratedGuardedExpression,
+    abstractions: &[signature::SkolemisedAbstraction],
     expected: TypeId,
 ) -> QueryResult<ElaboratedGuardedExpression>
 where
@@ -91,11 +93,53 @@ where
             expression: alternative.where_expression.expression,
         };
         let expression =
+            instantiate_expression_abstractions(state, context, expression, abstractions)?;
+        let expression =
             terms::application::subtype_expression(state, context, expression, expected)?;
         alternative.where_expression.expression = expression.expression;
     }
     guarded.type_id = expected;
     Ok(guarded)
+}
+
+fn instantiate_expression_abstractions<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    mut expression: terms::ElaboratedExpression,
+    abstractions: &[signature::SkolemisedAbstraction],
+) -> QueryResult<terms::ElaboratedExpression>
+where
+    Q: ExternalQueries,
+{
+    for abstraction in abstractions {
+        let type_id = normalise::expand(state, context, expression.type_id)?;
+        match (*abstraction, context.lookup_type(type_id)) {
+            (
+                signature::SkolemisedAbstraction::Type { rigid, .. },
+                Type::Forall(inferred_binder, body),
+            ) => {
+                let binder = context.lookup_forall_binder(inferred_binder);
+                expression.type_id = SubstituteName::one(state, context, binder.name, rigid, body)?;
+            }
+            (
+                signature::SkolemisedAbstraction::Constraint { constraint },
+                Type::Constrained(inferred_constraint, result),
+            ) => {
+                unification::unify(state, context, inferred_constraint, constraint)?;
+                let evidence = state.push_wanted(constraint);
+                let kind = tree::ExpressionKind::EvidenceApplication {
+                    function: expression.expression,
+                    evidence,
+                    constraint,
+                };
+                expression = terms::allocate_expression(state, result, kind);
+            }
+            _ => panic!(
+                "invariant violated: inferred alias type abstractions do not match signature"
+            ),
+        }
+    }
+    Ok(expression)
 }
 
 fn guarded_expression_core<Q>(

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.nbe.snap
@@ -22,41 +22,47 @@ expression: report
 
 @export inlineCapturedClosure = \captured%11 -> \$boolean%10@(_) -> captured%11
 
-@export keepMultiUseClosure = \captured%14 ->
+@export inlineNestedClosureCapture = \record%15 ->
+  \$boolean%12@(_) ->
+    let
+      projected%14 = record%15.value
+    in \$boolean%13@(_) -> projected%14
+
+@export keepMultiUseClosure = \captured%18 ->
   let
-    closure%12 = \$boolean%13@(_) -> captured%14
-  in { first: closure%12, second: closure%12 }
+    closure%16 = \$boolean%17@(_) -> captured%18
+  in { first: closure%16, second: closure%16 }
 
-@export keepMultiUse = \record%16 ->
+@export keepMultiUse = \record%20 ->
   let
-    value%15 = record%16.value
-  in { first: value%15, second: value%15 }
+    value%19 = record%20.value
+  in { first: value%19, second: value%19 }
 
-@export inlineAcrossCall = \record%17 function%18 ->
-  { projected: record%17.value, called: function%18 true }
+@export inlineAcrossCall = \record%21 function%22 ->
+  { projected: record%21.value, called: function%22 true }
 
-@export inlineOrderedCalls = \first%19 second%20 ->
-  { first: first%19 true, second: second%20 false }
+@export inlineOrderedCalls = \first%23 second%24 ->
+  { first: first%23 true, second: second%24 false }
 
-@export keepReorderedCalls = \first%24 second%23 ->
+@export keepReorderedCalls = \first%28 second%27 ->
   let
-    firstResult%22 = first%24 true
+    firstResult%26 = first%28 true
   in let
-    secondResult%21 = second%23 false
-  in { first: secondResult%21, second: firstResult%22 }
+    secondResult%25 = second%27 false
+  in { first: secondResult%25, second: firstResult%26 }
 
-@export keepMultiUseCall = \function%26 value%27 ->
+@export keepMultiUseCall = \function%30 value%31 ->
   let
-    result%25 = function%26 value%27
-  in { first: result%25, second: result%25 }
+    result%29 = function%30 value%31
+  in { first: result%29, second: result%29 }
 
-@export keepCallBeforeBranch = \condition%28 function%31 value%30 ->
+@export keepCallBeforeBranch = \condition%32 function%35 value%34 ->
   let
-    result%29 = function%31 value%30
-  in if condition%28 then result%29 else value%30
+    result%33 = function%35 value%34
+  in if condition%32 then result%33 else value%34
 
-@export keepTestCall = \function%32 value%33 ->
-  case function%32 value%33 of
+@export keepTestCall = \function%36 value%37 ->
+  case function%36 value%37 of
     [] ->
       true
     _ ->

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.purs
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.purs
@@ -27,6 +27,15 @@ inlineRecord value = { value }
 inlineCapturedClosure :: Boolean -> Boolean -> Boolean
 inlineCapturedClosure captured = \_ -> captured
 
+inlineNestedClosureCapture
+  :: { value :: Boolean }
+  -> Boolean
+  -> Boolean
+  -> Boolean
+inlineNestedClosureCapture record = \_ ->
+  let projected = record.value
+  in \_ -> projected
+
 keepMultiUseClosure
   :: Boolean
   -> { first :: Boolean -> Boolean, second :: Boolean -> Boolean }

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.snap
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.snap
@@ -13,6 +13,8 @@ inlineCall :: (Prim.Boolean -> Prim.Boolean) -> Prim.Boolean -> Prim.Boolean
 inlineArray :: Prim.Boolean -> Prim.Array Prim.Boolean
 inlineRecord :: Prim.Boolean -> { value :: Prim.Boolean }
 inlineCapturedClosure :: Prim.Boolean -> Prim.Boolean -> Prim.Boolean
+inlineNestedClosureCapture ::
+  { value :: Prim.Boolean } -> Prim.Boolean -> Prim.Boolean -> Prim.Boolean
 keepMultiUseClosure ::
   Prim.Boolean -> { first :: Prim.Boolean -> Prim.Boolean, second :: Prim.Boolean -> Prim.Boolean }
 keepMultiUse :: { value :: Prim.Boolean } -> { first :: Prim.Boolean, second :: Prim.Boolean }

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.ssa.snap
@@ -83,6 +83,13 @@ expression: ssa_report
   }
 }
 
+@export function inlineNestedClosureCapture(record) {
+  entry() {
+    const closure = closure(inlineNestedClosureCapture$closure, record);
+    return closure;
+  }
+}
+
 @export function keepMultiUseClosure(captured) {
   entry() {
     const closure = closure(keepMultiUseClosure$closure, captured);
@@ -197,6 +204,20 @@ closure inlineClosure$closure[](item) {
 closure inlineCapturedClosure$closure[captured]($boolean) {
   entry() {
     return captured;
+  }
+}
+
+closure inlineNestedClosureCapture$closure$closure[projected]($boolean) {
+  entry() {
+    return projected;
+  }
+}
+
+closure inlineNestedClosureCapture$closure[record]($boolean) {
+  entry() {
+    const value = record.value;
+    const closure = closure(inlineNestedClosureCapture$closure$closure, value);
+    return closure;
   }
 }
 

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/output/Main/index.js
@@ -40,6 +40,10 @@ export function inlineCapturedClosure(captured) {
   return $boolean => captured;
 }
 
+export function inlineNestedClosureCapture(record) {
+  return $boolean => (projected => $boolean => projected)(record.value);
+}
+
 export function keepMultiUseClosure(captured) {
   function keepMultiUseClosure$closure(captured) {
     return $boolean => {

--- a/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/output/Main/index.js
@@ -9,23 +9,11 @@ export function liftApplicative(applicativeFunctorDict) {
 }
 
 export function applyMonad(monadMonadDict) {
-  function applyMonad$closure(monadMonadDict) {
-    return functions => {
-      return values => {
-        function applyMonad$closure$closure(monadMonadDict, values) {
-          return $function => {
-            return (monadMonadDict.Bind1()).bind(values)(
-              value => (monadMonadDict.Applicative0()).pure($function(value))
-            );
-          };
-        }
-        return (monadMonadDict.Bind1()).bind(functions)(
-          applyMonad$closure$closure(monadMonadDict, values)
-        );
-      };
-    };
-  }
-  return applyMonad$closure(monadMonadDict);
+  return functions => values => (monadMonadDict.Bind1()).bind(functions)(
+    $function => (monadMonadDict.Bind1()).bind(values)(
+      value => (monadMonadDict.Applicative0()).pure($function(value))
+    )
+  );
 }
 
 const $lazy_functorBox = $runtime.binding("functorBox", () => {

--- a/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/Main.nbe.snap
@@ -1,0 +1,12 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export constructor Pair/2
+
+@export identity = \value%0 -> value%0
+
+@export use = let
+  alias%1 = identity
+in Pair (alias%1 42) (alias%1 "x")

--- a/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/Main.purs
+++ b/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+data Pair a b = Pair a b
+
+identity :: forall a. a -> a
+identity value = value
+
+use :: Pair Int String
+use = Pair (alias 42) (alias "x")
+  where
+  alias = identity

--- a/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/Main.snap
+++ b/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 268
+expression: diagnostics_report
+---
+Terms
+Pair :: forall @a @b. a -> b -> Main.Pair a b
+identity :: forall a. a -> a
+use :: Main.Pair Prim.Int Prim.String
+
+Types
+Pair :: Prim.Type -> Prim.Type -> Prim.Type
+
+Roles
+Pair = [Representational, Representational]

--- a/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/Main.ssa.snap
@@ -1,0 +1,26 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 269
+expression: ssa_report
+---
+@export constructor Pair/2;
+
+@export function identity(value) {
+  entry() {
+    return value;
+  }
+}
+
+@export const use = initialize {
+  entry() {
+    const identity = global(identity);
+    const Pair = constructor(Pair);
+    const literal = 42;
+    const call = source.call(identity, literal);
+    const call$1 = source.call(Pair, call);
+    const literal$1 = "x";
+    const call$2 = source.call(identity, literal$1);
+    const call$3 = source.call(call$1, call$2);
+    return call$3;
+  }
+}

--- a/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/output/Main/index.js
@@ -1,0 +1,10 @@
+export const Pair = $value0 => $value1 => ["Pair", $value0, $value1];
+
+export function identity(value) {
+  return value;
+}
+
+export const use = (() => {
+  const identity$1 = identity;
+  return Pair(identity$1(42 | 0))(identity$1("x"));
+})();

--- a/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/verify.mjs
+++ b/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/verify.mjs
@@ -1,0 +1,6 @@
+import * as Main from "./output/Main/index.js";
+
+const value = Main.use;
+if (value[1] !== 42 || value[2] !== "x") {
+  throw new Error("expected the non-member alias to remain polymorphic");
+}

--- a/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/Main.nbe.snap
@@ -4,7 +4,7 @@ assertion_line: 14
 expression: report
 ---
 @export use = \namedBodyDict%0 ->
-  \$body%2@(_) ->
+  \$body%3@(_) ->
     let
-      alias%1 = name
+      alias%1 = \namedBodyDict%2 -> namedBodyDict%2.name
     in alias%1 namedBodyDict%0

--- a/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/Main.nbe.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export use = \namedBodyDict%0 ->
+  \$body%2@(_) ->
+    let
+      alias%1 = name
+    in alias%1 namedBodyDict%0

--- a/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/Main.purs
+++ b/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+class Named a where
+  name :: String
+
+use :: forall body. Named body => body -> String
+use _ = alias
+  where
+  alias = name @body

--- a/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/Main.snap
+++ b/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 268
+expression: diagnostics_report
+---
+Terms
+name :: forall t0 (@a :: t0). Main.Named @t0 (a :: t0) => Prim.String
+use :: forall body. Main.Named @Prim.Type body => body -> Prim.String
+
+Types
+Named :: forall t0. t0 -> Prim.Constraint
+
+Classes
+class forall (t0 :: Prim.Type) (a :: t0). Main.Named @t0 (a :: t0)
+  name :: forall t0 (@a :: t0). Main.Named @t0 (a :: t0) => Prim.String

--- a/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/Main.ssa.snap
@@ -10,10 +10,17 @@ expression: ssa_report
   }
 }
 
+closure use$closure$closure[](namedBodyDict) {
+  entry() {
+    const name = namedBodyDict.name;
+    return name;
+  }
+}
+
 closure use$closure[namedBodyDict]($body) {
   entry() {
-    const name = global(name);
-    const call = source.call(name, namedBodyDict);
+    const closure = closure(use$closure$closure);
+    const call = source.call(closure, namedBodyDict);
     return call;
   }
 }

--- a/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/Main.ssa.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 269
+expression: ssa_report
+---
+@export function use(namedBodyDict) {
+  entry() {
+    const closure = closure(use$closure, namedBodyDict);
+    return closure;
+  }
+}
+
+closure use$closure[namedBodyDict]($body) {
+  entry() {
+    const name = global(name);
+    const call = source.call(name, namedBodyDict);
+    return call;
+  }
+}

--- a/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/output/Main/index.js
@@ -1,8 +1,3 @@
 export function use(namedBodyDict) {
-  function use$closure(namedBodyDict) {
-    return $body => {
-      return (namedBodyDict => namedBodyDict.name)(namedBodyDict);
-    };
-  }
-  return use$closure(namedBodyDict);
+  return $body => (namedBodyDict => namedBodyDict.name)(namedBodyDict);
 }

--- a/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/output/Main/index.js
@@ -1,0 +1,8 @@
+export function use(namedBodyDict) {
+  function use$closure(namedBodyDict) {
+    return $body => {
+      return (namedBodyDict => namedBodyDict.name)(namedBodyDict);
+    };
+  }
+  return use$closure(namedBodyDict);
+}

--- a/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/output/error.txt
+++ b/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/output/error.txt
@@ -1,1 +1,0 @@
-cannot convert SSA module Idx::<File>(42) to JavaScript: local global "name" has no JavaScript declaration

--- a/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/output/error.txt
+++ b/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/output/error.txt
@@ -1,0 +1,1 @@
+cannot convert SSA module Idx::<File>(42) to JavaScript: local global "name" has no JavaScript declaration

--- a/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/verify.mjs
+++ b/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/verify.mjs
@@ -1,0 +1,5 @@
+import * as Main from "./output/Main/index.js";
+
+if (Main.use({ name: "visible" })({}) !== "visible") {
+  throw new Error("expected the visibly applied class member to use its dictionary");
+}

--- a/tests-integration/fixtures/backend/1787591220_where_bound_class_member/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787591220_where_bound_class_member/Main.nbe.snap
@@ -8,11 +8,11 @@ expression: report
 @export use = \namedADict%1 ->
   \value%3 ->
     let
-      alias%2 = name
+      alias%2 = \namedADict%4 -> namedADict%4.name
     in alias%2 namedADict%1 value%3
 
-@export useLet = \namedADict%4 ->
-  \value%6 ->
+@export useLet = \namedADict%5 ->
+  \value%7 ->
     let
-      alias%5 = name
-    in alias%5 namedADict%4 value%6
+      alias%6 = \namedADict%8 -> namedADict%8.name
+    in alias%6 namedADict%5 value%7

--- a/tests-integration/fixtures/backend/1787591220_where_bound_class_member/Main.nbe.snap
+++ b/tests-integration/fixtures/backend/1787591220_where_bound_class_member/Main.nbe.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/tests/nbe.rs
+assertion_line: 14
+expression: report
+---
+@export instance namedString = { name: \value%0 -> value%0 }
+
+@export use = \namedADict%1 ->
+  \value%3 ->
+    let
+      alias%2 = name
+    in alias%2 namedADict%1 value%3
+
+@export useLet = \namedADict%4 ->
+  \value%6 ->
+    let
+      alias%5 = name
+    in alias%5 namedADict%4 value%6

--- a/tests-integration/fixtures/backend/1787591220_where_bound_class_member/Main.purs
+++ b/tests-integration/fixtures/backend/1787591220_where_bound_class_member/Main.purs
@@ -1,0 +1,19 @@
+module Main where
+
+class Named a where
+  name :: a -> String
+
+instance Named String where
+  name value = value
+
+use :: forall a. Named a => a -> String
+use value = alias value
+  where
+  alias = name
+
+useLet :: forall a. Named a => a -> String
+useLet value =
+  let
+    alias = name
+  in
+    alias value

--- a/tests-integration/fixtures/backend/1787591220_where_bound_class_member/Main.snap
+++ b/tests-integration/fixtures/backend/1787591220_where_bound_class_member/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 268
+expression: diagnostics_report
+---
+Terms
+name :: forall @a. Main.Named a => a -> Prim.String
+use :: forall a. Main.Named a => a -> Prim.String
+useLet :: forall a. Main.Named a => a -> Prim.String
+
+Types
+Named :: Prim.Type -> Prim.Constraint
+
+Classes
+class forall (a :: Prim.Type). Main.Named a
+  name :: forall @a. Main.Named a => a -> Prim.String
+
+Instances
+instance Main.Named Prim.String

--- a/tests-integration/fixtures/backend/1787591220_where_bound_class_member/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787591220_where_bound_class_member/Main.ssa.snap
@@ -31,19 +31,33 @@ closure namedString$initialize$closure[](value) {
   }
 }
 
+closure use$closure$closure[](namedADict) {
+  entry() {
+    const name = namedADict.name;
+    return name;
+  }
+}
+
 closure use$closure[namedADict](value) {
   entry() {
-    const name = global(name);
-    const call = source.call(name, namedADict);
+    const closure = closure(use$closure$closure);
+    const call = source.call(closure, namedADict);
     const call$1 = source.call(call, value);
     return call$1;
   }
 }
 
+closure useLet$closure$closure[](namedADict) {
+  entry() {
+    const name = namedADict.name;
+    return name;
+  }
+}
+
 closure useLet$closure[namedADict](value) {
   entry() {
-    const name = global(name);
-    const call = source.call(name, namedADict);
+    const closure = closure(useLet$closure$closure);
+    const call = source.call(closure, namedADict);
     const call$1 = source.call(call, value);
     return call$1;
   }

--- a/tests-integration/fixtures/backend/1787591220_where_bound_class_member/Main.ssa.snap
+++ b/tests-integration/fixtures/backend/1787591220_where_bound_class_member/Main.ssa.snap
@@ -1,0 +1,50 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 269
+expression: ssa_report
+---
+@export instance const namedString = initialize {
+  entry() {
+    const closure = closure(namedString$initialize$closure);
+    const record = { name: closure };
+    return record;
+  }
+}
+
+@export function use(namedADict) {
+  entry() {
+    const closure = closure(use$closure, namedADict);
+    return closure;
+  }
+}
+
+@export function useLet(namedADict) {
+  entry() {
+    const closure = closure(useLet$closure, namedADict);
+    return closure;
+  }
+}
+
+closure namedString$initialize$closure[](value) {
+  entry() {
+    return value;
+  }
+}
+
+closure use$closure[namedADict](value) {
+  entry() {
+    const name = global(name);
+    const call = source.call(name, namedADict);
+    const call$1 = source.call(call, value);
+    return call$1;
+  }
+}
+
+closure useLet$closure[namedADict](value) {
+  entry() {
+    const name = global(name);
+    const call = source.call(name, namedADict);
+    const call$1 = source.call(call, value);
+    return call$1;
+  }
+}

--- a/tests-integration/fixtures/backend/1787591220_where_bound_class_member/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787591220_where_bound_class_member/output/Main/index.js
@@ -1,0 +1,21 @@
+export function use(namedADict) {
+  function use$closure(namedADict) {
+    return value => {
+      return (namedADict => namedADict.name)(namedADict)(value);
+    };
+  }
+  return use$closure(namedADict);
+}
+
+export function useLet(namedADict) {
+  function useLet$closure(namedADict) {
+    return value => {
+      return (namedADict => namedADict.name)(namedADict)(value);
+    };
+  }
+  return useLet$closure(namedADict);
+}
+
+export const namedString = (() => {
+  return { name: value => value };
+})();

--- a/tests-integration/fixtures/backend/1787591220_where_bound_class_member/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787591220_where_bound_class_member/output/Main/index.js
@@ -1,19 +1,9 @@
 export function use(namedADict) {
-  function use$closure(namedADict) {
-    return value => {
-      return (namedADict => namedADict.name)(namedADict)(value);
-    };
-  }
-  return use$closure(namedADict);
+  return value => (namedADict => namedADict.name)(namedADict)(value);
 }
 
 export function useLet(namedADict) {
-  function useLet$closure(namedADict) {
-    return value => {
-      return (namedADict => namedADict.name)(namedADict)(value);
-    };
-  }
-  return useLet$closure(namedADict);
+  return value => (namedADict => namedADict.name)(namedADict)(value);
 }
 
 export const namedString = (() => {

--- a/tests-integration/fixtures/backend/1787591220_where_bound_class_member/output/error.txt
+++ b/tests-integration/fixtures/backend/1787591220_where_bound_class_member/output/error.txt
@@ -1,1 +1,0 @@
-cannot convert SSA module Idx::<File>(42) to JavaScript: local global "name" has no JavaScript declaration

--- a/tests-integration/fixtures/backend/1787591220_where_bound_class_member/output/error.txt
+++ b/tests-integration/fixtures/backend/1787591220_where_bound_class_member/output/error.txt
@@ -1,0 +1,1 @@
+cannot convert SSA module Idx::<File>(42) to JavaScript: local global "name" has no JavaScript declaration

--- a/tests-integration/fixtures/backend/1787591220_where_bound_class_member/verify.mjs
+++ b/tests-integration/fixtures/backend/1787591220_where_bound_class_member/verify.mjs
@@ -1,0 +1,9 @@
+import * as Main from "./output/Main/index.js";
+
+if (Main.use({ name: value => value })("x") !== "x") {
+  throw new Error("expected the where-bound class member to use its dictionary");
+}
+
+if (Main.useLet({ name: value => value })("x") !== "x") {
+  throw new Error("expected the let-bound class member to use its dictionary");
+}

--- a/tests-integration/fixtures/checking/1787594580_deferred_constrained_alias_evidence/Main.purs
+++ b/tests-integration/fixtures/checking/1787594580_deferred_constrained_alias_evidence/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+class Named a where
+  name :: String
+
+instance Named String where
+  name = "x"
+
+select :: forall @fixed @selected. Named selected => String
+select = name @selected
+
+test :: String
+test = alias @String
+  where
+  alias = select @String

--- a/tests-integration/fixtures/checking/1787594580_deferred_constrained_alias_evidence/Main.snap
+++ b/tests-integration/fixtures/checking/1787594580_deferred_constrained_alias_evidence/Main.snap
@@ -18,11 +18,3 @@ class forall (t0 :: Prim.Type) (a :: t0). Main.Named @t0 (a :: t0)
 
 Instances
 instance Main.Named @Prim.Type Prim.String
-
-Diagnostics
-error[NoInstanceFound]: No instance found for: Named @Type ?9
-  --> 12:1..12:15
-   |
-12 | test :: String
-   | ^~~~~~~~~~~~~~
-  trivia: Named @Type selected is in scope

--- a/tests-integration/fixtures/checking/1787594580_deferred_constrained_alias_evidence/Main.snap
+++ b/tests-integration/fixtures/checking/1787594580_deferred_constrained_alias_evidence/Main.snap
@@ -1,0 +1,28 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 288
+expression: report
+---
+Terms
+name :: forall t0 (@a :: t0). Main.Named @t0 (a :: t0) => Prim.String
+select ::
+  forall t0 t1 (@fixed :: t0) (@selected :: t1). Main.Named @t1 (selected :: t1) => Prim.String
+test :: Prim.String
+
+Types
+Named :: forall t0. t0 -> Prim.Constraint
+
+Classes
+class forall (t0 :: Prim.Type) (a :: t0). Main.Named @t0 (a :: t0)
+  name :: forall t0 (@a :: t0). Main.Named @t0 (a :: t0) => Prim.String
+
+Instances
+instance Main.Named @Prim.Type Prim.String
+
+Diagnostics
+error[NoInstanceFound]: No instance found for: Named @Type ?9
+  --> 12:1..12:15
+   |
+12 | test :: String
+   | ^~~~~~~~~~~~~~
+  trivia: Named @Type selected is in scope


### PR DESCRIPTION
## Problem

A class member referenced through a simple local `let` or `where` alias retained the member's source-level global reference without elaborating its dictionary application. JavaScript generation then failed because class member accessors have no standalone runtime declaration.

This also affected nullary members selected with visible type application, such as `name @body`.

## Solution

Treat inferred simple local aliases as polymorphic signatures before lowering their elaborated guarded expressions:

- bind the inferred type and evidence abstractions,
- subsume each already-elaborated guarded result against the skolemised result type, and
- retain the resulting evidence applications in the checked tree.

This preserves ordinary polymorphic aliases while turning class member references into dictionary projections.

The generated code exposed a separate JavaScript optimization limitation: a single-use closure was not inlined when its body constructed another closure. Closure-expression inlining now recursively handles nested inlineable closures.

## Tests

Backend regression fixtures cover:

- class members aliased in `where` and `let` bindings,
- a nullary member with visible type application,
- a non-member polymorphic function alias used at multiple types, and
- runtime dictionary selection for the repaired cases.

Validation:

- `just t backend`
- `just t checking`
- `just integration` (844 tests)
- `cargo nextest run` (633 tests)