### PR TITLE
[functional] Inline simple local bindings

### DIFF
--- a/compiler-backend/functional/src/convert.rs
+++ b/compiler-backend/functional/src/convert.rs
@@ -18,6 +18,7 @@ use smol_str::{SmolStr, format_smolstr};
 use thiserror::Error;
 
 use crate::error::{ModuleError, ModuleResult, UnsupportedState};
+use crate::optimize::inline_simple_bindings;
 use crate::tree::{
     BinaryOperator, Binding, CaseAlternative, Declaration, DeclarationKind, Expression,
     ExpressionId, ExpressionKind, Field, FieldIdentity, Global, GlobalId, Guard,
@@ -206,6 +207,16 @@ fn convert(mut context: Context<'_, impl checking::ExternalQueries>) -> Conversi
         declarations.extend(declaration);
     }
     validate_runtime_exports(&context, &declarations, &surface)?;
+
+    let recursive_globals = declarations
+        .iter()
+        .filter_map(|declaration| declaration.recursive_group.map(|_| declaration.global.id));
+    let recursive_globals = recursive_globals.collect::<FxHashSet<_>>();
+    for declaration in &declarations {
+        if let DeclarationKind::Value(expression) = declaration.kind {
+            inline_simple_bindings(&mut context.storage, expression, &recursive_globals);
+        }
+    }
 
     let dependencies = context.dependencies.iter().map(|(&file_id, module_name)| {
         ModuleDependency { file_id, module_name: SmolStr::clone(module_name) }

--- a/compiler-backend/functional/src/lib.rs
+++ b/compiler-backend/functional/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod convert;
 pub mod error;
+pub mod optimize;
 pub mod pretty;
 pub mod tree;
 

--- a/compiler-backend/functional/src/optimize.rs
+++ b/compiler-backend/functional/src/optimize.rs
@@ -1,5 +1,6 @@
 //! Simplification of functional trees before backend-specific code generation.
 
+use itertools::Itertools;
 use rustc_hash::FxHashSet;
 
 use crate::tree::{
@@ -215,8 +216,8 @@ fn expression_children(kind: &ExpressionKind) -> Vec<ExpressionId> {
             children
         }
         ExpressionKind::Let { bindings, body, .. } => {
-            let mut children =
-                bindings.iter().map(|binding| binding.expression).collect::<Vec<_>>();
+            let binding_expressions = bindings.iter().map(|binding| binding.expression);
+            let mut children = binding_expressions.collect_vec();
             children.push(*body);
             children
         }

--- a/compiler-backend/functional/src/optimize.rs
+++ b/compiler-backend/functional/src/optimize.rs
@@ -1,0 +1,238 @@
+//! Simplification of functional trees before backend-specific code generation.
+
+use rustc_hash::FxHashSet;
+
+use crate::tree::{
+    Binding, EffectExpression, ExpressionId, ExpressionKind, GlobalId, Guard, LocalId,
+    RecordUpdate, Storage,
+};
+
+pub fn inline_simple_bindings(
+    storage: &mut Storage,
+    expression: ExpressionId,
+    recursive_globals: &FxHashSet<GlobalId>,
+) {
+    let mut visited = FxHashSet::default();
+    optimize_expression(storage, expression, recursive_globals, &mut visited);
+}
+
+fn optimize_expression(
+    storage: &mut Storage,
+    expression: ExpressionId,
+    recursive_globals: &FxHashSet<GlobalId>,
+    visited: &mut FxHashSet<ExpressionId>,
+) {
+    if !visited.insert(expression) {
+        return;
+    }
+
+    let kind = storage[expression].kind.clone();
+    for child in expression_children(&kind) {
+        optimize_expression(storage, child, recursive_globals, visited);
+    }
+
+    let ExpressionKind::Let { recursive: false, bindings, body } = kind else {
+        return;
+    };
+    let mut bindings = bindings.to_vec();
+    while let Some(position) = bindings.iter().position(|binding| {
+        let uses = binding_uses(storage, &bindings, body, binding.parameter.id);
+        uses > 0
+            && (is_trivial_expression(storage, binding.expression, recursive_globals)
+                || uses == 1
+                    && is_simple_expression(storage, binding.expression, recursive_globals))
+    }) {
+        let binding = bindings.remove(position);
+        for remaining in &bindings {
+            substitute_local(
+                storage,
+                remaining.expression,
+                binding.parameter.id,
+                binding.expression,
+            );
+        }
+        substitute_local(storage, body, binding.parameter.id, binding.expression);
+    }
+
+    let replacement = if bindings.is_empty() {
+        storage[body].kind.clone()
+    } else {
+        ExpressionKind::Let { recursive: false, bindings: bindings.into(), body }
+    };
+    storage.replace_expression_kind(expression, replacement);
+}
+
+fn binding_uses(
+    storage: &Storage,
+    bindings: &[Binding],
+    body: ExpressionId,
+    parameter: LocalId,
+) -> usize {
+    let binding_uses = bindings
+        .iter()
+        .map(|binding| local_uses(storage, binding.expression, parameter))
+        .sum::<usize>();
+    binding_uses + local_uses(storage, body, parameter)
+}
+
+fn local_uses(storage: &Storage, expression: ExpressionId, parameter: LocalId) -> usize {
+    if matches!(
+        &storage[expression].kind,
+        ExpressionKind::Local { parameter: local } if local.id == parameter
+    ) {
+        return 1;
+    }
+    expression_children(&storage[expression].kind)
+        .into_iter()
+        .map(|child| local_uses(storage, child, parameter))
+        .sum()
+}
+
+fn substitute_local(
+    storage: &mut Storage,
+    expression: ExpressionId,
+    parameter: LocalId,
+    replacement: ExpressionId,
+) {
+    if matches!(
+        &storage[expression].kind,
+        ExpressionKind::Local { parameter: local } if local.id == parameter
+    ) {
+        let replacement = storage[replacement].kind.clone();
+        storage.replace_expression_kind(expression, replacement);
+        return;
+    }
+    let kind = storage[expression].kind.clone();
+    for child in expression_children(&kind) {
+        substitute_local(storage, child, parameter, replacement);
+    }
+}
+
+fn is_trivial_expression(
+    storage: &Storage,
+    expression: ExpressionId,
+    recursive_globals: &FxHashSet<GlobalId>,
+) -> bool {
+    match &storage[expression].kind {
+        ExpressionKind::Literal { .. }
+        | ExpressionKind::Constructor { .. }
+        | ExpressionKind::Local { .. }
+        | ExpressionKind::SynthesizedEvidence { .. }
+        | ExpressionKind::TrivialEvidence => true,
+        ExpressionKind::Global { global } => !recursive_globals.contains(&global.id),
+        _ => false,
+    }
+}
+
+fn is_simple_expression(
+    storage: &Storage,
+    expression: ExpressionId,
+    recursive_globals: &FxHashSet<GlobalId>,
+) -> bool {
+    match &storage[expression].kind {
+        ExpressionKind::Literal { .. }
+        | ExpressionKind::Constructor { .. }
+        | ExpressionKind::Local { .. }
+        | ExpressionKind::Abstraction { .. }
+        | ExpressionKind::UncurriedAbstraction { .. }
+        | ExpressionKind::SynthesizedEvidence { .. }
+        | ExpressionKind::TrivialEvidence => true,
+        ExpressionKind::Global { global } => !recursive_globals.contains(&global.id),
+        ExpressionKind::Array { elements } => elements
+            .iter()
+            .all(|element| is_simple_expression(storage, *element, recursive_globals)),
+        ExpressionKind::Record { fields } => fields
+            .iter()
+            .all(|field| is_simple_expression(storage, field.expression, recursive_globals)),
+        ExpressionKind::Project { record, .. } | ExpressionKind::Unary { value: record, .. } => {
+            is_simple_expression(storage, *record, recursive_globals)
+        }
+        ExpressionKind::Binary { left, right, .. } => {
+            is_simple_expression(storage, *left, recursive_globals)
+                && is_simple_expression(storage, *right, recursive_globals)
+        }
+        ExpressionKind::RecordUpdate { .. }
+        | ExpressionKind::Application { .. }
+        | ExpressionKind::UncurriedApplication { .. }
+        | ExpressionKind::IfThenElse { .. }
+        | ExpressionKind::Case { .. }
+        | ExpressionKind::Guarded { .. }
+        | ExpressionKind::Let { .. }
+        | ExpressionKind::LetPattern { .. }
+        | ExpressionKind::Effect { .. } => false,
+    }
+}
+
+fn expression_children(kind: &ExpressionKind) -> Vec<ExpressionId> {
+    match kind {
+        ExpressionKind::Literal { .. }
+        | ExpressionKind::Constructor { .. }
+        | ExpressionKind::Global { .. }
+        | ExpressionKind::Local { .. }
+        | ExpressionKind::SynthesizedEvidence { .. }
+        | ExpressionKind::TrivialEvidence => Vec::new(),
+        ExpressionKind::Array { elements } => elements.to_vec(),
+        ExpressionKind::Record { fields } => fields.iter().map(|field| field.expression).collect(),
+        ExpressionKind::RecordUpdate { record, updates } => {
+            let mut children = vec![*record];
+            update_children(updates, &mut children);
+            children
+        }
+        ExpressionKind::Project { record, .. } | ExpressionKind::Unary { value: record, .. } => {
+            vec![*record]
+        }
+        ExpressionKind::Binary { left, right, .. } => vec![*left, *right],
+        ExpressionKind::Abstraction { body, .. }
+        | ExpressionKind::UncurriedAbstraction { body, .. } => vec![*body],
+        ExpressionKind::Application { function, arguments }
+        | ExpressionKind::UncurriedApplication { function, arguments } => {
+            let mut children = Vec::with_capacity(arguments.len() + 1);
+            children.push(*function);
+            children.extend(arguments.iter().copied());
+            children
+        }
+        ExpressionKind::IfThenElse { condition, then, else_ } => {
+            vec![*condition, *then, *else_]
+        }
+        ExpressionKind::Case { scrutinees, alternatives } => {
+            let mut children = scrutinees.to_vec();
+            children.extend(alternatives.iter().map(|alternative| alternative.expression));
+            children
+        }
+        ExpressionKind::Guarded { alternatives } => {
+            let mut children = Vec::new();
+            for alternative in alternatives.iter() {
+                for guard in alternative.guards.iter() {
+                    let expression = match guard {
+                        Guard::Boolean(expression) | Guard::Pattern { expression, .. } => {
+                            *expression
+                        }
+                    };
+                    children.push(expression);
+                }
+                children.push(alternative.expression);
+            }
+            children
+        }
+        ExpressionKind::Let { bindings, body, .. } => {
+            let mut children =
+                bindings.iter().map(|binding| binding.expression).collect::<Vec<_>>();
+            children.push(*body);
+            children
+        }
+        ExpressionKind::LetPattern { value, body, .. } => vec![*value, *body],
+        ExpressionKind::Effect { effect } => match effect {
+            EffectExpression::Pure(value) => vec![*value],
+            EffectExpression::Bind { action, body, .. } => vec![*action, *body],
+        },
+    }
+}
+
+fn update_children(updates: &[RecordUpdate], children: &mut Vec<ExpressionId>) {
+    for update in updates {
+        match update {
+            RecordUpdate::Leaf { expression, .. } => children.push(*expression),
+            RecordUpdate::Branch { updates, .. } => update_children(updates, children),
+        }
+    }
+}

--- a/compiler-backend/functional/src/tree.rs
+++ b/compiler-backend/functional/src/tree.rs
@@ -161,12 +161,12 @@ pub enum Literal {
     Number(SmolStr),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Expression {
     pub kind: ExpressionKind,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExpressionKind {
     Literal { literal: Literal },
     Array { elements: Arc<[ExpressionId]> },
@@ -205,44 +205,44 @@ pub enum BinaryOperator {
     IntegerMultiply,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EffectExpression {
     Pure(ExpressionId),
     Bind { action: ExpressionId, parameter: Parameter, body: ExpressionId },
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RecordField {
     pub field: Field,
     pub expression: ExpressionId,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RecordUpdate {
     Leaf { field: Field, expression: ExpressionId },
     Branch { field: Field, updates: Arc<[RecordUpdate]> },
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Binding {
     pub parameter: Parameter,
     pub expression: ExpressionId,
     pub source_order: usize,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CaseAlternative {
     pub patterns: Arc<[PatternId]>,
     pub expression: ExpressionId,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GuardedAlternative {
     pub guards: Arc<[Guard]>,
     pub expression: ExpressionId,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Guard {
     Boolean(ExpressionId),
     Pattern { expression: ExpressionId, pattern: PatternId },

--- a/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/Main.functional.snap
@@ -1,10 +1,6 @@
 ---
 source: tests-integration/tests/functional.rs
+assertion_line: 14
 expression: report
 ---
-@export sequence = \input%2 ->
-  let
-    first%1 = input%2
-  in let
-    second%0 = first%1
-  in second%0
+@export sequence = \input%2 -> input%2

--- a/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787081160_sequential_local_bindings/output/Main/index.js
@@ -1,5 +1,3 @@
 export function sequence(input) {
-  const first = input;
-  const second = first;
-  return second;
+  return input;
 }

--- a/tests-integration/fixtures/backend/1787081220_javascript_execution/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787081220_javascript_execution/Main.functional.snap
@@ -1,5 +1,6 @@
 ---
 source: tests-integration/tests/functional.rs
+assertion_line: 14
 expression: report
 ---
 @export foreign addInt
@@ -46,10 +47,8 @@ expression: report
 @export nestedJoin = \outer%8 inner%11 ->
   if outer%8
     then let
-      captured%9 = foreignValue
-    in let
       result%10 = if inner%11 then 1 else 2
-    in addInt captured%9 result%10
+    in addInt foreignValue result%10
     else 0
 
 @export recursive[19] countdown = \value%12 ->

--- a/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
@@ -29,7 +29,6 @@ export function addCaptured(amount) {
 export function nestedJoin(outer) {
   return inner => {
     if (outer) {
-      const captured = foreignValue;
       let $result;
       if (inner) {
         $result = 1 | 0;
@@ -37,7 +36,7 @@ export function nestedJoin(outer) {
         $result = 2 | 0;
       }
       const result = $result;
-      return addInt(captured)(result);
+      return addInt(foreignValue)(result);
     } else {
       return 0 | 0;
     }

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.functional.snap
@@ -1,5 +1,6 @@
 ---
 source: tests-integration/tests/functional.rs
+assertion_line: 14
 expression: report
 ---
 @export compareTwice = \eqADict%0 ->
@@ -88,9 +89,10 @@ expression: report
     else false
 
 @export whereIsolation = \left%54 right%55 ->
-  let
-    helper%53 = \helperLeft%56 helperRight%57 -> eq (eqArray eqInt) helperLeft%56 helperRight%57
-  in if helper%53 left%54 right%55 then eq (eqArray eqInt) left%54 right%55 else false
+  if (\helperLeft%56 helperRight%57 -> eq (eqArray eqInt) helperLeft%56 helperRight%57) left%54
+    right%55
+    then eq (eqArray eqInt) left%54 right%55
+    else false
 
 @export equationScope = \$boolean%58 $array%59 $array%60 ->
   let

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
@@ -197,12 +197,9 @@ export function lambdaScope(left) {
 
 export function whereIsolation(left) {
   return right => {
-    const helper = helperLeft => {
-      return helperRight => {
-        return Data_Eq.eq(Data_Eq.eqArray(Data_Eq.eqInt))(helperLeft)(helperRight);
-      };
-    };
-    if (helper(left)(right)) {
+    if ((helperLeft => helperRight => Data_Eq.eq(Data_Eq.eqArray(Data_Eq.eqInt))(helperLeft)(
+      helperRight
+    ))(left)(right)) {
       return Data_Eq.eq(Data_Eq.eqArray(Data_Eq.eqInt))(left)(right);
     } else {
       return false;

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.functional.snap
@@ -1,5 +1,6 @@
 ---
 source: tests-integration/tests/functional.rs
+assertion_line: 14
 expression: report
 ---
 @export identity = \value%0 -> value%0
@@ -21,41 +22,47 @@ expression: report
 
 @export inlineCapturedClosure = \captured%11 -> \$boolean%10@(_) -> captured%11
 
-@export keepMultiUseClosure = \captured%14 ->
+@export inlineAlias = \value%13 -> value%13
+
+@export inlineRepeatedAlias = \value%15 -> { first: value%15, second: value%15 }
+
+@export inlineSingleUseProperty = \record%17 -> identity record%17.value
+
+@export keepMultiUseClosure = \captured%20 ->
   let
-    closure%12 = \$boolean%13@(_) -> captured%14
-  in { first: closure%12, second: closure%12 }
+    closure%18 = \$boolean%19@(_) -> captured%20
+  in { first: closure%18, second: closure%18 }
 
-@export keepMultiUse = \record%16 ->
+@export keepMultiUse = \record%22 ->
   let
-    value%15 = record%16.value
-  in { first: value%15, second: value%15 }
+    value%21 = record%22.value
+  in { first: value%21, second: value%21 }
 
-@export inlineAcrossCall = \record%17 function%18 ->
-  { projected: record%17.value, called: function%18 true }
+@export inlineAcrossCall = \record%23 function%24 ->
+  { projected: record%23.value, called: function%24 true }
 
-@export inlineOrderedCalls = \first%19 second%20 ->
-  { first: first%19 true, second: second%20 false }
+@export inlineOrderedCalls = \first%25 second%26 ->
+  { first: first%25 true, second: second%26 false }
 
-@export keepReorderedCalls = \first%24 second%23 ->
+@export keepReorderedCalls = \first%30 second%29 ->
   let
-    firstResult%22 = first%24 true
+    firstResult%28 = first%30 true
   in let
-    secondResult%21 = second%23 false
-  in { first: secondResult%21, second: firstResult%22 }
+    secondResult%27 = second%29 false
+  in { first: secondResult%27, second: firstResult%28 }
 
-@export keepMultiUseCall = \function%26 value%27 ->
+@export keepMultiUseCall = \function%32 value%33 ->
   let
-    result%25 = function%26 value%27
-  in { first: result%25, second: result%25 }
+    result%31 = function%32 value%33
+  in { first: result%31, second: result%31 }
 
-@export keepCallBeforeBranch = \condition%28 function%31 value%30 ->
+@export keepCallBeforeBranch = \condition%34 function%37 value%36 ->
   let
-    result%29 = function%31 value%30
-  in if condition%28 then result%29 else value%30
+    result%35 = function%37 value%36
+  in if condition%34 then result%35 else value%36
 
-@export keepTestCall = \function%32 value%33 ->
-  case function%32 value%33 of
+@export keepTestCall = \function%38 value%39 ->
+  case function%38 value%39 of
     [] ->
       true
     _ ->

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.purs
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.purs
@@ -27,6 +27,21 @@ inlineRecord value = { value }
 inlineCapturedClosure :: Boolean -> Boolean -> Boolean
 inlineCapturedClosure captured = \_ -> captured
 
+inlineAlias :: Boolean -> Boolean
+inlineAlias value =
+  let alias = value
+  in alias
+
+inlineRepeatedAlias :: Boolean -> { first :: Boolean, second :: Boolean }
+inlineRepeatedAlias value =
+  let alias = value
+  in { first: alias, second: alias }
+
+inlineSingleUseProperty :: { value :: Boolean } -> Boolean
+inlineSingleUseProperty record =
+  let value = record.value
+  in identity value
+
 keepMultiUseClosure
   :: Boolean
   -> { first :: Boolean -> Boolean, second :: Boolean -> Boolean }

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.snap
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 268
+assertion_line: 262
 expression: diagnostics_report
 ---
 Terms
@@ -13,6 +13,9 @@ inlineCall :: (Prim.Boolean -> Prim.Boolean) -> Prim.Boolean -> Prim.Boolean
 inlineArray :: Prim.Boolean -> Prim.Array Prim.Boolean
 inlineRecord :: Prim.Boolean -> { value :: Prim.Boolean }
 inlineCapturedClosure :: Prim.Boolean -> Prim.Boolean -> Prim.Boolean
+inlineAlias :: Prim.Boolean -> Prim.Boolean
+inlineRepeatedAlias :: Prim.Boolean -> { first :: Prim.Boolean, second :: Prim.Boolean }
+inlineSingleUseProperty :: { value :: Prim.Boolean } -> Prim.Boolean
 keepMultiUseClosure ::
   Prim.Boolean -> { first :: Prim.Boolean -> Prim.Boolean, second :: Prim.Boolean -> Prim.Boolean }
 keepMultiUse :: { value :: Prim.Boolean } -> { first :: Prim.Boolean, second :: Prim.Boolean }

--- a/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787296860_single_use_javascript_inlining/output/Main/index.js
@@ -40,6 +40,18 @@ export function inlineCapturedClosure(captured) {
   return $boolean => captured;
 }
 
+export function inlineAlias(value) {
+  return value;
+}
+
+export function inlineRepeatedAlias(value) {
+  return { first: value, second: value };
+}
+
+export function inlineSingleUseProperty(record) {
+  return identity(record.value);
+}
+
 export function keepMultiUseClosure(captured) {
   const closure = $boolean => {
     return captured;

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/Main.functional.snap
@@ -1,5 +1,6 @@
 ---
 source: tests-integration/tests/functional.rs
+assertion_line: 14
 expression: report
 ---
 @export foreign same
@@ -36,10 +37,8 @@ in same first%5.value second%6
 
 @export letRecursive = \condition%13 ->
   let
-    rec go%12 = let
-      wrapped%14 = \current%15 ->
-        if current%15 then go%12 false else 40
-    in wrapped%14
+    rec go%12 = \current%15 ->
+      if current%15 then go%12 false else 40
   in go%12 condition%13
 
 @export strictCycle = \$boolean%17@(_) ->

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/Main/index.js
@@ -58,18 +58,13 @@ export function caseRecursive(condition) {
 }
 
 export function letRecursive(condition) {
-  let $lazy_go;
-  $lazy_go = $runtime.binding("go", () => {
-    const wrapped = current => {
-      if (current) {
-        return $lazy_go()(false);
-      } else {
-        return 40 | 0;
-      }
-    };
-    return wrapped;
-  });
-  const go = $lazy_go();
+  const go = current => {
+    if (current) {
+      return go(false);
+    } else {
+      return 40 | 0;
+    }
+  };
   return go(condition);
 }
 

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.functional.snap
@@ -1,5 +1,6 @@
 ---
 source: tests-integration/tests/functional.rs
+assertion_line: 14
 expression: report
 ---
 @export foreign observe
@@ -10,14 +11,16 @@ expression: report
 
 @export integerAdd = \left%1 right%2 -> integer.add left%1 right%2
 
-@export integerSubtract = \left%3 right%4 -> integer.subtract left%3 right%4
+@export inlineIntegerAdd = \left%4 right%5 -> integer.add left%4 right%5
 
-@export integerMultiply = \left%5 right%6 -> integer.multiply left%5 right%6
+@export integerSubtract = \left%6 right%7 -> integer.subtract left%6 right%7
 
-@export integerNegate = \value%7 -> integer.negate value%7
+@export integerMultiply = \left%8 right%9 -> integer.multiply left%8 right%9
 
-@export integerAddOrder = \$boolean%8@(_) -> integer.add (observe "left" 20) (observe "right" 22)
+@export integerNegate = \value%10 -> integer.negate value%10
+
+@export integerAddOrder = \$boolean%11@(_) -> integer.add (observe "left" 20) (observe "right" 22)
 
 @export partiallyAppliedAdd = add semiringInt 1
 
-@export lookalikeAdd = \left%9 right%10 -> add semiringInt left%9 right%10
+@export lookalikeAdd = \left%12 right%13 -> add semiringInt left%12 right%13

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.purs
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.purs
@@ -14,6 +14,11 @@ booleanNot value = HeytingAlgebra.not value
 integerAdd :: Int -> Int -> Int
 integerAdd left right = Semiring.add left right
 
+inlineIntegerAdd :: Int -> Int -> Int
+inlineIntegerAdd left right =
+  let result = Semiring.add left right
+  in result
+
 integerSubtract :: Int -> Int -> Int
 integerSubtract left right = Ring.sub left right
 

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.snap
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 268
+assertion_line: 262
 expression: diagnostics_report
 ---
 Terms
@@ -8,6 +8,7 @@ observe :: forall value. Prim.String -> value -> value
 readTrace :: Prim.Boolean -> Prim.Array Prim.String
 booleanNot :: Prim.Boolean -> Prim.Boolean
 integerAdd :: Prim.Int -> Prim.Int -> Prim.Int
+inlineIntegerAdd :: Prim.Int -> Prim.Int -> Prim.Int
 integerSubtract :: Prim.Int -> Prim.Int -> Prim.Int
 integerMultiply :: Prim.Int -> Prim.Int -> Prim.Int
 integerNegate :: Prim.Int -> Prim.Int

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Main/index.js
@@ -12,6 +12,12 @@ export function integerAdd(left) {
   };
 }
 
+export function inlineIntegerAdd(left) {
+  return right => {
+    return left + right | 0;
+  };
+}
+
 export function integerSubtract(left) {
   return right => {
     return left - right | 0;

--- a/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/Main.functional.snap
@@ -1,11 +1,10 @@
 ---
 source: tests-integration/tests/functional.rs
+assertion_line: 14
 expression: report
 ---
 @export constructor Pair/2
 
 @export identity = \value%0 -> value%0
 
-@export use = let
-  alias%1 = identity
-in Pair (alias%1 42) (alias%1 "x")
+@export use = Pair (identity 42) (identity "x")

--- a/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787591220_polymorphic_function_alias/output/Main/index.js
@@ -4,7 +4,4 @@ export function identity(value) {
   return value;
 }
 
-export const use = (() => {
-  const alias = identity;
-  return Pair(alias(42 | 0))(alias("x"));
-})();
+export const use = Pair(identity(42 | 0))(identity("x"));

--- a/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/Main.functional.snap
@@ -1,11 +1,8 @@
 ---
 source: tests-integration/tests/functional.rs
+assertion_line: 14
 expression: report
 ---
 @export name = \dictionary%0 -> dictionary%0.name
 
-@export use = \namedBodyDict%1 ->
-  \$body%3@(_) ->
-    let
-      alias%2 = name
-    in alias%2 namedBodyDict%1
+@export use = \namedBodyDict%1 -> \$body%3@(_) -> name namedBodyDict%1

--- a/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787591220_visible_type_applied_class_member_alias/output/Main/index.js
@@ -3,9 +3,5 @@ export function name(dictionary) {
 }
 
 export function use(namedBodyDict) {
-  const $closure = $body => {
-    const alias = name;
-    return alias(namedBodyDict);
-  };
-  return $closure;
+  return $body => name(namedBodyDict);
 }

--- a/tests-integration/fixtures/backend/1787591220_where_bound_class_member/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787591220_where_bound_class_member/Main.functional.snap
@@ -1,19 +1,12 @@
 ---
 source: tests-integration/tests/functional.rs
+assertion_line: 14
 expression: report
 ---
 @export name = \dictionary%0 -> dictionary%0.name
 
 @export instance namedString = { name: \value%1 -> value%1 }
 
-@export use = \namedADict%2 ->
-  \value%4 ->
-    let
-      alias%3 = name
-    in alias%3 namedADict%2 value%4
+@export use = \namedADict%2 -> \value%4 -> name namedADict%2 value%4
 
-@export useLet = \namedADict%5 ->
-  \value%7 ->
-    let
-      alias%6 = name
-    in alias%6 namedADict%5 value%7
+@export useLet = \namedADict%5 -> \value%7 -> name namedADict%5 value%7

--- a/tests-integration/fixtures/backend/1787591220_where_bound_class_member/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787591220_where_bound_class_member/output/Main/index.js
@@ -3,19 +3,11 @@ export function name(dictionary) {
 }
 
 export function use(namedADict) {
-  const $closure = value => {
-    const alias = name;
-    return alias(namedADict)(value);
-  };
-  return $closure;
+  return value => name(namedADict)(value);
 }
 
 export function useLet(namedADict) {
-  const $closure = value => {
-    const alias = name;
-    return alias(namedADict)(value);
-  };
-  return $closure;
+  return value => name(namedADict)(value);
 }
 
 export const namedString = { name: value => value };


### PR DESCRIPTION
## Summary

- add a shared functional-tree optimization that substitutes trivial aliases and single-use simple expressions
- retain applications, effects, control flow, repeated nontrivial work, recursive bindings, and recursive globals to preserve strict evaluation behavior
- update functional and JavaScript fixtures for compact alias, projection, closure, and integer primitive output

## Verification

- `just t backend`
- `cargo check -p functional --tests`
- `cargo check -p javascript --tests`
- `cargo doc -p functional --no-deps`