### PR TITLE
[javascript] Destructure constructor pattern bindings

### DIFF
--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -1812,18 +1812,8 @@ impl Generator<'_> {
                     argument_names.push(name);
                 }
                 if argument_names.iter().any(Option::is_some) {
-                    let constructor_bindings = plan
-                        .bindings
-                        .iter()
-                        .filter(|binding| matches!(binding, PatternBinding::Constructor { .. }))
-                        .count();
-                    let discarded = if constructor_bindings == 0 {
-                        "_".to_owned()
-                    } else {
-                        format!("_${constructor_bindings}")
-                    };
                     let mut names = Vec::with_capacity(argument_names.len() + 1);
-                    names.push(Some(discarded));
+                    names.push(None);
                     names.extend(argument_names.iter().cloned());
                     while names.last().is_some_and(Option::is_none) {
                         names.pop();

--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -1800,10 +1800,6 @@ impl Generator<'_> {
                 if arguments.is_empty() {
                     plan.conditions.push(tree.binary(BinaryOperator::StrictEqual, value, expected));
                 } else {
-                    let array = tree.identifier("Array");
-                    let is_array = tree.member(array, "isArray");
-                    let is_array = tree.call(is_array, vec![value]);
-                    plan.conditions.push(is_array);
                     let zero = tree.number("0");
                     let tag = tree.index(value, zero);
                     plan.conditions.push(tree.binary(BinaryOperator::StrictEqual, tag, expected));

--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -80,7 +80,12 @@ enum CapturedEffect {
 #[derive(Default)]
 struct PatternPlan {
     conditions: Vec<ExpressionId>,
-    bindings: Vec<(String, ExpressionId)>,
+    bindings: Vec<PatternBinding>,
+}
+
+enum PatternBinding {
+    Variable { name: String, value: ExpressionId },
+    Constructor { names: Vec<Option<String>>, value: ExpressionId },
 }
 
 // Pending expressions must be evaluated before rendering an eager later sibling.
@@ -1712,8 +1717,15 @@ impl Generator<'_> {
     }
 
     fn render_pattern_bindings(&self, tree: &Tree, writer: &mut Writer<'_>, plan: &PatternPlan) {
-        for (name, value) in &plan.bindings {
-            writer.constant(tree, name, *value, false);
+        for binding in &plan.bindings {
+            match binding {
+                PatternBinding::Variable { name, value } => {
+                    writer.constant(tree, name, *value, false);
+                }
+                PatternBinding::Constructor { names, value } => {
+                    writer.constant_array_pattern(tree, names, *value);
+                }
+            }
         }
     }
 
@@ -1796,10 +1808,46 @@ impl Generator<'_> {
                     let tag = tree.index(value, zero);
                     plan.conditions.push(tree.binary(BinaryOperator::StrictEqual, tag, expected));
                 }
-                for (index, pattern) in arguments.iter().enumerate() {
+
+                let mut argument_names = Vec::with_capacity(arguments.len());
+                for pattern in arguments.iter() {
+                    let name = pattern_parameter(&self.module.storage, *pattern)
+                        .map(|parameter| context.allocate(&parameter.name));
+                    argument_names.push(name);
+                }
+                if argument_names.iter().any(Option::is_some) {
+                    let constructor_bindings = plan
+                        .bindings
+                        .iter()
+                        .filter(|binding| matches!(binding, PatternBinding::Constructor { .. }))
+                        .count();
+                    let discarded = if constructor_bindings == 0 {
+                        "_".to_owned()
+                    } else {
+                        format!("_${constructor_bindings}")
+                    };
+                    let mut names = Vec::with_capacity(argument_names.len() + 1);
+                    names.push(Some(discarded));
+                    names.extend(argument_names.iter().cloned());
+                    while names.last().is_some_and(Option::is_none) {
+                        names.pop();
+                    }
+                    plan.bindings.push(PatternBinding::Constructor { names, value });
+                }
+
+                for (index, (pattern, name)) in
+                    arguments.iter().zip(argument_names.iter()).enumerate()
+                {
                     let index = tree.number((index + 1).to_string());
                     let argument = tree.index(value, index);
-                    self.extend_pattern_plan(tree, *pattern, argument, None, context, plan)?;
+                    self.extend_pattern_plan(
+                        tree,
+                        *pattern,
+                        argument,
+                        name.as_deref(),
+                        context,
+                        plan,
+                    )?;
                 }
             }
         }
@@ -1819,7 +1867,7 @@ impl Generator<'_> {
         } else {
             let name = context.allocate(&parameter.name);
             context.bind_direct(parameter, name.clone());
-            plan.bindings.push((name, value));
+            plan.bindings.push(PatternBinding::Variable { name, value });
         }
     }
 

--- a/compiler-backend/javascript/src/writer.rs
+++ b/compiler-backend/javascript/src/writer.rs
@@ -167,6 +167,34 @@ impl<'a> Writer<'a> {
         self.statements.push(statement);
     }
 
+    pub(crate) fn constant_array_pattern(
+        &mut self,
+        tree: &Tree<'_>,
+        names: &[Option<String>],
+        value: ExpressionId,
+    ) {
+        let names = names.iter().map(|name| name.as_deref().map(|name| self.binding_pattern(name)));
+        let names = ArenaVec::from_iter_in(names, &self.allocator);
+        let pattern = BindingPattern::new_array_pattern(SPAN, names, None, &self.builder);
+        let declarator = VariableDeclarator::new(
+            SPAN,
+            pattern,
+            None,
+            Some(tree.expression_in(value, self.allocator)),
+            false,
+            &self.builder,
+        );
+        let declarations = ArenaVec::from_array_in([declarator], &self.allocator);
+        let declaration = VariableDeclaration::boxed(
+            SPAN,
+            VariableDeclarationKind::Const,
+            declarations,
+            false,
+            &self.builder,
+        );
+        self.statements.push(Statement::VariableDeclaration(declaration));
+    }
+
     pub(crate) fn mutable(&mut self, name: &str) {
         let statement = self.variable_statement(VariableDeclarationKind::Let, name, None, false);
         self.statements.push(statement);

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.functional.snap
@@ -24,15 +24,22 @@ expression: report
         _ ->
           "Empty"
 
-@export unwrap = \value%4 -> value%4
+@export pair = \$choice%4 ->
+  case $choice%4 of
+    Pair left%5 right%6 ->
+      ["Pair", left%5, right%6]
+    choice%7 ->
+      choice%7
 
-@export nested = \$nested%5 ->
-  case $nested%5 of
-    Outer (One value%6) ->
-      ["One", value%6]
+@export unwrap = \value%8 -> value%8
+
+@export nested = \$nested%9 ->
+  case $nested%9 of
+    Outer (One value%10) ->
+      ["One", value%10]
     _ ->
       "Empty"
 
-@export bind = \value%8 continuation%7 -> continuation%7 value%8
+@export bind = \value%12 continuation%11 -> continuation%11 value%12
 
-@export ordinaryBind = \identity%9 -> bind identity%9 (\value%10 -> value%10)
+@export ordinaryBind = \identity%13 -> bind identity%13 (\value%14 -> value%14)

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.purs
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.purs
@@ -13,6 +13,10 @@ first whole@(Pair left _) = case whole of
   Pair _ _ -> One left
   _ -> Empty
 
+pair :: forall a. Choice a -> Choice a
+pair (Pair left right) = Pair left right
+pair choice = choice
+
 unwrap :: forall a. Identity a -> a
 unwrap (Identity value) = value
 

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.snap
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.snap
@@ -1,5 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
+assertion_line: 262
 expression: diagnostics_report
 ---
 Terms
@@ -9,6 +10,7 @@ Pair :: forall @a. a -> a -> Main.Choice a
 Identity :: forall @a. a -> Main.Identity a
 Outer :: forall @a. Main.Choice a -> Main.Nested a
 first :: forall a. Main.Choice a -> Main.Choice a
+pair :: forall a. Main.Choice a -> Main.Choice a
 unwrap :: forall a. Main.Identity a -> a
 nested :: forall a. Main.Nested a -> Main.Choice a
 bind :: forall a b. a -> (a -> b) -> b

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/output/Main/index.js
@@ -11,12 +11,12 @@ export function first($choice) {
     return "Empty";
   }
   if (Array.isArray($choice) && $choice[0] === "One") {
-    const value = $choice[1];
+    const [_, value] = $choice;
     return ["One", value];
   }
   if (Array.isArray($choice) && $choice[0] === "Pair") {
     const whole = $choice;
-    const left = $choice[1];
+    const [_, left] = $choice;
     if (Array.isArray(whole) && whole[0] === "Pair") {
       return ["One", left];
     }
@@ -24,12 +24,24 @@ export function first($choice) {
   }
   throw new Error("Pattern match failure");
 }
+export function pair($choice) {
+  if (Array.isArray($choice) && $choice[0] === "Pair") {
+    const [_, left, right] = $choice;
+    return [
+      "Pair",
+      left,
+      right
+    ];
+  }
+  const choice = $choice;
+  return choice;
+}
 export function unwrap(value) {
   return value;
 }
 export function nested($nested) {
   if (Array.isArray($nested) && $nested[0] === "Outer" && Array.isArray($nested[1]) && $nested[1][0] === "One") {
-    const value = $nested[1][1];
+    const [_, value] = $nested[1];
     return ["One", value];
   }
   return "Empty";

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/output/Main/index.js
@@ -11,12 +11,12 @@ export function first($choice) {
     return "Empty";
   }
   if ($choice[0] === "One") {
-    const [_, value] = $choice;
+    const [, value] = $choice;
     return ["One", value];
   }
   if ($choice[0] === "Pair") {
     const whole = $choice;
-    const [_, left] = $choice;
+    const [, left] = $choice;
     if (whole[0] === "Pair") {
       return ["One", left];
     }
@@ -26,7 +26,7 @@ export function first($choice) {
 }
 export function pair($choice) {
   if ($choice[0] === "Pair") {
-    const [_, left, right] = $choice;
+    const [, left, right] = $choice;
     return [
       "Pair",
       left,
@@ -41,7 +41,7 @@ export function unwrap(value) {
 }
 export function nested($nested) {
   if ($nested[0] === "Outer" && $nested[1][0] === "One") {
-    const [_, value] = $nested[1];
+    const [, value] = $nested[1];
     return ["One", value];
   }
   return "Empty";

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/output/Main/index.js
@@ -10,14 +10,14 @@ export function first($choice) {
   if ($choice === "Empty") {
     return "Empty";
   }
-  if (Array.isArray($choice) && $choice[0] === "One") {
+  if ($choice[0] === "One") {
     const [_, value] = $choice;
     return ["One", value];
   }
-  if (Array.isArray($choice) && $choice[0] === "Pair") {
+  if ($choice[0] === "Pair") {
     const whole = $choice;
     const [_, left] = $choice;
-    if (Array.isArray(whole) && whole[0] === "Pair") {
+    if (whole[0] === "Pair") {
       return ["One", left];
     }
     return "Empty";
@@ -25,7 +25,7 @@ export function first($choice) {
   throw new Error("Pattern match failure");
 }
 export function pair($choice) {
-  if (Array.isArray($choice) && $choice[0] === "Pair") {
+  if ($choice[0] === "Pair") {
     const [_, left, right] = $choice;
     return [
       "Pair",
@@ -40,7 +40,7 @@ export function unwrap(value) {
   return value;
 }
 export function nested($nested) {
-  if (Array.isArray($nested) && $nested[0] === "Outer" && Array.isArray($nested[1]) && $nested[1][0] === "One") {
+  if ($nested[0] === "Outer" && $nested[1][0] === "One") {
     const [_, value] = $nested[1];
     return ["One", value];
   }

--- a/tests-integration/fixtures/backend/1787021700_guards/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021700_guards/output/Main/index.js
@@ -11,7 +11,7 @@ export function booleanGuard(value) {
 }
 export function patternGuard(choice) {
   if (Array.isArray(choice) && choice[0] === "One") {
-    const value = choice[1];
+    const [_, value] = choice;
     return value;
   }
   if (true) {
@@ -30,7 +30,7 @@ export function caseBooleanGuard(value) {
 export function casePatternGuard(choice) {
   {
     if (Array.isArray(choice) && choice[0] === "One") {
-      const value = choice[1];
+      const [_, value] = choice;
       return value;
     }
   }

--- a/tests-integration/fixtures/backend/1787021700_guards/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021700_guards/output/Main/index.js
@@ -10,7 +10,7 @@ export function booleanGuard(value) {
   throw new Error("Pattern match failure");
 }
 export function patternGuard(choice) {
-  if (Array.isArray(choice) && choice[0] === "One") {
+  if (choice[0] === "One") {
     const [_, value] = choice;
     return value;
   }
@@ -29,7 +29,7 @@ export function caseBooleanGuard(value) {
 }
 export function casePatternGuard(choice) {
   {
-    if (Array.isArray(choice) && choice[0] === "One") {
+    if (choice[0] === "One") {
       const [_, value] = choice;
       return value;
     }

--- a/tests-integration/fixtures/backend/1787021700_guards/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021700_guards/output/Main/index.js
@@ -11,7 +11,7 @@ export function booleanGuard(value) {
 }
 export function patternGuard(choice) {
   if (choice[0] === "One") {
-    const [_, value] = choice;
+    const [, value] = choice;
     return value;
   }
   if (true) {
@@ -30,7 +30,7 @@ export function caseBooleanGuard(value) {
 export function casePatternGuard(choice) {
   {
     if (choice[0] === "One") {
-      const [_, value] = choice;
+      const [, value] = choice;
       return value;
     }
   }

--- a/tests-integration/fixtures/backend/1787022120_cross_module_references/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787022120_cross_module_references/output/Main/index.js
@@ -1,7 +1,7 @@
 import * as Library from "../Library/index.js";
 export function unbox($box) {
   if (Array.isArray($box) && $box[0] === "Box") {
-    const value = $box[1];
+    const [_, value] = $box;
     return value;
   } else {
     throw new Error("Pattern match failure");

--- a/tests-integration/fixtures/backend/1787022120_cross_module_references/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787022120_cross_module_references/output/Main/index.js
@@ -1,7 +1,7 @@
 import * as Library from "../Library/index.js";
 export function unbox($box) {
   if ($box[0] === "Box") {
-    const [_, value] = $box;
+    const [, value] = $box;
     return value;
   } else {
     throw new Error("Pattern match failure");

--- a/tests-integration/fixtures/backend/1787022120_cross_module_references/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787022120_cross_module_references/output/Main/index.js
@@ -1,6 +1,6 @@
 import * as Library from "../Library/index.js";
 export function unbox($box) {
-  if (Array.isArray($box) && $box[0] === "Box") {
+  if ($box[0] === "Box") {
     const [_, value] = $box;
     return value;
   } else {

--- a/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
@@ -88,14 +88,14 @@ export function first(choice) {
     return 0 | 0;
   }
   if (choice[0] === "Pair") {
-    const [_, left] = choice;
+    const [, left] = choice;
     return left;
   }
   throw new Error("Pattern match failure");
 }
 export function partialPattern($choice) {
   if ($choice[0] === "Pair") {
-    const [_, left] = $choice;
+    const [, left] = $choice;
     return left;
   } else {
     throw new Error("Pattern match failure");
@@ -103,7 +103,7 @@ export function partialPattern($choice) {
 }
 export function unwrapWrapped($wrapped) {
   if ($wrapped[0] === "Wrapped") {
-    const [_, value] = $wrapped;
+    const [, value] = $wrapped;
     return value;
   } else {
     throw new Error("Pattern match failure");

--- a/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
@@ -87,14 +87,14 @@ export function first(choice) {
   if (choice === "None") {
     return 0 | 0;
   }
-  if (Array.isArray(choice) && choice[0] === "Pair") {
+  if (choice[0] === "Pair") {
     const [_, left] = choice;
     return left;
   }
   throw new Error("Pattern match failure");
 }
 export function partialPattern($choice) {
-  if (Array.isArray($choice) && $choice[0] === "Pair") {
+  if ($choice[0] === "Pair") {
     const [_, left] = $choice;
     return left;
   } else {
@@ -102,7 +102,7 @@ export function partialPattern($choice) {
   }
 }
 export function unwrapWrapped($wrapped) {
-  if (Array.isArray($wrapped) && $wrapped[0] === "Wrapped") {
+  if ($wrapped[0] === "Wrapped") {
     const [_, value] = $wrapped;
     return value;
   } else {

--- a/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
@@ -88,14 +88,14 @@ export function first(choice) {
     return 0 | 0;
   }
   if (Array.isArray(choice) && choice[0] === "Pair") {
-    const left = choice[1];
+    const [_, left] = choice;
     return left;
   }
   throw new Error("Pattern match failure");
 }
 export function partialPattern($choice) {
   if (Array.isArray($choice) && $choice[0] === "Pair") {
-    const left = $choice[1];
+    const [_, left] = $choice;
     return left;
   } else {
     throw new Error("Pattern match failure");
@@ -103,7 +103,7 @@ export function partialPattern($choice) {
 }
 export function unwrapWrapped($wrapped) {
   if (Array.isArray($wrapped) && $wrapped[0] === "Wrapped") {
-    const value = $wrapped[1];
+    const [_, value] = $wrapped;
     return value;
   } else {
     throw new Error("Pattern match failure");

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Origin/index.js
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Origin/index.js
@@ -20,8 +20,8 @@ export const eqOption = /* @__PURE__ */ (() => {
   const $closure = (left) => {
     return (right) => {
       if (left[0] === "Just" && right[0] === "Just") {
-        const [_, left0] = left;
-        const [_$1, right0] = right;
+        const [, left0] = left;
+        const [, right0] = right;
         if (/* @__PURE__ */ Data_Eq.eq(Data_Eq.eqInt)(left0)(right0)) {
           return true;
         } else {

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Origin/index.js
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Origin/index.js
@@ -19,7 +19,7 @@ const $await = 17 | 0;
 export const eqOption = /* @__PURE__ */ (() => {
   const $closure = (left) => {
     return (right) => {
-      if (Array.isArray(left) && left[0] === "Just" && Array.isArray(right) && right[0] === "Just") {
+      if (left[0] === "Just" && right[0] === "Just") {
         const [_, left0] = left;
         const [_$1, right0] = right;
         if (/* @__PURE__ */ Data_Eq.eq(Data_Eq.eqInt)(left0)(right0)) {

--- a/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Origin/index.js
+++ b/tests-integration/fixtures/backend/1787130720_module_re_exports/output/Origin/index.js
@@ -20,8 +20,8 @@ export const eqOption = /* @__PURE__ */ (() => {
   const $closure = (left) => {
     return (right) => {
       if (Array.isArray(left) && left[0] === "Just" && Array.isArray(right) && right[0] === "Just") {
-        const left0 = left[1];
-        const right0 = right[1];
+        const [_, left0] = left;
+        const [_$1, right0] = right;
         if (/* @__PURE__ */ Data_Eq.eq(Data_Eq.eqInt)(left0)(right0)) {
           return true;
         } else {

--- a/tests-integration/fixtures/backend/1787317740_descriptive_closure_argument_names/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787317740_descriptive_closure_argument_names/output/Main/index.js
@@ -5,7 +5,7 @@ export function multiEquation($choice) {
   if ($choice === "None") {
     return 0 | 0;
   }
-  if (Array.isArray($choice) && $choice[0] === "Some") {
+  if ($choice[0] === "Some") {
     const [_, value] = $choice;
     return value;
   }
@@ -24,7 +24,7 @@ export function mixedArity($boolean) {
   };
 }
 export function singleConstructor($box) {
-  if (Array.isArray($box) && $box[0] === "Box") {
+  if ($box[0] === "Box") {
     const [_, value] = $box;
     return value;
   } else {

--- a/tests-integration/fixtures/backend/1787317740_descriptive_closure_argument_names/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787317740_descriptive_closure_argument_names/output/Main/index.js
@@ -6,7 +6,7 @@ export function multiEquation($choice) {
     return 0 | 0;
   }
   if ($choice[0] === "Some") {
-    const [_, value] = $choice;
+    const [, value] = $choice;
     return value;
   }
   throw new Error("Pattern match failure");
@@ -25,7 +25,7 @@ export function mixedArity($boolean) {
 }
 export function singleConstructor($box) {
   if ($box[0] === "Box") {
-    const [_, value] = $box;
+    const [, value] = $box;
     return value;
   } else {
     throw new Error("Pattern match failure");

--- a/tests-integration/fixtures/backend/1787317740_descriptive_closure_argument_names/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787317740_descriptive_closure_argument_names/output/Main/index.js
@@ -6,7 +6,7 @@ export function multiEquation($choice) {
     return 0 | 0;
   }
   if (Array.isArray($choice) && $choice[0] === "Some") {
-    const value = $choice[1];
+    const [_, value] = $choice;
     return value;
   }
   throw new Error("Pattern match failure");
@@ -25,7 +25,7 @@ export function mixedArity($boolean) {
 }
 export function singleConstructor($box) {
   if (Array.isArray($box) && $box[0] === "Box") {
-    const value = $box[1];
+    const [_, value] = $box;
     return value;
   } else {
     throw new Error("Pattern match failure");

--- a/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/output/Main/index.js
@@ -27,7 +27,7 @@ const $lazy_applicativeBox = $runtime.binding("applicativeBox", () => {
 });
 const $lazy_bindBox = $runtime.binding("bindBox", () => {
   const $closure = ($box) => {
-    if (Array.isArray($box) && $box[0] === "Box") {
+    if ($box[0] === "Box") {
       const [_, value] = $box;
       return (continuation) => {
         return continuation(value);
@@ -54,7 +54,7 @@ export const bindBox = $lazy_bindBox();
 export const monadBox = $lazy_monadBox();
 export const result = /* @__PURE__ */ (() => {
   const $scrutinee = /* @__PURE__ */ Data_Functor.map($lazy_functorBox())((value) => value)(["Box", 42 | 0]);
-  if (Array.isArray($scrutinee) && $scrutinee[0] === "Box") {
+  if ($scrutinee[0] === "Box") {
     const [_, value$1] = $scrutinee;
     return value$1;
   }

--- a/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/output/Main/index.js
@@ -28,7 +28,7 @@ const $lazy_applicativeBox = $runtime.binding("applicativeBox", () => {
 const $lazy_bindBox = $runtime.binding("bindBox", () => {
   const $closure = ($box) => {
     if (Array.isArray($box) && $box[0] === "Box") {
-      const value = $box[1];
+      const [_, value] = $box;
       return (continuation) => {
         return continuation(value);
       };
@@ -55,7 +55,7 @@ export const monadBox = $lazy_monadBox();
 export const result = /* @__PURE__ */ (() => {
   const $scrutinee = /* @__PURE__ */ Data_Functor.map($lazy_functorBox())((value) => value)(["Box", 42 | 0]);
   if (Array.isArray($scrutinee) && $scrutinee[0] === "Box") {
-    const value$1 = $scrutinee[1];
+    const [_, value$1] = $scrutinee;
     return value$1;
   }
   throw new Error("Pattern match failure");

--- a/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787392080_cyclic_instance_dictionaries/output/Main/index.js
@@ -28,7 +28,7 @@ const $lazy_applicativeBox = $runtime.binding("applicativeBox", () => {
 const $lazy_bindBox = $runtime.binding("bindBox", () => {
   const $closure = ($box) => {
     if ($box[0] === "Box") {
-      const [_, value] = $box;
+      const [, value] = $box;
       return (continuation) => {
         return continuation(value);
       };
@@ -55,7 +55,7 @@ export const monadBox = $lazy_monadBox();
 export const result = /* @__PURE__ */ (() => {
   const $scrutinee = /* @__PURE__ */ Data_Functor.map($lazy_functorBox())((value) => value)(["Box", 42 | 0]);
   if ($scrutinee[0] === "Box") {
-    const [_, value$1] = $scrutinee;
+    const [, value$1] = $scrutinee;
     return value$1;
   }
   throw new Error("Pattern match failure");

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
@@ -32,11 +32,11 @@ export const genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntCons
       return "Empty";
     }
     if (representation[0] === "Inr" && representation[1][0] === "Inl" && representation[1][1][0] === "Constructor") {
-      const [_, field0] = representation[1][1];
+      const [, field0] = representation[1][1];
       return ["Single", field0];
     }
     if (representation[0] === "Inr" && representation[1][0] === "Inr" && representation[1][1][0] === "Constructor" && representation[1][1][1][0] === "Product") {
-      const [_, field0$1, field1] = representation[1][1][1];
+      const [, field0$1, field1] = representation[1][1][1];
       return [
         "Pair",
         field0$1,
@@ -50,11 +50,11 @@ export const genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntCons
       return ["Inl", ["Constructor", "NoArguments"]];
     }
     if (value[0] === "Single") {
-      const [_, field0$2] = value;
+      const [, field0$2] = value;
       return ["Inr", ["Inl", ["Constructor", field0$2]]];
     }
     if (value[0] === "Pair") {
-      const [_, field0$3, field1$1] = value;
+      const [, field0$3, field1$1] = value;
       return ["Inr", ["Inr", ["Constructor", [
         "Product",
         field0$3,

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
@@ -28,14 +28,14 @@ export const wrapped = 42 | 0;
 export const unwrapped = /* @__PURE__ */ Data_Newtype.unwrap(newtypeTypeIdentifierInt)(wrapped);
 export const genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntConstructorProductArgumentIntArgumentInt = /* @__PURE__ */ (() => {
   const $closure = (representation) => {
-    if (Array.isArray(representation) && representation[0] === "Inl" && Array.isArray(representation[1]) && representation[1][0] === "Constructor" && representation[1][1] === "NoArguments") {
+    if (representation[0] === "Inl" && representation[1][0] === "Constructor" && representation[1][1] === "NoArguments") {
       return "Empty";
     }
-    if (Array.isArray(representation) && representation[0] === "Inr" && Array.isArray(representation[1]) && representation[1][0] === "Inl" && Array.isArray(representation[1][1]) && representation[1][1][0] === "Constructor") {
+    if (representation[0] === "Inr" && representation[1][0] === "Inl" && representation[1][1][0] === "Constructor") {
       const [_, field0] = representation[1][1];
       return ["Single", field0];
     }
-    if (Array.isArray(representation) && representation[0] === "Inr" && Array.isArray(representation[1]) && representation[1][0] === "Inr" && Array.isArray(representation[1][1]) && representation[1][1][0] === "Constructor" && Array.isArray(representation[1][1][1]) && representation[1][1][1][0] === "Product") {
+    if (representation[0] === "Inr" && representation[1][0] === "Inr" && representation[1][1][0] === "Constructor" && representation[1][1][1][0] === "Product") {
       const [_, field0$1, field1] = representation[1][1][1];
       return [
         "Pair",
@@ -49,11 +49,11 @@ export const genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntCons
     if (value === "Empty") {
       return ["Inl", ["Constructor", "NoArguments"]];
     }
-    if (Array.isArray(value) && value[0] === "Single") {
+    if (value[0] === "Single") {
       const [_, field0$2] = value;
       return ["Inr", ["Inl", ["Constructor", field0$2]]];
     }
-    if (Array.isArray(value) && value[0] === "Pair") {
+    if (value[0] === "Pair") {
       const [_, field0$3, field1$1] = value;
       return ["Inr", ["Inr", ["Constructor", [
         "Product",

--- a/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787415600_derived_newtype_generic_runtime/output/Main/index.js
@@ -32,12 +32,11 @@ export const genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntCons
       return "Empty";
     }
     if (Array.isArray(representation) && representation[0] === "Inr" && Array.isArray(representation[1]) && representation[1][0] === "Inl" && Array.isArray(representation[1][1]) && representation[1][1][0] === "Constructor") {
-      const field0 = representation[1][1][1];
+      const [_, field0] = representation[1][1];
       return ["Single", field0];
     }
     if (Array.isArray(representation) && representation[0] === "Inr" && Array.isArray(representation[1]) && representation[1][0] === "Inr" && Array.isArray(representation[1][1]) && representation[1][1][0] === "Constructor" && Array.isArray(representation[1][1][1]) && representation[1][1][1][0] === "Product") {
-      const field0$1 = representation[1][1][1][1];
-      const field1 = representation[1][1][1][2];
+      const [_, field0$1, field1] = representation[1][1][1];
       return [
         "Pair",
         field0$1,
@@ -51,12 +50,11 @@ export const genericChoiceSumConstructorNoArgumentsSumConstructorArgumentIntCons
       return ["Inl", ["Constructor", "NoArguments"]];
     }
     if (Array.isArray(value) && value[0] === "Single") {
-      const field0$2 = value[1];
+      const [_, field0$2] = value;
       return ["Inr", ["Inl", ["Constructor", field0$2]]];
     }
     if (Array.isArray(value) && value[0] === "Pair") {
-      const field0$3 = value[1];
-      const field1$1 = value[2];
+      const [_, field0$3, field1$1] = value;
       return ["Inr", ["Inr", ["Constructor", [
         "Product",
         field0$3,

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Main/index.js
@@ -96,7 +96,7 @@ export function joinedPattern(condition) {
     $result = ["Box", observe("pattern-else")(12 | 0)];
   }
   if ($result[0] === "Box") {
-    const [_, value] = $result;
+    const [, value] = $result;
     return value;
   }
   throw new Error("Pattern match failure");

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Main/index.js
@@ -95,7 +95,7 @@ export function joinedPattern(condition) {
   } else {
     $result = ["Box", observe("pattern-else")(12 | 0)];
   }
-  if (Array.isArray($result) && $result[0] === "Box") {
+  if ($result[0] === "Box") {
     const [_, value] = $result;
     return value;
   }

--- a/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787719500_reusable_rendered_expression_boundaries/output/Main/index.js
@@ -96,7 +96,7 @@ export function joinedPattern(condition) {
     $result = ["Box", observe("pattern-else")(12 | 0)];
   }
   if (Array.isArray($result) && $result[0] === "Box") {
-    const value = $result[1];
+    const [_, value] = $result;
     return value;
   }
   throw new Error("Pattern match failure");


### PR DESCRIPTION
## Summary

- emit one array destructuring declaration for variables bound by a constructor pattern
- elide the constructor tag rather than creating throwaway bindings
- trust the compiler-owned constructor representation and match tags directly without `Array.isArray`

## Motivation

Constructor fields were previously bound through a separate indexed `const` declaration for each variable. Grouping those bindings reflects the constructor's runtime layout directly and reduces generated code. Direct tag checks also avoid a redundant shape check for values whose representation is controlled by the compiler.

## Verification

- `just t backend`
- `cargo check -p javascript --tests`
