### PR TITLE
[diagnostics] Render rich command-line diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,6 +672,8 @@ dependencies = [
  "smol_str",
  "stabilizing",
  "syntax",
+ "textwrap",
+ "unicode-width",
 ]
 
 [[package]]

--- a/compiler-bin/src/cli.rs
+++ b/compiler-bin/src/cli.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::path::PathBuf;
 
 use clap::builder::{PathBufValueParser, TypedValueParser};
-use clap::{ArgAction, Args, Parser, Subcommand};
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use path_absolutize::Absolutize;
 use tracing::level_filters::LevelFilter;
 
@@ -110,9 +110,20 @@ pub struct CompileOptions {
     #[arg(long, value_name("COUNT"))]
     pub diagnostic_limit: Option<usize>,
 
+    /// When to use colors in human-readable diagnostics.
+    #[arg(long, value_enum, default_value_t = ColorChoice::Auto)]
+    pub color: ColorChoice,
+
     /// PureScript source paths or glob patterns.
     #[arg(value_name("INPUT"), required = true)]
     pub inputs: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ColorChoice {
+    Auto,
+    Always,
+    Never,
 }
 
 #[derive(Debug, Args)]
@@ -249,6 +260,8 @@ mod tests {
             "--json-errors",
             "--diagnostic-limit",
             "20",
+            "--color",
+            "always",
             "src/**/*.purs",
             ".spago/p/prelude-6.0.2/src/**/*.purs",
         ]);
@@ -257,6 +270,7 @@ mod tests {
         assert_eq!(options.codegen.as_deref(), Some("corefn,docs,js,sourcemaps"));
         assert!(options.json_errors);
         assert_eq!(options.diagnostic_limit, Some(20));
+        assert_eq!(options.color, ColorChoice::Always);
         assert_eq!(
             options.inputs,
             vec![

--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -18,6 +18,7 @@ use rayon::prelude::*;
 use thiserror::Error;
 use url::Url;
 
+use crate::cli::ColorChoice;
 use crate::walk;
 
 const CARGO_PROGRESS_REGION_WIDTH: usize = 50;
@@ -29,6 +30,7 @@ pub struct CompileConfig {
     pub inputs: Vec<PathBuf>,
     pub json_errors: bool,
     pub diagnostic_limit: Option<usize>,
+    pub color: ColorChoice,
 }
 
 #[derive(Debug, Error)]
@@ -94,7 +96,22 @@ fn compile(config: CompileConfig) -> Result<(), CompileError> {
         return Err(io::Error::new(io::ErrorKind::NotFound, "no input files found").into());
     }
 
-    let has_errors = report_diagnostics(&engine, &files, &source_ids, config.diagnostic_limit)?;
+    let color = match config.color {
+        ColorChoice::Auto => {
+            let no_color = std::env::var_os("NO_COLOR").is_some_and(|value| !value.is_empty());
+            io::stderr().is_terminal() && !no_color
+        }
+        ColorChoice::Always => true,
+        ColorChoice::Never => false,
+    };
+    let has_errors = report_diagnostics(
+        &engine,
+        &files,
+        &source_ids,
+        &current_directory,
+        config.diagnostic_limit,
+        color,
+    )?;
     if has_errors {
         return Err(CompileError::Diagnostics);
     }
@@ -168,11 +185,21 @@ fn load_source(
     Ok(source_id)
 }
 
+fn display_source_path(source_path: &str, current_directory: &Path) -> String {
+    if let Some(file_path) = Url::parse(source_path).ok().and_then(|url| url.to_file_path().ok()) {
+        file_path.strip_prefix(current_directory).unwrap_or(&file_path).display().to_string()
+    } else {
+        source_path.to_owned()
+    }
+}
+
 fn report_diagnostics(
     engine: &QueryEngine,
     files: &FileLifecycle<(), ()>,
     source_ids: &[FileId],
+    current_directory: &Path,
     diagnostic_limit: Option<usize>,
+    color: bool,
 ) -> Result<bool, CompileError> {
     let progress = MultiProgress::new();
     progress.set_move_cursor(true);
@@ -229,12 +256,9 @@ fn report_diagnostics(
         let display_path = if all.is_empty() {
             None
         } else {
-            let path = files.source_path(file_id).expect("input source has no lifecycle path");
-            let display_path = Url::parse(&path)
-                .ok()
-                .and_then(|url| url.to_file_path().ok())
-                .map_or_else(|| path.to_string(), |path| path.display().to_string());
-            Some(display_path)
+            let source_path =
+                files.source_path(file_id).expect("input source has no lifecycle path");
+            Some(display_source_path(&source_path, current_directory))
         };
         Ok::<_, CompileError>((has_errors, all, content, display_path))
     });
@@ -245,6 +269,8 @@ fn report_diagnostics(
     let mut has_errors = false;
     let mut remaining = diagnostic_limit.unwrap_or(usize::MAX);
     let mut omitted = 0;
+    let mut rendered_any = false;
+    let separate_from_progress = io::stderr().is_terminal();
     for (file_has_errors, all, content, display_path) in diagnostics {
         has_errors |= file_has_errors;
         let rendered_count = remaining.min(all.len());
@@ -252,12 +278,17 @@ fn report_diagnostics(
         remaining -= rendered_count;
 
         if rendered_count > 0 {
+            if !rendered_any && separate_from_progress {
+                eprint!("\n\n");
+            }
+            rendered_any = true;
             let display_path =
                 display_path.expect("non-empty diagnostics must have a display path");
-            let rendered = diagnostics::format_rustc_with_path(
+            let rendered = diagnostics::format_rich_with_path(
                 &all[..rendered_count],
                 &content,
                 &display_path,
+                color,
             );
             eprint!("{rendered}");
         }

--- a/compiler-bin/src/lib.rs
+++ b/compiler-bin/src/lib.rs
@@ -44,6 +44,7 @@ pub fn run() {
                 inputs: options.inputs,
                 json_errors: options.json_errors,
                 diagnostic_limit: options.diagnostic_limit,
+                color: options.color,
             });
         }
         cli::Command::Docs(options) => {

--- a/compiler-frontend/diagnostics/Cargo.toml
+++ b/compiler-frontend/diagnostics/Cargo.toml
@@ -17,3 +17,5 @@ lsp-types.workspace = true
 line-index = "0.1.2"
 itertools = "0.15.0"
 smol_str = "0.3.2"
+textwrap = "0.16.2"
+unicode-width = "0.2.2"

--- a/compiler-frontend/diagnostics/src/lib.rs
+++ b/compiler-frontend/diagnostics/src/lib.rs
@@ -7,6 +7,6 @@ pub use context::{DiagnosticsContext, ExternalQueries};
 pub use convert::ToDiagnostics;
 pub use model::{Diagnostic, DiagnosticCode, RelatedSpan, Severity, Span};
 pub use render::{
-    format_rustc, format_rustc_with_path, format_text, to_lsp_diagnostic,
+    format_rich_with_path, format_rustc, format_rustc_with_path, format_text, to_lsp_diagnostic,
     to_lsp_diagnostic_with_line_index,
 };

--- a/compiler-frontend/diagnostics/src/render.rs
+++ b/compiler-frontend/diagnostics/src/render.rs
@@ -4,8 +4,19 @@ use lsp_types::{
     DiagnosticRelatedInformation, DiagnosticSeverity, Location, NumberOrString, Position, Range,
 };
 use syntax::TextSize;
+use unicode_width::UnicodeWidthChar;
 
 use crate::{Diagnostic, Severity, Span};
+
+const DIAGNOSTIC_WIDTH: usize = 100;
+const RICH_BRANCH: &str = "  •";
+const RICH_STEM: &str = "  │";
+const RICH_SEPARATOR: &str = "·";
+const ANSI_RESET: &str = "\x1b[0m";
+const ANSI_BOLD_RED: &str = "\x1b[1;31m";
+const ANSI_BOLD_YELLOW: &str = "\x1b[1;33m";
+const ANSI_CYAN: &str = "\x1b[36m";
+const ANSI_DIM: &str = "\x1b[2m";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct DisplayPosition {
@@ -72,9 +83,196 @@ pub fn format_rustc(diagnostics: &[Diagnostic], content: &str) -> String {
     format_rustc_inner(diagnostics, content, None)
 }
 
-/// Renders diagnostics in rustc style with a file path in the `-->` lines.
+/// Retained for integration and compatibility snapshot stability, not command-line output.
 pub fn format_rustc_with_path(diagnostics: &[Diagnostic], content: &str, path: &str) -> String {
     format_rustc_inner(diagnostics, content, Some(path))
+}
+
+pub fn format_rich_with_path(
+    diagnostics: &[Diagnostic],
+    content: &str,
+    path: &str,
+    color: bool,
+) -> String {
+    let line_index = LineIndex::new(content);
+    let mut output = String::new();
+
+    for diagnostic in diagnostics {
+        let severity_text = match diagnostic.severity {
+            Severity::Error => "Error!",
+            Severity::Warning => "Warning!",
+        };
+        let severity = painted(severity_text, severity_color(diagnostic.severity), color);
+        let separator = painted(RICH_SEPARATOR, ANSI_DIM, color);
+        let code = painted(diagnostic.code.to_string(), ANSI_BOLD_YELLOW, color);
+        let location = span_location(&line_index, content, diagnostic.span).map_or_else(
+            || path.to_string(),
+            |((line, column), _)| format!("{path}:{}:{}", line + 1, column + 1),
+        );
+        let location = painted(location, ANSI_BOLD_YELLOW, color);
+        output.push_str(&format!("{severity} {separator} [{code}] {separator} {location}\n"));
+
+        let branch = painted(RICH_BRANCH, ANSI_DIM, color);
+        let stem = painted(RICH_STEM, ANSI_DIM, color);
+        output.push_str(&format!("{branch}\n{stem}\n"));
+
+        let message_width = DIAGNOSTIC_WIDTH.saturating_sub(RICH_BRANCH.chars().count() + 1);
+        let wrapped = textwrap::wrap(&diagnostic.message, message_width);
+        for (index, line) in wrapped.iter().enumerate() {
+            let gutter = if index == 0 { &branch } else { &stem };
+            output.push_str(&format!("{gutter} {}\n", paint_quoted_text(line, color)));
+        }
+        output.push_str(&format!("{stem}\n"));
+        render_rich_source(
+            &mut output,
+            &line_index,
+            content,
+            diagnostic.span,
+            diagnostic.severity,
+            color,
+        );
+
+        for related in &diagnostic.related {
+            output.push_str(&format!("{branch}\n"));
+            let wrapped = textwrap::wrap(&related.message, message_width);
+            for line in wrapped {
+                let message = paint_quoted_text(&line, color);
+                output.push_str(&format!("{stem} {message}\n"));
+            }
+            output.push_str(&format!("{stem}\n"));
+            render_rich_source(
+                &mut output,
+                &line_index,
+                content,
+                related.span,
+                diagnostic.severity,
+                color,
+            );
+        }
+
+        if !diagnostic.trivia.is_empty() {
+            output.push_str(&format!("{branch} while\n{stem}\n"));
+            for trivia in &diagnostic.trivia {
+                let wrapped = textwrap::wrap(trivia, message_width.saturating_sub(2));
+                for line in wrapped {
+                    let trivia = paint_quoted_text(&line, color);
+                    output.push_str(&format!("{stem}   {trivia}\n"));
+                }
+            }
+        }
+        output.push_str(&format!("{branch}\n\n"));
+    }
+
+    output
+}
+
+fn render_rich_source(
+    output: &mut String,
+    line_index: &LineIndex,
+    content: &str,
+    span: Span,
+    severity: Severity,
+    color: bool,
+) {
+    let Some(((start_line, start_column), (end_line, end_column))) =
+        span_location(line_index, content, span)
+    else {
+        return;
+    };
+    let Some(original_source_line) = line_text(line_index, content, start_line) else { return };
+    let source_line = expand_tabs(original_source_line);
+    let start_column = visual_column(original_source_line, start_column);
+    let end_column = if start_line == end_line {
+        visual_column(original_source_line, end_column)
+    } else {
+        display_width(original_source_line)
+    };
+    let marker = visual_highlight_marker(start_column, end_column, display_width(&source_line));
+    let marker = painted(marker, severity_color(severity), color);
+    let stem = painted(RICH_STEM, ANSI_DIM, color);
+    output.push_str(&format!("{stem}   {source_line}\n"));
+    output.push_str(&format!("{stem}   {marker}\n"));
+}
+
+fn painted(text: impl AsRef<str>, ansi: &str, color: bool) -> String {
+    if color { format!("{ansi}{}{ANSI_RESET}", text.as_ref()) } else { text.as_ref().to_string() }
+}
+
+fn severity_name(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+    }
+}
+
+fn severity_color(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => ANSI_BOLD_RED,
+        Severity::Warning => ANSI_BOLD_YELLOW,
+    }
+}
+
+fn expand_tabs(line: &str) -> String {
+    let mut expanded = String::new();
+    let mut column = 0;
+    for character in line.chars() {
+        if character == '\t' {
+            let spaces = 4 - column % 4;
+            expanded.push_str(&" ".repeat(spaces));
+            column += spaces;
+        } else {
+            expanded.push(character);
+            column += character.width().unwrap_or(0);
+        }
+    }
+    expanded
+}
+
+fn visual_column(line: &str, character_column: u32) -> u32 {
+    let mut column = 0;
+    for character in line.chars().take(character_column as usize) {
+        if character == '\t' {
+            column += 4 - column % 4;
+        } else {
+            column += character.width().unwrap_or(0);
+        }
+    }
+    column as u32
+}
+
+fn display_width(line: &str) -> u32 {
+    visual_column(line, line.chars().count() as u32)
+}
+
+fn visual_highlight_marker(start_column: u32, end_column: u32, line_width: u32) -> String {
+    let start = start_column.min(line_width);
+    let end = end_column.min(line_width);
+    if end <= start {
+        format!("{}╰", " ".repeat(start as usize))
+    } else {
+        let line_count = end.saturating_sub(start).saturating_sub(1) as usize;
+        format!("{}╰{}", " ".repeat(start as usize), "─".repeat(line_count))
+    }
+}
+
+fn paint_quoted_text(text: &str, color: bool) -> String {
+    if !color {
+        return text.to_string();
+    }
+
+    let mut output = String::new();
+    let mut quoted = false;
+    for character in text.chars() {
+        if character == '\'' {
+            output.push_str(if quoted { ANSI_RESET } else { ANSI_CYAN });
+            quoted = !quoted;
+        }
+        output.push(character);
+    }
+    if quoted {
+        output.push_str(ANSI_RESET);
+    }
+    output
 }
 
 fn format_rustc_inner(diagnostics: &[Diagnostic], content: &str, path: Option<&str>) -> String {
@@ -82,11 +280,7 @@ fn format_rustc_inner(diagnostics: &[Diagnostic], content: &str, path: Option<&s
     let mut output = String::new();
 
     for diagnostic in diagnostics {
-        let severity = match diagnostic.severity {
-            Severity::Error => "error",
-            Severity::Warning => "warning",
-        };
-
+        let severity = severity_name(diagnostic.severity);
         output.push_str(&format!("{severity}[{}]: {}\n", diagnostic.code, diagnostic.message));
 
         let primary = diagnostic.span;


### PR DESCRIPTION
## Intent

Make compiler diagnostics easier to scan in a terminal by presenting the primary message, source location, highlighted code, and related semantic information as one vertical narrative.

## Changes

- render command-line diagnostics with a Unicode gutter and source underline
- color severity, diagnostic codes, and quoted semantic fragments while respecting terminal detection, `NO_COLOR`, and `--color`
- wrap diagnostic messages to a fixed readable width and display source paths relative to the working directory
- separate diagnostics from completed progress loaders
- retain the existing plain renderer for integration snapshots and compatibility reporting, and leave LSP diagnostics unchanged

## Validation

- `cargo check -p purescript-alexandrite --tests`
- `cargo nextest run -p diagnostics`
- `cargo nextest run -p purescript-alexandrite cli::tests`
- `just t checking expression_hole`