### PR TITLE
[ci] Cache package compatibility artifacts

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -70,6 +70,21 @@ jobs:
       - name: Install Rust toolchain
         run: rustup update stable && rustup default stable
 
+      - name: Cache compatibility build and package artifacts
+        uses: Swatinem/rust-cache@v2.9.1
+        with:
+          cache-bin: "false"
+          cache-directories: |
+            compatibility-cache/downloads
+            compatibility-cache/sources
+          cache-on-failure: "true"
+          key: >-
+            ${{ github.event.pull_request.base.sha }}-${{ hashFiles('base/tests-compatibility/purescript-*.txt', 'candidate/tests-compatibility/purescript-*.txt') }}
+          prefix-key: "v1-compatibility"
+          workspaces: |
+            base -> target
+            candidate -> target
+
       - name: Build compatibility verifiers
         run: |
           cargo build --release --manifest-path base/Cargo.toml -p tests-compatibility
@@ -77,12 +92,20 @@ jobs:
 
       - name: Prepare core and Acme corpus
         working-directory: candidate
-        run: target/release/tests-compatibility prepare --preset core --preset acme
+        env:
+          CORPUS_DIR: ${{ github.workspace }}/compatibility-cache
+        run: |
+          target/release/tests-compatibility prepare \
+            --preset core \
+            --preset acme \
+            --registry-dir "$CORPUS_DIR/registry" \
+            --index-dir "$CORPUS_DIR/registry-index" \
+            --cache-dir "$CORPUS_DIR"
 
       - name: Collect base and candidate reports
         id: reports
         env:
-          CORPUS_DIR: ${{ github.workspace }}/candidate/target/compatibility
+          CORPUS_DIR: ${{ github.workspace }}/compatibility-cache
           REPORT_DIR: ${{ github.workspace }}/compatibility-artifacts
         run: |
           mkdir -p "$REPORT_DIR"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -93,19 +93,18 @@ jobs:
       - name: Prepare core and Acme corpus
         working-directory: candidate
         env:
-          CORPUS_DIR: ${{ github.workspace }}/compatibility-cache
+          PACKAGE_CACHE_DIR: ${{ github.workspace }}/compatibility-cache
         run: |
           target/release/tests-compatibility prepare \
             --preset core \
             --preset acme \
-            --registry-dir "$CORPUS_DIR/registry" \
-            --index-dir "$CORPUS_DIR/registry-index" \
-            --cache-dir "$CORPUS_DIR"
+            --cache-dir "$PACKAGE_CACHE_DIR"
 
       - name: Collect base and candidate reports
         id: reports
         env:
-          CORPUS_DIR: ${{ github.workspace }}/compatibility-cache
+          CORPUS_DIR: ${{ github.workspace }}/candidate/target/compatibility
+          PACKAGE_CACHE_DIR: ${{ github.workspace }}/compatibility-cache
           REPORT_DIR: ${{ github.workspace }}/compatibility-artifacts
         run: |
           mkdir -p "$REPORT_DIR"
@@ -119,7 +118,7 @@ jobs:
               --preset acme \
               --registry-dir "$CORPUS_DIR/registry" \
               --index-dir "$CORPUS_DIR/registry-index" \
-              --cache-dir "$CORPUS_DIR" \
+              --cache-dir "$PACKAGE_CACHE_DIR" \
               --json-output "$REPORT_DIR/base.json"
           ) > "$REPORT_DIR/base.log" 2>&1
           base_status=$?
@@ -131,7 +130,7 @@ jobs:
               --preset acme \
               --registry-dir "$CORPUS_DIR/registry" \
               --index-dir "$CORPUS_DIR/registry-index" \
-              --cache-dir "$CORPUS_DIR" \
+              --cache-dir "$PACKAGE_CACHE_DIR" \
               --json-output "$REPORT_DIR/candidate.json"
           ) > "$REPORT_DIR/candidate.log" 2>&1
           candidate_status=$?


### PR DESCRIPTION
## Summary

Cache both release-build dependencies and the downloaded package corpus used by the package compatibility job. The cache key follows the base revision and the core/Acme package lists, while registry checkouts remain fresh for each run.

This reduces repeated compilation and package extraction without changing which package set the verifier selects. Compatibility artifacts are retained even when the job reports a regression, so follow-up revisions can reuse them.

## Verification

- Ran `just compatibility` against `origin/main`: 631 packages and 7,356 source files checked with no regressions
- Ran the verifier's `prepare` and `verify` commands with the CI-specific external corpus path; both exited successfully
- Validated `.github/workflows/checks.yml` with `yaml-lint` and `git diff --check`