### PR TITLE
[javascript] Reduce rendering intermediates

### DIFF
--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -83,6 +83,12 @@ struct PatternPlan {
     bindings: Vec<(String, ExpressionId)>,
 }
 
+// Pending expressions must be evaluated before rendering an eager later sibling.
+struct RenderedExpression {
+    value: ExpressionId,
+    pending_evaluation: bool,
+}
+
 struct ModuleRenderer<'a, 'm, 'd> {
     generator: &'a Generator<'m>,
     tree: &'a mut Tree,
@@ -676,101 +682,193 @@ impl Generator<'_> {
         expression: FunctionalExpressionId,
         context: &mut FunctionContext,
     ) -> ModuleResult<ExpressionId> {
+        let expression = self.rendered_expression(tree, writer, expression, context)?;
+        Ok(expression.value)
+    }
+
+    fn rendered_expression(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        expression: FunctionalExpressionId,
+        context: &mut FunctionContext,
+    ) -> ModuleResult<RenderedExpression> {
         if let Some(expression) = self.try_inline_expression(tree, expression, context)? {
-            return Ok(expression);
+            return Ok(RenderedExpression { value: expression, pending_evaluation: true });
         }
+        self.render_non_inline_expression(tree, writer, expression, context)
+    }
+
+    fn render_non_inline_expression(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        expression: FunctionalExpressionId,
+        context: &mut FunctionContext,
+    ) -> ModuleResult<RenderedExpression> {
         match &self.module.storage[expression].kind {
             ExpressionKind::Array { elements } => {
                 let mut values = Vec::with_capacity(elements.len());
                 for element in elements.iter() {
-                    let value = self.expression_value(tree, writer, *element, context)?;
-                    let value = self.materialize_value(tree, writer, value, "$element", context);
+                    let value =
+                        if let Some(value) = self.try_inline_expression(tree, *element, context)? {
+                            RenderedExpression { value, pending_evaluation: true }
+                        } else {
+                            if self.expression_rendering_is_eager(*element) {
+                                self.materialize_rendered_expressions(
+                                    tree,
+                                    writer,
+                                    &mut values,
+                                    "$element",
+                                    context,
+                                );
+                            }
+                            self.render_non_inline_expression(tree, writer, *element, context)?
+                        };
                     values.push(value);
                 }
-                let array = tree.array(values);
-                Ok(self.materialize_value(tree, writer, array, "$array", context))
+                let values = values.into_iter().map(|value| value.value).collect();
+                let value = tree.array(values);
+                Ok(RenderedExpression { value, pending_evaluation: true })
             }
             ExpressionKind::Record { fields } => {
-                let mut properties = Vec::with_capacity(fields.len());
+                let mut rendered_fields = Vec::with_capacity(fields.len());
                 for field in fields.iter() {
-                    let value = self.expression_value(tree, writer, field.expression, context)?;
-                    let value = self.materialize_value(tree, writer, value, "$field", context);
-                    properties
-                        .push(ObjectProperty::Field { name: field.field.name.to_string(), value });
+                    let value = if let Some(value) =
+                        self.try_inline_expression(tree, field.expression, context)?
+                    {
+                        RenderedExpression { value, pending_evaluation: true }
+                    } else {
+                        if self.expression_rendering_is_eager(field.expression) {
+                            let values = rendered_fields.iter_mut().map(|(_, value)| value);
+                            for value in values {
+                                self.materialize_rendered_expression(
+                                    tree, writer, value, "$field", context,
+                                );
+                            }
+                        }
+                        self.render_non_inline_expression(tree, writer, field.expression, context)?
+                    };
+                    rendered_fields.push((field.field.name.to_string(), value));
                 }
-                let record = tree.object(properties);
-                Ok(self.materialize_value(tree, writer, record, "$record", context))
+                let properties = rendered_fields
+                    .into_iter()
+                    .map(|(name, value)| ObjectProperty::Field { name, value: value.value });
+                let value = tree.object(properties.collect());
+                Ok(RenderedExpression { value, pending_evaluation: true })
             }
             ExpressionKind::RecordUpdate { record, updates } => {
-                let update =
+                let value =
                     self.record_update_expression(tree, writer, *record, updates, context)?;
-                Ok(self.materialize_value(tree, writer, update, "$update", context))
+                Ok(RenderedExpression { value, pending_evaluation: true })
             }
             ExpressionKind::Project { record, field } => {
-                let record = self.expression_value(tree, writer, *record, context)?;
-                let record = self.materialize_value(tree, writer, record, "$record", context);
-                let value = tree.member(record, field.name.as_str());
-                Ok(self.materialize_value(tree, writer, value, "$field", context))
+                let record = self.rendered_expression(tree, writer, *record, context)?;
+                let value = tree.member(record.value, field.name.as_str());
+                Ok(RenderedExpression { value, pending_evaluation: true })
             }
             ExpressionKind::Unary { operator, value } => {
-                let value = self.expression_value(tree, writer, *value, context)?;
-                let value = self.materialize_value(tree, writer, value, "$operand", context);
-                let result = unary_expression(tree, *operator, value);
-                Ok(self.materialize_value(tree, writer, result, "$result", context))
+                let value = self.rendered_expression(tree, writer, *value, context)?;
+                let value = unary_expression(tree, *operator, value.value);
+                Ok(RenderedExpression { value, pending_evaluation: true })
             }
             ExpressionKind::Binary { operator, left, right } => {
-                let left = self.expression_value(tree, writer, *left, context)?;
-                let left = self.materialize_value(tree, writer, left, "$left", context);
-                let right = self.expression_value(tree, writer, *right, context)?;
-                let right = self.materialize_value(tree, writer, right, "$right", context);
-                let result = binary_expression(tree, *operator, left, right);
-                Ok(self.materialize_value(tree, writer, result, "$result", context))
+                let mut left = self.rendered_expression(tree, writer, *left, context)?;
+                let right =
+                    if let Some(value) = self.try_inline_expression(tree, *right, context)? {
+                        RenderedExpression { value, pending_evaluation: true }
+                    } else {
+                        if self.expression_rendering_is_eager(*right) {
+                            self.materialize_rendered_expression(
+                                tree, writer, &mut left, "$left", context,
+                            );
+                        }
+                        self.render_non_inline_expression(tree, writer, *right, context)?
+                    };
+                let value = binary_expression(tree, *operator, left.value, right.value);
+                Ok(RenderedExpression { value, pending_evaluation: true })
             }
             ExpressionKind::Abstraction { parameters, body } => {
                 let name = context.allocate("$closure");
                 self.render_abstraction_binding(
                     tree, writer, &name, parameters, *body, false, context,
                 )?;
-                Ok(tree.identifier(name))
+                let value = tree.identifier(name);
+                Ok(RenderedExpression { value, pending_evaluation: false })
             }
             ExpressionKind::UncurriedAbstraction { parameters, body } => {
                 let name = context.allocate("$closure");
                 self.render_abstraction_binding(
                     tree, writer, &name, parameters, *body, true, context,
                 )?;
-                Ok(tree.identifier(name))
+                let value = tree.identifier(name);
+                Ok(RenderedExpression { value, pending_evaluation: false })
             }
             ExpressionKind::Application { function, arguments } => {
-                let function = self.expression_value(tree, writer, *function, context)?;
-                let mut function =
-                    self.materialize_value(tree, writer, function, "$function", context);
+                let mut function = self.rendered_expression(tree, writer, *function, context)?;
                 if arguments.is_empty() {
-                    let call = tree.call(function, vec![]);
-                    return Ok(self.materialize_value(tree, writer, call, "$call", context));
+                    let value = tree.call(function.value, vec![]);
+                    return Ok(RenderedExpression { value, pending_evaluation: true });
                 }
                 for argument in arguments.iter() {
-                    let value = self.expression_value(tree, writer, *argument, context)?;
-                    let value = self.materialize_value(tree, writer, value, "$argument", context);
-                    let call = tree.call(function, vec![value]);
-                    function = self.materialize_value(tree, writer, call, "$call", context);
+                    let argument = if let Some(value) =
+                        self.try_inline_expression(tree, *argument, context)?
+                    {
+                        RenderedExpression { value, pending_evaluation: true }
+                    } else {
+                        if self.expression_rendering_is_eager(*argument) {
+                            self.materialize_rendered_expression(
+                                tree,
+                                writer,
+                                &mut function,
+                                "$function",
+                                context,
+                            );
+                        }
+                        self.render_non_inline_expression(tree, writer, *argument, context)?
+                    };
+                    let value = tree.call(function.value, vec![argument.value]);
+                    function = RenderedExpression { value, pending_evaluation: true };
                 }
                 Ok(function)
             }
             ExpressionKind::UncurriedApplication { function, arguments } => {
-                let function = self.expression_value(tree, writer, *function, context)?;
-                let function = self.materialize_value(tree, writer, function, "$function", context);
+                let mut function = self.rendered_expression(tree, writer, *function, context)?;
                 let mut values = Vec::with_capacity(arguments.len());
                 for argument in arguments.iter() {
-                    let value = self.expression_value(tree, writer, *argument, context)?;
-                    let value = self.materialize_value(tree, writer, value, "$argument", context);
+                    let value = if let Some(value) =
+                        self.try_inline_expression(tree, *argument, context)?
+                    {
+                        RenderedExpression { value, pending_evaluation: true }
+                    } else {
+                        if self.expression_rendering_is_eager(*argument) {
+                            self.materialize_rendered_expression(
+                                tree,
+                                writer,
+                                &mut function,
+                                "$function",
+                                context,
+                            );
+                            self.materialize_rendered_expressions(
+                                tree,
+                                writer,
+                                &mut values,
+                                "$argument",
+                                context,
+                            );
+                        }
+                        self.render_non_inline_expression(tree, writer, *argument, context)?
+                    };
                     values.push(value);
                 }
-                let call = tree.call(function, values);
-                Ok(self.materialize_value(tree, writer, call, "$call", context))
+                let values = values.into_iter().map(|value| value.value).collect();
+                let value = tree.call(function.value, values);
+                Ok(RenderedExpression { value, pending_evaluation: true })
             }
             ExpressionKind::Effect { effect } => {
                 let mut renderer = self.renderer(tree, writer, context);
-                effect_expression(&mut renderer, effect)
+                let value = effect_expression(&mut renderer, effect)?;
+                Ok(RenderedExpression { value, pending_evaluation: false })
             }
             ExpressionKind::IfThenElse { .. }
             | ExpressionKind::Case { .. }
@@ -786,7 +884,8 @@ impl Generator<'_> {
                     Destination::Assign(&name),
                     context,
                 )?;
-                Ok(tree.identifier(name))
+                let value = tree.identifier(name);
+                Ok(RenderedExpression { value, pending_evaluation: false })
             }
             ExpressionKind::Literal { .. }
             | ExpressionKind::Constructor { .. }
@@ -796,6 +895,47 @@ impl Generator<'_> {
             | ExpressionKind::TrivialEvidence => {
                 unreachable!("invariant violated: atomic functional expression was not inlineable")
             }
+        }
+    }
+
+    fn expression_rendering_is_eager(&self, expression: FunctionalExpressionId) -> bool {
+        match &self.module.storage[expression].kind {
+            ExpressionKind::Literal { .. }
+            | ExpressionKind::Constructor { .. }
+            | ExpressionKind::Global { .. }
+            | ExpressionKind::Local { .. }
+            | ExpressionKind::Abstraction { .. }
+            | ExpressionKind::UncurriedAbstraction { .. }
+            | ExpressionKind::SynthesizedEvidence { .. }
+            | ExpressionKind::TrivialEvidence => false,
+            ExpressionKind::Array { elements } => {
+                elements.iter().any(|element| self.expression_rendering_is_eager(*element))
+            }
+            ExpressionKind::Record { fields } => {
+                fields.iter().any(|field| self.expression_rendering_is_eager(field.expression))
+            }
+            ExpressionKind::Project { record, .. }
+            | ExpressionKind::Unary { value: record, .. } => {
+                self.expression_rendering_is_eager(*record)
+            }
+            ExpressionKind::Binary { left, right, .. } => {
+                self.expression_rendering_is_eager(*left)
+                    || self.expression_rendering_is_eager(*right)
+            }
+            ExpressionKind::Application { function, arguments }
+            | ExpressionKind::UncurriedApplication { function, arguments } => {
+                self.expression_rendering_is_eager(*function)
+                    || arguments
+                        .iter()
+                        .any(|argument| self.expression_rendering_is_eager(*argument))
+            }
+            ExpressionKind::RecordUpdate { .. }
+            | ExpressionKind::IfThenElse { .. }
+            | ExpressionKind::Case { .. }
+            | ExpressionKind::Guarded { .. }
+            | ExpressionKind::Let { .. }
+            | ExpressionKind::LetPattern { .. }
+            | ExpressionKind::Effect { .. } => true,
         }
     }
 
@@ -1586,6 +1726,35 @@ impl Generator<'_> {
         let name = context.allocate("$scrutinee");
         writer.expression_line(format!("const {name} = "), tree, value, ";");
         tree.identifier(name)
+    }
+
+    fn materialize_rendered_expression(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        expression: &mut RenderedExpression,
+        preferred: &str,
+        context: &mut FunctionContext,
+    ) {
+        if !expression.pending_evaluation {
+            return;
+        }
+        expression.value =
+            self.materialize_value(tree, writer, expression.value, preferred, context);
+        expression.pending_evaluation = false;
+    }
+
+    fn materialize_rendered_expressions(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        expressions: &mut [RenderedExpression],
+        preferred: &str,
+        context: &mut FunctionContext,
+    ) {
+        for expression in expressions {
+            self.materialize_rendered_expression(tree, writer, expression, preferred, context);
+        }
     }
 
     fn materialize_value(

--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -609,13 +609,15 @@ impl Generator<'_> {
             }
             ExpressionKind::LetPattern { pattern, value, body } => {
                 let source = *value;
-                let value = self.expression_value(tree, writer, source, context)?;
+                let value = self.rendered_expression(tree, writer, source, context)?;
                 let value = self.materialize_pattern_value(tree, writer, source, value, context);
                 let plan = self.pattern_plan(tree, *pattern, value, None, context)?;
                 self.render_pattern_scope(tree, writer, plan, context, |tree, writer, context| {
                     self.render_expression(tree, writer, *body, destination, context)
                 })
             }
+            ExpressionKind::Effect { effect } if !destination.is_effect() => self
+                .render_effect_expression_destination(tree, writer, effect, destination, context),
             _ => {
                 if destination.is_effect() {
                     return self.render_effect_destination(
@@ -674,6 +676,38 @@ impl Generator<'_> {
         let effect = self.expression_value(tree, writer, expression, context)?;
         let value = tree.call(effect, vec![]);
         self.render_destination(tree, writer, value, destination);
+        Ok(())
+    }
+
+    fn render_effect_expression_destination(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        effect: &EffectExpression,
+        destination: Destination<'_>,
+        context: &mut FunctionContext,
+    ) -> ModuleResult<()> {
+        let mut renderer = self.renderer(tree, writer, context);
+        let effect = capture_effect(&mut renderer, effect)?;
+        let (header, break_label) = match destination {
+            Destination::Return => ("return () => {".to_owned(), None),
+            Destination::Assign(name) => (format!("{name} = () => {{"), None),
+            Destination::AssignAndBreak { name, label } => {
+                (format!("{name} = () => {{"), Some(label))
+            }
+            Destination::EffectReturn
+            | Destination::EffectAssign(_)
+            | Destination::EffectAssignAndBreak { .. } => {
+                unreachable!("invariant violated: effect destination returned an effect thunk")
+            }
+        };
+        writer.block(header, "};", |writer| {
+            let mut renderer = self.renderer(tree, writer, context);
+            execute_effect(&mut renderer, effect, Destination::Return)
+        })?;
+        if let Some(label) = break_label {
+            writer.line(format!("break {label};"));
+        }
         Ok(())
     }
 
@@ -1370,7 +1404,7 @@ fn render_case(
     let context = &mut *renderer.context;
     let mut values = Vec::with_capacity(scrutinees.len());
     for scrutinee in scrutinees {
-        let value = generator.expression_value(tree, writer, *scrutinee, context)?;
+        let value = generator.rendered_expression(tree, writer, *scrutinee, context)?;
         let value = generator.materialize_pattern_value(tree, writer, *scrutinee, value, context);
         values.push(value);
     }
@@ -1591,7 +1625,7 @@ impl Generator<'_> {
             }
             Guard::Pattern { expression: value, pattern } => {
                 let source = *value;
-                let value = self.expression_value(tree, writer, source, context)?;
+                let value = self.rendered_expression(tree, writer, source, context)?;
                 let value = self.materialize_pattern_value(tree, writer, source, value, context);
                 let plan = self.pattern_plan(tree, *pattern, value, None, context)?;
                 let condition = combine_conditions(tree, &plan.conditions);
@@ -1780,20 +1814,22 @@ impl Generator<'_> {
         tree: &mut Tree,
         writer: &mut Writer<'_>,
         source: FunctionalExpressionId,
-        value: ExpressionId,
+        value: RenderedExpression,
         context: &mut FunctionContext,
     ) -> ExpressionId {
-        if matches!(
-            self.module.storage[source].kind,
-            ExpressionKind::Literal { .. }
-                | ExpressionKind::Constructor { .. }
-                | ExpressionKind::Global { .. }
-                | ExpressionKind::Local { .. }
-        ) {
-            return value;
+        if !value.pending_evaluation
+            || matches!(
+                self.module.storage[source].kind,
+                ExpressionKind::Literal { .. }
+                    | ExpressionKind::Constructor { .. }
+                    | ExpressionKind::Global { .. }
+                    | ExpressionKind::Local { .. }
+            )
+        {
+            return value.value;
         }
         let name = context.allocate("$scrutinee");
-        writer.expression_line(format!("const {name} = "), tree, value, ";");
+        writer.expression_line(format!("const {name} = "), tree, value.value, ";");
         tree.identifier(name)
     }
 
@@ -1805,7 +1841,7 @@ impl Generator<'_> {
         preferred: &str,
         context: &mut FunctionContext,
     ) {
-        if !expression.pending_evaluation {
+        if rendered_expression_is_reusable(tree, expression) {
             return;
         }
         expression.value =
@@ -1978,9 +2014,13 @@ fn capture_effect_value(
     let tree = &mut *renderer.tree;
     let writer = &mut *renderer.writer;
     let context = &mut *renderer.context;
-    let value = generator.expression_value(tree, writer, expression, context)?;
+    let expression_is_reusable = generator.functional_expression_is_reusable(expression, context);
+    let value = generator.rendered_expression(tree, writer, expression, context)?;
+    if expression_is_reusable || rendered_expression_is_reusable(tree, &value) {
+        return Ok(value.value);
+    }
     let name = context.allocate(preferred_name);
-    writer.expression_line(format!("const {name} = "), tree, value, ";");
+    writer.expression_line(format!("const {name} = "), tree, value.value, ";");
     Ok(tree.identifier(name))
 }
 
@@ -2011,7 +2051,7 @@ fn execute_effect(
             )
         }
         CapturedEffect::Map { function, action } => {
-            let (value, _) = execute_effect_action(renderer, action, "$value")?;
+            let value = execute_effect_action_value(renderer, action, "$value")?;
             let result = renderer.tree.call(function, vec![value]);
             renderer.generator.render_destination(
                 renderer.tree,
@@ -2022,8 +2062,12 @@ fn execute_effect(
             Ok(())
         }
         CapturedEffect::Apply { function_action, argument_action } => {
-            let (function, _) = execute_effect_action(renderer, function_action, "$function")?;
-            let (argument, _) = execute_effect_action(renderer, argument_action, "$argument")?;
+            let function = if matches!(&argument_action, CapturedEffectAction::Effect(_)) {
+                execute_effect_action(renderer, function_action, "$function")?.0
+            } else {
+                execute_effect_action_value(renderer, function_action, "$function")?
+            };
+            let argument = execute_effect_action_value(renderer, argument_action, "$argument")?;
             let result = renderer.tree.call(function, vec![argument]);
             renderer.generator.render_destination(
                 renderer.tree,
@@ -2032,6 +2076,22 @@ fn execute_effect(
                 destination,
             );
             Ok(())
+        }
+    }
+}
+
+fn execute_effect_action_value(
+    renderer: &mut FunctionRenderer<'_, '_, '_>,
+    action: CapturedEffectAction,
+    preferred_name: &str,
+) -> ModuleResult<ExpressionId> {
+    match action {
+        CapturedEffectAction::Expression(action) => Ok(renderer.tree.call(action, vec![])),
+        CapturedEffectAction::Effect(effect) => {
+            let name = renderer.context.allocate(preferred_name);
+            renderer.writer.line(format!("let {name};"));
+            execute_effect(renderer, *effect, Destination::Assign(&name))?;
+            Ok(renderer.tree.identifier(name))
         }
     }
 }

--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -20,7 +20,9 @@ use super::super::names::NameAllocator;
 use crate::error::{ModuleError, ModuleResult, UnsupportedState};
 use crate::module::{Module, module_filename, runtime_filename};
 use crate::pretty::Writer;
-use crate::tree::{BinaryOperator, ExpressionId, ObjectProperty, Tree};
+use crate::tree::{
+    BinaryOperator, Expression as JavascriptExpression, ExpressionId, ObjectProperty, Tree,
+};
 
 use self::analysis::{VisitState, visit_initializer};
 use self::inline::{is_abstraction, pattern_parameter};
@@ -714,7 +716,7 @@ impl Generator<'_> {
                         if let Some(value) = self.try_inline_expression(tree, *element, context)? {
                             RenderedExpression { value, pending_evaluation: true }
                         } else {
-                            if self.expression_rendering_is_eager(*element) {
+                            if self.expression_rendering_is_eager(*element, context) {
                                 self.materialize_rendered_expressions(
                                     tree,
                                     writer,
@@ -739,7 +741,7 @@ impl Generator<'_> {
                     {
                         RenderedExpression { value, pending_evaluation: true }
                     } else {
-                        if self.expression_rendering_is_eager(field.expression) {
+                        if self.expression_rendering_is_eager(field.expression, context) {
                             let values = rendered_fields.iter_mut().map(|(_, value)| value);
                             for value in values {
                                 self.materialize_rendered_expression(
@@ -778,7 +780,7 @@ impl Generator<'_> {
                     if let Some(value) = self.try_inline_expression(tree, *right, context)? {
                         RenderedExpression { value, pending_evaluation: true }
                     } else {
-                        if self.expression_rendering_is_eager(*right) {
+                        if self.expression_rendering_is_eager(*right, context) {
                             self.materialize_rendered_expression(
                                 tree, writer, &mut left, "$left", context,
                             );
@@ -816,7 +818,7 @@ impl Generator<'_> {
                     {
                         RenderedExpression { value, pending_evaluation: true }
                     } else {
-                        if self.expression_rendering_is_eager(*argument) {
+                        if self.expression_rendering_is_eager(*argument, context) {
                             self.materialize_rendered_expression(
                                 tree,
                                 writer,
@@ -841,7 +843,7 @@ impl Generator<'_> {
                     {
                         RenderedExpression { value, pending_evaluation: true }
                     } else {
-                        if self.expression_rendering_is_eager(*argument) {
+                        if self.expression_rendering_is_eager(*argument, context) {
                             self.materialize_rendered_expression(
                                 tree,
                                 writer,
@@ -898,7 +900,11 @@ impl Generator<'_> {
         }
     }
 
-    fn expression_rendering_is_eager(&self, expression: FunctionalExpressionId) -> bool {
+    fn expression_rendering_is_eager(
+        &self,
+        expression: FunctionalExpressionId,
+        context: &FunctionContext,
+    ) -> bool {
         match &self.module.storage[expression].kind {
             ExpressionKind::Literal { .. }
             | ExpressionKind::Constructor { .. }
@@ -909,33 +915,96 @@ impl Generator<'_> {
             | ExpressionKind::SynthesizedEvidence { .. }
             | ExpressionKind::TrivialEvidence => false,
             ExpressionKind::Array { elements } => {
-                elements.iter().any(|element| self.expression_rendering_is_eager(*element))
+                elements.iter().any(|element| self.expression_rendering_is_eager(*element, context))
             }
-            ExpressionKind::Record { fields } => {
-                fields.iter().any(|field| self.expression_rendering_is_eager(field.expression))
+            ExpressionKind::Record { fields } => fields
+                .iter()
+                .any(|field| self.expression_rendering_is_eager(field.expression, context)),
+            ExpressionKind::RecordUpdate { record, updates } => {
+                self.expression_rendering_is_eager(*record, context)
+                    || record_updates_reuse_source(updates)
+                        && !self.functional_expression_is_reusable(*record, context)
+                    || self.record_updates_rendering_is_eager(updates, context)
             }
             ExpressionKind::Project { record, .. }
             | ExpressionKind::Unary { value: record, .. } => {
-                self.expression_rendering_is_eager(*record)
+                self.expression_rendering_is_eager(*record, context)
             }
             ExpressionKind::Binary { left, right, .. } => {
-                self.expression_rendering_is_eager(*left)
-                    || self.expression_rendering_is_eager(*right)
+                self.expression_rendering_is_eager(*left, context)
+                    || self.expression_rendering_is_eager(*right, context)
             }
             ExpressionKind::Application { function, arguments }
             | ExpressionKind::UncurriedApplication { function, arguments } => {
-                self.expression_rendering_is_eager(*function)
+                self.expression_rendering_is_eager(*function, context)
                     || arguments
                         .iter()
-                        .any(|argument| self.expression_rendering_is_eager(*argument))
+                        .any(|argument| self.expression_rendering_is_eager(*argument, context))
             }
-            ExpressionKind::RecordUpdate { .. }
-            | ExpressionKind::IfThenElse { .. }
+            ExpressionKind::IfThenElse { .. }
             | ExpressionKind::Case { .. }
             | ExpressionKind::Guarded { .. }
             | ExpressionKind::Let { .. }
             | ExpressionKind::LetPattern { .. }
             | ExpressionKind::Effect { .. } => true,
+        }
+    }
+
+    fn functional_expression_is_reusable(
+        &self,
+        expression: FunctionalExpressionId,
+        context: &FunctionContext,
+    ) -> bool {
+        match &self.module.storage[expression].kind {
+            ExpressionKind::Literal { .. } => true,
+            ExpressionKind::Constructor { global } | ExpressionKind::Global { global } => {
+                global_file(global.id) == self.module.file_id
+                    && !self.lazy_global_names.contains_key(&global.id)
+            }
+            ExpressionKind::Local { parameter } => {
+                matches!(context.locals.get(&parameter.id), Some(LocalBinding::Direct(_)))
+            }
+            ExpressionKind::Array { .. }
+            | ExpressionKind::Record { .. }
+            | ExpressionKind::RecordUpdate { .. }
+            | ExpressionKind::Project { .. }
+            | ExpressionKind::Unary { .. }
+            | ExpressionKind::Binary { .. }
+            | ExpressionKind::Abstraction { .. }
+            | ExpressionKind::UncurriedAbstraction { .. }
+            | ExpressionKind::Application { .. }
+            | ExpressionKind::UncurriedApplication { .. }
+            | ExpressionKind::IfThenElse { .. }
+            | ExpressionKind::Case { .. }
+            | ExpressionKind::Guarded { .. }
+            | ExpressionKind::Let { .. }
+            | ExpressionKind::LetPattern { .. }
+            | ExpressionKind::Effect { .. }
+            | ExpressionKind::SynthesizedEvidence { .. }
+            | ExpressionKind::TrivialEvidence => false,
+        }
+    }
+
+    fn record_updates_rendering_is_eager(
+        &self,
+        updates: &[RecordUpdate],
+        context: &FunctionContext,
+    ) -> bool {
+        updates.iter().any(|update| self.record_update_rendering_is_eager(update, context))
+    }
+
+    fn record_update_rendering_is_eager(
+        &self,
+        update: &RecordUpdate,
+        context: &FunctionContext,
+    ) -> bool {
+        match update {
+            RecordUpdate::Leaf { expression, .. } => {
+                self.expression_rendering_is_eager(*expression, context)
+            }
+            RecordUpdate::Branch { updates, .. } => {
+                self.record_updates_rendering_is_eager(updates, context)
+            }
         }
     }
 
@@ -1778,39 +1847,66 @@ impl Generator<'_> {
         updates: &[RecordUpdate],
         context: &mut FunctionContext,
     ) -> ModuleResult<ExpressionId> {
-        let record = self.expression_value(tree, writer, record, context)?;
-        let record_name = context.allocate("$record");
-        writer.expression_line(format!("const {record_name} = "), tree, record, ";");
-        let record = tree.identifier(record_name);
-        self.record_updates(tree, writer, record, updates, context)
+        let record = self.rendered_expression(tree, writer, record, context)?;
+        let record_is_reusable = rendered_expression_is_reusable(tree, &record);
+        self.record_updates(tree, writer, record.value, record_is_reusable, updates, context)
     }
 
     fn record_updates(
         &self,
         tree: &mut Tree,
         writer: &mut Writer<'_>,
-        record: ExpressionId,
+        mut record: ExpressionId,
+        record_is_reusable: bool,
         updates: &[RecordUpdate],
         context: &mut FunctionContext,
     ) -> ModuleResult<ExpressionId> {
+        if record_updates_reuse_source(updates) && !record_is_reusable {
+            record = self.materialize_value(tree, writer, record, "$record", context);
+        }
         let mut properties = Vec::with_capacity(updates.len() + 1);
         properties.push(ObjectProperty::Spread(record));
         for update in updates {
+            if self.record_update_rendering_is_eager(update, context) {
+                let value = tree.object(std::mem::take(&mut properties));
+                let value = self.materialize_value(tree, writer, value, "$record", context);
+                properties.push(ObjectProperty::Spread(value));
+            }
             match update {
                 RecordUpdate::Leaf { field, expression } => {
-                    let value = self.expression_value(tree, writer, *expression, context)?;
-                    let value = self.materialize_value(tree, writer, value, "$field", context);
-                    properties.push(ObjectProperty::Field { name: field.name.to_string(), value });
+                    let value = self.rendered_expression(tree, writer, *expression, context)?;
+                    properties.push(ObjectProperty::Field {
+                        name: field.name.to_string(),
+                        value: value.value,
+                    });
                 }
                 RecordUpdate::Branch { field, updates } => {
+                    // Nested updates revisit their original source paths. Reusing the path here
+                    // preserves each observable property read while the root record remains stable.
                     let nested = tree.member(record, field.name.as_str());
-                    let value = self.record_updates(tree, writer, nested, updates, context)?;
+                    let value =
+                        self.record_updates(tree, writer, nested, true, updates, context)?;
                     properties.push(ObjectProperty::Field { name: field.name.to_string(), value });
                 }
             }
         }
         Ok(tree.object(properties))
     }
+}
+
+fn rendered_expression_is_reusable(tree: &Tree, expression: &RenderedExpression) -> bool {
+    !expression.pending_evaluation
+        || matches!(
+            tree[expression.value],
+            JavascriptExpression::Identifier(_)
+                | JavascriptExpression::String(_)
+                | JavascriptExpression::Number(_)
+                | JavascriptExpression::Boolean(_)
+        )
+}
+
+fn record_updates_reuse_source(updates: &[RecordUpdate]) -> bool {
+    updates.iter().any(|update| matches!(update, RecordUpdate::Branch { .. }))
 }
 
 fn effect_expression(

--- a/tests-integration/fixtures/backend/1787021340_record_updates/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021340_record_updates/output/Main/index.js
@@ -5,10 +5,9 @@ export const updated = (() => {
   const $field = 1 | 0;
   const $field$1 = false;
   const $field$2 = "after";
-  const $update = {
+  return {
     ...$record,
     count: $field,
     nested: { ...$record.nested, enabled: $field$1, label: $field$2 }
   };
-  return $update;
 })();

--- a/tests-integration/fixtures/backend/1787021340_record_updates/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021340_record_updates/output/Main/index.js
@@ -1,13 +1,5 @@
 export const model = { count: 0 | 0, nested: { enabled: true, label: "before" } };
 
 export const updated = (() => {
-  const $record = model;
-  const $field = 1 | 0;
-  const $field$1 = false;
-  const $field$2 = "after";
-  return {
-    ...$record,
-    count: $field,
-    nested: { ...$record.nested, enabled: $field$1, label: $field$2 }
-  };
+  return { ...model, count: 1 | 0, nested: { ...model.nested, enabled: false, label: "after" } };
 })();

--- a/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/output/Main/index.js
@@ -30,9 +30,7 @@ export const recursiveValue = (() => {
       return recursivePeer.run(true);
     }
   };
-  const $field = $closure;
-  const $record = { run: $field };
-  return $record;
+  return { run: $closure };
 })();
 
 export const recursivePeer = (() => {
@@ -43,7 +41,5 @@ export const recursivePeer = (() => {
       return recursiveValue.run(true);
     }
   };
-  const $field = $closure;
-  const $record = { run: $field };
-  return $record;
+  return { run: $closure };
 })();

--- a/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787022000_do_and_ado/output/Main/index.js
@@ -5,32 +5,23 @@ export const secondAction = $foreign["secondAction"];
 export const independentAction = $foreign["independentAction"];
 
 export const sequential = (() => {
-  const $action = firstAction;
-  const $effect = () => {
-    const first = $action();
+  return () => {
+    const first = firstAction();
     return secondAction(first)();
   };
-  return $effect;
 })();
 
 export const independent = (() => {
   const $function = first => second => ({ first: first, second: second });
-  const $action = firstAction;
-  const $argumentAction = independentAction;
-  const $effect = () => {
+  return () => {
     let $function$1;
-    const $value = $action();
-    $function$1 = $function($value);
-    const $argument = $argumentAction();
-    return $function$1($argument);
+    $function$1 = $function(firstAction());
+    return $function$1(independentAction());
   };
-  return $effect;
 })();
 
 export const pureValue = (() => {
-  const $value = 42 | 0;
-  const $effect = () => {
-    return $value;
+  return () => {
+    return 42 | 0;
   };
-  return $effect;
 })();

--- a/tests-integration/fixtures/backend/1787080920_derived_instance/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787080920_derived_instance/output/Main/index.js
@@ -16,9 +16,7 @@ export const eqBox = (() => {
       throw new Error("Pattern match failure");
     };
   };
-  const $field = $closure;
-  const $record = { eq: $field };
-  return $record;
+  return { eq: $closure };
 })();
 
 export const equal = Data_Eq.eq(eqBox)(Box)(Box);

--- a/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
@@ -147,10 +147,7 @@ export const model = {
 };
 
 export const updated = (() => {
-  const $record = model;
-  const $field = 1 | 0;
-  const $field$1 = false;
-  return { ...$record, count: $field, nested: { ...$record.nested, enabled: $field$1 } };
+  return { ...model, count: 1 | 0, nested: { ...model.nested, enabled: false } };
 })();
 
 export const curried = apply(addCaptured(2 | 0))(40 | 0);

--- a/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
@@ -150,8 +150,7 @@ export const updated = (() => {
   const $record = model;
   const $field = 1 | 0;
   const $field$1 = false;
-  const $update = { ...$record, count: $field, nested: { ...$record.nested, enabled: $field$1 } };
-  return $update;
+  return { ...$record, count: $field, nested: { ...$record.nested, enabled: $field$1 } };
 })();
 
 export const curried = apply(addCaptured(2 | 0))(40 | 0);

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Origin/index.js
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Origin/index.js
@@ -44,9 +44,7 @@ export const eqOption = (() => {
       return false;
     };
   };
-  const $field = $closure;
-  const $record = { eq: $field };
-  return $record;
+  return { eq: $closure };
 })();
 
 export const measureInt = { measure: value => value };

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
@@ -175,13 +175,7 @@ export function lambdaScope(left) {
           }
         };
       };
-      const $function = $closure;
-      const $argument = left;
-      const $call = $function($argument);
-      const $function$1 = $call;
-      const $argument$1 = right;
-      const $call$1 = $function$1($argument$1);
-      return $call$1;
+      return $closure(left)(right);
     } else {
       return false;
     }

--- a/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/output/Main/index.js
@@ -33,7 +33,6 @@ const $lazy_applicativeBox = $runtime.binding("applicativeBox", () => {
 });
 
 const $lazy_bindBox = $runtime.binding("bindBox", () => {
-  const $field = () => $lazy_applyBox();
   const $closure = $box => {
     if (Array.isArray($box) && $box[0] === "Box") {
       const value = $box[1];
@@ -44,9 +43,7 @@ const $lazy_bindBox = $runtime.binding("bindBox", () => {
       throw new Error("Pattern match failure");
     }
   };
-  const $field$1 = $closure;
-  const $record = { Apply0: $field, bind: $field$1 };
-  return $record;
+  return { Apply0: () => $lazy_applyBox(), bind: $closure };
 });
 
 const $lazy_monadBox = $runtime.binding("monadBox", () => {

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
@@ -20,13 +20,10 @@ const $lazy_genericVoidNoConstructors = $runtime.binding("genericVoidNoConstruct
   const $closure = value => {
     return Data_Generic_Rep.to($lazy_genericVoidNoConstructors())(value);
   };
-  const $field = $closure;
   const $closure$1 = value$1 => {
     return Data_Generic_Rep.from($lazy_genericVoidNoConstructors())(value$1);
   };
-  const $field$1 = $closure$1;
-  const $record = { to: $field, from: $field$1 };
-  return $record;
+  return { to: $closure, from: $closure$1 };
 });
 
 export const newtypeTypeIdentifierInt = { Coercible0: () => ({}) };
@@ -63,7 +60,6 @@ export const genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntCons
     }
     throw new Error("Pattern match failure");
   };
-  const $field = $closure;
   const $closure$1 = value => {
     if (value === "Empty") {
       return Data_Generic_Rep.Inl(Data_Generic_Rep.Constructor(Data_Generic_Rep.NoArguments));
@@ -83,9 +79,7 @@ export const genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntCons
     }
     throw new Error("Pattern match failure");
   };
-  const $field$1 = $closure$1;
-  const $record = { to: $field, from: $field$1 };
-  return $record;
+  return { to: $closure, from: $closure$1 };
 })();
 
 export const emptyRoundTrip = roundTrip(Empty);

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/Main/index.js
@@ -5,7 +5,6 @@ export function applicationRecursive(token) {
   let $lazy_first;
   let $lazy_second;
   $lazy_first = $runtime.binding("first", () => {
-    const $function = observe("first");
     const $closure = condition => {
       if (condition) {
         return $lazy_second()(false);
@@ -13,12 +12,9 @@ export function applicationRecursive(token) {
         return 1 | 0;
       }
     };
-    const $argument = $closure;
-    const $call = $function($argument);
-    return $call;
+    return observe("first")($closure);
   });
   $lazy_second = $runtime.binding("second", () => {
-    const $function$1 = observe("second");
     const $closure$1 = condition$1 => {
       if (condition$1) {
         return $lazy_first()(false);
@@ -26,9 +22,7 @@ export function applicationRecursive(token) {
         return 2 | 0;
       }
     };
-    const $argument$1 = $closure$1;
-    const $call$1 = $function$1($argument$1);
-    return $call$1;
+    return observe("second")($closure$1);
   });
   const first = $lazy_first();
   const second = $lazy_second();

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.HeytingAlgebra/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.HeytingAlgebra/index.js
@@ -10,7 +10,5 @@ export const heytingAlgebraBoolean = (() => {
       return true;
     }
   };
-  const $field = $closure;
-  const $record = { not: $field };
-  return $record;
+  return { not: $closure };
 })();

--- a/tests-integration/fixtures/backend/1787673600_effect_ado_thunks/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787673600_effect_ado_thunks/output/Main/index.js
@@ -4,14 +4,11 @@ export function timedAdo(seed) {
   const $function = first => second => ({ first: first, second: second });
   const $action = constructEffect("ado-first")(seed);
   const $argumentAction = constructEffect("ado-second")({ seed: seed });
-  const $effect = () => {
+  return () => {
     let $function$1;
-    const $value = $action();
-    $function$1 = $function($value);
-    const $argument = $argumentAction();
-    return $function$1($argument);
+    $function$1 = $function($action());
+    return $function$1($argumentAction());
   };
-  return $effect;
 }
 
 export const constructEffect = $foreign["constructEffect"];

--- a/tests-integration/fixtures/backend/1787673600_effect_do_thunks/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787673600_effect_do_thunks/output/Main/index.js
@@ -3,33 +3,30 @@ import * as $foreign from "./foreign.js";
 
 export function chained(seed) {
   const $action = constructEffect("first")(seed);
-  const $effect = () => {
+  return () => {
     const first = $action();
     const $action$1 = constructEffect("second")({ first: first });
     const second = $action$1();
     return constructEffect("third")({ first: first, second: second })();
   };
-  return $effect;
 }
 
 export function discarded(seed) {
   const $action = constructEffect("discard-first")(Data_Unit.Unit);
-  const $effect = () => {
+  return () => {
     const $unit = $action();
     const result = mark("discard-let")(seed);
     return constructEffect("discard-second")(result)();
   };
-  return $effect;
 }
 
 export function pureAfterBind(seed) {
   const $action = constructEffect("pure-action")(seed);
-  const $effect = () => {
+  return () => {
     const value = $action();
     const $value = mark("pure-body")({ value: value });
     return $value;
   };
-  return $effect;
 }
 
 export const constructEffect = $foreign["constructEffect"];

--- a/tests-integration/fixtures/backend/1787678880_effect_do_boundaries/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787678880_effect_do_boundaries/output/Main/index.js
@@ -17,11 +17,10 @@ export const mark = $foreign["mark"];
 
 export const deferredEffect = (() => {
   const $action = constructEffect("deferred-action")("ignored");
-  const $effect = () => {
+  return () => {
     const value = $action();
     return constructEffect("deferred-result")(deferredValue)();
   };
-  return $effect;
 })();
 
 export const deferredValue = mark("deferred-value")("deferred");

--- a/tests-integration/fixtures/backend/1787678880_effect_do_control_flow/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787678880_effect_do_control_flow/output/Main/index.js
@@ -3,7 +3,7 @@ import * as $foreign from "./foreign.js";
 export function branched(choose) {
   return seed => {
     const $action = constructEffect("branch-action")(seed);
-    const $effect = () => {
+    return () => {
       const value = $action();
       if (choose) {
         return constructEffect("branch-then")(value)();
@@ -11,19 +11,17 @@ export function branched(choose) {
         return constructEffect("branch-else")(value)();
       }
     };
-    return $effect;
   };
 }
 
 export function patternLet(seed) {
   const $action = constructEffect("pattern-action")(seed);
-  const $effect = () => {
+  return () => {
     const value = $action();
     const $scrutinee = { selected: value };
     const selected = $scrutinee.selected;
     return constructEffect("pattern-result")(selected)();
   };
-  return $effect;
 }
 
 export const constructEffect = $foreign["constructEffect"];

--- a/tests-integration/fixtures/backend/1787678880_effect_primitive_thunks/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787678880_effect_primitive_thunks/output/Main/index.js
@@ -7,30 +7,24 @@ export function identity(value) {
 export function mapped(value) {
   const $function = mark("map-function")(identity);
   const $action = constructEffect("map-action")(value);
-  const $effect = () => {
-    const $value = $action();
-    return $function($value);
+  return () => {
+    return $function($action());
   };
-  return $effect;
 }
 
 export function applied(value) {
   const $functionAction = constructEffect("apply-function-action")(identity);
   const $argumentAction = constructEffect("apply-value-action")(value);
-  const $effect = () => {
-    const $function = $functionAction();
-    const $argument = $argumentAction();
-    return $function($argument);
+  return () => {
+    return $functionAction()($argumentAction());
   };
-  return $effect;
 }
 
 export function capturedPure(value) {
   const $value = mark("pure-value")(value);
-  const $effect = () => {
+  return () => {
     return $value;
   };
-  return $effect;
 }
 
 export const constructEffect = $foreign["constructEffect"];

--- a/tests-integration/fixtures/backend/1787679720_st_ado_thunks/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787679720_st_ado_thunks/output/Main/index.js
@@ -4,14 +4,11 @@ export function timedAdo(seed) {
   const $function = first => second => ({ first: first, second: second });
   const $action = constructST("ado-first")(seed);
   const $argumentAction = constructST("ado-second")({ seed: seed });
-  const $effect = () => {
+  return () => {
     let $function$1;
-    const $value = $action();
-    $function$1 = $function($value);
-    const $argument = $argumentAction();
-    return $function$1($argument);
+    $function$1 = $function($action());
+    return $function$1($argumentAction());
   };
-  return $effect;
 }
 
 export function identity(value) {
@@ -21,30 +18,24 @@ export function identity(value) {
 export function mapped(value) {
   const $function = mark("map-function")(identity);
   const $action = constructST("map-action")(value);
-  const $effect = () => {
-    const $value = $action();
-    return $function($value);
+  return () => {
+    return $function($action());
   };
-  return $effect;
 }
 
 export function applied(value) {
   const $functionAction = constructST("apply-function-action")(identity);
   const $argumentAction = constructST("apply-value-action")(value);
-  const $effect = () => {
-    const $function = $functionAction();
-    const $argument = $argumentAction();
-    return $function($argument);
+  return () => {
+    return $functionAction()($argumentAction());
   };
-  return $effect;
 }
 
 export function capturedPure(value) {
   const $value = mark("pure-value")(value);
-  const $effect = () => {
+  return () => {
     return $value;
   };
-  return $effect;
 }
 
 export const constructST = $foreign["constructST"];

--- a/tests-integration/fixtures/backend/1787679720_st_control_boundaries/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787679720_st_control_boundaries/output/Main/index.js
@@ -5,7 +5,7 @@ import * as $foreign from "./foreign.js";
 export function branched(choose) {
   return seed => {
     const $action = constructST("branch-action")(seed);
-    const $effect = () => {
+    return () => {
       const value = $action();
       if (choose) {
         return constructST("branch-then")(value)();
@@ -13,19 +13,17 @@ export function branched(choose) {
         return constructST("branch-else")(value)();
       }
     };
-    return $effect;
   };
 }
 
 export function patternLet(seed) {
   const $action = constructST("pattern-action")(seed);
-  const $effect = () => {
+  return () => {
     const value = $action();
     const $scrutinee = { selected: value };
     const selected = $scrutinee.selected;
     return constructST("pattern-result")(selected)();
   };
-  return $effect;
 }
 
 export function genericBind(bindMDict) {
@@ -43,11 +41,10 @@ export const mark = $foreign["mark"];
 
 export const deferredST = (() => {
   const $action = constructST("deferred-action")("ignored");
-  const $effect = () => {
+  return () => {
     const value = $action();
     return constructST("deferred-result")(deferredValue)();
   };
-  return $effect;
 })();
 
 export const deferredValue = mark("deferred-value")("deferred");

--- a/tests-integration/fixtures/backend/1787679720_st_do_thunks/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787679720_st_do_thunks/output/Main/index.js
@@ -3,33 +3,30 @@ import * as $foreign from "./foreign.js";
 
 export function chained(seed) {
   const $action = constructST("first")(seed);
-  const $effect = () => {
+  return () => {
     const first = $action();
     const $action$1 = constructST("second")({ first: first });
     const second = $action$1();
     return constructST("third")({ first: first, second: second })();
   };
-  return $effect;
 }
 
 export function discarded(seed) {
   const $action = constructST("discard-first")(Data_Unit.Unit);
-  const $effect = () => {
+  return () => {
     const $unit = $action();
     const result = mark("discard-let")(seed);
     return constructST("discard-second")(result)();
   };
-  return $effect;
 }
 
 export function pureAfterBind(seed) {
   const $action = constructST("pure-action")(seed);
-  const $effect = () => {
+  return () => {
     const value = $action();
     const $value = mark("pure-body")({ value: value });
     return $value;
   };
-  return $effect;
 }
 
 export const constructST = $foreign["constructST"];

--- a/tests-integration/fixtures/backend/1787690760_nested_curried_application_rendering/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787690760_nested_curried_application_rendering/Main.functional.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign node
+
+@export foreign attribute
+
+@export foreign text
+
+@export render = \state%1 ->
+  node "main" [attribute "root"]
+    [node "span"
+        [attribute
+            ((\value%2 ->
+              if value%2 then "active" else "inactive")
+              state%1)]
+        [text "first"],
+      node "span" [] [text "second"]]

--- a/tests-integration/fixtures/backend/1787690760_nested_curried_application_rendering/Main.js
+++ b/tests-integration/fixtures/backend/1787690760_nested_curried_application_rendering/Main.js
@@ -1,0 +1,6 @@
+export const node = name => attributes => children =>
+  `<${name} ${attributes.join(" ")}>${children.join("")}</${name}>`;
+
+export const attribute = value => `class=${value}`;
+
+export const text = value => value;

--- a/tests-integration/fixtures/backend/1787690760_nested_curried_application_rendering/Main.purs
+++ b/tests-integration/fixtures/backend/1787690760_nested_curried_application_rendering/Main.purs
@@ -1,0 +1,21 @@
+module Main where
+
+foreign import node :: String -> Array String -> Array String -> String
+
+foreign import attribute :: String -> String
+
+foreign import text :: String -> String
+
+render :: Boolean -> String
+render state =
+  let
+    dynamicClass value =
+      if value then "active" else "inactive"
+  in
+    node "main"
+      [ attribute "root" ]
+      [ node "span"
+          [ attribute (dynamicClass state) ]
+          [ text "first" ]
+      , node "span" [] [ text "second" ]
+      ]

--- a/tests-integration/fixtures/backend/1787690760_nested_curried_application_rendering/Main.snap
+++ b/tests-integration/fixtures/backend/1787690760_nested_curried_application_rendering/Main.snap
@@ -1,0 +1,12 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 262
+expression: diagnostics_report
+---
+Terms
+node :: Prim.String -> Prim.Array Prim.String -> Prim.Array Prim.String -> Prim.String
+attribute :: Prim.String -> Prim.String
+text :: Prim.String -> Prim.String
+render :: Prim.Boolean -> Prim.String
+
+Types

--- a/tests-integration/fixtures/backend/1787690760_nested_curried_application_rendering/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787690760_nested_curried_application_rendering/output/Main/foreign.js
@@ -1,0 +1,6 @@
+export const node = name => attributes => children =>
+  `<${name} ${attributes.join(" ")}>${children.join("")}</${name}>`;
+
+export const attribute = value => `class=${value}`;
+
+export const text = value => value;

--- a/tests-integration/fixtures/backend/1787690760_nested_curried_application_rendering/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787690760_nested_curried_application_rendering/output/Main/index.js
@@ -1,9 +1,6 @@
 import * as $foreign from "./foreign.js";
 
 export function render(state) {
-  const $function = node("main")([attribute("root")]);
-  const $function$1 = node("span");
-  const $function$2 = attribute;
   const $closure = value => {
     if (value) {
       return "active";
@@ -11,24 +8,12 @@ export function render(state) {
       return "inactive";
     }
   };
-  const $function$3 = $closure;
-  const $argument = state;
-  const $call = $function$3($argument);
-  const $argument$1 = $call;
-  const $call$1 = $function$2($argument$1);
-  const $element = $call$1;
-  const $array = [$element];
-  const $argument$2 = $array;
-  const $call$2 = $function$1($argument$2);
-  const $function$4 = $call$2;
-  const $argument$3 = [text("first")];
-  const $call$3 = $function$4($argument$3);
-  const $element$1 = $call$3;
-  const $element$2 = node("span")([])([text("second")]);
-  const $array$1 = [$element$1, $element$2];
-  const $argument$4 = $array$1;
-  const $call$4 = $function($argument$4);
-  return $call$4;
+  return node("main")([attribute("root")])(
+    [
+      node("span")([attribute($closure(state))])([text("first")]),
+      node("span")([])([text("second")])
+    ]
+  );
 }
 
 export const node = $foreign["node"];

--- a/tests-integration/fixtures/backend/1787690760_nested_curried_application_rendering/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787690760_nested_curried_application_rendering/output/Main/index.js
@@ -1,0 +1,36 @@
+import * as $foreign from "./foreign.js";
+
+export function render(state) {
+  const $function = node("main")([attribute("root")]);
+  const $function$1 = node("span");
+  const $function$2 = attribute;
+  const $closure = value => {
+    if (value) {
+      return "active";
+    } else {
+      return "inactive";
+    }
+  };
+  const $function$3 = $closure;
+  const $argument = state;
+  const $call = $function$3($argument);
+  const $argument$1 = $call;
+  const $call$1 = $function$2($argument$1);
+  const $element = $call$1;
+  const $array = [$element];
+  const $argument$2 = $array;
+  const $call$2 = $function$1($argument$2);
+  const $function$4 = $call$2;
+  const $argument$3 = [text("first")];
+  const $call$3 = $function$4($argument$3);
+  const $element$1 = $call$3;
+  const $element$2 = node("span")([])([text("second")]);
+  const $array$1 = [$element$1, $element$2];
+  const $argument$4 = $array$1;
+  const $call$4 = $function($argument$4);
+  return $call$4;
+}
+
+export const node = $foreign["node"];
+export const attribute = $foreign["attribute"];
+export const text = $foreign["text"];

--- a/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/Main.functional.snap
@@ -1,0 +1,23 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign collect
+
+@export foreign failAt
+
+@export foreign observe
+
+@export foreign observedRecord
+
+@export ordered = \branch%2 shouldThrow%1 ->
+  collect (observe "before" observedRecord.value)
+    ((\value%3 ->
+      if branch%2 then observe "branch-true" value%3 else observe "branch-false" value%3)
+      (failAt "middle" shouldThrow%1 2))
+    (observe "after" 3)
+
+@export reused = let
+  value%4 = observe "reused" 4
+in [value%4, value%4]

--- a/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/Main.js
+++ b/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/Main.js
@@ -1,0 +1,36 @@
+let trace = [];
+
+export const collect = first => {
+  trace.push(`collect:first:${first}`);
+  return second => {
+    trace.push(`collect:second:${second}`);
+    return third => {
+      trace.push(`collect:third:${third}`);
+      return [first, second, third];
+    };
+  };
+};
+
+export const failAt = label => shouldThrow => value => {
+  trace.push(`fail:${label}`);
+  if (shouldThrow) throw new Error(label);
+  return value;
+};
+
+export const observe = label => value => {
+  trace.push(`observe:${label}`);
+  return value;
+};
+
+export const observedRecord = {
+  get value() {
+    trace.push("read:record");
+    return 1;
+  },
+};
+
+export const readTrace = () => trace.slice();
+
+export const resetTrace = () => {
+  trace = [];
+};

--- a/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/Main.purs
+++ b/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/Main.purs
@@ -1,0 +1,26 @@
+module Main where
+
+foreign import collect :: Int -> Int -> Int -> Array Int
+
+foreign import failAt :: String -> Boolean -> Int -> Int
+
+foreign import observe :: String -> Int -> Int
+
+foreign import observedRecord :: { value :: Int }
+
+ordered :: Boolean -> Boolean -> Array Int
+ordered branch shouldThrow =
+  let
+    choose value =
+      if branch then observe "branch-true" value
+      else observe "branch-false" value
+  in
+    collect
+      (observe "before" observedRecord.value)
+      (choose (failAt "middle" shouldThrow 2))
+      (observe "after" 3)
+
+reused :: Array Int
+reused =
+  let value = observe "reused" 4
+  in [ value, value ]

--- a/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/Main.snap
+++ b/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/Main.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 262
+expression: diagnostics_report
+---
+Terms
+collect :: Prim.Int -> Prim.Int -> Prim.Int -> Prim.Array Prim.Int
+failAt :: Prim.String -> Prim.Boolean -> Prim.Int -> Prim.Int
+observe :: Prim.String -> Prim.Int -> Prim.Int
+observedRecord :: { value :: Prim.Int }
+ordered :: Prim.Boolean -> Prim.Boolean -> Prim.Array Prim.Int
+reused :: Prim.Array Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/output/Main/foreign.js
@@ -1,0 +1,36 @@
+let trace = [];
+
+export const collect = first => {
+  trace.push(`collect:first:${first}`);
+  return second => {
+    trace.push(`collect:second:${second}`);
+    return third => {
+      trace.push(`collect:third:${third}`);
+      return [first, second, third];
+    };
+  };
+};
+
+export const failAt = label => shouldThrow => value => {
+  trace.push(`fail:${label}`);
+  if (shouldThrow) throw new Error(label);
+  return value;
+};
+
+export const observe = label => value => {
+  trace.push(`observe:${label}`);
+  return value;
+};
+
+export const observedRecord = {
+  get value() {
+    trace.push("read:record");
+    return 1;
+  },
+};
+
+export const readTrace = () => trace.slice();
+
+export const resetTrace = () => {
+  trace = [];
+};

--- a/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/output/Main/index.js
@@ -1,0 +1,33 @@
+import * as $foreign from "./foreign.js";
+
+export function ordered(branch) {
+  return shouldThrow => {
+    const $function = collect(observe("before")(observedRecord.value));
+    const $closure = value => {
+      if (branch) {
+        return observe("branch-true")(value);
+      } else {
+        return observe("branch-false")(value);
+      }
+    };
+    const $function$1 = $closure;
+    const $argument = failAt("middle")(shouldThrow)(2 | 0);
+    const $call = $function$1($argument);
+    const $argument$1 = $call;
+    const $call$1 = $function($argument$1);
+    const $function$2 = $call$1;
+    const $argument$2 = observe("after")(3 | 0);
+    const $call$2 = $function$2($argument$2);
+    return $call$2;
+  };
+}
+
+export const collect = $foreign["collect"];
+export const failAt = $foreign["failAt"];
+export const observe = $foreign["observe"];
+export const observedRecord = $foreign["observedRecord"];
+
+export const reused = (() => {
+  const value = observe("reused")(4 | 0);
+  return [value, value];
+})();

--- a/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/output/Main/index.js
@@ -2,7 +2,6 @@ import * as $foreign from "./foreign.js";
 
 export function ordered(branch) {
   return shouldThrow => {
-    const $function = collect(observe("before")(observedRecord.value));
     const $closure = value => {
       if (branch) {
         return observe("branch-true")(value);
@@ -10,15 +9,9 @@ export function ordered(branch) {
         return observe("branch-false")(value);
       }
     };
-    const $function$1 = $closure;
-    const $argument = failAt("middle")(shouldThrow)(2 | 0);
-    const $call = $function$1($argument);
-    const $argument$1 = $call;
-    const $call$1 = $function($argument$1);
-    const $function$2 = $call$1;
-    const $argument$2 = observe("after")(3 | 0);
-    const $call$2 = $function$2($argument$2);
-    return $call$2;
+    return collect(observe("before")(observedRecord.value))(
+      $closure(failAt("middle")(shouldThrow)(2 | 0))
+    )(observe("after")(3 | 0));
   };
 }
 

--- a/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/package.json
+++ b/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/verify.mjs
+++ b/tests-integration/fixtures/backend/1787690760_rendered_expression_evaluation_order/verify.mjs
@@ -1,0 +1,31 @@
+import { deepStrictEqual, strictEqual, throws } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+import { readTrace, resetTrace } from "./output/Main/foreign.js";
+
+deepStrictEqual(Main.reused, [4, 4]);
+deepStrictEqual(readTrace(), ["observe:reused"]);
+
+resetTrace();
+deepStrictEqual(Main.ordered(true)(false), [1, 2, 3]);
+deepStrictEqual(readTrace(), [
+  "read:record",
+  "observe:before",
+  "collect:first:1",
+  "fail:middle",
+  "observe:branch-true",
+  "collect:second:2",
+  "observe:after",
+  "collect:third:3",
+]);
+
+resetTrace();
+throws(() => Main.ordered(false)(true), error => {
+  strictEqual(error.message, "middle");
+  return true;
+});
+deepStrictEqual(readTrace(), [
+  "read:record",
+  "observe:before",
+  "collect:first:1",
+  "fail:middle",
+]);

--- a/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.functional.snap
@@ -23,10 +23,16 @@ expression: report
     last = observe "call-last" 30
   }
 
-@export updateControl = \condition%3 source%2 ->
-  source%2 {
-    first = observe "control-first" 10,
-    last = if condition%3 then observe "control-then" 30 else observe "control-else" 31
+@export updateDeep = \$boolean%2@(_) ->
+  (makeModel "deep") {
+    nested { value = observe "deep-nested" 50, inner { value = observe "deep-inner" 60 } }
   }
 
-@export updateOpen = \source%4 -> source%4 { first = observe "open-first" 40 }
+@export updateControl = \condition%4 source%3 ->
+  source%3 {
+    first = observe "control-first" 10,
+    nested { value = if condition%4 then observe "control-then" 30 else observe "control-else" 31 },
+    last = observe "control-last" 32
+  }
+
+@export updateOpen = \source%5 -> source%5 { first = observe "open-first" 40 }

--- a/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.functional.snap
@@ -1,0 +1,32 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign failAt
+
+@export foreign makeModel
+
+@export foreign observe
+
+@export updateLocal = \source%0 ->
+  source%0 {
+    first = observe "local-first" 10,
+    nested { value = observe "local-nested" 20 },
+    last = observe "local-last" 30
+  }
+
+@export updateCall = \shouldThrow%1 ->
+  (makeModel "call") {
+    first = observe "call-first" 10,
+    nested { value = failAt "call-nested" shouldThrow%1 20 },
+    last = observe "call-last" 30
+  }
+
+@export updateControl = \condition%3 source%2 ->
+  source%2 {
+    first = observe "control-first" 10,
+    last = if condition%3 then observe "control-then" 30 else observe "control-else" 31
+  }
+
+@export updateOpen = \source%4 -> source%4 { first = observe "open-first" 40 }

--- a/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.js
+++ b/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.js
@@ -1,0 +1,51 @@
+let trace = [];
+
+export const symbolKey = Symbol("marker");
+
+const tracedRecord = (label, fields) =>
+  new Proxy(fields, {
+    ownKeys(target) {
+      trace.push(`${label}:keys`);
+      return Reflect.ownKeys(target);
+    },
+    getOwnPropertyDescriptor(target, property) {
+      trace.push(`${label}:descriptor:${String(property)}`);
+      return Reflect.getOwnPropertyDescriptor(target, property);
+    },
+    get(target, property, receiver) {
+      trace.push(`${label}:get:${String(property)}`);
+      return Reflect.get(target, property, receiver);
+    },
+  });
+
+export const makeModel = label => {
+  trace.push(`make:${label}`);
+  const nested = tracedRecord(`${label}.nested`, {
+    value: 2,
+    untouched: 5,
+  });
+  return tracedRecord(label, {
+    first: 1,
+    nested,
+    last: 3,
+    untouched: 4,
+    [symbolKey]: "symbol-value",
+  });
+};
+
+export const observe = label => value => {
+  trace.push(`observe:${label}`);
+  return value;
+};
+
+export const failAt = label => shouldThrow => value => {
+  trace.push(`fail:${label}`);
+  if (shouldThrow) throw new Error(label);
+  return value;
+};
+
+export const readTrace = () => trace.slice();
+
+export const resetTrace = () => {
+  trace = [];
+};

--- a/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.js
+++ b/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.js
@@ -20,8 +20,13 @@ const tracedRecord = (label, fields) =>
 
 export const makeModel = label => {
   trace.push(`make:${label}`);
+  const inner = tracedRecord(`${label}.nested.inner`, {
+    value: 6,
+    untouched: 7,
+  });
   const nested = tracedRecord(`${label}.nested`, {
     value: 2,
+    inner,
     untouched: 5,
   });
   return tracedRecord(label, {

--- a/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.purs
+++ b/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.purs
@@ -1,7 +1,13 @@
 module Main where
 
+type Inner =
+  { value :: Int
+  , untouched :: Int
+  }
+
 type Nested =
   { value :: Int
+  , inner :: Inner
   , untouched :: Int
   }
 
@@ -34,13 +40,25 @@ updateCall shouldThrow =
     , last = observe "call-last" 30
     }
 
+updateDeep :: Boolean -> Model
+updateDeep _ =
+  (makeModel "deep")
+    { nested
+        { value = observe "deep-nested" 50
+        , inner { value = observe "deep-inner" 60 }
+        }
+    }
+
 updateControl :: Boolean -> Model -> Model
 updateControl condition source =
   source
     { first = observe "control-first" 10
-    , last =
-        if condition then observe "control-then" 30
-        else observe "control-else" 31
+    , nested
+        { value =
+            if condition then observe "control-then" 30
+            else observe "control-else" 31
+        }
+    , last = observe "control-last" 32
     }
 
 updateOpen

--- a/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.purs
+++ b/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.purs
@@ -1,0 +1,50 @@
+module Main where
+
+type Nested =
+  { value :: Int
+  , untouched :: Int
+  }
+
+type Model =
+  { first :: Int
+  , nested :: Nested
+  , last :: Int
+  , untouched :: Int
+  }
+
+foreign import failAt :: String -> Boolean -> Int -> Int
+
+foreign import makeModel :: String -> Model
+
+foreign import observe :: String -> Int -> Int
+
+updateLocal :: Model -> Model
+updateLocal source =
+  source
+    { first = observe "local-first" 10
+    , nested { value = observe "local-nested" 20 }
+    , last = observe "local-last" 30
+    }
+
+updateCall :: Boolean -> Model
+updateCall shouldThrow =
+  (makeModel "call")
+    { first = observe "call-first" 10
+    , nested { value = failAt "call-nested" shouldThrow 20 }
+    , last = observe "call-last" 30
+    }
+
+updateControl :: Boolean -> Model -> Model
+updateControl condition source =
+  source
+    { first = observe "control-first" 10
+    , last =
+        if condition then observe "control-then" 30
+        else observe "control-else" 31
+    }
+
+updateOpen
+  :: forall row
+   . { first :: Int | row }
+  -> { first :: Int | row }
+updateOpen source = source { first = observe "open-first" 40 }

--- a/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.snap
+++ b/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.snap
@@ -1,0 +1,24 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 262
+expression: diagnostics_report
+---
+Terms
+failAt :: Prim.String -> Prim.Boolean -> Prim.Int -> Prim.Int
+makeModel :: Prim.String -> Main.Model
+observe :: Prim.String -> Prim.Int -> Prim.Int
+updateLocal :: Main.Model -> Main.Model
+updateCall :: Prim.Boolean -> Main.Model
+updateControl :: Prim.Boolean -> Main.Model -> Main.Model
+updateOpen ::
+  forall (row :: Prim.Row Prim.Type).
+    { first :: Prim.Int | (row :: Prim.Row Prim.Type) } ->
+    { first :: Prim.Int | (row :: Prim.Row Prim.Type) }
+
+Types
+Nested :: Prim.Type
+Model :: Prim.Type
+
+Synonyms
+type Nested = { untouched :: Prim.Int, value :: Prim.Int }
+type Model = { first :: Prim.Int, last :: Prim.Int, nested :: Main.Nested, untouched :: Prim.Int }

--- a/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.snap
+++ b/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/Main.snap
@@ -9,6 +9,7 @@ makeModel :: Prim.String -> Main.Model
 observe :: Prim.String -> Prim.Int -> Prim.Int
 updateLocal :: Main.Model -> Main.Model
 updateCall :: Prim.Boolean -> Main.Model
+updateDeep :: Prim.Boolean -> Main.Model
 updateControl :: Prim.Boolean -> Main.Model -> Main.Model
 updateOpen ::
   forall (row :: Prim.Row Prim.Type).
@@ -16,9 +17,11 @@ updateOpen ::
     { first :: Prim.Int | (row :: Prim.Row Prim.Type) }
 
 Types
+Inner :: Prim.Type
 Nested :: Prim.Type
 Model :: Prim.Type
 
 Synonyms
-type Nested = { untouched :: Prim.Int, value :: Prim.Int }
+type Inner = { untouched :: Prim.Int, value :: Prim.Int }
+type Nested = { inner :: Main.Inner, untouched :: Prim.Int, value :: Prim.Int }
 type Model = { first :: Prim.Int, last :: Prim.Int, nested :: Main.Nested, untouched :: Prim.Int }

--- a/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/output/Main/foreign.js
@@ -1,0 +1,51 @@
+let trace = [];
+
+export const symbolKey = Symbol("marker");
+
+const tracedRecord = (label, fields) =>
+  new Proxy(fields, {
+    ownKeys(target) {
+      trace.push(`${label}:keys`);
+      return Reflect.ownKeys(target);
+    },
+    getOwnPropertyDescriptor(target, property) {
+      trace.push(`${label}:descriptor:${String(property)}`);
+      return Reflect.getOwnPropertyDescriptor(target, property);
+    },
+    get(target, property, receiver) {
+      trace.push(`${label}:get:${String(property)}`);
+      return Reflect.get(target, property, receiver);
+    },
+  });
+
+export const makeModel = label => {
+  trace.push(`make:${label}`);
+  const nested = tracedRecord(`${label}.nested`, {
+    value: 2,
+    untouched: 5,
+  });
+  return tracedRecord(label, {
+    first: 1,
+    nested,
+    last: 3,
+    untouched: 4,
+    [symbolKey]: "symbol-value",
+  });
+};
+
+export const observe = label => value => {
+  trace.push(`observe:${label}`);
+  return value;
+};
+
+export const failAt = label => shouldThrow => value => {
+  trace.push(`fail:${label}`);
+  if (shouldThrow) throw new Error(label);
+  return value;
+};
+
+export const readTrace = () => trace.slice();
+
+export const resetTrace = () => {
+  trace = [];
+};

--- a/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/output/Main/foreign.js
@@ -20,8 +20,13 @@ const tracedRecord = (label, fields) =>
 
 export const makeModel = label => {
   trace.push(`make:${label}`);
+  const inner = tracedRecord(`${label}.nested.inner`, {
+    value: 6,
+    untouched: 7,
+  });
   const nested = tracedRecord(`${label}.nested`, {
     value: 2,
+    inner,
     untouched: 5,
   });
   return tracedRecord(label, {

--- a/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/output/Main/index.js
@@ -1,0 +1,52 @@
+import * as $foreign from "./foreign.js";
+
+export function updateLocal(source) {
+  const $record = source;
+  const $field = observe("local-first")(10 | 0);
+  const $field$1 = observe("local-nested")(20 | 0);
+  const $field$2 = observe("local-last")(30 | 0);
+  return {
+    ...$record,
+    first: $field,
+    nested: { ...$record.nested, value: $field$1 },
+    last: $field$2
+  };
+}
+
+export function updateCall(shouldThrow) {
+  const $record = makeModel("call");
+  const $field = observe("call-first")(10 | 0);
+  const $field$1 = failAt("call-nested")(shouldThrow)(20 | 0);
+  const $field$2 = observe("call-last")(30 | 0);
+  return {
+    ...$record,
+    first: $field,
+    nested: { ...$record.nested, value: $field$1 },
+    last: $field$2
+  };
+}
+
+export function updateControl(condition) {
+  return source => {
+    const $record = source;
+    const $field = observe("control-first")(10 | 0);
+    let $result;
+    if (condition) {
+      $result = observe("control-then")(30 | 0);
+    } else {
+      $result = observe("control-else")(31 | 0);
+    }
+    const $field$1 = $result;
+    return { ...$record, first: $field, last: $field$1 };
+  };
+}
+
+export function updateOpen(source) {
+  const $record = source;
+  const $field = observe("open-first")(40 | 0);
+  return { ...$record, first: $field };
+}
+
+export const failAt = $foreign["failAt"];
+export const makeModel = $foreign["makeModel"];
+export const observe = $foreign["observe"];

--- a/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/output/Main/index.js
@@ -1,50 +1,56 @@
 import * as $foreign from "./foreign.js";
 
 export function updateLocal(source) {
-  const $record = source;
-  const $field = observe("local-first")(10 | 0);
-  const $field$1 = observe("local-nested")(20 | 0);
-  const $field$2 = observe("local-last")(30 | 0);
   return {
-    ...$record,
-    first: $field,
-    nested: { ...$record.nested, value: $field$1 },
-    last: $field$2
+    ...source,
+    first: observe("local-first")(10 | 0),
+    nested: { ...source.nested, value: observe("local-nested")(20 | 0) },
+    last: observe("local-last")(30 | 0)
   };
 }
 
 export function updateCall(shouldThrow) {
   const $record = makeModel("call");
-  const $field = observe("call-first")(10 | 0);
-  const $field$1 = failAt("call-nested")(shouldThrow)(20 | 0);
-  const $field$2 = observe("call-last")(30 | 0);
   return {
     ...$record,
-    first: $field,
-    nested: { ...$record.nested, value: $field$1 },
-    last: $field$2
+    first: observe("call-first")(10 | 0),
+    nested: { ...$record.nested, value: failAt("call-nested")(shouldThrow)(20 | 0) },
+    last: observe("call-last")(30 | 0)
+  };
+}
+
+export function updateDeep($boolean) {
+  const $record = makeModel("deep");
+  return {
+    ...$record,
+    nested: {
+      ...$record.nested,
+      value: observe("deep-nested")(50 | 0),
+      inner: { ...$record.nested.inner, value: observe("deep-inner")(60 | 0) }
+    }
   };
 }
 
 export function updateControl(condition) {
   return source => {
-    const $record = source;
-    const $field = observe("control-first")(10 | 0);
+    const $record = { ...source, first: observe("control-first")(10 | 0) };
+    const $record$1 = { ...source.nested };
     let $result;
     if (condition) {
       $result = observe("control-then")(30 | 0);
     } else {
       $result = observe("control-else")(31 | 0);
     }
-    const $field$1 = $result;
-    return { ...$record, first: $field, last: $field$1 };
+    return {
+      ...$record,
+      nested: { ...$record$1, value: $result },
+      last: observe("control-last")(32 | 0)
+    };
   };
 }
 
 export function updateOpen(source) {
-  const $record = source;
-  const $field = observe("open-first")(40 | 0);
-  return { ...$record, first: $field };
+  return { ...source, first: observe("open-first")(40 | 0) };
 }
 
 export const failAt = $foreign["failAt"];

--- a/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/package.json
+++ b/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/verify.mjs
+++ b/tests-integration/fixtures/backend/1787718060_record_update_evaluation_order/verify.mjs
@@ -1,0 +1,148 @@
+import { deepStrictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+import {
+  makeModel,
+  readTrace,
+  resetTrace,
+  symbolKey,
+} from "./output/Main/foreign.js";
+
+resetTrace();
+const localSource = makeModel("local");
+const local = Main.updateLocal(localSource);
+const localTrace = readTrace();
+
+resetTrace();
+const call = Main.updateCall(false);
+const callTrace = readTrace();
+
+resetTrace();
+let callError;
+try {
+  Main.updateCall(true);
+} catch (error) {
+  callError = error.message;
+}
+const throwingCallTrace = readTrace();
+
+resetTrace();
+const deep = Main.updateDeep(false);
+const deepTrace = readTrace();
+
+resetTrace();
+const control = Main.updateControl(true);
+const controlConstructionTrace = readTrace();
+const controlSource = makeModel("control");
+const controlled = control(controlSource);
+const controlTrace = readTrace();
+
+resetTrace();
+const openSource = makeModel("open");
+const open = Main.updateOpen(openSource);
+const openTrace = readTrace();
+
+const copyTrace = label => [
+  `${label}:keys`,
+  `${label}:descriptor:first`,
+  `${label}:get:first`,
+  `${label}:descriptor:nested`,
+  `${label}:get:nested`,
+  `${label}:descriptor:last`,
+  `${label}:get:last`,
+  `${label}:descriptor:untouched`,
+  `${label}:get:untouched`,
+  `${label}:descriptor:Symbol(marker)`,
+  `${label}:get:Symbol(marker)`,
+];
+
+const nestedCopyTrace = label => [
+  `${label}:keys`,
+  `${label}:descriptor:value`,
+  `${label}:get:value`,
+  `${label}:descriptor:inner`,
+  `${label}:get:inner`,
+  `${label}:descriptor:untouched`,
+  `${label}:get:untouched`,
+];
+
+const innerCopyTrace = label => [
+  `${label}:keys`,
+  `${label}:descriptor:value`,
+  `${label}:get:value`,
+  `${label}:descriptor:untouched`,
+  `${label}:get:untouched`,
+];
+
+deepStrictEqual(
+  {
+    localTrace,
+    localValues: [local.first, local.nested.value, local.last],
+    callTrace,
+    callValues: [call.first, call.nested.value, call.last],
+    callError,
+    throwingCallTrace,
+    deepTrace,
+    deepValues: [deep.nested.value, deep.nested.inner.value],
+    controlConstructionTrace,
+    controlTrace,
+    controlValues: [controlled.first, controlled.nested.value, controlled.last],
+    openTrace,
+    openValues: [open.first, open.untouched, open[symbolKey]],
+  },
+  {
+    localTrace: [
+      "make:local",
+      ...copyTrace("local"),
+      "observe:local-first",
+      "local:get:nested",
+      ...nestedCopyTrace("local.nested"),
+      "observe:local-nested",
+      "observe:local-last",
+    ],
+    localValues: [10, 20, 30],
+    callTrace: [
+      "make:call",
+      ...copyTrace("call"),
+      "observe:call-first",
+      "call:get:nested",
+      ...nestedCopyTrace("call.nested"),
+      "fail:call-nested",
+      "observe:call-last",
+    ],
+    callValues: [10, 20, 30],
+    callError: "call-nested",
+    throwingCallTrace: [
+      "make:call",
+      ...copyTrace("call"),
+      "observe:call-first",
+      "call:get:nested",
+      ...nestedCopyTrace("call.nested"),
+      "fail:call-nested",
+    ],
+    deepTrace: [
+      "make:deep",
+      ...copyTrace("deep"),
+      "deep:get:nested",
+      ...nestedCopyTrace("deep.nested"),
+      "observe:deep-nested",
+      "deep:get:nested",
+      "deep.nested:get:inner",
+      ...innerCopyTrace("deep.nested.inner"),
+      "observe:deep-inner",
+    ],
+    deepValues: [50, 60],
+    controlConstructionTrace: [],
+    controlTrace: [
+      "make:control",
+      ...copyTrace("control"),
+      "observe:control-first",
+      "control:get:nested",
+      ...nestedCopyTrace("control.nested"),
+      "observe:control-then",
+      "observe:control-last",
+    ],
+    controlValues: [10, 30, 32],
+    openTrace: ["make:open", ...copyTrace("open"), "observe:open-first"],
+    openValues: [40, 4, "symbol-value"],
+  },
+);

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/Main.functional.snap
@@ -1,0 +1,48 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export constructor Box/1
+
+@export foreign constructEffect
+
+@export foreign observe
+
+@export foreign observed
+
+@export stableApplication = \function%0 condition%1 ->
+  function%0 (if condition%1 then observe "application-then" 1 else observe "application-else" 2)
+
+@export observedApplication = \condition%2 ->
+  observed.apply (if condition%2 then observe "observed-then" 3 else observe "observed-else" 4)
+
+@export stableArray = \value%3 condition%4 ->
+  [value%3, if condition%4 then observe "array-then" 5 else observe "array-else" 6]
+
+@export observedArray = \condition%5 ->
+  [observed.value,
+    if condition%5 then observe "observed-array-then" 7 else observe "observed-array-else" 8]
+
+@export stablePure = \value%6 -> effect.pure value%6
+
+@export stableMap = \function%7 -> effect.map function%7 (constructEffect "stable-map" 9)
+
+@export observedMap = \$boolean%8@(_) ->
+  effect.map observed.apply (constructEffect "observed-map" 10)
+
+@export mixedApply = \$boolean%11@(_) ->
+  effect.apply
+    (constructEffect "mixed-function" (\value%9 -> observe "mixed-call" value%9))
+    (effect.bind (constructEffect "mixed-argument-first" 18)
+      \value%10 -> constructEffect "mixed-argument-second" value%10)
+
+@export joinedEffect = \condition%12 ->
+  [if condition%12
+      then effect.map observed.apply (constructEffect "joined-then" 16)
+      else effect.map observed.apply (constructEffect "joined-else" 17)]
+
+@export joinedPattern = \condition%13 ->
+  case if condition%13 then Box (observe "pattern-then" 11) else Box (observe "pattern-else" 12) of
+    Box value%14 ->
+      value%14

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/Main.js
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/Main.js
@@ -1,0 +1,34 @@
+let trace = [];
+
+export const constructEffect = label => value => {
+  trace.push(`construct:${label}`);
+  return () => {
+    trace.push(`run:${label}`);
+    return value;
+  };
+};
+
+export const observe = label => value => {
+  trace.push(`observe:${label}`);
+  return value;
+};
+
+export const observed = {
+  get apply() {
+    trace.push("read:apply");
+    return value => {
+      trace.push("apply");
+      return value;
+    };
+  },
+  get value() {
+    trace.push("read:value");
+    return 13;
+  },
+};
+
+export const readTrace = () => trace.slice();
+
+export const resetTrace = () => {
+  trace = [];
+};

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/Main.purs
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/Main.purs
@@ -1,0 +1,77 @@
+module Main where
+
+import Control.Applicative (pure)
+import Control.Apply (apply)
+import Control.Bind (bind)
+import Data.Functor (map)
+import Effect (Effect)
+
+data Box = Box Int
+
+foreign import constructEffect :: forall a. String -> a -> Effect a
+
+foreign import observe :: String -> Int -> Int
+
+foreign import observed
+  :: { apply :: Int -> Int
+     , value :: Int
+     }
+
+stableApplication :: (Int -> Int) -> Boolean -> Int
+stableApplication function condition =
+  function
+    if condition then observe "application-then" 1
+    else observe "application-else" 2
+
+observedApplication :: Boolean -> Int
+observedApplication condition =
+  observed.apply
+    if condition then observe "observed-then" 3
+    else observe "observed-else" 4
+
+stableArray :: Int -> Boolean -> Array Int
+stableArray value condition =
+  [ value
+  , if condition then observe "array-then" 5
+    else observe "array-else" 6
+  ]
+
+observedArray :: Boolean -> Array Int
+observedArray condition =
+  [ observed.value
+  , if condition then observe "observed-array-then" 7
+    else observe "observed-array-else" 8
+  ]
+
+stablePure :: Int -> Effect Int
+stablePure value = pure value
+
+stableMap :: (Int -> Int) -> Effect Int
+stableMap function = map function (constructEffect "stable-map" 9)
+
+observedMap :: Boolean -> Effect Int
+observedMap _ = map observed.apply (constructEffect "observed-map" 10)
+
+mixedApply :: Boolean -> Effect Int
+mixedApply _ =
+  apply
+    (constructEffect "mixed-function" (\value -> observe "mixed-call" value))
+    do
+      value <- constructEffect "mixed-argument-first" 18
+      constructEffect "mixed-argument-second" value
+
+joinedEffect :: Boolean -> Array (Effect Int)
+joinedEffect condition =
+  [ if condition then
+      map observed.apply (constructEffect "joined-then" 16)
+    else
+      map observed.apply (constructEffect "joined-else" 17)
+  ]
+
+joinedPattern :: Boolean -> Int
+joinedPattern condition =
+  case
+    if condition then Box (observe "pattern-then" 11)
+    else Box (observe "pattern-else" 12)
+  of
+    Box value -> value

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/Main.snap
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/Main.snap
@@ -1,0 +1,26 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 262
+expression: diagnostics_report
+---
+Terms
+Box :: Prim.Int -> Main.Box
+constructEffect :: forall a. Prim.String -> a -> Effect.Effect a
+observe :: Prim.String -> Prim.Int -> Prim.Int
+observed :: { apply :: Prim.Int -> Prim.Int, value :: Prim.Int }
+stableApplication :: (Prim.Int -> Prim.Int) -> Prim.Boolean -> Prim.Int
+observedApplication :: Prim.Boolean -> Prim.Int
+stableArray :: Prim.Int -> Prim.Boolean -> Prim.Array Prim.Int
+observedArray :: Prim.Boolean -> Prim.Array Prim.Int
+stablePure :: Prim.Int -> Effect.Effect Prim.Int
+stableMap :: (Prim.Int -> Prim.Int) -> Effect.Effect Prim.Int
+observedMap :: Prim.Boolean -> Effect.Effect Prim.Int
+mixedApply :: Prim.Boolean -> Effect.Effect Prim.Int
+joinedEffect :: Prim.Boolean -> Prim.Array (Effect.Effect Prim.Int)
+joinedPattern :: Prim.Boolean -> Prim.Int
+
+Types
+Box :: Prim.Type
+
+Roles
+Box = []

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Control.Applicative/index.js
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Control.Applicative/index.js
@@ -1,0 +1,3 @@
+export function pure(dictionary) {
+  return dictionary.pure;
+}

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Control.Apply/index.js
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Control.Apply/index.js
@@ -1,0 +1,7 @@
+import * as Data_Functor from "../Data.Functor/index.js";
+
+export function apply(dictionary) {
+  return dictionary.apply;
+}
+
+export const applyFn = { Functor0: () => Data_Functor.functorFn, apply: f => g => x => f(x)(g(x)) };

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Control.Bind/index.js
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Control.Bind/index.js
@@ -1,0 +1,9 @@
+export function bind(dictionary) {
+  return dictionary.bind;
+}
+
+export function discard(dictionary) {
+  return dictionary.discard;
+}
+
+export const discardUnit = { discard: bindFDict => bind(bindFDict) };

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Data.Functor/index.js
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Data.Functor/index.js
@@ -1,0 +1,5 @@
+export function map(dictionary) {
+  return dictionary.map;
+}
+
+export const functorFn = { map: f => g => x => f(g(x)) };

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Effect/foreign.js
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Effect/foreign.js
@@ -1,0 +1,4 @@
+export const mapEffect = transform => action => () => transform(action());
+export const applyEffect = functionAction => valueAction => () => functionAction()(valueAction());
+export const pureEffect = value => () => value;
+export const bindEffect = action => continuation => () => continuation(action())();

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Effect/index.js
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Effect/index.js
@@ -1,0 +1,16 @@
+import * as $foreign from "./foreign.js";
+
+export const mapEffect = $foreign["mapEffect"];
+export const applyEffect = $foreign["applyEffect"];
+export const pureEffect = $foreign["pureEffect"];
+export const bindEffect = $foreign["bindEffect"];
+
+export const functorEffect = { map: mapEffect };
+
+export const applyEffect1 = { Functor0: () => functorEffect, apply: applyEffect };
+
+export const applicativeEffect = { Apply0: () => applyEffect1, pure: pureEffect };
+
+export const bindEffect1 = { Apply0: () => applyEffect1, bind: bindEffect };
+
+export const monadEffect = { Applicative0: () => applicativeEffect, Bind1: () => bindEffect1 };

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Main/foreign.js
@@ -1,0 +1,34 @@
+let trace = [];
+
+export const constructEffect = label => value => {
+  trace.push(`construct:${label}`);
+  return () => {
+    trace.push(`run:${label}`);
+    return value;
+  };
+};
+
+export const observe = label => value => {
+  trace.push(`observe:${label}`);
+  return value;
+};
+
+export const observed = {
+  get apply() {
+    trace.push("read:apply");
+    return value => {
+      trace.push("apply");
+      return value;
+    };
+  },
+  get value() {
+    trace.push("read:value");
+    return 13;
+  },
+};
+
+export const readTrace = () => trace.slice();
+
+export const resetTrace = () => {
+  trace = [];
+};

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Main/index.js
@@ -1,0 +1,133 @@
+import * as $foreign from "./foreign.js";
+
+export const Box = $value0 => ["Box", $value0];
+
+export function stableApplication($function) {
+  return condition => {
+    const $function$1 = $function;
+    let $result;
+    if (condition) {
+      $result = observe("application-then")(1 | 0);
+    } else {
+      $result = observe("application-else")(2 | 0);
+    }
+    return $function$1($result);
+  };
+}
+
+export function observedApplication(condition) {
+  const $function = observed.apply;
+  let $result;
+  if (condition) {
+    $result = observe("observed-then")(3 | 0);
+  } else {
+    $result = observe("observed-else")(4 | 0);
+  }
+  return $function($result);
+}
+
+export function stableArray(value) {
+  return condition => {
+    const $element = value;
+    let $result;
+    if (condition) {
+      $result = observe("array-then")(5 | 0);
+    } else {
+      $result = observe("array-else")(6 | 0);
+    }
+    return [$element, $result];
+  };
+}
+
+export function observedArray(condition) {
+  const $element = observed.value;
+  let $result;
+  if (condition) {
+    $result = observe("observed-array-then")(7 | 0);
+  } else {
+    $result = observe("observed-array-else")(8 | 0);
+  }
+  return [$element, $result];
+}
+
+export function stablePure(value) {
+  const $value = value;
+  const $effect = () => {
+    return $value;
+  };
+  return $effect;
+}
+
+export function stableMap($function) {
+  const $function$1 = $function;
+  const $action = constructEffect("stable-map")(9 | 0);
+  const $effect = () => {
+    const $value = $action();
+    return $function$1($value);
+  };
+  return $effect;
+}
+
+export function observedMap($boolean) {
+  const $function = observed.apply;
+  const $action = constructEffect("observed-map")(10 | 0);
+  const $effect = () => {
+    const $value = $action();
+    return $function($value);
+  };
+  return $effect;
+}
+
+export function mixedApply($boolean) {
+  const $functionAction = constructEffect("mixed-function")(value => observe("mixed-call")(value));
+  const $action = constructEffect("mixed-argument-first")(18 | 0);
+  const $effect = () => {
+    const $function = $functionAction();
+    let $argument;
+    const value$1 = $action();
+    $argument = constructEffect("mixed-argument-second")(value$1)();
+    return $function($argument);
+  };
+  return $effect;
+}
+
+export function joinedEffect(condition) {
+  let $result;
+  if (condition) {
+    const $function = observed.apply;
+    const $action = constructEffect("joined-then")(16 | 0);
+    const $effect = () => {
+      const $value = $action();
+      return $function($value);
+    };
+    $result = $effect;
+  } else {
+    const $function$1 = observed.apply;
+    const $action$1 = constructEffect("joined-else")(17 | 0);
+    const $effect$1 = () => {
+      const $value$1 = $action$1();
+      return $function$1($value$1);
+    };
+    $result = $effect$1;
+  }
+  return [$result];
+}
+
+export function joinedPattern(condition) {
+  let $result;
+  if (condition) {
+    $result = Box(observe("pattern-then")(11 | 0));
+  } else {
+    $result = Box(observe("pattern-else")(12 | 0));
+  }
+  const $scrutinee = $result;
+  if (Array.isArray($scrutinee) && $scrutinee[0] === "Box") {
+    const value = $scrutinee[1];
+    return value;
+  }
+  throw new Error("Pattern match failure");
+}
+
+export const constructEffect = $foreign["constructEffect"];
+export const observe = $foreign["observe"];
+export const observed = $foreign["observed"];

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Main/index.js
@@ -4,14 +4,13 @@ export const Box = $value0 => ["Box", $value0];
 
 export function stableApplication($function) {
   return condition => {
-    const $function$1 = $function;
     let $result;
     if (condition) {
       $result = observe("application-then")(1 | 0);
     } else {
       $result = observe("application-else")(2 | 0);
     }
-    return $function$1($result);
+    return $function($result);
   };
 }
 
@@ -28,14 +27,13 @@ export function observedApplication(condition) {
 
 export function stableArray(value) {
   return condition => {
-    const $element = value;
     let $result;
     if (condition) {
       $result = observe("array-then")(5 | 0);
     } else {
       $result = observe("array-else")(6 | 0);
     }
-    return [$element, $result];
+    return [value, $result];
   };
 }
 
@@ -51,44 +49,36 @@ export function observedArray(condition) {
 }
 
 export function stablePure(value) {
-  const $value = value;
-  const $effect = () => {
-    return $value;
+  return () => {
+    return value;
   };
-  return $effect;
 }
 
 export function stableMap($function) {
-  const $function$1 = $function;
   const $action = constructEffect("stable-map")(9 | 0);
-  const $effect = () => {
-    const $value = $action();
-    return $function$1($value);
+  return () => {
+    return $function($action());
   };
-  return $effect;
 }
 
 export function observedMap($boolean) {
   const $function = observed.apply;
   const $action = constructEffect("observed-map")(10 | 0);
-  const $effect = () => {
-    const $value = $action();
-    return $function($value);
+  return () => {
+    return $function($action());
   };
-  return $effect;
 }
 
 export function mixedApply($boolean) {
   const $functionAction = constructEffect("mixed-function")(value => observe("mixed-call")(value));
   const $action = constructEffect("mixed-argument-first")(18 | 0);
-  const $effect = () => {
+  return () => {
     const $function = $functionAction();
     let $argument;
     const value$1 = $action();
     $argument = constructEffect("mixed-argument-second")(value$1)();
     return $function($argument);
   };
-  return $effect;
 }
 
 export function joinedEffect(condition) {
@@ -96,19 +86,15 @@ export function joinedEffect(condition) {
   if (condition) {
     const $function = observed.apply;
     const $action = constructEffect("joined-then")(16 | 0);
-    const $effect = () => {
-      const $value = $action();
-      return $function($value);
+    $result = () => {
+      return $function($action());
     };
-    $result = $effect;
   } else {
     const $function$1 = observed.apply;
     const $action$1 = constructEffect("joined-else")(17 | 0);
-    const $effect$1 = () => {
-      const $value$1 = $action$1();
-      return $function$1($value$1);
+    $result = () => {
+      return $function$1($action$1());
     };
-    $result = $effect$1;
   }
   return [$result];
 }
@@ -120,9 +106,8 @@ export function joinedPattern(condition) {
   } else {
     $result = Box(observe("pattern-else")(12 | 0));
   }
-  const $scrutinee = $result;
-  if (Array.isArray($scrutinee) && $scrutinee[0] === "Box") {
-    const value = $scrutinee[1];
+  if (Array.isArray($result) && $result[0] === "Box") {
+    const value = $result[1];
     return value;
   }
   throw new Error("Pattern match failure");

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/package.json
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/verify.mjs
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/verify.mjs
@@ -1,0 +1,78 @@
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+import { readTrace, resetTrace } from "./output/Main/foreign.js";
+
+resetTrace();
+strictEqual(Main.stableApplication(value => value + 1)(true), 2);
+deepStrictEqual(readTrace(), ["observe:application-then"]);
+
+resetTrace();
+strictEqual(Main.observedApplication(true), 3);
+deepStrictEqual(readTrace(), ["read:apply", "observe:observed-then", "apply"]);
+
+resetTrace();
+deepStrictEqual(Main.stableArray(14)(false), [14, 6]);
+deepStrictEqual(readTrace(), ["observe:array-else"]);
+
+resetTrace();
+deepStrictEqual(Main.observedArray(true), [13, 7]);
+deepStrictEqual(readTrace(), ["read:value", "observe:observed-array-then"]);
+
+resetTrace();
+const pureEffect = Main.stablePure(15);
+deepStrictEqual(readTrace(), []);
+strictEqual(pureEffect(), 15);
+deepStrictEqual(readTrace(), []);
+
+resetTrace();
+const mappedEffect = Main.stableMap(Main.observe("stable-map-result"));
+deepStrictEqual(readTrace(), ["construct:stable-map"]);
+strictEqual(mappedEffect(), 9);
+deepStrictEqual(readTrace(), [
+  "construct:stable-map",
+  "run:stable-map",
+  "observe:stable-map-result",
+]);
+
+resetTrace();
+const observedEffect = Main.observedMap(false);
+deepStrictEqual(readTrace(), ["read:apply", "construct:observed-map"]);
+strictEqual(observedEffect(), 10);
+deepStrictEqual(readTrace(), [
+  "read:apply",
+  "construct:observed-map",
+  "run:observed-map",
+  "apply",
+]);
+
+resetTrace();
+const mixedEffect = Main.mixedApply(false);
+deepStrictEqual(readTrace(), [
+  "construct:mixed-function",
+  "construct:mixed-argument-first",
+]);
+strictEqual(mixedEffect(), 18);
+deepStrictEqual(readTrace(), [
+  "construct:mixed-function",
+  "construct:mixed-argument-first",
+  "run:mixed-function",
+  "run:mixed-argument-first",
+  "construct:mixed-argument-second",
+  "run:mixed-argument-second",
+  "observe:mixed-call",
+]);
+
+resetTrace();
+const [joinedEffect] = Main.joinedEffect(true);
+deepStrictEqual(readTrace(), ["read:apply", "construct:joined-then"]);
+strictEqual(joinedEffect(), 16);
+deepStrictEqual(readTrace(), [
+  "read:apply",
+  "construct:joined-then",
+  "run:joined-then",
+  "apply",
+]);
+
+resetTrace();
+strictEqual(Main.joinedPattern(false), 12);
+deepStrictEqual(readTrace(), ["observe:pattern-else"]);


### PR DESCRIPTION
## Summary

- preserve composable JavaScript expressions instead of materializing every fallback-rendered subexpression
- retain temporaries only where a later render step eagerly evaluates user code and therefore establishes a sequencing boundary
- add Halogen-shaped and executable evaluation-order regression fixtures

## Motivation

The functional optimizer already produces nested applications and safely simplifies source-level local bindings. When a descendant such as an inlined local helper contained control flow, however, the JavaScript renderer could no longer render the entire expression atomically. Its fallback then introduced a `const` for every callee, argument, call, array element, and composite result.

This made dynamic Halogen render trees substantially larger even though the functional tree was already nested. The new renderer state distinguishes a pending expression from a value that has already been evaluated. Pending expressions remain nested until rendering a later sibling would execute user code.

Closure declarations do not form such a boundary: creating an arrow function does not evaluate its body. Calls, property reads, and foreign expressions therefore remain in their original JavaScript expression and retain JavaScript's callee-before-arguments and left-to-right evaluation order. Control-flow joins, effects, record updates, recursive/lazy initialization, and reused bindings keep explicit boundaries.

In the focused Halogen-shaped fixture, generated `const $...` declarations fall from 21 to 1 and output falls from 1,086 to 490 bytes. Across the generated JavaScript snapshots changed by this pull request, 62 generated temporaries and 1,838 bytes are removed.

## Verification

- `just format`
- `cargo check -p javascript --tests`
- focused backend fixtures, including Node verification of getter/call order, throwing behavior, and single evaluation of reused bindings
- `just t backend`