### PR TITLE
[functional] Hoist closed type class evidence

### DIFF
--- a/compiler-backend/functional/src/convert.rs
+++ b/compiler-backend/functional/src/convert.rs
@@ -21,13 +21,13 @@ use crate::error::{ModuleError, ModuleResult, UnsupportedState};
 use crate::optimize::inline_simple_bindings;
 use crate::tree::{
     Declaration, DeclarationKind, Expression, ExpressionId, ExpressionKind, Field, FieldIdentity,
-    Global, GlobalId, IndirectModuleExports, InstanceIdentity, LocalId, Module, ModuleDependency,
-    ModuleSurface, Parameter, Pattern, PatternId, PatternKind, RecursiveGroupId, Storage,
-    SuperclassIdentity,
+    GeneratedGlobalId, Global, GlobalId, IndirectModuleExports, InstanceIdentity, LocalId, Module,
+    ModuleDependency, ModuleSurface, Parameter, Pattern, PatternId, PatternKind, RecursiveGroupId,
+    Storage, SuperclassIdentity,
 };
 
 use self::declaration::{derive_declaration, instance_declaration, term_declaration};
-use self::evidence::EvidenceScope;
+use self::evidence::{EvidenceHoisting, EvidenceScope};
 
 type ConversionResult<T> = Result<T, ConversionError>;
 
@@ -80,8 +80,10 @@ struct Context<'c, Q> {
 
     parameters: FxHashMap<BindingSource, Parameter>,
     next_local: u32,
+    next_generated_global: u32,
     lowering_evidence: FxHashSet<EvidenceVarId>,
     evidence_scopes: Vec<EvidenceScope>,
+    evidence_hoisting: EvidenceHoisting,
 
     storage: Storage,
 }
@@ -139,8 +141,10 @@ where
 
             parameters: FxHashMap::default(),
             next_local: 0,
+            next_generated_global: 0,
             lowering_evidence: FxHashSet::default(),
             evidence_scopes: Vec::new(),
+            evidence_hoisting: EvidenceHoisting::default(),
 
             storage: Storage::default(),
         })
@@ -168,6 +172,7 @@ fn convert(mut context: Context<'_, impl checking::ExternalQueries>) -> Conversi
         declarations.extend(declaration);
     }
     validate_runtime_exports(&context, &declarations, &surface)?;
+    context.hoist_closed_evidence(&mut declarations)?;
 
     let recursive_globals = declarations
         .iter()
@@ -432,6 +437,15 @@ where
             .checked_add(1)
             .ok_or_else(|| self.unsupported(UnsupportedState::LocalIdentityOverflow))?;
         Ok(Parameter { id, name })
+    }
+
+    fn fresh_generated_global(&mut self, item_name: SmolStr) -> ConversionResult<Global> {
+        let id = GeneratedGlobalId(self.next_generated_global);
+        self.next_generated_global = self
+            .next_generated_global
+            .checked_add(1)
+            .ok_or_else(|| self.unsupported(UnsupportedState::GeneratedGlobalIdentityOverflow))?;
+        Ok(Global { id: GlobalId::Generated(self.file_id, id), item_name })
     }
 
     fn parameter_abstraction(

--- a/compiler-backend/functional/src/convert/declaration.rs
+++ b/compiler-backend/functional/src/convert/declaration.rs
@@ -117,13 +117,14 @@ fn convert_instance_declaration(
     let parameters = parameters.collect::<ConversionResult<Vec<_>>>()?;
 
     let body = context.evidence_scope(|context| match &instance.implementation {
-        checking_tree::InstanceImplementation::Delegate { evidence, .. } => {
-            evidence_variable(context, *evidence)
+        checking_tree::InstanceImplementation::Delegate { constraint, evidence } => {
+            evidence_variable(context, *evidence, Some(*constraint))
         }
         checking_tree::InstanceImplementation::Members(members) => {
             let mut fields = Vec::new();
             for superclass in instance.superclasses.iter() {
-                let expression = evidence_variable(context, superclass.evidence)?;
+                let expression =
+                    evidence_variable(context, superclass.evidence, Some(superclass.constraint))?;
                 let expression = context.expression(ExpressionKind::Abstraction {
                     parameters: Arc::from([]),
                     body: expression,

--- a/compiler-backend/functional/src/convert/evidence.rs
+++ b/compiler-backend/functional/src/convert/evidence.rs
@@ -4,12 +4,15 @@ use building_types::QueryResult;
 use checking::evidence::{
     Evidence, EvidenceBinderId, EvidenceId, EvidenceState, EvidenceVarId, InstanceCandidateOrigin,
 };
+use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smol_str::{SmolStr, format_smolstr};
 
 use crate::error::UnsupportedState;
+use crate::optimize::{expression_globals, reachable_expressions};
 use crate::tree::{
-    Binding, ExpressionId, ExpressionKind, Parameter, ReflectableEvidence, ReflectableOrdering,
+    Binding, Declaration, DeclarationKind, Expression, ExpressionId, ExpressionKind, Global,
+    GlobalId, InstanceIdentity, Parameter, ReflectableEvidence, ReflectableOrdering, Storage,
     SynthesizedEvidence,
 };
 
@@ -19,8 +22,27 @@ const MAX_EVIDENCE_NAME_FRAGMENTS: usize = 4;
 
 #[derive(Default)]
 pub(super) struct EvidenceScope {
+    // Evidence containing local dictionary parameters cannot escape its lexical scope.
     constructions: FxHashMap<EvidenceKey, EvidenceConstruction>,
     bindings: Vec<EvidenceBinding>,
+}
+
+#[derive(Default)]
+pub(super) struct EvidenceHoisting {
+    // Closed evidence is collected across lexical scopes so repetition can introduce a module global.
+    occurrences: FxHashMap<ClosedEvidenceKey, EvidenceOccurrences>,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum ClosedEvidenceKey {
+    Dictionary(EvidenceKey),
+    Member { member: (files::FileId, indexing::TermItemId), evidence: EvidenceKey },
+}
+
+#[derive(Default)]
+struct EvidenceOccurrences {
+    expressions: Vec<ExpressionId>,
+    constraint_name: Option<SmolStr>,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -32,6 +54,14 @@ enum EvidenceKey {
 }
 
 impl EvidenceKey {
+    fn is_closed(&self) -> bool {
+        match self {
+            EvidenceKey::Given(_) | EvidenceKey::Opaque(_) => false,
+            EvidenceKey::Instance { subgoals, .. } => subgoals.iter().all(EvidenceKey::is_closed),
+            EvidenceKey::Superclass { parent, .. } => parent.is_closed(),
+        }
+    }
+
     fn dependency_order(&self) -> usize {
         match self {
             EvidenceKey::Given(_) | EvidenceKey::Opaque(_) => 0,
@@ -40,6 +70,41 @@ impl EvidenceKey {
                 orders.max().unwrap_or(0).saturating_add(1)
             }
             EvidenceKey::Superclass { parent, .. } => parent.dependency_order().saturating_add(1),
+        }
+    }
+}
+
+impl ClosedEvidenceKey {
+    fn dependency_order(&self) -> usize {
+        match self {
+            ClosedEvidenceKey::Dictionary(evidence) => evidence.dependency_order(),
+            ClosedEvidenceKey::Member { evidence, .. } => {
+                evidence.dependency_order().saturating_add(1)
+            }
+        }
+    }
+
+    fn contains_unsafe_instance(&self, unsafe_instances: &FxHashSet<InstanceIdentity>) -> bool {
+        let evidence = match self {
+            ClosedEvidenceKey::Dictionary(evidence)
+            | ClosedEvidenceKey::Member { evidence, .. } => evidence,
+        };
+        evidence_contains_unsafe_instance(evidence, unsafe_instances)
+    }
+}
+
+impl EvidenceHoisting {
+    fn record(
+        &mut self,
+        key: ClosedEvidenceKey,
+        expression: ExpressionId,
+        constraint_name: Option<SmolStr>,
+    ) {
+        let occurrences = self.occurrences.entry(key).or_default();
+        occurrences.expressions.push(expression);
+
+        if occurrences.constraint_name.is_none() {
+            occurrences.constraint_name = constraint_name;
         }
     }
 }
@@ -58,6 +123,7 @@ struct EvidenceBinding {
 pub(super) fn evidence_variable(
     context: &mut Context<'_, impl checking::ExternalQueries>,
     variable: EvidenceVarId,
+    constraint: Option<checking::TypeId>,
 ) -> ConversionResult<ExpressionId> {
     if !context.lowering_evidence.insert(variable) {
         return Err(context.unsupported(UnsupportedState::CyclicEvidence(variable)));
@@ -66,7 +132,7 @@ pub(super) fn evidence_variable(
         EvidenceState::Unsolved => {
             Err(context.unsupported(UnsupportedState::UnsolvedEvidence(variable)))
         }
-        EvidenceState::Solved(evidence) => convert_evidence(context, evidence),
+        EvidenceState::Solved(evidence) => convert_evidence(context, evidence, constraint),
         EvidenceState::Error => Err(context.unsupported(UnsupportedState::EvidenceError(variable))),
     };
     context.lowering_evidence.remove(&variable);
@@ -76,10 +142,11 @@ pub(super) fn evidence_variable(
 fn convert_evidence(
     context: &mut Context<'_, impl checking::ExternalQueries>,
     evidence_id: EvidenceId,
+    constraint: Option<checking::TypeId>,
 ) -> ConversionResult<ExpressionId> {
     let checked = Arc::clone(&context.checked);
     match &checked.evidence[evidence_id] {
-        Evidence::Variable(variable) => evidence_variable(context, *variable),
+        Evidence::Variable(variable) => evidence_variable(context, *variable, constraint),
         Evidence::Given(binder) => {
             let parameter = context.evidence_parameter(*binder)?;
             Ok(context.expression(ExpressionKind::Local { parameter }))
@@ -92,13 +159,14 @@ fn convert_evidence(
             let global = context.instance_global(*origin)?;
             let name = format_smolstr!("{}Dict", global.item_name);
             let function = context.expression(ExpressionKind::Global { global });
-            let arguments = subgoals.iter().map(|&subgoal| evidence_variable(context, subgoal));
+            let arguments =
+                subgoals.iter().map(|&subgoal| evidence_variable(context, subgoal, None));
             let arguments = arguments.collect::<ConversionResult<Vec<_>>>()?;
             let construction = context.application(function, arguments)?;
             if subgoals.is_empty() {
                 Ok(construction)
             } else {
-                context.record_evidence(evidence, construction, name)
+                context.record_evidence(evidence, construction, name, constraint)
             }
         }
         Evidence::Superclass { parent, superclass } => {
@@ -106,7 +174,7 @@ fn convert_evidence(
             if let Some(expression) = context.shared_evidence(&evidence)? {
                 return Ok(expression);
             }
-            let record = convert_evidence(context, *parent)?;
+            let record = convert_evidence(context, *parent, None)?;
             let field = context.superclass_field(*superclass)?;
             let name = format_smolstr!("{}Dict", field.name);
             let accessor = context.expression(ExpressionKind::Project { record, field });
@@ -114,7 +182,7 @@ fn convert_evidence(
                 function: accessor,
                 arguments: Arc::from([]),
             });
-            context.record_evidence(evidence, construction, name)
+            context.record_evidence(evidence, construction, name, constraint)
         }
         Evidence::Trivial => Ok(context.expression(ExpressionKind::TrivialEvidence)),
         Evidence::Synthesized(evidence) => {
@@ -195,10 +263,120 @@ where
         }))
     }
 
+    pub(super) fn hoist_closed_evidence(
+        &mut self,
+        declarations: &mut Vec<Declaration>,
+    ) -> ConversionResult<()> {
+        let roots = declarations.iter().filter_map(|declaration| match declaration.kind {
+            DeclarationKind::Value(expression) => Some(expression),
+            DeclarationKind::Constructor { .. } | DeclarationKind::Foreign => None,
+        });
+        let reachable = reachable_expressions(&self.storage, roots);
+        let unsafe_instances = unsafe_local_instances(&self.storage, declarations);
+        let occurrences = std::mem::take(&mut self.evidence_hoisting.occurrences);
+
+        let mut candidates = Vec::new();
+        for (key, mut occurrences) in occurrences {
+            let mut seen = FxHashSet::default();
+            occurrences
+                .expressions
+                .retain(|expression| reachable.contains(expression) && seen.insert(*expression));
+
+            // Evidence construction is shareable by compiler contract, but forcing
+            // a local recursive initializer during module initialization is not.
+            let repeated = occurrences.expressions.len() >= 2;
+            let safe = !key.contains_unsafe_instance(&unsafe_instances);
+            if !repeated || !safe {
+                continue;
+            }
+
+            candidates.push((key, occurrences));
+        }
+
+        candidates.sort_by_key(|(key, occurrences)| {
+            let first = occurrences.expressions[0].into_raw().into_u32();
+            (key.dependency_order(), first)
+        });
+
+        for (key, occurrences) in candidates {
+            let name = match occurrences.constraint_name {
+                Some(name) => name,
+                None => self.closed_evidence_name(&key)?,
+            };
+            let global = self.fresh_generated_global(name)?;
+            let replacement = ExpressionKind::Global { global: Global::clone(&global) };
+
+            let (first, remaining) = occurrences
+                .expressions
+                .split_first()
+                .expect("invariant violated: repeated evidence has no occurrence");
+            let initializer =
+                self.storage.replace_expression_kind(*first, ExpressionKind::clone(&replacement));
+            let initializer = self.storage.allocate_expression(Expression { kind: initializer });
+
+            for &expression in remaining {
+                self.storage
+                    .replace_expression_kind(expression, ExpressionKind::clone(&replacement));
+            }
+
+            let declaration = Declaration {
+                global,
+                exported: false,
+                recursive_group: None,
+                kind: DeclarationKind::Value(initializer),
+            };
+            declarations.push(declaration);
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn record_closed_member_selection(
+        &mut self,
+        function: ExpressionId,
+        evidence_variable: EvidenceVarId,
+        constraint: checking::TypeId,
+        selection: ExpressionId,
+    ) -> ConversionResult<ExpressionId> {
+        let ExpressionKind::Global { global } = &self.storage[function].kind else {
+            return Ok(selection);
+        };
+        let global = Global::clone(global);
+
+        let GlobalId::Term(file_id, term_id) = global.id else {
+            return Ok(selection);
+        };
+        let indexed = self.indexed_module(file_id)?;
+        let indexing::IndexedTermItemKind::ClassMember { .. } = indexed.items[term_id].kind else {
+            return Ok(selection);
+        };
+
+        let EvidenceState::Solved(evidence_id) = self.checked.evidence[evidence_variable].state
+        else {
+            return Ok(selection);
+        };
+        let evidence = self.evidence_key(evidence_id);
+        if !evidence.is_closed() {
+            return Ok(selection);
+        }
+
+        let dictionary_name = self.evidence_parameter_name(constraint)?;
+        let member_name = uppercase_initial(&global.item_name);
+        let name = format_smolstr!("{dictionary_name}{member_name}");
+
+        let key = ClosedEvidenceKey::Member { member: (file_id, term_id), evidence };
+        self.evidence_hoisting.record(key, selection, Some(name));
+
+        Ok(selection)
+    }
+
     fn shared_evidence(
         &mut self,
         evidence: &EvidenceKey,
     ) -> ConversionResult<Option<ExpressionId>> {
+        if evidence.is_closed() {
+            return Ok(None);
+        }
         let Some(scope) = self.evidence_scopes.last() else { return Ok(None) };
         let Some(construction) = scope.constructions.get(evidence).cloned() else {
             return Ok(None);
@@ -238,7 +416,16 @@ where
         evidence: EvidenceKey,
         construction: ExpressionId,
         name: SmolStr,
+        constraint: Option<checking::TypeId>,
     ) -> ConversionResult<ExpressionId> {
+        if evidence.is_closed() {
+            let name = constraint
+                .map(|constraint| self.evidence_parameter_name(constraint))
+                .transpose()?;
+            let key = ClosedEvidenceKey::Dictionary(evidence);
+            self.evidence_hoisting.record(key, construction, name);
+            return Ok(construction);
+        }
         let Some(scope) = self.evidence_scopes.last_mut() else { return Ok(construction) };
         scope
             .constructions
@@ -286,6 +473,50 @@ where
         };
         visiting.remove(&evidence);
         Some(key)
+    }
+
+    fn evidence_dictionary_name(&self, evidence: &EvidenceKey) -> ConversionResult<SmolStr> {
+        let base = self.evidence_name_base(evidence)?;
+        Ok(format_smolstr!("{base}Dict"))
+    }
+
+    fn closed_evidence_name(&self, evidence: &ClosedEvidenceKey) -> ConversionResult<SmolStr> {
+        match evidence {
+            ClosedEvidenceKey::Dictionary(evidence) => self.evidence_dictionary_name(evidence),
+            ClosedEvidenceKey::Member { member: (file_id, term_id), evidence } => {
+                let dictionary_name = self.evidence_dictionary_name(evidence)?;
+                let indexed = self.indexed_module(*file_id)?;
+                let member_name = indexed.items[*term_id]
+                    .name
+                    .as_ref()
+                    .map_or_else(|| String::from("Member"), |name| uppercase_initial(name));
+                Ok(format_smolstr!("{dictionary_name}{member_name}"))
+            }
+        }
+    }
+
+    fn evidence_name_base(&self, evidence: &EvidenceKey) -> ConversionResult<SmolStr> {
+        let mut name = match evidence {
+            EvidenceKey::Instance { origin, .. } => {
+                let identity = instance_identity(*origin);
+                self.instance_name(identity)?.to_string()
+            }
+            EvidenceKey::Superclass { parent, superclass } => {
+                let parent = self.evidence_name_base(parent)?;
+                let field = self.superclass_field(*superclass)?;
+                format!("{parent}{}", uppercase_initial(&field.name))
+            }
+            EvidenceKey::Given(_) | EvidenceKey::Opaque(_) => String::from("evidence"),
+        };
+
+        if let EvidenceKey::Instance { subgoals, .. } = evidence {
+            for subgoal in subgoals {
+                let subgoal = self.evidence_name_base(subgoal)?;
+                name.push_str(&uppercase_initial(&subgoal));
+            }
+        }
+
+        Ok(SmolStr::new(name))
     }
 
     pub(super) fn evidence_parameter(
@@ -380,4 +611,124 @@ fn append_evidence_name_fragment(name: &mut String, fragment: &str, fragments: &
     name.extend(first.to_uppercase());
     name.push_str(characters.as_str());
     *fragments += 1;
+}
+
+fn instance_identity(origin: InstanceCandidateOrigin) -> InstanceIdentity {
+    match origin {
+        InstanceCandidateOrigin::Instance(file_id, instance) => {
+            InstanceIdentity::Declared(file_id, instance)
+        }
+        InstanceCandidateOrigin::Derive(file_id, derive) => {
+            InstanceIdentity::Derived(file_id, derive)
+        }
+    }
+}
+
+fn evidence_contains_unsafe_instance(
+    evidence: &EvidenceKey,
+    unsafe_instances: &FxHashSet<InstanceIdentity>,
+) -> bool {
+    match evidence {
+        EvidenceKey::Given(_) | EvidenceKey::Opaque(_) => false,
+        EvidenceKey::Instance { origin, subgoals } => {
+            unsafe_instances.contains(&instance_identity(*origin))
+                || subgoals
+                    .iter()
+                    .any(|subgoal| evidence_contains_unsafe_instance(subgoal, unsafe_instances))
+        }
+        EvidenceKey::Superclass { parent, .. } => {
+            evidence_contains_unsafe_instance(parent, unsafe_instances)
+        }
+    }
+}
+
+fn unsafe_local_instances(
+    storage: &Storage,
+    declarations: &[Declaration],
+) -> FxHashSet<InstanceIdentity> {
+    let values = declarations.iter().filter_map(|declaration| match declaration.kind {
+        DeclarationKind::Value(expression) => {
+            Some((declaration.global.id, declaration.recursive_group, expression))
+        }
+        DeclarationKind::Constructor { .. } | DeclarationKind::Foreign => None,
+    });
+    let values = values.collect_vec();
+
+    let positions = values.iter().enumerate().map(|(position, (global, _, _))| (*global, position));
+    let positions = positions.collect::<FxHashMap<_, _>>();
+
+    let mut dependencies = vec![Vec::new(); values.len()];
+    for (position, (_, _, expression)) in values.iter().enumerate() {
+        let globals = expression_globals(storage, *expression);
+        let dependency_positions =
+            globals.into_iter().filter_map(|global| positions.get(&global).copied());
+        dependencies[position].extend(dependency_positions);
+        dependencies[position].sort_unstable();
+        dependencies[position].dedup();
+    }
+
+    let mut hazards = FxHashSet::default();
+    for (position, (_, recursive_group, _)) in values.iter().enumerate() {
+        let mut visited = FxHashSet::default();
+        if recursive_group.is_some()
+            || reaches_declaration(position, position, &dependencies, &mut visited)
+        {
+            hazards.insert(position);
+        }
+    }
+
+    let mut unsafe_instances = FxHashSet::default();
+    for (position, (global, _, _)) in values.iter().enumerate() {
+        let GlobalId::Instance(identity) = global else {
+            continue;
+        };
+        let mut pending = vec![position];
+        let mut visited = FxHashSet::default();
+        let mut unsafe_instance = false;
+        while let Some(dependency) = pending.pop() {
+            if !visited.insert(dependency) {
+                continue;
+            }
+
+            if hazards.contains(&dependency) {
+                unsafe_instance = true;
+                break;
+            }
+
+            let next_dependencies = dependencies[dependency].iter().copied();
+            pending.extend(next_dependencies);
+        }
+
+        if unsafe_instance {
+            unsafe_instances.insert(*identity);
+        }
+    }
+
+    unsafe_instances
+}
+
+fn reaches_declaration(
+    current: usize,
+    target: usize,
+    dependencies: &[Vec<usize>],
+    visited: &mut FxHashSet<usize>,
+) -> bool {
+    for &dependency in &dependencies[current] {
+        if dependency == target {
+            return true;
+        }
+        if visited.insert(dependency)
+            && reaches_declaration(dependency, target, dependencies, visited)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn uppercase_initial(name: &str) -> String {
+    let mut characters = name.chars();
+    let Some(first) = characters.next() else { return String::new() };
+    let first = first.to_uppercase().collect::<String>();
+    format!("{first}{}", characters.as_str())
 }

--- a/compiler-backend/functional/src/convert/expression.rs
+++ b/compiler-backend/functional/src/convert/expression.rs
@@ -98,10 +98,16 @@ pub(super) fn convert_expression(
             let argument = convert_expression(context, *argument)?;
             return context.application(function, [argument]);
         }
-        checking_tree::ExpressionKind::EvidenceApplication { function, evidence, .. } => {
-            let evidence = evidence_variable(context, *evidence)?;
+        checking_tree::ExpressionKind::EvidenceApplication { function, evidence, constraint } => {
+            let evidence_expression = evidence_variable(context, *evidence, Some(*constraint))?;
             let function = convert_expression(context, *function)?;
-            return context.application(function, [evidence]);
+            let selection = context.application(function, [evidence_expression])?;
+            return context.record_closed_member_selection(
+                function,
+                *evidence,
+                *constraint,
+                selection,
+            );
         }
         checking_tree::ExpressionKind::EvidenceAbstraction { binder, expression } => {
             let parameter = context.evidence_parameter(*binder)?;

--- a/compiler-backend/functional/src/error.rs
+++ b/compiler-backend/functional/src/error.rs
@@ -48,4 +48,6 @@ pub enum UnsupportedState {
     InvalidInstancePrerequisite,
     #[error("local identity space is exhausted")]
     LocalIdentityOverflow,
+    #[error("generated global identity space is exhausted")]
+    GeneratedGlobalIdentityOverflow,
 }

--- a/compiler-backend/functional/src/optimize.rs
+++ b/compiler-backend/functional/src/optimize.rs
@@ -17,6 +17,35 @@ pub fn inline_simple_bindings(
     optimize_expression(storage, expression, recursive_globals, &mut visited);
 }
 
+pub(crate) fn reachable_expressions(
+    storage: &Storage,
+    roots: impl IntoIterator<Item = ExpressionId>,
+) -> FxHashSet<ExpressionId> {
+    let mut reachable = FxHashSet::default();
+    let mut pending = roots.into_iter().collect::<Vec<_>>();
+    while let Some(expression) = pending.pop() {
+        if !reachable.insert(expression) {
+            continue;
+        }
+        pending.extend(expression_children(&storage[expression].kind));
+    }
+    reachable
+}
+
+pub(crate) fn expression_globals(
+    storage: &Storage,
+    expression: ExpressionId,
+) -> FxHashSet<GlobalId> {
+    let reachable = reachable_expressions(storage, [expression]);
+    let globals = reachable.into_iter().filter_map(|expression| match &storage[expression].kind {
+        ExpressionKind::Constructor { global } | ExpressionKind::Global { global } => {
+            Some(global.id)
+        }
+        _ => None,
+    });
+    globals.collect()
+}
+
 fn optimize_expression(
     storage: &mut Storage,
     expression: ExpressionId,

--- a/compiler-backend/functional/src/pretty.rs
+++ b/compiler-backend/functional/src/pretty.rs
@@ -61,7 +61,7 @@ impl<'a> Printer<'a, '_> {
             }
             DeclarationKind::Value(expression) => {
                 let prefix = match declaration.global.id {
-                    GlobalId::Term(..) => "",
+                    GlobalId::Term(..) | GlobalId::Generated(..) => "",
                     GlobalId::Instance(..) => "instance ",
                 };
                 let recursion = declaration

--- a/compiler-backend/functional/src/tree.rs
+++ b/compiler-backend/functional/src/tree.rs
@@ -112,6 +112,7 @@ pub struct Global {
 pub enum GlobalId {
     Term(FileId, TermItemId),
     Instance(InstanceIdentity),
+    Generated(FileId, GeneratedGlobalId),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -119,6 +120,9 @@ pub enum InstanceIdentity {
     Declared(FileId, InstanceId),
     Derived(FileId, DeriveId),
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GeneratedGlobalId(pub u32);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RecursiveGroupId(pub u32);

--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -501,6 +501,8 @@ fn render_lazy_initializers(renderer: &mut ModuleRenderer<'_, '_, '_>) -> Module
 
 fn render_value_declarations(renderer: &mut ModuleRenderer<'_, '_, '_>) -> ModuleResult<()> {
     let generator = renderer.generator;
+    let mut rendered = false;
+    let mut previous_was_generated = false;
     for declaration in sorted_value_declarations(generator)? {
         let DeclarationKind::Value(expression) = declaration.kind else {
             unreachable!("invariant violated: sorted JavaScript declaration is not a value")
@@ -508,12 +510,20 @@ fn render_value_declarations(renderer: &mut ModuleRenderer<'_, '_, '_>) -> Modul
         if is_abstraction(&generator.module.storage[expression].kind) {
             continue;
         }
+
+        let generated = matches!(declaration.global.id, GlobalId::Generated(_, _));
+        if rendered && (!previous_was_generated || !generated) {
+            renderer.writer.blank();
+        }
+
         let name = generator.global_name(declaration.global.id);
         let export =
             if generator.declaration_is_inline_exported(declaration) { "export " } else { "" };
+
         if let Some(lazy_name) = generator.lazy_global_names.get(&declaration.global.id) {
             renderer.writer.line(format!("{export}const {name} = {lazy_name}();"));
-            renderer.writer.blank();
+            rendered = true;
+            previous_was_generated = generated;
             continue;
         }
 
@@ -542,6 +552,11 @@ fn render_value_declarations(renderer: &mut ModuleRenderer<'_, '_, '_>) -> Modul
                 },
             )?;
         }
+
+        rendered = true;
+        previous_was_generated = generated;
+    }
+    if rendered {
         renderer.writer.blank();
     }
     Ok(())

--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -1919,7 +1919,7 @@ impl Generator<'_> {
 
 fn global_file(id: GlobalId) -> FileId {
     match id {
-        GlobalId::Term(file_id, _) => file_id,
+        GlobalId::Term(file_id, _) | GlobalId::Generated(file_id, _) => file_id,
         GlobalId::Instance(
             functional::tree::InstanceIdentity::Declared(file_id, _)
             | functional::tree::InstanceIdentity::Derived(file_id, _),

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.functional.snap
@@ -8,106 +8,104 @@ expression: report
     if eq eqADict%0 left%1 right%2 then eq eqADict%0 right%2 left%1 else false
 
 @export compareIntsTwice = \left%3 right%4 ->
-  if eq eqInt left%3 right%4 then eq eqInt right%4 left%3 else false
+  if eqIntDictEq left%3 right%4 then eqIntDictEq right%4 left%3 else false
 
 @export compareArraysTwice = \left%5 right%6 ->
-  let
-    eqArrayDict%7 = eqArray eqInt
-  in if eq eqArrayDict%7 left%5 right%6 then eq eqArrayDict%7 right%6 left%5 else false
+  if eqArrayIntDictEq left%5 right%6 then eqArrayIntDictEq right%6 left%5 else false
 
-@export compareArraysOnce = \left%8 right%9 -> eq (eqArray eqInt) left%8 right%9
+@export compareArraysOnce = \left%7 right%8 -> eqArrayIntDictEq left%7 right%8
 
-@export compareGenericArraysTwice = \eqADict%10 ->
-  \left%11 right%12 ->
+@export compareGenericArraysTwice = \eqADict%9 ->
+  \left%10 right%11 ->
     let
-      eqArrayDict%13 = eqArray eqADict%10
-    in if eq eqArrayDict%13 left%11 right%12 then eq eqArrayDict%13 right%12 left%11 else false
+      eqArrayDict%12 = eqArray eqADict%9
+    in if eq eqArrayDict%12 left%10 right%11 then eq eqArrayDict%12 right%11 left%10 else false
 
-@export compareNestedArraysTwice = \left%18 right%19 nestedLeft%14 nestedRight%15 ->
-  let
-    eqArrayDict%17 = eqArray eqInt
-    eqArrayDict%16 = eqArray eqArrayDict%17
-  in if eq eqArrayDict%16 nestedLeft%14 nestedRight%15
-    then eq eqArrayDict%16 nestedRight%15 nestedLeft%14
-    else eq eqArrayDict%17 left%18 right%19
+@export compareNestedArraysTwice = \left%15 right%16 nestedLeft%13 nestedRight%14 ->
+  if eqArrayArrayIntDictEq nestedLeft%13 nestedRight%14
+    then eqArrayArrayIntDictEq nestedRight%14 nestedLeft%13
+    else eqArrayIntDictEq left%15 right%16
 
-@export distinctGivens = \eqADict%20 eqBDict%24 ->
-  \leftA%21 rightA%22 leftB%25 rightB%26 ->
+@export distinctGivens = \eqADict%17 eqBDict%21 ->
+  \leftA%18 rightA%19 leftB%22 rightB%23 ->
     let
-      eqArrayDict%23 = eqArray eqADict%20
-      eqArrayDict%27 = eqArray eqBDict%24
-    in if eq eqArrayDict%23 leftA%21 rightA%22
-      then eq eqArrayDict%23 rightA%22 leftA%21
-      else if eq eqArrayDict%27 leftB%25 rightB%26
-        then eq eqArrayDict%27 rightB%26 leftB%25
+      eqArrayDict%20 = eqArray eqADict%17
+      eqArrayDict%24 = eqArray eqBDict%21
+    in if eq eqArrayDict%20 leftA%18 rightA%19
+      then eq eqArrayDict%20 rightA%19 leftA%18
+      else if eq eqArrayDict%24 leftB%22 rightB%23
+        then eq eqArrayDict%24 rightB%23 leftB%22
         else false
 
-@export distinctSubgoals = \leftInt%28 rightInt%29 leftBoolean%31 rightBoolean%32 ->
-  let
-    eqArrayDict%30 = eqArray eqInt
-    eqArrayDict%33 = eqArray eqBoolean
-  in if eq eqArrayDict%30 leftInt%28 rightInt%29
-    then eq eqArrayDict%30 rightInt%29 leftInt%28
-    else if eq eqArrayDict%33 leftBoolean%31 rightBoolean%32
-      then eq eqArrayDict%33 rightBoolean%32 leftBoolean%31
+@export distinctSubgoals = \leftInt%25 rightInt%26 leftBoolean%27 rightBoolean%28 ->
+  if eqArrayIntDictEq leftInt%25 rightInt%26
+    then eqArrayIntDictEq rightInt%26 leftInt%25
+    else if eqArrayBooleanDictEq leftBoolean%27 rightBoolean%28
+      then eqArrayBooleanDictEq rightBoolean%28 leftBoolean%27
       else false
 
-@export compareArraysThrice = \left%34 right%35 ->
-  let
-    eqArrayDict%36 = eqArray eqInt
-  in if eq eqArrayDict%36 left%34 right%35
-    then if eq eqArrayDict%36 right%35 left%34 then eq eqArrayDict%36 left%34 right%35 else false
+@export compareArraysThrice = \left%29 right%30 ->
+  if eqArrayIntDictEq left%29 right%30
+    then if eqArrayIntDictEq right%30 left%29 then eqArrayIntDictEq left%29 right%30 else false
     else false
 
-@export compareNestedArraysWhole = \left%37 right%38 ->
-  let
-    eqArrayDict%39 = eqArray (eqArray eqInt)
-  in if eq eqArrayDict%39 left%37 right%38 then eq eqArrayDict%39 right%38 left%37 else false
+@export compareNestedArraysWhole = \left%31 right%32 ->
+  if eqArrayArrayIntDictEq left%31 right%32 then eqArrayArrayIntDictEq right%32 left%31 else false
 
-@export compareSuperclassArraysTwice = \orderedADict%40 ->
-  \left%41 right%42 ->
+@export compareSuperclassArraysTwice = \orderedADict%33 ->
+  \left%34 right%35 ->
     let
-      eqArrayDict%43 = eqArray (orderedADict%40."Eq0"())
-    in if eq eqArrayDict%43 left%41 right%42 then eq eqArrayDict%43 right%42 left%41 else false
+      eqArrayDict%36 = eqArray (orderedADict%33."Eq0"())
+    in if eq eqArrayDict%36 left%34 right%35 then eq eqArrayDict%36 right%35 left%34 else false
 
-@export compareSuperclassTwice = \orderedADict%44 ->
-  \left%45 right%46 ->
+@export compareSuperclassTwice = \orderedADict%37 ->
+  \left%38 right%39 ->
     let
-      Eq0Dict%47 = orderedADict%44."Eq0"()
-    in if eq Eq0Dict%47 left%45 right%46 then eq Eq0Dict%47 right%46 left%45 else false
+      Eq0Dict%40 = orderedADict%37."Eq0"()
+    in if eq Eq0Dict%40 left%38 right%39 then eq Eq0Dict%40 right%39 left%38 else false
 
-@export lambdaScope = \left%48 right%49 ->
-  if eq (eqArray eqInt) left%48 right%49
-    then (\lambdaLeft%50 lambdaRight%51 ->
-      let
-        eqArrayDict%52 = eqArray eqInt
-      in if eq eqArrayDict%52 lambdaLeft%50 lambdaRight%51
-        then eq eqArrayDict%52 lambdaRight%51 lambdaLeft%50
+@export lambdaScope = \left%41 right%42 ->
+  if eqArrayIntDictEq left%41 right%42
+    then (\lambdaLeft%43 lambdaRight%44 ->
+      if eqArrayIntDictEq lambdaLeft%43 lambdaRight%44
+        then eqArrayIntDictEq lambdaRight%44 lambdaLeft%43
         else false)
-      left%48
-      right%49
+      left%41
+      right%42
     else false
 
-@export whereIsolation = \left%54 right%55 ->
-  if (\helperLeft%56 helperRight%57 -> eq (eqArray eqInt) helperLeft%56 helperRight%57) left%54
-    right%55
-    then eq (eqArray eqInt) left%54 right%55
+@export whereIsolation = \left%46 right%47 ->
+  if (\helperLeft%48 helperRight%49 -> eqArrayIntDictEq helperLeft%48 helperRight%49) left%46
+    right%47
+    then eqArrayIntDictEq left%46 right%47
     else false
 
-@export equationScope = \$boolean%58 $array%59 $array%60 ->
-  let
-    eqArrayDict%65 = eqArray eqInt
-  in case $boolean%58, $array%59, $array%60 of
-    true, left%61, right%62 ->
-      eq eqArrayDict%65 left%61 right%62
-    false, left%63, right%64 ->
-      eq eqArrayDict%65 right%64 left%63
+@export equationScope = \$boolean%50 $array%51 $array%52 ->
+  case $boolean%50, $array%51, $array%52 of
+    true, left%53, right%54 ->
+      eqArrayIntDictEq left%53 right%54
+    false, left%55, right%56 ->
+      eqArrayIntDictEq right%56 left%55
 
-@export firstComparison = eq eqInt 1 2
+@export firstComparison = eqIntDictEq 1 2
 
-@export secondComparison = eq eqInt 3 4
+@export secondComparison = eqIntDictEq 3 4
 
-@export instance eqRecursive = { eq: \left%66 right%67 -> eq eqRecursive left%66 right%67 }
+@export instance eqRecursive = { eq: \left%57 right%58 -> eq eqRecursive left%57 right%58 }
 
-@export compareRecursiveTwice = \left%68 right%69 ->
-  if eq eqRecursive left%68 right%69 then eq eqRecursive right%69 left%68 else false
+@export compareRecursiveTwice = \left%59 right%60 ->
+  if eq eqRecursive left%59 right%60 then eq eqRecursive right%60 left%59 else false
+
+eqIntDictEq = eq eqInt
+
+eqArrayIntDict = eqArray eqInt
+
+eqArrayBooleanDict = eqArray eqBoolean
+
+eqArrayIntDictEq = eq eqArrayIntDict
+
+eqArrayArrayIntDict = eqArray eqArrayIntDict
+
+eqArrayBooleanDictEq = eq eqArrayBooleanDict
+
+eqArrayArrayIntDictEq = eq eqArrayArrayIntDict

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.functional.snap
@@ -106,3 +106,8 @@ expression: report
 @export firstComparison = eq eqInt 1 2
 
 @export secondComparison = eq eqInt 3 4
+
+@export instance eqRecursive = { eq: \left%66 right%67 -> eq eqRecursive left%66 right%67 }
+
+@export compareRecursiveTwice = \left%68 right%69 ->
+  if eq eqRecursive left%68 right%69 then eq eqRecursive right%69 left%68 else false

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.purs
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.purs
@@ -109,3 +109,12 @@ firstComparison = Eq.eq 1 2
 
 secondComparison :: Boolean
 secondComparison = Eq.eq 3 4
+
+data Recursive
+
+instance Eq.Eq Recursive where
+  eq left right = Eq.eq left right
+
+compareRecursiveTwice :: Recursive -> Recursive -> Boolean
+compareRecursiveTwice left right =
+  if Eq.eq left right then Eq.eq right left else false

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.snap
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/Main.snap
@@ -1,5 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
+assertion_line: 262
 expression: diagnostics_report
 ---
 Terms
@@ -36,5 +37,13 @@ whereIsolation :: Prim.Array Prim.Int -> Prim.Array Prim.Int -> Prim.Boolean
 equationScope :: Prim.Boolean -> Prim.Array Prim.Int -> Prim.Array Prim.Int -> Prim.Boolean
 firstComparison :: Prim.Boolean
 secondComparison :: Prim.Boolean
+compareRecursiveTwice :: Main.Recursive -> Main.Recursive -> Prim.Boolean
 
 Types
+Recursive :: Prim.Type
+
+Instances
+instance Data.Eq.Eq Main.Recursive
+
+Roles
+Recursive = []

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
@@ -16,8 +16,8 @@ export function compareTwice(eqADict) {
 
 export function compareIntsTwice(left) {
   return right => {
-    if (Data_Eq.eq(Data_Eq.eqInt)(left)(right)) {
-      return Data_Eq.eq(Data_Eq.eqInt)(right)(left);
+    if (eqIntDictEq(left)(right)) {
+      return eqIntDictEq(right)(left);
     } else {
       return false;
     }
@@ -26,9 +26,8 @@ export function compareIntsTwice(left) {
 
 export function compareArraysTwice(left) {
   return right => {
-    const eqArrayDict = Data_Eq.eqArray(Data_Eq.eqInt);
-    if (Data_Eq.eq(eqArrayDict)(left)(right)) {
-      return Data_Eq.eq(eqArrayDict)(right)(left);
+    if (eqArrayIntDictEq(left)(right)) {
+      return eqArrayIntDictEq(right)(left);
     } else {
       return false;
     }
@@ -37,7 +36,7 @@ export function compareArraysTwice(left) {
 
 export function compareArraysOnce(left) {
   return right => {
-    return Data_Eq.eq(Data_Eq.eqArray(Data_Eq.eqInt))(left)(right);
+    return eqArrayIntDictEq(left)(right);
   };
 }
 
@@ -59,12 +58,10 @@ export function compareNestedArraysTwice(left) {
   return right => {
     return nestedLeft => {
       return nestedRight => {
-        const eqArrayDict = Data_Eq.eqArray(Data_Eq.eqInt);
-        const eqArrayDict$1 = Data_Eq.eqArray(eqArrayDict);
-        if (Data_Eq.eq(eqArrayDict$1)(nestedLeft)(nestedRight)) {
-          return Data_Eq.eq(eqArrayDict$1)(nestedRight)(nestedLeft);
+        if (eqArrayArrayIntDictEq(nestedLeft)(nestedRight)) {
+          return eqArrayArrayIntDictEq(nestedRight)(nestedLeft);
         } else {
-          return Data_Eq.eq(eqArrayDict)(left)(right);
+          return eqArrayIntDictEq(left)(right);
         }
       };
     };
@@ -100,13 +97,11 @@ export function distinctSubgoals(leftInt) {
   return rightInt => {
     return leftBoolean => {
       return rightBoolean => {
-        const eqArrayDict = Data_Eq.eqArray(Data_Eq.eqInt);
-        const eqArrayDict$1 = Data_Eq.eqArray(Data_Eq.eqBoolean);
-        if (Data_Eq.eq(eqArrayDict)(leftInt)(rightInt)) {
-          return Data_Eq.eq(eqArrayDict)(rightInt)(leftInt);
+        if (eqArrayIntDictEq(leftInt)(rightInt)) {
+          return eqArrayIntDictEq(rightInt)(leftInt);
         } else {
-          if (Data_Eq.eq(eqArrayDict$1)(leftBoolean)(rightBoolean)) {
-            return Data_Eq.eq(eqArrayDict$1)(rightBoolean)(leftBoolean);
+          if (eqArrayBooleanDictEq(leftBoolean)(rightBoolean)) {
+            return eqArrayBooleanDictEq(rightBoolean)(leftBoolean);
           } else {
             return false;
           }
@@ -118,10 +113,9 @@ export function distinctSubgoals(leftInt) {
 
 export function compareArraysThrice(left) {
   return right => {
-    const eqArrayDict = Data_Eq.eqArray(Data_Eq.eqInt);
-    if (Data_Eq.eq(eqArrayDict)(left)(right)) {
-      if (Data_Eq.eq(eqArrayDict)(right)(left)) {
-        return Data_Eq.eq(eqArrayDict)(left)(right);
+    if (eqArrayIntDictEq(left)(right)) {
+      if (eqArrayIntDictEq(right)(left)) {
+        return eqArrayIntDictEq(left)(right);
       } else {
         return false;
       }
@@ -133,9 +127,8 @@ export function compareArraysThrice(left) {
 
 export function compareNestedArraysWhole(left) {
   return right => {
-    const eqArrayDict = Data_Eq.eqArray(Data_Eq.eqArray(Data_Eq.eqInt));
-    if (Data_Eq.eq(eqArrayDict)(left)(right)) {
-      return Data_Eq.eq(eqArrayDict)(right)(left);
+    if (eqArrayArrayIntDictEq(left)(right)) {
+      return eqArrayArrayIntDictEq(right)(left);
     } else {
       return false;
     }
@@ -172,12 +165,11 @@ export function compareSuperclassTwice(orderedADict) {
 
 export function lambdaScope(left) {
   return right => {
-    if (Data_Eq.eq(Data_Eq.eqArray(Data_Eq.eqInt))(left)(right)) {
+    if (eqArrayIntDictEq(left)(right)) {
       const $closure = lambdaLeft => {
         return lambdaRight => {
-          const eqArrayDict = Data_Eq.eqArray(Data_Eq.eqInt);
-          if (Data_Eq.eq(eqArrayDict)(lambdaLeft)(lambdaRight)) {
-            return Data_Eq.eq(eqArrayDict)(lambdaRight)(lambdaLeft);
+          if (eqArrayIntDictEq(lambdaLeft)(lambdaRight)) {
+            return eqArrayIntDictEq(lambdaRight)(lambdaLeft);
           } else {
             return false;
           }
@@ -198,10 +190,8 @@ export function lambdaScope(left) {
 
 export function whereIsolation(left) {
   return right => {
-    if ((helperLeft => helperRight => Data_Eq.eq(Data_Eq.eqArray(Data_Eq.eqInt))(helperLeft)(
-      helperRight
-    ))(left)(right)) {
-      return Data_Eq.eq(Data_Eq.eqArray(Data_Eq.eqInt))(left)(right);
+    if ((helperLeft => helperRight => eqArrayIntDictEq(helperLeft)(helperRight))(left)(right)) {
+      return eqArrayIntDictEq(left)(right);
     } else {
       return false;
     }
@@ -211,16 +201,15 @@ export function whereIsolation(left) {
 export function equationScope($boolean) {
   return $array => {
     return $array$1 => {
-      const eqArrayDict = Data_Eq.eqArray(Data_Eq.eqInt);
       if ($boolean === true) {
         const left = $array;
         const right = $array$1;
-        return Data_Eq.eq(eqArrayDict)(left)(right);
+        return eqArrayIntDictEq(left)(right);
       }
       if ($boolean === false) {
         const left$1 = $array;
         const right$1 = $array$1;
-        return Data_Eq.eq(eqArrayDict)(right$1)(left$1);
+        return eqArrayIntDictEq(right$1)(left$1);
       }
       throw new Error("Pattern match failure");
     };
@@ -241,8 +230,22 @@ const $lazy_eqRecursive = $runtime.binding("eqRecursive", () => {
   return { eq: left => right => Data_Eq.eq($lazy_eqRecursive())(left)(right) };
 });
 
-export const firstComparison = Data_Eq.eq(Data_Eq.eqInt)(1 | 0)(2 | 0);
+const eqIntDictEq = Data_Eq.eq(Data_Eq.eqInt);
 
-export const secondComparison = Data_Eq.eq(Data_Eq.eqInt)(3 | 0)(4 | 0);
+export const firstComparison = eqIntDictEq(1 | 0)(2 | 0);
+
+export const secondComparison = eqIntDictEq(3 | 0)(4 | 0);
 
 export const eqRecursive = $lazy_eqRecursive();
+
+const eqArrayIntDict = Data_Eq.eqArray(Data_Eq.eqInt);
+
+const eqArrayBooleanDict = Data_Eq.eqArray(Data_Eq.eqBoolean);
+
+const eqArrayIntDictEq = Data_Eq.eq(eqArrayIntDict);
+
+const eqArrayArrayIntDict = Data_Eq.eqArray(eqArrayIntDict);
+
+const eqArrayBooleanDictEq = Data_Eq.eq(eqArrayBooleanDict);
+
+const eqArrayArrayIntDictEq = Data_Eq.eq(eqArrayArrayIntDict);

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
@@ -1,4 +1,5 @@
 import * as Data_Eq from "../Data.Eq/index.js";
+import * as $runtime from "../runtime.js";
 
 export function compareTwice(eqADict) {
   const $closure = left => {
@@ -226,6 +227,22 @@ export function equationScope($boolean) {
   };
 }
 
+export function compareRecursiveTwice(left) {
+  return right => {
+    if (Data_Eq.eq($lazy_eqRecursive())(left)(right)) {
+      return Data_Eq.eq($lazy_eqRecursive())(right)(left);
+    } else {
+      return false;
+    }
+  };
+}
+
+const $lazy_eqRecursive = $runtime.binding("eqRecursive", () => {
+  return { eq: left => right => Data_Eq.eq($lazy_eqRecursive())(left)(right) };
+});
+
 export const firstComparison = Data_Eq.eq(Data_Eq.eqInt)(1 | 0)(2 | 0);
 
 export const secondComparison = Data_Eq.eq(Data_Eq.eqInt)(3 | 0)(4 | 0);
+
+export const eqRecursive = $lazy_eqRecursive();

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
@@ -239,13 +239,8 @@ export const secondComparison = eqIntDictEq(3 | 0)(4 | 0);
 export const eqRecursive = $lazy_eqRecursive();
 
 const eqArrayIntDict = Data_Eq.eqArray(Data_Eq.eqInt);
-
 const eqArrayBooleanDict = Data_Eq.eqArray(Data_Eq.eqBoolean);
-
 const eqArrayIntDictEq = Data_Eq.eq(eqArrayIntDict);
-
 const eqArrayArrayIntDict = Data_Eq.eqArray(eqArrayIntDict);
-
 const eqArrayBooleanDictEq = Data_Eq.eq(eqArrayBooleanDict);
-
 const eqArrayArrayIntDictEq = Data_Eq.eq(eqArrayArrayIntDict);

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/runtime.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/runtime.js
@@ -1,0 +1,14 @@
+export function binding(name, initialize) {
+  let state = 0;
+  let value;
+  return () => {
+    if (state === 2) return value;
+    if (state === 1) {
+      throw new ReferenceError(`${name} was needed before it finished initializing`);
+    }
+    state = 1;
+    value = initialize();
+    state = 2;
+    return value;
+  };
+}

--- a/tests-integration/fixtures/backend/1787717940_single_concrete_evidence_use/Data.Eq.purs
+++ b/tests-integration/fixtures/backend/1787717940_single_concrete_evidence_use/Data.Eq.purs
@@ -1,0 +1,10 @@
+module Data.Eq where
+
+class Eq a where
+  eq :: a -> a -> Boolean
+
+instance Eq Int where
+  eq _ _ = true
+
+instance eqArray :: Eq a => Eq (Array a) where
+  eq _ _ = true

--- a/tests-integration/fixtures/backend/1787717940_single_concrete_evidence_use/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787717940_single_concrete_evidence_use/Main.functional.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export compareArraysOnce = \left%0 right%1 -> eq (eqArray eqInt) left%0 right%1

--- a/tests-integration/fixtures/backend/1787717940_single_concrete_evidence_use/Main.purs
+++ b/tests-integration/fixtures/backend/1787717940_single_concrete_evidence_use/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Eq as Eq
+
+compareArraysOnce :: Array Int -> Array Int -> Boolean
+compareArraysOnce left right = Eq.eq left right

--- a/tests-integration/fixtures/backend/1787717940_single_concrete_evidence_use/Main.snap
+++ b/tests-integration/fixtures/backend/1787717940_single_concrete_evidence_use/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 262
+expression: diagnostics_report
+---
+Terms
+compareArraysOnce :: Prim.Array Prim.Int -> Prim.Array Prim.Int -> Prim.Boolean
+
+Types

--- a/tests-integration/fixtures/backend/1787717940_single_concrete_evidence_use/output/Data.Eq/index.js
+++ b/tests-integration/fixtures/backend/1787717940_single_concrete_evidence_use/output/Data.Eq/index.js
@@ -1,0 +1,9 @@
+export function eq(dictionary) {
+  return dictionary.eq;
+}
+
+export function eqArray(eqADict) {
+  return { eq: $array => $array$1 => true };
+}
+
+export const eqInt = { eq: $int => $int$1 => true };

--- a/tests-integration/fixtures/backend/1787717940_single_concrete_evidence_use/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787717940_single_concrete_evidence_use/output/Main/index.js
@@ -1,0 +1,7 @@
+import * as Data_Eq from "../Data.Eq/index.js";
+
+export function compareArraysOnce(left) {
+  return right => {
+    return Data_Eq.eq(Data_Eq.eqArray(Data_Eq.eqInt))(left)(right);
+  };
+}


### PR DESCRIPTION
## Motivation

Repeated uses of closed, compiler-resolved type-class evidence currently reconstruct dictionaries and select class members inside each invocation. Functional IR should share those pure evidence expressions at module scope, producing JavaScript closer to `purs` while keeping the JavaScript backend a renderer.

## Changes

- collect repeated closed dictionary construction and class-member selection in functional conversion
- identify evidence through stable instance, subgoal, superclass, and member identities
- introduce generated functional globals for shared evidence and preserve dependency order
- retain lexical sharing for evidence containing runtime dictionary parameters
- reject recursive initializer hazards and leave single-use evidence inline
- add backend coverage for concrete, nested, generic, distinct, superclass, single-use, and cyclic evidence paths

## Verification

- `just format`
- `cargo check -p functional --tests`
- `cargo nextest run -p functional --no-tests pass`
- `cargo check -p javascript --tests`
- `just t backend`
- `git diff --check`