### PR TITLE
[javascript] Order hoisted evidence before source initializers

### DIFF
--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -2182,8 +2182,11 @@ fn sorted_value_declarations<'m>(
         .module
         .declarations
         .iter()
-        .filter(|declaration| matches!(declaration.kind, DeclarationKind::Value(_)))
-        .collect_vec();
+        .filter(|declaration| matches!(declaration.kind, DeclarationKind::Value(_)));
+    let mut values = values.collect_vec();
+    // An ordinary initializer can call a source function whose body uses generated evidence.
+    // Prefer generated declarations whenever explicit dependencies leave their order unconstrained.
+    values.sort_by_key(|declaration| !matches!(declaration.global.id, GlobalId::Generated(_, _)));
     let positions = values
         .iter()
         .enumerate()

--- a/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787250120_repeated_qualified_class_method/output/Main/index.js
@@ -207,12 +207,12 @@ const $lazy_eqRecursive = $runtime.binding("eqRecursive", () => {
   return { eq: (left) => (right) => /* @__PURE__ */ Data_Eq.eq($lazy_eqRecursive())(left)(right) };
 });
 const eqIntDictEq = /* @__PURE__ */ Data_Eq.eq(Data_Eq.eqInt);
-export const firstComparison = /* @__PURE__ */ eqIntDictEq(1 | 0)(2 | 0);
-export const secondComparison = /* @__PURE__ */ eqIntDictEq(3 | 0)(4 | 0);
-export const eqRecursive = $lazy_eqRecursive();
 const eqArrayIntDict = /* @__PURE__ */ Data_Eq.eqArray(Data_Eq.eqInt);
 const eqArrayBooleanDict = /* @__PURE__ */ Data_Eq.eqArray(Data_Eq.eqBoolean);
 const eqArrayIntDictEq = /* @__PURE__ */ Data_Eq.eq(eqArrayIntDict);
 const eqArrayArrayIntDict = /* @__PURE__ */ Data_Eq.eqArray(eqArrayIntDict);
 const eqArrayBooleanDictEq = /* @__PURE__ */ Data_Eq.eq(eqArrayBooleanDict);
 const eqArrayArrayIntDictEq = /* @__PURE__ */ Data_Eq.eq(eqArrayArrayIntDict);
+export const firstComparison = /* @__PURE__ */ eqIntDictEq(1 | 0)(2 | 0);
+export const secondComparison = /* @__PURE__ */ eqIntDictEq(3 | 0)(4 | 0);
+export const eqRecursive = $lazy_eqRecursive();

--- a/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/Main.functional.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export compareInts = \left%0 right%1 ->
+  if eqIntDictEq left%0 right%1 then eqIntDictEq right%1 left%0 else false
+
+@export initialized = compareInts 1 1
+
+eqIntDictEq = eq eqInt

--- a/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/Main.purs
+++ b/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Eq as Eq
+
+compareInts :: Int -> Int -> Boolean
+compareInts left right =
+  if Eq.eq left right then Eq.eq right left else false
+
+initialized :: Boolean
+initialized = compareInts 1 1

--- a/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/Main.snap
+++ b/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/Main.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 262
+expression: diagnostics_report
+---
+Terms
+compareInts :: Prim.Int -> Prim.Int -> Prim.Boolean
+initialized :: Prim.Boolean
+
+Types

--- a/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/output/Data.Eq/index.js
+++ b/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/output/Data.Eq/index.js
@@ -1,0 +1,26 @@
+export function eq(dictionary) {
+  return dictionary.eq;
+}
+export function eq1(dictionary) {
+  return dictionary.eq1;
+}
+export function eqRec(rowToListRowListDict) {
+  return (eqRecordListRowDict) => {
+    return { eq: ($record) => ($record$1) => true };
+  };
+}
+export function eqRecord(dictionary) {
+  return dictionary.eqRecord;
+}
+export function eqRecordConsType(eqRecordRowlistTailRowDict) {
+  return (consKeyFocusRowTailRowDict) => {
+    return (isSymbolKeyDict) => {
+      return (eqFocusDict) => {
+        return { eqRecord: ($cons) => ($record) => ($record$1) => true };
+      };
+    };
+  };
+}
+export const eqInt = { eq: ($int) => ($int$1) => true };
+export const eqBoolean = { eq: ($boolean) => ($boolean$1) => true };
+export const eqRecordNilType = { eqRecord: ($nil) => ($record) => ($record$1) => true };

--- a/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/output/Main/index.js
@@ -1,0 +1,12 @@
+import * as Data_Eq from "../Data.Eq/index.js";
+export function compareInts(left) {
+  return (right) => {
+    if (/* @__PURE__ */ eqIntDictEq(left)(right)) {
+      return /* @__PURE__ */ eqIntDictEq(right)(left);
+    } else {
+      return false;
+    }
+  };
+}
+export const initialized = compareInts(1 | 0)(1 | 0);
+const eqIntDictEq = /* @__PURE__ */ Data_Eq.eq(Data_Eq.eqInt);

--- a/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/output/Main/index.js
@@ -8,5 +8,5 @@ export function compareInts(left) {
     }
   };
 }
-export const initialized = compareInts(1 | 0)(1 | 0);
 const eqIntDictEq = /* @__PURE__ */ Data_Eq.eq(Data_Eq.eqInt);
+export const initialized = compareInts(1 | 0)(1 | 0);

--- a/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/package.json
+++ b/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/verify.mjs
+++ b/tests-integration/fixtures/backend/1787738880_hoisted_evidence_initializer_ordering/verify.mjs
@@ -1,0 +1,4 @@
+import { strictEqual } from "node:assert/strict";
+import { initialized } from "./output/Main/index.js";
+
+strictEqual(initialized, true);


### PR DESCRIPTION
## Summary

- prefer generated evidence declarations before ordinary source values when initializer dependencies leave their order unconstrained
- preserve the existing topological ordering for explicit helper dependencies
- add an executable regression fixture where an eager source initializer calls a function that uses hoisted evidence

## Motivation

Closed type class evidence is appended as generated module declarations. An ordinary eager initializer can call a source function whose body references one of those helpers, but initializer dependency analysis intentionally does not descend into function bodies. This allowed the ordinary initializer to run before the generated helper and fail in its temporal dead zone.

## Verification

- `cargo check -p javascript --tests`
- `just t backend` (128 tests)
- executable Node verification in `1787738880_hoisted_evidence_initializer_ordering`