### PR TITLE
[diagnostics] Use rich output in test snapshots

### DIFF
--- a/compiler-frontend/diagnostics/src/lib.rs
+++ b/compiler-frontend/diagnostics/src/lib.rs
@@ -7,6 +7,5 @@ pub use context::{DiagnosticsContext, ExternalQueries};
 pub use convert::ToDiagnostics;
 pub use model::{Diagnostic, DiagnosticCode, RelatedSpan, Severity, Span};
 pub use render::{
-    format_rich_with_path, format_rustc, format_rustc_with_path, format_text, to_lsp_diagnostic,
-    to_lsp_diagnostic_with_line_index,
+    format_rich_with_path, format_text, to_lsp_diagnostic, to_lsp_diagnostic_with_line_index,
 };

--- a/compiler-frontend/diagnostics/src/render.rs
+++ b/compiler-frontend/diagnostics/src/render.rs
@@ -56,19 +56,6 @@ fn line_text<'a>(line_index: &LineIndex, content: &'a str, line: u32) -> Option<
     Some(text.trim_end_matches(['\n', '\r']))
 }
 
-fn caret_marker(line: &str, start_col: u32, end_col: Option<u32>) -> String {
-    let line_len = line.chars().count() as u32;
-    let start = start_col.min(line_len);
-    let end = end_col.unwrap_or(line_len).min(line_len);
-
-    if end <= start {
-        format!("{}^", " ".repeat(start as usize))
-    } else {
-        let tilde_count = (end - start).saturating_sub(1) as usize;
-        format!("{}^{}", " ".repeat(start as usize), "~".repeat(tilde_count))
-    }
-}
-
 fn span_location(
     line_index: &LineIndex,
     content: &str,
@@ -77,15 +64,6 @@ fn span_location(
     let start = offset_to_display_position(line_index, content, TextSize::from(span.start))?;
     let end = offset_to_display_position(line_index, content, TextSize::from(span.end))?;
     Some(((start.line, start.column), (end.line, end.column)))
-}
-
-pub fn format_rustc(diagnostics: &[Diagnostic], content: &str) -> String {
-    format_rustc_inner(diagnostics, content, None)
-}
-
-/// Retained for integration and compatibility snapshot stability, not command-line output.
-pub fn format_rustc_with_path(diagnostics: &[Diagnostic], content: &str, path: &str) -> String {
-    format_rustc_inner(diagnostics, content, Some(path))
 }
 
 pub fn format_rich_with_path(
@@ -198,13 +176,6 @@ fn painted(text: impl AsRef<str>, ansi: &str, color: bool) -> String {
     if color { format!("{ansi}{}{ANSI_RESET}", text.as_ref()) } else { text.as_ref().to_string() }
 }
 
-fn severity_name(severity: Severity) -> &'static str {
-    match severity {
-        Severity::Error => "error",
-        Severity::Warning => "warning",
-    }
-}
-
 fn severity_color(severity: Severity) -> &'static str {
     match severity {
         Severity::Error => ANSI_BOLD_RED,
@@ -272,94 +243,6 @@ fn paint_quoted_text(text: &str, color: bool) -> String {
     if quoted {
         output.push_str(ANSI_RESET);
     }
-    output
-}
-
-fn format_rustc_inner(diagnostics: &[Diagnostic], content: &str, path: Option<&str>) -> String {
-    let line_index = LineIndex::new(content);
-    let mut output = String::new();
-
-    for diagnostic in diagnostics {
-        let severity = severity_name(diagnostic.severity);
-        output.push_str(&format!("{severity}[{}]: {}\n", diagnostic.code, diagnostic.message));
-
-        let primary = diagnostic.span;
-        if let Some(((start_line, start_col), (end_line, end_col))) =
-            span_location(&line_index, content, primary)
-        {
-            let display_start_line = start_line + 1;
-            let display_start_col = start_col + 1;
-            let display_end_line = end_line + 1;
-            let display_end_col = end_col + 1;
-
-            if let Some(path) = path {
-                output.push_str(&format!(
-                    "  --> {path}:{}:{}..{}:{}\n",
-                    display_start_line, display_start_col, display_end_line, display_end_col
-                ));
-            } else {
-                output.push_str(&format!(
-                    "  --> {}:{}..{}:{}\n",
-                    display_start_line, display_start_col, display_end_line, display_end_col
-                ));
-            }
-
-            if let Some(line) = line_text(&line_index, content, start_line) {
-                let line_num_width = display_start_line.to_string().len();
-                output.push_str(&format!("{:>width$} |\n", "", width = line_num_width));
-                output.push_str(&format!("{} | {}\n", display_start_line, line));
-
-                let marker_end_col = if start_line == end_line { Some(end_col) } else { None };
-                let marker = caret_marker(line, start_col, marker_end_col);
-                output.push_str(&format!("{:>width$} | {}\n", "", marker, width = line_num_width));
-            }
-        }
-
-        for trivia in &diagnostic.trivia {
-            output.push_str(&format!("  trivia: {trivia}\n"));
-        }
-
-        for related in &diagnostic.related {
-            output.push_str(&format!("  note: {}\n", related.message));
-
-            if let Some(((start_line, start_col), (end_line, end_col))) =
-                span_location(&line_index, content, related.span)
-            {
-                let display_start_line = start_line + 1;
-                let display_start_col = start_col + 1;
-                let display_end_line = end_line + 1;
-                let display_end_col = end_col + 1;
-
-                if let Some(path) = path {
-                    output.push_str(&format!(
-                        "    --> {path}:{}:{}..{}:{}\n",
-                        display_start_line, display_start_col, display_end_line, display_end_col
-                    ));
-                } else {
-                    output.push_str(&format!(
-                        "    --> {}:{}..{}:{}\n",
-                        display_start_line, display_start_col, display_end_line, display_end_col
-                    ));
-                }
-
-                if let Some(line) = line_text(&line_index, content, start_line) {
-                    let line_num_width = display_start_line.to_string().len();
-                    output.push_str(&format!("  {:>width$} |\n", "", width = line_num_width));
-                    output.push_str(&format!("  {} | {}\n", display_start_line, line));
-
-                    let marker_end_col = if start_line == end_line { Some(end_col) } else { None };
-                    let marker = caret_marker(line, start_col, marker_end_col);
-                    output.push_str(&format!(
-                        "  {:>width$} | {}\n",
-                        "",
-                        marker,
-                        width = line_num_width
-                    ));
-                }
-            }
-        }
-    }
-
     output
 }
 

--- a/tests-compatibility/src/verifier/compile.rs
+++ b/tests-compatibility/src/verifier/compile.rs
@@ -3,7 +3,7 @@ use std::fs;
 
 use building::{QueryEngine, QueryError, prim};
 use diagnostics::{
-    Diagnostic, DiagnosticsContext, Severity, Span, ToDiagnostics, format_rustc_with_path,
+    Diagnostic, DiagnosticsContext, Severity, Span, ToDiagnostics, format_rich_with_path,
 };
 use files::{FileId, Files, ForeignFiles};
 use rayon::prelude::*;
@@ -384,10 +384,11 @@ fn compiler_diagnostic(
         Severity::Error => DiagnosticSeverity::Error,
         Severity::Warning => DiagnosticSeverity::Warning,
     };
-    let human = format_rustc_with_path(
+    let human = format_rich_with_path(
         std::slice::from_ref(&diagnostic),
         &metadata.content,
         &metadata.relative_path,
+        false,
     );
 
     CompilerDiagnostic {

--- a/tests-integration/fixtures/backend/1787081220_javascript_execution/Main.snap
+++ b/tests-integration/fixtures/backend/1787081220_javascript_execution/Main.snap
@@ -1,5 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
+assertion_line: 265
 expression: diagnostics_report
 ---
 Terms
@@ -60,8 +61,11 @@ Roles
 Choice = []
 
 Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: None
-  --> 106:1..106:32
-    |
-106 | partialPattern :: Choice -> Int
-    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Warning! · [MissingPatterns] · Main.purs:106:1
+  •
+  │
+  • Pattern match is not exhaustive. Missing: None
+  │
+  │   partialPattern :: Choice -> Int
+  │   ╰──────────────────────────────
+  •

--- a/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/Main.snap
+++ b/tests-integration/fixtures/backend/1787330460_ffi_missing_implementation/Main.snap
@@ -1,5 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
+assertion_line: 265
 expression: diagnostics_report
 ---
 Terms
@@ -8,8 +9,11 @@ requested :: Prim.Int
 Types
 
 Diagnostics
-error[MissingFFIImplementation]: JavaScript FFI module does not export 'requested'
-  --> 3:1..3:32
-  |
-3 | foreign import requested :: Int
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [MissingFFIImplementation] · Main.purs:3:1
+  •
+  │
+  • JavaScript FFI module does not export 'requested'
+  │
+  │   foreign import requested :: Int
+  │   ╰──────────────────────────────
+  •

--- a/tests-integration/fixtures/backend/1787330460_ffi_missing_module/Main.snap
+++ b/tests-integration/fixtures/backend/1787330460_ffi_missing_module/Main.snap
@@ -1,5 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
+assertion_line: 265
 expression: diagnostics_report
 ---
 Terms
@@ -8,8 +9,11 @@ requested :: Prim.Int
 Types
 
 Diagnostics
-error[MissingFFIModule]: No JavaScript FFI module was found for foreign import 'requested'
-  --> 3:1..3:32
-  |
-3 | foreign import requested :: Int
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [MissingFFIModule] · Main.purs:3:1
+  •
+  │
+  • No JavaScript FFI module was found for foreign import 'requested'
+  │
+  │   foreign import requested :: Int
+  │   ╰──────────────────────────────
+  •

--- a/tests-integration/fixtures/backend/1787331420_ffi_parse_error/Main.snap
+++ b/tests-integration/fixtures/backend/1787331420_ffi_parse_error/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 268
+assertion_line: 265
 expression: diagnostics_report
 ---
 Terms
@@ -9,8 +9,12 @@ _null :: Prim.Int
 Types
 
 Diagnostics
-warning[UnparseableFFIModule]: Oxc could not parse the JavaScript FFI module. Fix the invalid or unsupported JavaScript syntax; Alexandrite treated the module as opaque and skipped export-name validation: Unexpected token
-  --> 3:1..3:28
-  |
-3 | foreign import _null :: Int
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+Warning! · [UnparseableFFIModule] · Main.purs:3:1
+  •
+  │
+  • Oxc could not parse the JavaScript FFI module. Fix the invalid or unsupported JavaScript syntax;
+  │ Alexandrite treated the module as opaque and skipped export-name validation: Unexpected token
+  │
+  │   foreign import _null :: Int
+  │   ╰──────────────────────────
+  •

--- a/tests-integration/fixtures/backend/1787556240_ffi_xterm_parse_error/Main.snap
+++ b/tests-integration/fixtures/backend/1787556240_ffi_xterm_parse_error/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 268
+assertion_line: 265
 expression: diagnostics_report
 ---
 Terms
@@ -9,13 +9,24 @@ registerVersionProvider :: Prim.Int
 Types
 
 Diagnostics
-warning[UnparseableFFIModule]: Oxc could not parse the JavaScript FFI module. Fix the invalid or unsupported JavaScript syntax; Alexandrite treated the module as opaque and skipped export-name validation: Missing initializer in const declaration
-  --> 3:1..3:46
-  |
-3 | foreign import registerVersionProvider :: Int
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-warning[UnparseableFFIModule]: Oxc could not parse the JavaScript FFI module. Fix the invalid or unsupported JavaScript syntax; Alexandrite treated the module as opaque and skipped export-name validation: Expected a semicolon or an implicit semicolon after a statement, but found none
-  --> 3:1..3:46
-  |
-3 | foreign import registerVersionProvider :: Int
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Warning! · [UnparseableFFIModule] · Main.purs:3:1
+  •
+  │
+  • Oxc could not parse the JavaScript FFI module. Fix the invalid or unsupported JavaScript syntax;
+  │ Alexandrite treated the module as opaque and skipped export-name validation: Missing initializer
+  │ in const declaration
+  │
+  │   foreign import registerVersionProvider :: Int
+  │   ╰────────────────────────────────────────────
+  •
+
+Warning! · [UnparseableFFIModule] · Main.purs:3:1
+  •
+  │
+  • Oxc could not parse the JavaScript FFI module. Fix the invalid or unsupported JavaScript
+  │ syntax; Alexandrite treated the module as opaque and skipped export-name validation: Expected a
+  │ semicolon or an implicit semicolon after a statement, but found none
+  │
+  │   foreign import registerVersionProvider :: Int
+  │   ╰────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772011440_type_operator_chain_kind_error/Main.snap
+++ b/tests-integration/fixtures/checking/1772011440_type_operator_chain_kind_error/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -15,8 +15,11 @@ type Add a b = a
 type Bad = Main.Add Prim.Int "hello"
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'Symbol' with 'Type'
-  --> 8:18..8:25
-  |
-8 | type Bad = Int + "hello"
-  |                  ^~~~~~~
+Error! · [CannotUnify] · Main.purs:8:18
+  •
+  │
+  • Cannot unify 'Symbol' with 'Type'
+  │
+  │   type Bad = Int + "hello"
+  │                    ╰──────
+  •

--- a/tests-integration/fixtures/checking/1772011800_role_declaration_loosen_error/Main.snap
+++ b/tests-integration/fixtures/checking/1772011800_role_declaration_loosen_error/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -15,8 +15,11 @@ Roles
 F = [Representational, Nominal]
 
 Diagnostics
-error[InvalidRoleDeclaration]: Invalid role declaration: declared Phantom, inferred Nominal
-  --> 3:1..3:21
-  |
-3 | data F f a = F (f a)
-  | ^~~~~~~~~~~~~~~~~~~~
+Error! · [InvalidRoleDeclaration] · Main.purs:3:1
+  •
+  │
+  • Invalid role declaration: declared Phantom, inferred Nominal
+  │
+  │   data F f a = F (f a)
+  │   ╰───────────────────
+  •

--- a/tests-integration/fixtures/checking/1772045820_exhaustive_case_infer/Main.snap
+++ b/tests-integration/fixtures/checking/1772045820_exhaustive_case_infer/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -15,8 +15,11 @@ Roles
 Maybe = [Representational]
 
 Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Nothing
-  --> 5:8..6:14
-  |
-5 | test = case _ of
-  |        ^~~~~~~~~
+Warning! · [MissingPatterns] · Main.purs:5:8
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Nothing
+  │
+  │   test = case _ of
+  │          ╰────────
+  •

--- a/tests-integration/fixtures/checking/1772045880_exhaustive_case_redundant/Main.snap
+++ b/tests-integration/fixtures/checking/1772045880_exhaustive_case_redundant/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -15,8 +15,11 @@ Roles
 Maybe = [Representational]
 
 Diagnostics
-warning[RedundantPattern]: Pattern match has redundant patterns: Just _
-  --> 5:8..8:15
-  |
-5 | test = case _ of
-  |        ^~~~~~~~~
+Warning! · [RedundantPattern] · Main.purs:5:8
+  •
+  │
+  • Pattern match has redundant patterns: Just _
+  │
+  │   test = case _ of
+  │          ╰────────
+  •

--- a/tests-integration/fixtures/checking/1772045940_exhaustive_equation_signature/Main.snap
+++ b/tests-integration/fixtures/checking/1772045940_exhaustive_equation_signature/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -15,8 +15,11 @@ Roles
 Maybe = [Representational]
 
 Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Nothing
-  --> 5:1..5:25
-  |
-5 | test :: Maybe Int -> Int
-  | ^~~~~~~~~~~~~~~~~~~~~~~~
+Warning! · [MissingPatterns] · Main.purs:5:1
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Nothing
+  │
+  │   test :: Maybe Int -> Int
+  │   ╰───────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772046000_exhaustive_guards_otherwise/Main.snap
+++ b/tests-integration/fixtures/checking/1772046000_exhaustive_guards_otherwise/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,13 +16,20 @@ Roles
 Maybe = [Representational]
 
 Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Nothing
-  --> 7:9..8:26
-  |
-7 | test1 = case _ of
-  |         ^~~~~~~~~
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Just _
-  --> 10:9..11:22
-   |
-10 | test2 = case _ of
-   |         ^~~~~~~~~
+Warning! · [MissingPatterns] · Main.purs:7:9
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Nothing
+  │
+  │   test1 = case _ of
+  │           ╰────────
+  •
+
+Warning! · [MissingPatterns] · Main.purs:10:9
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Just _
+  │
+  │   test2 = case _ of
+  │           ╰────────
+  •

--- a/tests-integration/fixtures/checking/1772046060_exhaustive_let_pattern/Main.snap
+++ b/tests-integration/fixtures/checking/1772046060_exhaustive_let_pattern/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -15,8 +15,11 @@ Roles
 Maybe = [Representational]
 
 Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Nothing
-  --> 6:3..9:6
-  |
-6 |   let
-  |   ^~~
+Warning! · [MissingPatterns] · Main.purs:6:3
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Nothing
+  │
+  │     let
+  │     ╰──
+  •

--- a/tests-integration/fixtures/checking/1772046120_exhaustive_operator_constructor/Main.snap
+++ b/tests-integration/fixtures/checking/1772046120_exhaustive_operator_constructor/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,8 +16,11 @@ Roles
 List = [Representational]
 
 Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Nil
-  --> 7:1..7:30
-  |
-7 | head :: forall a. List a -> a
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Warning! · [MissingPatterns] · Main.purs:7:1
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Nil
+  │
+  │   head :: forall a. List a -> a
+  │   ╰────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772088540_synonym_partial_defer/Main.snap
+++ b/tests-integration/fixtures/checking/1772088540_synonym_partial_defer/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -27,13 +27,20 @@ Roles
 Identity = [Representational]
 
 Diagnostics
-error[PartialSynonymApplication]: Partial type synonym application
-  --> 13:12..13:23
-   |
-13 | type Bad = ReaderT Int
-   |            ^~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Type' with '?[invalid kind]'
-  --> 13:12..13:23
-   |
-13 | type Bad = ReaderT Int
-   |            ^~~~~~~~~~~
+Error! · [PartialSynonymApplication] · Main.purs:13:12
+  •
+  │
+  • Partial type synonym application
+  │
+  │   type Bad = ReaderT Int
+  │              ╰──────────
+  •
+
+Error! · [CannotUnify] · Main.purs:13:12
+  •
+  │
+  • Cannot unify 'Type' with '?[invalid kind]'
+  │
+  │   type Bad = ReaderT Int
+  │              ╰──────────
+  •

--- a/tests-integration/fixtures/checking/1772440200_prim_solver_apart/Main.snap
+++ b/tests-integration/fixtures/checking/1772440200_prim_solver_apart/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -20,23 +20,38 @@ forceSolve ::
 Types
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Add 2 3 10
-  --> 20:1..25:4
-   |
-20 | forceSolve =
-   | ^~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: Compare 5 1 LT
-  --> 20:1..25:4
-   |
-20 | forceSolve =
-   | ^~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: Append "hello" "world" "xyz"
-  --> 20:1..25:4
-   |
-20 | forceSolve =
-   | ^~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: Cons "hello" "world" "helloworld"
-  --> 20:1..25:4
-   |
-20 | forceSolve =
-   | ^~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:20:1
+  •
+  │
+  • No instance found for: Add 2 3 10
+  │
+  │   forceSolve =
+  │   ╰───────────
+  •
+
+Error! · [NoInstanceFound] · Main.purs:20:1
+  •
+  │
+  • No instance found for: Compare 5 1 LT
+  │
+  │   forceSolve =
+  │   ╰───────────
+  •
+
+Error! · [NoInstanceFound] · Main.purs:20:1
+  •
+  │
+  • No instance found for: Append "hello" "world" "xyz"
+  │
+  │   forceSolve =
+  │   ╰───────────
+  •
+
+Error! · [NoInstanceFound] · Main.purs:20:1
+  •
+  │
+  • No instance found for: Cons "hello" "world" "helloworld"
+  │
+  │   forceSolve =
+  │   ╰───────────
+  •

--- a/tests-integration/fixtures/checking/1772440380_prim_row_apart/Main.snap
+++ b/tests-integration/fixtures/checking/1772440380_prim_row_apart/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -32,23 +32,38 @@ forceSolve ::
 Types
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'String' with 'Int'
-  --> 15:1..19:4
-   |
-15 | forceSolve =
-   | ^~~~~~~~~~~~
-error[CannotUnify]: Cannot unify '( b :: String )' with '( b :: Int )'
-  --> 15:1..19:4
-   |
-15 | forceSolve =
-   | ^~~~~~~~~~~~
-error[CannotUnify]: Cannot unify '( a :: Int, b :: String )' with '( missing :: Int | (t0 :: Row Type) )'
-  --> 15:1..19:4
-   |
-15 | forceSolve =
-   | ^~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: Lacks @Type "b" ( a :: Int, b :: String )
-  --> 15:1..19:4
-   |
-15 | forceSolve =
-   | ^~~~~~~~~~~~
+Error! · [CannotUnify] · Main.purs:15:1
+  •
+  │
+  • Cannot unify 'String' with 'Int'
+  │
+  │   forceSolve =
+  │   ╰───────────
+  •
+
+Error! · [CannotUnify] · Main.purs:15:1
+  •
+  │
+  • Cannot unify '( b :: String )' with '( b :: Int )'
+  │
+  │   forceSolve =
+  │   ╰───────────
+  •
+
+Error! · [CannotUnify] · Main.purs:15:1
+  •
+  │
+  • Cannot unify '( a :: Int, b :: String )' with '( missing :: Int | (t0 :: Row Type) )'
+  │
+  │   forceSolve =
+  │   ╰───────────
+  •
+
+Error! · [NoInstanceFound] · Main.purs:15:1
+  •
+  │
+  • No instance found for: Lacks @Type "b" ( a :: Int, b :: String )
+  │
+  │   forceSolve =
+  │   ╰───────────
+  •

--- a/tests-integration/fixtures/checking/1772440440_prim_row_open/Main.snap
+++ b/tests-integration/fixtures/checking/1772440440_prim_row_open/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -99,13 +99,20 @@ forceSolve ::
 Types
 
 Diagnostics
-error[AmbiguousConstraint]: Ambiguous constraint: Lacks @Type "missing" ?79
-  --> 33:1..43:4
-   |
-33 | forceSolve =
-   | ^~~~~~~~~~~~
-error[AmbiguousConstraint]: Ambiguous constraint: Lacks @Type "a" ( a :: Int | ?82 )
-  --> 33:1..43:4
-   |
-33 | forceSolve =
-   | ^~~~~~~~~~~~
+Error! · [AmbiguousConstraint] · Main.purs:33:1
+  •
+  │
+  • Ambiguous constraint: Lacks @Type "missing" ?79
+  │
+  │   forceSolve =
+  │   ╰───────────
+  •
+
+Error! · [AmbiguousConstraint] · Main.purs:33:1
+  •
+  │
+  • Ambiguous constraint: Lacks @Type "a" ( a :: Int | ?82 )
+  │
+  │   forceSolve =
+  │   ╰───────────
+  •

--- a/tests-integration/fixtures/checking/1772440620_prim_row_record/Main.snap
+++ b/tests-integration/fixtures/checking/1772440620_prim_row_record/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -33,8 +33,12 @@ test2 :: { a :: Prim.Int, b :: Prim.String, x :: Prim.Int }
 Types
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Union @Type (r :: Row Type) ( b :: String ) ( b :: String | (r :: Row Type) )
-  --> 10:1..10:72
-   |
-10 | addField :: forall r. { a :: Int | r } -> { a :: Int, b :: String | r }
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:10:1
+  •
+  │
+  • No instance found for: Union @Type (r :: Row Type) ( b :: String ) ( b :: String | (r :: Row
+  │ Type) )
+  │
+  │   addField :: forall r. { a :: Int | r } -> { a :: Int, b :: String | r }
+  │   ╰──────────────────────────────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772442660_prim_type_error_warn/Main.snap
+++ b/tests-integration/fixtures/checking/1772442660_prim_type_error_warn/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -68,44 +68,75 @@ Roles
 Proxy = [Phantom]
 
 Diagnostics
-warning[CustomWarning]: This function is deprecated
-  --> 11:1..11:20
-   |
-11 | useWarnBasic :: Int
-   | ^~~~~~~~~~~~~~~~~~~
-warning[CustomWarning]: Left Right
-  --> 17:1..17:21
-   |
-17 | useWarnBeside :: Int
-   | ^~~~~~~~~~~~~~~~~~~~
-warning[CustomWarning]: Line 1
-Line 2
-  --> 23:1..23:20
-   |
-23 | useWarnAbove :: Int
-   | ^~~~~~~~~~~~~~~~~~~
-warning[CustomWarning]: Got type: Int
-  --> 29:1..29:26
-   |
-29 | useWarnQuote :: Proxy Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~
-warning[CustomWarning]: Label: myField
-  --> 35:1..35:25
-   |
-35 | useWarnQuoteLabel :: Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~
-warning[CustomWarning]: Label: "h e l l o"
-  --> 41:1..41:31
-   |
-41 | useWarnQuoteLabelSpaces :: Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-warning[CustomWarning]: Label: "hel\"lo"
-  --> 47:1..47:30
-   |
-47 | useWarnQuoteLabelQuote :: Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-warning[CustomWarning]: Label: """raw\nstring"""
-  --> 53:1..53:28
-   |
-53 | useWarnQuoteLabelRaw :: Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+Warning! · [CustomWarning] · Main.purs:11:1
+  •
+  │
+  • This function is deprecated
+  │
+  │   useWarnBasic :: Int
+  │   ╰──────────────────
+  •
+
+Warning! · [CustomWarning] · Main.purs:17:1
+  •
+  │
+  • Left Right
+  │
+  │   useWarnBeside :: Int
+  │   ╰───────────────────
+  •
+
+Warning! · [CustomWarning] · Main.purs:23:1
+  •
+  │
+  • Line 1
+  │ Line 2
+  │
+  │   useWarnAbove :: Int
+  │   ╰──────────────────
+  •
+
+Warning! · [CustomWarning] · Main.purs:29:1
+  •
+  │
+  • Got type: Int
+  │
+  │   useWarnQuote :: Proxy Int
+  │   ╰────────────────────────
+  •
+
+Warning! · [CustomWarning] · Main.purs:35:1
+  •
+  │
+  • Label: myField
+  │
+  │   useWarnQuoteLabel :: Int
+  │   ╰───────────────────────
+  •
+
+Warning! · [CustomWarning] · Main.purs:41:1
+  •
+  │
+  • Label: "h e l l o"
+  │
+  │   useWarnQuoteLabelSpaces :: Int
+  │   ╰─────────────────────────────
+  •
+
+Warning! · [CustomWarning] · Main.purs:47:1
+  •
+  │
+  • Label: "hel\"lo"
+  │
+  │   useWarnQuoteLabelQuote :: Int
+  │   ╰────────────────────────────
+  •
+
+Warning! · [CustomWarning] · Main.purs:53:1
+  •
+  │
+  • Label: """raw\nstring"""
+  │
+  │   useWarnQuoteLabelRaw :: Int
+  │   ╰──────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772442720_prim_type_error_fail/Main.snap
+++ b/tests-integration/fixtures/checking/1772442720_prim_type_error_fail/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -26,14 +26,21 @@ Roles
 Proxy = [Phantom]
 
 Diagnostics
-error[CustomFailure]: This operation is not allowed
-  --> 11:1..11:20
-   |
-11 | useFailBasic :: Int
-   | ^~~~~~~~~~~~~~~~~~~
-error[CustomFailure]: Error:
-Type String
-  --> 17:1..17:31
-   |
-17 | useFailComplex :: Proxy String
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CustomFailure] · Main.purs:11:1
+  •
+  │
+  • This operation is not allowed
+  │
+  │   useFailBasic :: Int
+  │   ╰──────────────────
+  •
+
+Error! · [CustomFailure] · Main.purs:17:1
+  •
+  │
+  • Error:
+  │ Type String
+  │
+  │   useFailComplex :: Proxy String
+  │   ╰─────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772475480_prim_coercible_apart/Main.snap
+++ b/tests-integration/fixtures/checking/1772475480_prim_coercible_apart/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -19,8 +19,11 @@ Maybe = [Representational]
 Either = [Representational, Representational]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Coercible @Type (Maybe Int) (Either Int String)
-  --> 9:1..9:50
-  |
-9 | coerceDifferent :: Maybe Int -> Either Int String
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:9:1
+  •
+  │
+  • No instance found for: Coercible @Type (Maybe Int) (Either Int String)
+  │
+  │   coerceDifferent :: Maybe Int -> Either Int String
+  │   ╰────────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772475540_prim_coercible_hidden_constructor/Main.snap
+++ b/tests-integration/fixtures/checking/1772475540_prim_coercible_hidden_constructor/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -9,13 +9,20 @@ coerceHidden :: Prim.Int -> Lib.HiddenAge
 Types
 
 Diagnostics
-error[CoercibleConstructorNotInScope]: Constructor not in scope for Coercible
-  --> 6:1..6:33
-  |
-6 | coerceHidden :: Int -> HiddenAge
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: Coercible @Type Int HiddenAge
-  --> 6:1..6:33
-  |
-6 | coerceHidden :: Int -> HiddenAge
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CoercibleConstructorNotInScope] · Main.purs:6:1
+  •
+  │
+  • Constructor not in scope for Coercible
+  │
+  │   coerceHidden :: Int -> HiddenAge
+  │   ╰───────────────────────────────
+  •
+
+Error! · [NoInstanceFound] · Main.purs:6:1
+  •
+  │
+  • No instance found for: Coercible @Type Int HiddenAge
+  │
+  │   coerceHidden :: Int -> HiddenAge
+  │   ╰───────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772475840_instance_member_missing_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1772475840_instance_member_missing_constraint/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -22,8 +22,11 @@ Roles
 Box = [Representational]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Show a
-  --> 9:1..11:24
-  |
-9 | instance Show (Box a) where
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:9:1
+  •
+  │
+  • No instance found for: Show a
+  │
+  │   instance Show (Box a) where
+  │   ╰──────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772475900_instance_member_signature_mismatch/Main.snap
+++ b/tests-integration/fixtures/checking/1772475900_instance_member_signature_mismatch/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -17,13 +17,20 @@ Instances
 instance Main.Show Prim.Int
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'Int' with 'String'
-  --> 7:1..9:13
-  |
-7 | instance Show Int where
-  | ^~~~~~~~~~~~~~~~~~~~~~~
-error[InstanceMemberTypeMismatch]: Instance member type mismatch: expected 'Int -> String', got 'Int -> Int'
-  --> 7:1..9:13
-  |
-7 | instance Show Int where
-  | ^~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotUnify] · Main.purs:7:1
+  •
+  │
+  • Cannot unify 'Int' with 'String'
+  │
+  │   instance Show Int where
+  │   ╰──────────────────────
+  •
+
+Error! · [InstanceMemberTypeMismatch] · Main.purs:7:1
+  •
+  │
+  • Instance member type mismatch: expected 'Int -> String', got 'Int -> Int'
+  │
+  │   instance Show Int where
+  │   ╰──────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772476020_instance_member_too_many_binders/Main.snap
+++ b/tests-integration/fixtures/checking/1772476020_instance_member_too_many_binders/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -17,8 +17,11 @@ Instances
 instance Main.Show Prim.Int
 
 Diagnostics
-error[TooManyBinders]: Too many binders: expected 1, got 2
-  --> 7:1..8:20
-  |
-7 | instance Show Int where
-  | ^~~~~~~~~~~~~~~~~~~~~~~
+Error! · [TooManyBinders] · Main.purs:7:1
+  •
+  │
+  • Too many binders: expected 1, got 2
+  │
+  │   instance Show Int where
+  │   ╰──────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772564580_derive_ord_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772564580_derive_ord_simple/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -31,8 +31,11 @@ NoOrd = []
 ContainsNoOrd = []
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Ord NoOrd
-  --> 23:1..23:34
-   |
-23 | derive instance Ord ContainsNoOrd
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:23:1
+  •
+  │
+  • No instance found for: Ord NoOrd
+  │
+  │   derive instance Ord ContainsNoOrd
+  │   ╰────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772564640_derive_ord_1_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772564640_derive_ord_1_higher_kinded/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -36,17 +36,28 @@ Wrap = [Representational, Nominal]
 WrapNoOrd1 = [Representational, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Ord1 (f :: Type -> Type)
-  --> 14:1..14:46
-   |
-14 | derive instance Ord a => Ord (WrapNoOrd1 f a)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord a is in scope
-  trivia: Eq a is in scope
-error[NoInstanceFound]: No instance found for: Eq1 (f :: Type -> Type)
-  --> 14:1..14:46
-   |
-14 | derive instance Ord a => Ord (WrapNoOrd1 f a)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord a is in scope
-  trivia: Eq a is in scope
+Error! · [NoInstanceFound] · Main.purs:14:1
+  •
+  │
+  • No instance found for: Ord1 (f :: Type -> Type)
+  │
+  │   derive instance Ord a => Ord (WrapNoOrd1 f a)
+  │   ╰────────────────────────────────────────────
+  • while
+  │
+  │   Ord a is in scope
+  │   Eq a is in scope
+  •
+
+Error! · [NoInstanceFound] · Main.purs:14:1
+  •
+  │
+  • No instance found for: Eq1 (f :: Type -> Type)
+  │
+  │   derive instance Ord a => Ord (WrapNoOrd1 f a)
+  │   ╰────────────────────────────────────────────
+  • while
+  │
+  │   Ord a is in scope
+  │   Eq a is in scope
+  •

--- a/tests-integration/fixtures/checking/1772564700_derive_eq_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772564700_derive_eq_simple/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -23,8 +23,11 @@ NoEq = []
 ContainsNoEq = []
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Eq NoEq
-  --> 13:1..13:32
-   |
-13 | derive instance Eq ContainsNoEq
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:13:1
+  •
+  │
+  • No instance found for: Eq NoEq
+  │
+  │   derive instance Eq ContainsNoEq
+  │   ╰──────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772564820_derive_eq_missing_instance/Main.snap
+++ b/tests-integration/fixtures/checking/1772564820_derive_eq_missing_instance/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -19,8 +19,11 @@ NoEq = []
 Box = []
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Eq NoEq
-  --> 9:1..9:23
-  |
-9 | derive instance Eq Box
-  | ^~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:9:1
+  •
+  │
+  • No instance found for: Eq NoEq
+  │
+  │   derive instance Eq Box
+  │   ╰─────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772564880_derive_eq_1/Main.snap
+++ b/tests-integration/fixtures/checking/1772564880_derive_eq_1/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -69,16 +69,27 @@ Either' = [Representational]
 NoEq = [Representational]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Eq ((g :: Type -> Type) t0)
-  --> 34:1..34:43
-   |
-34 | derive instance Eq1 f => Eq1 (Compose f g)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq1 (f :: Type -> Type) is in scope
-  trivia: Eq t0 is in scope
-error[NoInstanceFound]: No instance found for: Eq (NoEq t1)
-  --> 43:1..43:25
-   |
-43 | derive instance Eq1 NoEq
-   | ^~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq t1 is in scope
+Error! · [NoInstanceFound] · Main.purs:34:1
+  •
+  │
+  • No instance found for: Eq ((g :: Type -> Type) t0)
+  │
+  │   derive instance Eq1 f => Eq1 (Compose f g)
+  │   ╰─────────────────────────────────────────
+  • while
+  │
+  │   Eq1 (f :: Type -> Type) is in scope
+  │   Eq t0 is in scope
+  •
+
+Error! · [NoInstanceFound] · Main.purs:43:1
+  •
+  │
+  • No instance found for: Eq (NoEq t1)
+  │
+  │   derive instance Eq1 NoEq
+  │   ╰───────────────────────
+  • while
+  │
+  │   Eq t1 is in scope
+  •

--- a/tests-integration/fixtures/checking/1772564940_derive_ord_1/Main.snap
+++ b/tests-integration/fixtures/checking/1772564940_derive_ord_1/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -68,26 +68,43 @@ Compose = [Representational, Representational, Nominal]
 NoOrd = [Representational]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Eq ((g :: Type -> Type) t0)
-  --> 25:1..25:43
-   |
-25 | derive instance Eq1 f => Eq1 (Compose f g)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq1 (f :: Type -> Type) is in scope
-  trivia: Eq t0 is in scope
-error[NoInstanceFound]: No instance found for: Ord ((g1 :: Type -> Type) t1)
-  --> 26:1..26:45
-   |
-26 | derive instance Ord1 f => Ord1 (Compose f g)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord1 (f1 :: Type -> Type) is in scope
-  trivia: Ord t1 is in scope
-  trivia: Eq1 (f1 :: Type -> Type) is in scope
-  trivia: Eq t1 is in scope
-error[NoInstanceFound]: No instance found for: Ord (NoOrd t2)
-  --> 32:1..32:27
-   |
-32 | derive instance Ord1 NoOrd
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord t2 is in scope
-  trivia: Eq t2 is in scope
+Error! · [NoInstanceFound] · Main.purs:25:1
+  •
+  │
+  • No instance found for: Eq ((g :: Type -> Type) t0)
+  │
+  │   derive instance Eq1 f => Eq1 (Compose f g)
+  │   ╰─────────────────────────────────────────
+  • while
+  │
+  │   Eq1 (f :: Type -> Type) is in scope
+  │   Eq t0 is in scope
+  •
+
+Error! · [NoInstanceFound] · Main.purs:26:1
+  •
+  │
+  • No instance found for: Ord ((g1 :: Type -> Type) t1)
+  │
+  │   derive instance Ord1 f => Ord1 (Compose f g)
+  │   ╰───────────────────────────────────────────
+  • while
+  │
+  │   Ord1 (f1 :: Type -> Type) is in scope
+  │   Ord t1 is in scope
+  │   Eq1 (f1 :: Type -> Type) is in scope
+  │   Eq t1 is in scope
+  •
+
+Error! · [NoInstanceFound] · Main.purs:32:1
+  •
+  │
+  • No instance found for: Ord (NoOrd t2)
+  │
+  │   derive instance Ord1 NoOrd
+  │   ╰─────────────────────────
+  • while
+  │
+  │   Ord t2 is in scope
+  │   Eq t2 is in scope
+  •

--- a/tests-integration/fixtures/checking/1772565060_derive_functor_contravariant_error/Main.snap
+++ b/tests-integration/fixtures/checking/1772565060_derive_functor_contravariant_error/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -24,8 +24,11 @@ Reader = [Representational, Representational]
 Cont = [Representational, Representational]
 
 Diagnostics
-error[ContravariantOccurrence]: Type variable occurs in contravariant position: t0
-  --> 6:1..6:34
-  |
-6 | derive instance Functor Predicate
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [ContravariantOccurrence] · Main.purs:6:1
+  •
+  │
+  • Type variable occurs in contravariant position: t0
+  │
+  │   derive instance Functor Predicate
+  │   ╰────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772565120_derive_functor_insufficient_params/Main.snap
+++ b/tests-integration/fixtures/checking/1772565120_derive_functor_insufficient_params/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -20,23 +20,38 @@ Pair = [Representational, Representational]
 Unit = []
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'Type' with 'Type -> Type'
-  --> 6:25..6:42
-  |
-6 | derive instance Functor (Pair Int String)
-  |                         ^~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Type' with 'Type -> Type'
-  --> 9:25..9:29
-  |
-9 | derive instance Functor Unit
-  |                         ^~~~
-error[CannotDeriveForType]: Cannot derive for type: Pair Int String
-  --> 6:1..6:42
-  |
-6 | derive instance Functor (Pair Int String)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: Unit
-  --> 9:1..9:29
-  |
-9 | derive instance Functor Unit
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotUnify] · Main.purs:6:25
+  •
+  │
+  • Cannot unify 'Type' with 'Type -> Type'
+  │
+  │   derive instance Functor (Pair Int String)
+  │                           ╰────────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:9:25
+  •
+  │
+  • Cannot unify 'Type' with 'Type -> Type'
+  │
+  │   derive instance Functor Unit
+  │                           ╰───
+  •
+
+Error! · [CannotDeriveForType] · Main.purs:6:1
+  •
+  │
+  • Cannot derive for type: Pair Int String
+  │
+  │   derive instance Functor (Pair Int String)
+  │   ╰────────────────────────────────────────
+  •
+
+Error! · [CannotDeriveForType] · Main.purs:9:1
+  •
+  │
+  • Cannot derive for type: Unit
+  │
+  │   derive instance Functor Unit
+  │   ╰───────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772565240_derive_bifunctor_missing_functor/Main.snap
+++ b/tests-integration/fixtures/checking/1772565240_derive_bifunctor_missing_functor/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -24,13 +24,20 @@ Roles
 WrapBoth = [Representational, Representational, Nominal, Nominal]
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: (f :: Type -> Type) t0
-  --> 6:1..6:41
-  |
-6 | derive instance Bifunctor (WrapBoth f g)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: (g :: Type -> Type) t1
-  --> 6:1..6:41
-  |
-6 | derive instance Bifunctor (WrapBoth f g)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveForType] · Main.purs:6:1
+  •
+  │
+  • Cannot derive for type: (f :: Type -> Type) t0
+  │
+  │   derive instance Bifunctor (WrapBoth f g)
+  │   ╰───────────────────────────────────────
+  •
+
+Error! · [CannotDeriveForType] · Main.purs:6:1
+  •
+  │
+  • Cannot derive for type: (g :: Type -> Type) t1
+  │
+  │   derive instance Bifunctor (WrapBoth f g)
+  │   ╰───────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772565300_derive_bifunctor_insufficient_params/Main.snap
+++ b/tests-integration/fixtures/checking/1772565300_derive_bifunctor_insufficient_params/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,13 +16,20 @@ Roles
 Triple = [Representational, Representational, Representational]
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'Type' with 'Type -> Type'
-  --> 6:27..6:46
-  |
-6 | derive instance Bifunctor (Triple Int String)
-  |                           ^~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: Triple Int String
-  --> 6:1..6:46
-  |
-6 | derive instance Bifunctor (Triple Int String)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotUnify] · Main.purs:6:27
+  •
+  │
+  • Cannot unify 'Type' with 'Type -> Type'
+  │
+  │   derive instance Bifunctor (Triple Int String)
+  │                             ╰──────────────────
+  •
+
+Error! · [CannotDeriveForType] · Main.purs:6:1
+  •
+  │
+  • Cannot derive for type: Triple Int String
+  │
+  │   derive instance Bifunctor (Triple Int String)
+  │   ╰────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772565480_derive_traversable_missing_superclass/Main.snap
+++ b/tests-integration/fixtures/checking/1772565480_derive_traversable_missing_superclass/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -23,25 +23,36 @@ Roles
 Compose = [Representational, Representational, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Functor (Compose @Type @Type (f :: Type -> Type) (g :: Type -> Type))
-  --> 6:1..6:76
-  |
-6 | derive instance (Traversable f, Traversable g) => Traversable (Compose f g)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Traversable (f :: Type -> Type) is in scope
-  trivia: Traversable (g :: Type -> Type) is in scope
-  trivia: Functor (f :: Type -> Type) is in scope
-  trivia: Foldable (f :: Type -> Type) is in scope
-  trivia: Functor (g :: Type -> Type) is in scope
-  trivia: Foldable (g :: Type -> Type) is in scope
-error[NoInstanceFound]: No instance found for: Foldable (Compose @Type @Type (f :: Type -> Type) (g :: Type -> Type))
-  --> 6:1..6:76
-  |
-6 | derive instance (Traversable f, Traversable g) => Traversable (Compose f g)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Traversable (f :: Type -> Type) is in scope
-  trivia: Traversable (g :: Type -> Type) is in scope
-  trivia: Functor (f :: Type -> Type) is in scope
-  trivia: Foldable (f :: Type -> Type) is in scope
-  trivia: Functor (g :: Type -> Type) is in scope
-  trivia: Foldable (g :: Type -> Type) is in scope
+Error! · [NoInstanceFound] · Main.purs:6:1
+  •
+  │
+  • No instance found for: Functor (Compose @Type @Type (f :: Type -> Type) (g :: Type -> Type))
+  │
+  │   derive instance (Traversable f, Traversable g) => Traversable (Compose f g)
+  │   ╰──────────────────────────────────────────────────────────────────────────
+  • while
+  │
+  │   Traversable (f :: Type -> Type) is in scope
+  │   Traversable (g :: Type -> Type) is in scope
+  │   Functor (f :: Type -> Type) is in scope
+  │   Foldable (f :: Type -> Type) is in scope
+  │   Functor (g :: Type -> Type) is in scope
+  │   Foldable (g :: Type -> Type) is in scope
+  •
+
+Error! · [NoInstanceFound] · Main.purs:6:1
+  •
+  │
+  • No instance found for: Foldable (Compose @Type @Type (f :: Type -> Type) (g :: Type -> Type))
+  │
+  │   derive instance (Traversable f, Traversable g) => Traversable (Compose f g)
+  │   ╰──────────────────────────────────────────────────────────────────────────
+  • while
+  │
+  │   Traversable (f :: Type -> Type) is in scope
+  │   Traversable (g :: Type -> Type) is in scope
+  │   Functor (f :: Type -> Type) is in scope
+  │   Foldable (f :: Type -> Type) is in scope
+  │   Functor (g :: Type -> Type) is in scope
+  │   Foldable (g :: Type -> Type) is in scope
+  •

--- a/tests-integration/fixtures/checking/1772565660_derive_newtype_not_newtype/Main.snap
+++ b/tests-integration/fixtures/checking/1772565660_derive_newtype_not_newtype/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,8 +16,11 @@ Roles
 Foo = []
 
 Diagnostics
-error[ExpectedNewtype]: Expected a newtype, got: Foo
-  --> 7:1..7:33
-  |
-7 | derive newtype instance Show Foo
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [ExpectedNewtype] · Main.purs:7:1
+  •
+  │
+  • Expected a newtype, got: Foo
+  │
+  │   derive newtype instance Show Foo
+  │   ╰───────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772565780_derive_profunctor_error/Main.snap
+++ b/tests-integration/fixtures/checking/1772565780_derive_profunctor_error/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -20,18 +20,29 @@ WrongFirst = [Representational, Representational]
 WrongSecond = [Representational, Representational]
 
 Diagnostics
-error[CovariantOccurrence]: Type variable occurs in covariant position: t0
-  --> 6:1..6:38
-  |
-6 | derive instance Profunctor WrongFirst
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[ContravariantOccurrence]: Type variable occurs in contravariant position: t1
-  --> 9:1..9:39
-  |
-9 | derive instance Profunctor WrongSecond
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CovariantOccurrence]: Type variable occurs in covariant position: t2
-  --> 9:1..9:39
-  |
-9 | derive instance Profunctor WrongSecond
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CovariantOccurrence] · Main.purs:6:1
+  •
+  │
+  • Type variable occurs in covariant position: t0
+  │
+  │   derive instance Profunctor WrongFirst
+  │   ╰────────────────────────────────────
+  •
+
+Error! · [ContravariantOccurrence] · Main.purs:9:1
+  •
+  │
+  • Type variable occurs in contravariant position: t1
+  │
+  │   derive instance Profunctor WrongSecond
+  │   ╰─────────────────────────────────────
+  •
+
+Error! · [CovariantOccurrence] · Main.purs:9:1
+  •
+  │
+  • Type variable occurs in covariant position: t2
+  │
+  │   derive instance Profunctor WrongSecond
+  │   ╰─────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772565900_derive_contravariant_error/Main.snap
+++ b/tests-integration/fixtures/checking/1772565900_derive_contravariant_error/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -20,13 +20,20 @@ Identity = [Representational]
 Producer = [Representational]
 
 Diagnostics
-error[CovariantOccurrence]: Type variable occurs in covariant position: t0
-  --> 6:1..6:39
-  |
-6 | derive instance Contravariant Identity
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CovariantOccurrence]: Type variable occurs in covariant position: t1
-  --> 9:1..9:39
-  |
-9 | derive instance Contravariant Producer
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CovariantOccurrence] · Main.purs:6:1
+  •
+  │
+  • Type variable occurs in covariant position: t0
+  │
+  │   derive instance Contravariant Identity
+  │   ╰─────────────────────────────────────
+  •
+
+Error! · [CovariantOccurrence] · Main.purs:9:1
+  •
+  │
+  • Type variable occurs in covariant position: t1
+  │
+  │   derive instance Contravariant Producer
+  │   ╰─────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772566020_derive_foldable_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772566020_derive_foldable_higher_kinded/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -27,8 +27,11 @@ Wrap = [Representational, Nominal]
 WrapNoFoldable = [Representational, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Foldable (f :: Type -> Type)
-  --> 9:1..9:44
-  |
-9 | derive instance Foldable (WrapNoFoldable f)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:9:1
+  •
+  │
+  • No instance found for: Foldable (f :: Type -> Type)
+  │
+  │   derive instance Foldable (WrapNoFoldable f)
+  │   ╰──────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772566260_derive_bifoldable_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772566260_derive_bifoldable_higher_kinded/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -43,13 +43,20 @@ WrapBoth = [Representational, Representational, Nominal, Nominal]
 WrapBothNoConstraint = [Representational, Representational, Nominal, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Foldable (f :: Type -> Type)
-  --> 10:1..10:54
-   |
-10 | derive instance Bifoldable (WrapBothNoConstraint f g)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: Foldable (g :: Type -> Type)
-  --> 10:1..10:54
-   |
-10 | derive instance Bifoldable (WrapBothNoConstraint f g)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:10:1
+  •
+  │
+  • No instance found for: Foldable (f :: Type -> Type)
+  │
+  │   derive instance Bifoldable (WrapBothNoConstraint f g)
+  │   ╰────────────────────────────────────────────────────
+  •
+
+Error! · [NoInstanceFound] · Main.purs:10:1
+  •
+  │
+  • No instance found for: Foldable (g :: Type -> Type)
+  │
+  │   derive instance Bifoldable (WrapBothNoConstraint f g)
+  │   ╰────────────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772566440_derive_newtype_class_not_newtype/Main.snap
+++ b/tests-integration/fixtures/checking/1772566440_derive_newtype_class_not_newtype/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,8 +16,11 @@ Roles
 NotANewtype = []
 
 Diagnostics
-error[ExpectedNewtype]: Expected a newtype, got: NotANewtype
-  --> 7:1..7:38
-  |
-7 | derive instance Newtype NotANewtype _
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [ExpectedNewtype] · Main.purs:7:1
+  •
+  │
+  • Expected a newtype, got: NotANewtype
+  │
+  │   derive instance Newtype NotANewtype _
+  │   ╰────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772566680_row_open_lacks/Main.snap
+++ b/tests-integration/fixtures/checking/1772566680_row_open_lacks/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -25,8 +25,11 @@ Roles
 Proxy = [Phantom]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Lacks @Type "a" ( a :: Int )
-  --> 17:1..17:78
-   |
-17 | forceSolve = { lacksOpen: lacksOpen empty, lacksPresent: lacksPresent empty }
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:17:1
+  •
+  │
+  • No instance found for: Lacks @Type "a" ( a :: Int )
+  │
+  │   forceSolve = { lacksOpen: lacksOpen empty, lacksPresent: lacksPresent empty }
+  │   ╰────────────────────────────────────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772566740_row_open_record/Main.snap
+++ b/tests-integration/fixtures/checking/1772566740_row_open_record/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -33,8 +33,12 @@ test2 :: { a :: Prim.Int, b :: Prim.String, x :: Prim.Int }
 Types
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Union @Type (r :: Row Type) ( b :: String ) ( b :: String | (r :: Row Type) )
-  --> 10:1..10:72
-   |
-10 | addField :: forall r. { a :: Int | r } -> { a :: Int, b :: String | r }
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:10:1
+  •
+  │
+  • No instance found for: Union @Type (r :: Row Type) ( b :: String ) ( b :: String | (r :: Row
+  │ Type) )
+  │
+  │   addField :: forall r. { a :: Int | r } -> { a :: Int, b :: String | r }
+  │   ╰──────────────────────────────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772566980_derive_newtype_missing_instance/Main.snap
+++ b/tests-integration/fixtures/checking/1772566980_derive_newtype_missing_instance/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,8 +16,11 @@ Roles
 Identity = [Representational]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Show String
-  --> 7:1..7:47
-  |
-7 | derive newtype instance Show (Identity String)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:7:1
+  •
+  │
+  • No instance found for: Show String
+  │
+  │   derive newtype instance Show (Identity String)
+  │   ╰─────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772567040_derive_newtype_missing_given/Main.snap
+++ b/tests-integration/fixtures/checking/1772567040_derive_newtype_missing_given/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,8 +16,11 @@ Roles
 Identity = [Representational]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Show a
-  --> 7:1..7:42
-  |
-7 | derive newtype instance Show (Identity a)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:7:1
+  •
+  │
+  • No instance found for: Show a
+  │
+  │   derive newtype instance Show (Identity a)
+  │   ╰────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772567340_derive_eq_1_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772567340_derive_eq_1_higher_kinded/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -28,9 +28,14 @@ Wrap = [Representational, Nominal]
 WrapNoEq1 = [Representational, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Eq1 (f :: Type -> Type)
-  --> 11:1..11:43
-   |
-11 | derive instance Eq a => Eq (WrapNoEq1 f a)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq a is in scope
+Error! · [NoInstanceFound] · Main.purs:11:1
+  •
+  │
+  • No instance found for: Eq1 (f :: Type -> Type)
+  │
+  │   derive instance Eq a => Eq (WrapNoEq1 f a)
+  │   ╰─────────────────────────────────────────
+  • while
+  │
+  │   Eq a is in scope
+  •

--- a/tests-integration/fixtures/checking/1772567400_derive_eq_partial/Main.snap
+++ b/tests-integration/fixtures/checking/1772567400_derive_eq_partial/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -18,15 +18,24 @@ Roles
 Either = [Representational, Representational]
 
 Diagnostics
-error[OverlappingInstances]: Overlapping type class instances found for: Eq (Either Int b)
-  --> 9:1..9:34
-  |
-9 | derive instance Eq (Either Int b)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: forall b1. Eq b1 => Eq (Either Int b1) is matching
-  trivia: forall b. Eq (Either Int b) is matching
-error[NoInstanceFound]: No instance found for: Eq b
-  --> 9:1..9:34
-  |
-9 | derive instance Eq (Either Int b)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [OverlappingInstances] · Main.purs:9:1
+  •
+  │
+  • Overlapping type class instances found for: Eq (Either Int b)
+  │
+  │   derive instance Eq (Either Int b)
+  │   ╰────────────────────────────────
+  • while
+  │
+  │   forall b1. Eq b1 => Eq (Either Int b1) is matching
+  │   forall b. Eq (Either Int b) is matching
+  •
+
+Error! · [NoInstanceFound] · Main.purs:9:1
+  •
+  │
+  • No instance found for: Eq b
+  │
+  │   derive instance Eq (Either Int b)
+  │   ╰────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772567460_derive_eq_ord_nested_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772567460_derive_eq_ord_nested_higher_kinded/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -51,29 +51,52 @@ U = [Representational]
 V = [Representational, Representational]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Eq ((g :: Type -> Type) Int)
-  --> 8:1..8:36
-  |
-8 | derive instance Eq1 f => Eq (T f g)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq1 (f :: Type -> Type) is in scope
-error[NoInstanceFound]: No instance found for: Ord ((g1 :: Type -> Type) Int)
-  --> 9:1..9:38
-  |
-9 | derive instance Ord1 f => Ord (T f g)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord1 (f1 :: Type -> Type) is in scope
-  trivia: Eq1 (f1 :: Type -> Type) is in scope
-error[NoInstanceFound]: No instance found for: Eq ((g2 :: Int -> Type) 42)
-  --> 23:1..23:36
-   |
-23 | derive instance Eq1 f => Eq (V f g)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq1 (f2 :: Type -> Type) is in scope
-error[NoInstanceFound]: No instance found for: Ord ((g3 :: Int -> Type) 42)
-  --> 24:1..24:38
-   |
-24 | derive instance Ord1 f => Ord (V f g)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord1 (f3 :: Type -> Type) is in scope
-  trivia: Eq1 (f3 :: Type -> Type) is in scope
+Error! · [NoInstanceFound] · Main.purs:8:1
+  •
+  │
+  • No instance found for: Eq ((g :: Type -> Type) Int)
+  │
+  │   derive instance Eq1 f => Eq (T f g)
+  │   ╰──────────────────────────────────
+  • while
+  │
+  │   Eq1 (f :: Type -> Type) is in scope
+  •
+
+Error! · [NoInstanceFound] · Main.purs:9:1
+  •
+  │
+  • No instance found for: Ord ((g1 :: Type -> Type) Int)
+  │
+  │   derive instance Ord1 f => Ord (T f g)
+  │   ╰────────────────────────────────────
+  • while
+  │
+  │   Ord1 (f1 :: Type -> Type) is in scope
+  │   Eq1 (f1 :: Type -> Type) is in scope
+  •
+
+Error! · [NoInstanceFound] · Main.purs:23:1
+  •
+  │
+  • No instance found for: Eq ((g2 :: Int -> Type) 42)
+  │
+  │   derive instance Eq1 f => Eq (V f g)
+  │   ╰──────────────────────────────────
+  • while
+  │
+  │   Eq1 (f2 :: Type -> Type) is in scope
+  •
+
+Error! · [NoInstanceFound] · Main.purs:24:1
+  •
+  │
+  • No instance found for: Ord ((g3 :: Int -> Type) 42)
+  │
+  │   derive instance Ord1 f => Ord (V f g)
+  │   ╰────────────────────────────────────
+  • while
+  │
+  │   Ord1 (f3 :: Type -> Type) is in scope
+  │   Eq1 (f3 :: Type -> Type) is in scope
+  •

--- a/tests-integration/fixtures/checking/1772567520_derive_functor_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772567520_derive_functor_higher_kinded/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -27,8 +27,11 @@ Wrap = [Representational, Nominal]
 WrapNoFunctor = [Representational, Nominal]
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: (f :: Type -> Type) t0
-  --> 9:1..9:42
-  |
-9 | derive instance Functor (WrapNoFunctor f)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveForType] · Main.purs:9:1
+  •
+  │
+  • Cannot derive for type: (f :: Type -> Type) t0
+  │
+  │   derive instance Functor (WrapNoFunctor f)
+  │   ╰────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772567580_derive_bifunctor_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772567580_derive_bifunctor_higher_kinded/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -43,13 +43,20 @@ WrapBoth = [Representational, Representational, Nominal, Nominal]
 WrapBothNoConstraint = [Representational, Representational, Nominal, Nominal]
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: (f :: Type -> Type) t0
-  --> 10:1..10:53
-   |
-10 | derive instance Bifunctor (WrapBothNoConstraint f g)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: (g :: Type -> Type) t1
-  --> 10:1..10:53
-   |
-10 | derive instance Bifunctor (WrapBothNoConstraint f g)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveForType] · Main.purs:10:1
+  •
+  │
+  • Cannot derive for type: (f :: Type -> Type) t0
+  │
+  │   derive instance Bifunctor (WrapBothNoConstraint f g)
+  │   ╰───────────────────────────────────────────────────
+  •
+
+Error! · [CannotDeriveForType] · Main.purs:10:1
+  •
+  │
+  • Cannot derive for type: (g :: Type -> Type) t1
+  │
+  │   derive instance Bifunctor (WrapBothNoConstraint f g)
+  │   ╰───────────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772567700_givens_scoped/Main.snap
+++ b/tests-integration/fixtures/checking/1772567700_givens_scoped/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -15,9 +15,14 @@ class forall (a :: Prim.Type). Main.Given a
   consume :: forall @a. Main.Given a => a -> a
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Given Int
-  --> 6:1..6:41
-  |
-6 | testGiven :: forall a. Given a => a -> a
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Given a is in scope
+Error! · [NoInstanceFound] · Main.purs:6:1
+  •
+  │
+  • No instance found for: Given Int
+  │
+  │   testGiven :: forall a. Given a => a -> a
+  │   ╰───────────────────────────────────────
+  • while
+  │
+  │   Given a is in scope
+  •

--- a/tests-integration/fixtures/checking/1772815740_derive_generic_insufficient_params/Main.snap
+++ b/tests-integration/fixtures/checking/1772815740_derive_generic_insufficient_params/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,18 +16,29 @@ Roles
 Box = []
 
 Diagnostics
-error[DeriveInvalidArity]: Invalid arity for derive: expected 2, got 1
-  --> 7:1..7:28
-  |
-7 | derive instance Generic Box
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Type -> Constraint' with 'Constraint'
-  --> 7:1..7:28
-  |
-7 | derive instance Generic Box
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[DeriveInvalidArity]: Invalid arity for derive: expected 2, got 1
-  --> 7:1..7:28
-  |
-7 | derive instance Generic Box
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [DeriveInvalidArity] · Main.purs:7:1
+  •
+  │
+  • Invalid arity for derive: expected 2, got 1
+  │
+  │   derive instance Generic Box
+  │   ╰──────────────────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:7:1
+  •
+  │
+  • Cannot unify 'Type -> Constraint' with 'Constraint'
+  │
+  │   derive instance Generic Box
+  │   ╰──────────────────────────
+  •
+
+Error! · [DeriveInvalidArity] · Main.purs:7:1
+  •
+  │
+  • Invalid arity for derive: expected 2, got 1
+  │
+  │   derive instance Generic Box
+  │   ╰──────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772815800_derive_generic_not_constructor/Main.snap
+++ b/tests-integration/fixtures/checking/1772815800_derive_generic_not_constructor/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -11,8 +11,11 @@ Derived
 derive forall t0. Data.Generic.Rep.Generic (Prim.Int -> Prim.Int) t0
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: Int -> Int
-  --> 5:1..5:39
-  |
-5 | derive instance Generic (Int -> Int) _
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveForType] · Main.purs:5:1
+  •
+  │
+  • Cannot derive for type: Int -> Int
+  │
+  │   derive instance Generic (Int -> Int) _
+  │   ╰─────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772815860_derive_generic_missing_rep/Main.snap
+++ b/tests-integration/fixtures/checking/1772815860_derive_generic_missing_rep/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,8 +16,11 @@ Roles
 Box = []
 
 Diagnostics
-error[CannotDeriveClass]: Cannot derive this class
-  --> 7:1..7:30
-  |
-7 | derive instance Generic Box _
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveClass] · Main.purs:7:1
+  •
+  │
+  • Cannot derive this class
+  │
+  │   derive instance Generic Box _
+  │   ╰────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772818200_do_empty_block/Main.snap
+++ b/tests-integration/fixtures/checking/1772818200_do_empty_block/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,13 +16,20 @@ Roles
 Effect = [Nominal]
 
 Diagnostics
-error[EmptyDoBlock]: Empty do block
-  --> 9:8..9:10
-  |
-9 | test = do
-  |        ^~
-error[CannotUnify]: Cannot unify 'Type' with '?[invalid kind]'
-  --> 9:8..9:10
-  |
-9 | test = do
-  |        ^~
+Error! · [EmptyDoBlock] · Main.purs:9:8
+  •
+  │
+  • Empty do block
+  │
+  │   test = do
+  │          ╰─
+  •
+
+Error! · [CannotUnify] · Main.purs:9:8
+  •
+  │
+  • Cannot unify 'Type' with '?[invalid kind]'
+  │
+  │   test = do
+  │          ╰─
+  •

--- a/tests-integration/fixtures/checking/1772818260_ado_empty_block/Main.snap
+++ b/tests-integration/fixtures/checking/1772818260_ado_empty_block/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -17,13 +17,20 @@ Roles
 Effect = [Nominal]
 
 Diagnostics
-error[EmptyAdoBlock]: Empty ado block
-  --> 9:9..9:12
-  |
-9 | test1 = ado
-  |         ^~~
-error[CannotUnify]: Cannot unify 'Type' with '?[invalid kind]'
-  --> 9:9..9:12
-  |
-9 | test1 = ado
-  |         ^~~
+Error! · [EmptyAdoBlock] · Main.purs:9:9
+  •
+  │
+  • Empty ado block
+  │
+  │   test1 = ado
+  │           ╰──
+  •
+
+Error! · [CannotUnify] · Main.purs:9:9
+  •
+  │
+  • Cannot unify 'Type' with '?[invalid kind]'
+  │
+  │   test1 = ado
+  │           ╰──
+  •

--- a/tests-integration/fixtures/checking/1772818320_do_ado_constrained/Main.snap
+++ b/tests-integration/fixtures/checking/1772818320_do_ado_constrained/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -107,13 +107,18 @@ Roles
 Tuple = [Representational, Representational]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Discard (m :: Type -> Type)
-  --> 44:1..44:44
-   |
-44 | testDoDiscard :: forall m. Monad m => m Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Monad (m :: Type -> Type) is in scope
-  trivia: Bind (m :: Type -> Type) is in scope
-  trivia: Applicative (m :: Type -> Type) is in scope
-  trivia: Apply (m :: Type -> Type) is in scope
-  trivia: Functor (m :: Type -> Type) is in scope
+Error! · [NoInstanceFound] · Main.purs:44:1
+  •
+  │
+  • No instance found for: Discard (m :: Type -> Type)
+  │
+  │   testDoDiscard :: forall m. Monad m => m Int
+  │   ╰──────────────────────────────────────────
+  • while
+  │
+  │   Monad (m :: Type -> Type) is in scope
+  │   Bind (m :: Type -> Type) is in scope
+  │   Applicative (m :: Type -> Type) is in scope
+  │   Apply (m :: Type -> Type) is in scope
+  │   Functor (m :: Type -> Type) is in scope
+  •

--- a/tests-integration/fixtures/checking/1772818380_do_let_premature_solve/Main.snap
+++ b/tests-integration/fixtures/checking/1772818380_do_let_premature_solve/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -31,13 +31,20 @@ Effect = [Nominal]
 Unit = []
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'Int' with 'String'
-  --> 27:15..27:18
-   |
-27 |   let f = a + 123
-   |               ^~~
-error[NoInstanceFound]: No instance found for: Semiring String
-  --> 24:1..24:20
-   |
-24 | test :: Effect Unit
-   | ^~~~~~~~~~~~~~~~~~~
+Error! · [CannotUnify] · Main.purs:27:15
+  •
+  │
+  • Cannot unify 'Int' with 'String'
+  │
+  │     let f = a + 123
+  │                 ╰──
+  •
+
+Error! · [NoInstanceFound] · Main.purs:24:1
+  •
+  │
+  • No instance found for: Semiring String
+  │
+  │   test :: Effect Unit
+  │   ╰──────────────────
+  •

--- a/tests-integration/fixtures/checking/1772818440_do_let_annotation_solve/Main.snap
+++ b/tests-integration/fixtures/checking/1772818440_do_let_annotation_solve/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -20,8 +20,11 @@ Effect = [Nominal]
 Unit = []
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'String' with 'Int'
-  --> 19:9..19:10
-   |
-19 |     f = a
-   |         ^
+Error! · [CannotUnify] · Main.purs:19:9
+  •
+  │
+  • Cannot unify 'String' with 'Int'
+  │
+  │       f = a
+  │           ╰
+  •

--- a/tests-integration/fixtures/checking/1772818500_ado_let_premature_solve/Main.snap
+++ b/tests-integration/fixtures/checking/1772818500_ado_let_premature_solve/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -31,13 +31,20 @@ Effect = [Nominal]
 Unit = []
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'Int' with 'String'
-  --> 27:15..27:18
-   |
-27 |   let f = a + 123
-   |               ^~~
-error[NoInstanceFound]: No instance found for: Semiring String
-  --> 24:1..24:20
-   |
-24 | test :: Effect Unit
-   | ^~~~~~~~~~~~~~~~~~~
+Error! · [CannotUnify] · Main.purs:27:15
+  •
+  │
+  • Cannot unify 'Int' with 'String'
+  │
+  │     let f = a + 123
+  │                 ╰──
+  •
+
+Error! · [NoInstanceFound] · Main.purs:24:1
+  •
+  │
+  • No instance found for: Semiring String
+  │
+  │   test :: Effect Unit
+  │   ╰──────────────────
+  •

--- a/tests-integration/fixtures/checking/1772818560_ado_let_annotation_solve/Main.snap
+++ b/tests-integration/fixtures/checking/1772818560_ado_let_annotation_solve/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -20,8 +20,11 @@ Effect = [Nominal]
 Unit = []
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'String' with 'Int'
-  --> 19:9..19:10
-   |
-19 |     f = a
-   |         ^
+Error! · [CannotUnify] · Main.purs:19:9
+  •
+  │
+  • Cannot unify 'String' with 'Int'
+  │
+  │       f = a
+  │           ╰
+  •

--- a/tests-integration/fixtures/checking/1772818680_do_final_bind/Main.snap
+++ b/tests-integration/fixtures/checking/1772818680_do_final_bind/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -13,13 +13,20 @@ test' ::
 Types
 
 Diagnostics
-warning[InvalidFinalBind]: Invalid final bind statement in do expression
-  --> 9:3..9:14
-  |
-9 |   x <- pure 1
-  |   ^~~~~~~~~~~
-warning[InvalidFinalBind]: Invalid final bind statement in do expression
-  --> 12:3..12:14
-   |
-12 |   x <- pure 1
-   |   ^~~~~~~~~~~
+Warning! · [InvalidFinalBind] · Main.purs:9:3
+  •
+  │
+  • Invalid final bind statement in do expression
+  │
+  │     x <- pure 1
+  │     ╰──────────
+  •
+
+Warning! · [InvalidFinalBind] · Main.purs:12:3
+  •
+  │
+  • Invalid final bind statement in do expression
+  │
+  │     x <- pure 1
+  │     ╰──────────
+  •

--- a/tests-integration/fixtures/checking/1772818740_do_final_let/Main.snap
+++ b/tests-integration/fixtures/checking/1772818740_do_final_let/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -10,13 +10,20 @@ test' :: forall t0. t0
 Types
 
 Diagnostics
-error[InvalidFinalLet]: Invalid final let statement in do expression
-  --> 7:3..7:12
-  |
-7 |   let x = 1
-  |   ^~~~~~~~~
-error[InvalidFinalLet]: Invalid final let statement in do expression
-  --> 10:3..10:12
-   |
-10 |   let x = 1
-   |   ^~~~~~~~~
+Error! · [InvalidFinalLet] · Main.purs:7:3
+  •
+  │
+  • Invalid final let statement in do expression
+  │
+  │     let x = 1
+  │     ╰────────
+  •
+
+Error! · [InvalidFinalLet] · Main.purs:10:3
+  •
+  │
+  • Invalid final let statement in do expression
+  │
+  │     let x = 1
+  │     ╰────────
+  •

--- a/tests-integration/fixtures/checking/1772818800_exhaustive_multiple/Main.snap
+++ b/tests-integration/fixtures/checking/1772818800_exhaustive_multiple/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -19,23 +19,38 @@ Roles
 Maybe = [Representational]
 
 Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Just _, Just _
-  --> 11:15..14:24
-   |
-11 | incomplete1 = case _, _ of
-   |               ^~~~~~~~~~~~
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Just _, Nothing
-  --> 16:15..19:24
-   |
-16 | incomplete2 = case _, _ of
-   |               ^~~~~~~~~~~~
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Nothing, Just _
-  --> 21:15..24:24
-   |
-21 | incomplete3 = case _, _ of
-   |               ^~~~~~~~~~~~
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Nothing, Nothing
-  --> 26:15..29:23
-   |
-26 | incomplete4 = case _, _ of
-   |               ^~~~~~~~~~~~
+Warning! · [MissingPatterns] · Main.purs:11:15
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Just _, Just _
+  │
+  │   incomplete1 = case _, _ of
+  │                 ╰───────────
+  •
+
+Warning! · [MissingPatterns] · Main.purs:16:15
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Just _, Nothing
+  │
+  │   incomplete2 = case _, _ of
+  │                 ╰───────────
+  •
+
+Warning! · [MissingPatterns] · Main.purs:21:15
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Nothing, Just _
+  │
+  │   incomplete3 = case _, _ of
+  │                 ╰───────────
+  •
+
+Warning! · [MissingPatterns] · Main.purs:26:15
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Nothing, Nothing
+  │
+  │   incomplete4 = case _, _ of
+  │                 ╰───────────
+  •

--- a/tests-integration/fixtures/checking/1772818860_exhaustive_tuple/Main.snap
+++ b/tests-integration/fixtures/checking/1772818860_exhaustive_tuple/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -22,23 +22,38 @@ Tuple = [Representational, Representational]
 Maybe = [Representational]
 
 Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Tuple (Just _) (Just _)
-  --> 13:15..16:29
-   |
-13 | incomplete1 = case _ of
-   |               ^~~~~~~~~
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Tuple (Just _) Nothing
-  --> 18:15..21:29
-   |
-18 | incomplete2 = case _ of
-   |               ^~~~~~~~~
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Tuple Nothing (Just _)
-  --> 23:15..26:29
-   |
-23 | incomplete3 = case _ of
-   |               ^~~~~~~~~
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Tuple Nothing Nothing
-  --> 28:15..31:30
-   |
-28 | incomplete4 = case _ of
-   |               ^~~~~~~~~
+Warning! · [MissingPatterns] · Main.purs:13:15
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Tuple (Just _) (Just _)
+  │
+  │   incomplete1 = case _ of
+  │                 ╰────────
+  •
+
+Warning! · [MissingPatterns] · Main.purs:18:15
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Tuple (Just _) Nothing
+  │
+  │   incomplete2 = case _ of
+  │                 ╰────────
+  •
+
+Warning! · [MissingPatterns] · Main.purs:23:15
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Tuple Nothing (Just _)
+  │
+  │   incomplete3 = case _ of
+  │                 ╰────────
+  •
+
+Warning! · [MissingPatterns] · Main.purs:28:15
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Tuple Nothing Nothing
+  │
+  │   incomplete4 = case _ of
+  │                 ╰────────
+  •

--- a/tests-integration/fixtures/checking/1772818920_exhaustive_equation_redundant/Main.snap
+++ b/tests-integration/fixtures/checking/1772818920_exhaustive_equation_redundant/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -21,23 +21,38 @@ Unit = []
 YesNo = []
 
 Diagnostics
-warning[RedundantPattern]: Pattern match has redundant patterns: _, Unit
-  --> 5:1..5:20
-  |
-5 | unit :: Unit -> Int
-  | ^~~~~~~~~~~~~~~~~~~
-warning[RedundantPattern]: Pattern match has redundant patterns: Yes
-  --> 12:1..12:20
-   |
-12 | yes :: YesNo -> Int
-   | ^~~~~~~~~~~~~~~~~~~
-warning[RedundantPattern]: Pattern match has redundant patterns: No
-  --> 17:1..17:19
-   |
-17 | no :: YesNo -> Int
-   | ^~~~~~~~~~~~~~~~~~
-warning[RedundantPattern]: Pattern match has redundant patterns: _
-  --> 22:1..22:22
-   |
-22 | yesNo :: YesNo -> Int
-   | ^~~~~~~~~~~~~~~~~~~~~
+Warning! · [RedundantPattern] · Main.purs:5:1
+  •
+  │
+  • Pattern match has redundant patterns: _, Unit
+  │
+  │   unit :: Unit -> Int
+  │   ╰──────────────────
+  •
+
+Warning! · [RedundantPattern] · Main.purs:12:1
+  •
+  │
+  • Pattern match has redundant patterns: Yes
+  │
+  │   yes :: YesNo -> Int
+  │   ╰──────────────────
+  •
+
+Warning! · [RedundantPattern] · Main.purs:17:1
+  •
+  │
+  • Pattern match has redundant patterns: No
+  │
+  │   no :: YesNo -> Int
+  │   ╰─────────────────
+  •
+
+Warning! · [RedundantPattern] · Main.purs:22:1
+  •
+  │
+  • Pattern match has redundant patterns: _
+  │
+  │   yesNo :: YesNo -> Int
+  │   ╰────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772818980_exhaustive_equation_guarded/Main.snap
+++ b/tests-integration/fixtures/checking/1772818980_exhaustive_equation_guarded/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -10,8 +10,11 @@ testGuardedBoth :: Prim.Boolean -> Prim.Int
 Types
 
 Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: true
-  --> 3:1..3:30
-  |
-3 | testGuarded :: Boolean -> Int
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Warning! · [MissingPatterns] · Main.purs:3:1
+  •
+  │
+  • Pattern match is not exhaustive. Missing: true
+  │
+  │   testGuarded :: Boolean -> Int
+  │   ╰────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772819040_exhaustive_let_equation/Main.snap
+++ b/tests-integration/fixtures/checking/1772819040_exhaustive_let_equation/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,13 +16,20 @@ Roles
 Maybe = [Representational]
 
 Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Nothing
-  --> 8:5..9:19
-  |
-8 |     f :: Maybe Int -> Int
-  |     ^~~~~~~~~~~~~~~~~~~~~
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Just _
-  --> 15:5..16:18
-   |
-15 |     g :: Maybe Int -> Int
-   |     ^~~~~~~~~~~~~~~~~~~~~
+Warning! · [MissingPatterns] · Main.purs:8:5
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Nothing
+  │
+  │       f :: Maybe Int -> Int
+  │       ╰────────────────────
+  •
+
+Warning! · [MissingPatterns] · Main.purs:15:5
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Just _
+  │
+  │       g :: Maybe Int -> Int
+  │       ╰────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772819100_exhaustive_instance_equation/Main.snap
+++ b/tests-integration/fixtures/checking/1772819100_exhaustive_instance_equation/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -17,8 +17,11 @@ Instances
 instance Main.C Prim.Boolean
 
 Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: false
-  --> 6:1..7:13
-  |
-6 | instance cBool :: C Boolean where
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Warning! · [MissingPatterns] · Main.purs:6:1
+  •
+  │
+  • Pattern match is not exhaustive. Missing: false
+  │
+  │   instance cBool :: C Boolean where
+  │   ╰────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772823240_instance_head_invalid_row/Main.snap
+++ b/tests-integration/fixtures/checking/1772823240_instance_head_invalid_row/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -23,43 +23,80 @@ Roles
 Proxy = [Phantom]
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'Type' with 'Constraint'
-  --> 1:1..12:32
-  |
-1 | module Main where
-  | ^~~~~~~~~~~~~~~~~
-error[InstanceHeadLabeledRow]: Instance argument at position 0 contains a labeled row, but this position is not determined by any functional dependency. Only the `( | r )` form is allowed. Got '( a :: Int )' instead.
-  --> 1:1..12:32
-  |
-1 | module Main where
-  | ^~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Type' with 'Constraint'
-  --> 1:1..12:32
-  |
-1 | module Main where
-  | ^~~~~~~~~~~~~~~~~
-error[InstanceHeadLabeledRow]: Instance argument at position 0 contains a labeled row, but this position is not determined by any functional dependency. Only the `( | r )` form is allowed. Got '{ a :: Int }' instead.
-  --> 1:1..12:32
-  |
-1 | module Main where
-  | ^~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Type' with 'Constraint'
-  --> 1:1..12:32
-  |
-1 | module Main where
-  | ^~~~~~~~~~~~~~~~~
-error[InstanceHeadLabeledRow]: Instance argument at position 0 contains a labeled row, but this position is not determined by any functional dependency. Only the `( | r )` form is allowed. Got 'Proxy @(Row Type) ( a :: Int )' instead.
-  --> 1:1..12:32
-  |
-1 | module Main where
-  | ^~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Type' with 'Constraint'
-  --> 1:1..12:32
-  |
-1 | module Main where
-  | ^~~~~~~~~~~~~~~~~
-error[InstanceHeadLabeledRow]: Instance argument at position 0 contains a labeled row, but this position is not determined by any functional dependency. Only the `( | r )` form is allowed. Got 'Proxy @Type { a :: Int }' instead.
-  --> 1:1..12:32
-  |
-1 | module Main where
-  | ^~~~~~~~~~~~~~~~~
+Error! · [CannotUnify] · Main.purs:1:1
+  •
+  │
+  • Cannot unify 'Type' with 'Constraint'
+  │
+  │   module Main where
+  │   ╰────────────────
+  •
+
+Error! · [InstanceHeadLabeledRow] · Main.purs:1:1
+  •
+  │
+  • Instance argument at position 0 contains a labeled row, but this position is not determined by
+  │ any functional dependency. Only the `( | r )` form is allowed. Got '( a :: Int )' instead.
+  │
+  │   module Main where
+  │   ╰────────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:1:1
+  •
+  │
+  • Cannot unify 'Type' with 'Constraint'
+  │
+  │   module Main where
+  │   ╰────────────────
+  •
+
+Error! · [InstanceHeadLabeledRow] · Main.purs:1:1
+  •
+  │
+  • Instance argument at position 0 contains a labeled row, but this position is not determined by
+  │ any functional dependency. Only the `( | r )` form is allowed. Got '{ a :: Int }' instead.
+  │
+  │   module Main where
+  │   ╰────────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:1:1
+  •
+  │
+  • Cannot unify 'Type' with 'Constraint'
+  │
+  │   module Main where
+  │   ╰────────────────
+  •
+
+Error! · [InstanceHeadLabeledRow] · Main.purs:1:1
+  •
+  │
+  • Instance argument at position 0 contains a labeled row, but this position is not determined by
+  │ any functional dependency. Only the `( | r )` form is allowed. Got 'Proxy @(Row Type) ( a ::
+  │ Int )' instead.
+  │
+  │   module Main where
+  │   ╰────────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:1:1
+  •
+  │
+  • Cannot unify 'Type' with 'Constraint'
+  │
+  │   module Main where
+  │   ╰────────────────
+  •
+
+Error! · [InstanceHeadLabeledRow] · Main.purs:1:1
+  •
+  │
+  • Instance argument at position 0 contains a labeled row, but this position is not determined by
+  │ any functional dependency. Only the `( | r )` form is allowed. Got 'Proxy @Type { a :: Int }'
+  │ instead.
+  │
+  │   module Main where
+  │   ╰────────────────
+  •

--- a/tests-integration/fixtures/checking/1772823540_type_application_invalid_basic/Main.snap
+++ b/tests-integration/fixtures/checking/1772823540_type_application_invalid_basic/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -12,13 +12,20 @@ Synonyms
 type Bad = Prim.Int Prim.String
 
 Diagnostics
-error[InvalidTypeApplication]: Cannot apply type 'Int' to 'String'. 'Int' has kind 'Type', which is not a function kind.
-  --> 3:12..3:22
-  |
-3 | type Bad = Int String
-  |            ^~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Type' with '?[invalid kind]'
-  --> 3:12..3:22
-  |
-3 | type Bad = Int String
-  |            ^~~~~~~~~~
+Error! · [InvalidTypeApplication] · Main.purs:3:12
+  •
+  │
+  • Cannot apply type 'Int' to 'String'. 'Int' has kind 'Type', which is not a function kind.
+  │
+  │   type Bad = Int String
+  │              ╰─────────
+  •
+
+Error! · [CannotUnify] · Main.purs:3:12
+  •
+  │
+  • Cannot unify 'Type' with '?[invalid kind]'
+  │
+  │   type Bad = Int String
+  │              ╰─────────
+  •

--- a/tests-integration/fixtures/checking/1772823600_type_application_invalid_too_many/Main.snap
+++ b/tests-integration/fixtures/checking/1772823600_type_application_invalid_too_many/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -12,13 +12,21 @@ Synonyms
 type Bad = Prim.Array Prim.Int Prim.String
 
 Diagnostics
-error[InvalidTypeApplication]: Cannot apply type 'Array Int' to 'String'. 'Array Int' has kind 'Type', which is not a function kind.
-  --> 3:12..3:28
-  |
-3 | type Bad = Array Int String
-  |            ^~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Type' with '?[invalid kind]'
-  --> 3:12..3:28
-  |
-3 | type Bad = Array Int String
-  |            ^~~~~~~~~~~~~~~~
+Error! · [InvalidTypeApplication] · Main.purs:3:12
+  •
+  │
+  • Cannot apply type 'Array Int' to 'String'. 'Array Int' has kind 'Type', which is not a function
+  │ kind.
+  │
+  │   type Bad = Array Int String
+  │              ╰───────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:3:12
+  •
+  │
+  • Cannot unify 'Type' with '?[invalid kind]'
+  │
+  │   type Bad = Array Int String
+  │              ╰───────────────
+  •

--- a/tests-integration/fixtures/checking/1772823720_record_expression_missing_field/Main.snap
+++ b/tests-integration/fixtures/checking/1772823720_record_expression_missing_field/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -9,8 +9,11 @@ test :: { a :: Prim.Int, b :: Prim.Int }
 Types
 
 Diagnostics
-error[PropertyIsMissing]: Missing required properties: b
-  --> 4:8..4:16
-  |
-4 | test = { a: 1 }
-  |        ^~~~~~~~
+Error! · [PropertyIsMissing] · Main.purs:4:8
+  •
+  │
+  • Missing required properties: b
+  │
+  │   test = { a: 1 }
+  │          ╰───────
+  •

--- a/tests-integration/fixtures/checking/1772823780_record_expression_additional_field/Main.snap
+++ b/tests-integration/fixtures/checking/1772823780_record_expression_additional_field/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -9,8 +9,11 @@ test :: { a :: Prim.Int }
 Types
 
 Diagnostics
-error[AdditionalProperty]: Additional properties not allowed: b
-  --> 4:8..4:22
-  |
-4 | test = { a: 1, b: 2 }
-  |        ^~~~~~~~~~~~~~
+Error! · [AdditionalProperty] · Main.purs:4:8
+  •
+  │
+  • Additional properties not allowed: b
+  │
+  │   test = { a: 1, b: 2 }
+  │          ╰─────────────
+  •

--- a/tests-integration/fixtures/checking/1772823840_record_expression_missing_and_additional/Main.snap
+++ b/tests-integration/fixtures/checking/1772823840_record_expression_missing_and_additional/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -9,13 +9,20 @@ test :: { a :: Prim.Int, b :: Prim.Int }
 Types
 
 Diagnostics
-error[PropertyIsMissing]: Missing required properties: b
-  --> 4:8..4:22
-  |
-4 | test = { a: 1, c: 3 }
-  |        ^~~~~~~~~~~~~~
-error[AdditionalProperty]: Additional properties not allowed: c
-  --> 4:8..4:22
-  |
-4 | test = { a: 1, c: 3 }
-  |        ^~~~~~~~~~~~~~
+Error! · [PropertyIsMissing] · Main.purs:4:8
+  •
+  │
+  • Missing required properties: b
+  │
+  │   test = { a: 1, c: 3 }
+  │          ╰─────────────
+  •
+
+Error! · [AdditionalProperty] · Main.purs:4:8
+  •
+  │
+  • Additional properties not allowed: c
+  │
+  │   test = { a: 1, c: 3 }
+  │          ╰─────────────
+  •

--- a/tests-integration/fixtures/checking/1772823900_record_expression_nested_additional/Main.snap
+++ b/tests-integration/fixtures/checking/1772823900_record_expression_nested_additional/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -9,8 +9,11 @@ test :: { outer :: { x :: Prim.Int } }
 Types
 
 Diagnostics
-error[AdditionalProperty]: Additional properties not allowed: y
-  --> 4:17..4:31
-  |
-4 | test = { outer: { x: 1, y: 2 } }
-  |                 ^~~~~~~~~~~~~~
+Error! · [AdditionalProperty] · Main.purs:4:17
+  •
+  │
+  • Additional properties not allowed: y
+  │
+  │   test = { outer: { x: 1, y: 2 } }
+  │                   ╰─────────────
+  •

--- a/tests-integration/fixtures/checking/1772824140_record_binder_additional_property/Main.snap
+++ b/tests-integration/fixtures/checking/1772824140_record_binder_additional_property/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -9,8 +9,11 @@ test :: { a :: Prim.Int } -> Prim.Int
 Types
 
 Diagnostics
-error[AdditionalProperty]: Additional properties not allowed: b, c
-  --> 4:6..4:17
-  |
-4 | test { a, b, c } = a
-  |      ^~~~~~~~~~~
+Error! · [AdditionalProperty] · Main.purs:4:6
+  •
+  │
+  • Additional properties not allowed: b, c
+  │
+  │   test { a, b, c } = a
+  │        ╰──────────
+  •

--- a/tests-integration/fixtures/checking/1772824200_record_binder_additional_property_nested/Main.snap
+++ b/tests-integration/fixtures/checking/1772824200_record_binder_additional_property_nested/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -9,8 +9,11 @@ test :: { outer :: { x :: Prim.Int } } -> Prim.Int
 Types
 
 Diagnostics
-error[AdditionalProperty]: Additional properties not allowed: y
-  --> 4:15..4:23
-  |
-4 | test { outer: { x, y } } = x
-  |               ^~~~~~~~
+Error! · [AdditionalProperty] · Main.purs:4:15
+  •
+  │
+  • Additional properties not allowed: y
+  │
+  │   test { outer: { x, y } } = x
+  │                 ╰───────
+  •

--- a/tests-integration/fixtures/checking/1772824380_binder_instantiation/Main.snap
+++ b/tests-integration/fixtures/checking/1772824380_binder_instantiation/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -22,13 +22,20 @@ Maybe = [Representational]
 Id = []
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'Boolean' with 'Int'
-  --> 11:31..11:35
-   |
-11 |   Just f -> let _ = f 42 in f true
-   |                               ^~~~
-error[CannotUnify]: Cannot unify 'Boolean' with 'Int'
-  --> 20:24..20:28
-   |
-20 |   in let _ = f 42 in f true
-   |                        ^~~~
+Error! · [CannotUnify] · Main.purs:11:31
+  •
+  │
+  • Cannot unify 'Boolean' with 'Int'
+  │
+  │     Just f -> let _ = f 42 in f true
+  │                                 ╰───
+  •
+
+Error! · [CannotUnify] · Main.purs:20:24
+  •
+  │
+  • Cannot unify 'Boolean' with 'Int'
+  │
+  │     in let _ = f 42 in f true
+  │                          ╰───
+  •

--- a/tests-integration/fixtures/checking/1772827200_coercible_different_heads_error/Main.snap
+++ b/tests-integration/fixtures/checking/1772827200_coercible_different_heads_error/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -19,8 +19,11 @@ Maybe = [Representational]
 Either = [Representational, Representational]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Coercible @Type (Maybe Int) (Either Int String)
-  --> 8:1..8:50
-  |
-8 | coerceDifferent :: Maybe Int -> Either Int String
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:8:1
+  •
+  │
+  • No instance found for: Coercible @Type (Maybe Int) (Either Int String)
+  │
+  │   coerceDifferent :: Maybe Int -> Either Int String
+  │   ╰────────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772827260_coercible_nominal/Main.snap
+++ b/tests-integration/fixtures/checking/1772827260_coercible_nominal/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -14,8 +14,11 @@ Roles
 Nominal = [Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Coercible @Type (Nominal Int) (Nominal String)
-  --> 12:1..12:56
-   |
-12 | coerceNominalDifferent :: Nominal Int -> Nominal String
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:12:1
+  •
+  │
+  • No instance found for: Coercible @Type (Nominal Int) (Nominal String)
+  │
+  │   coerceNominalDifferent :: Nominal Int -> Nominal String
+  │   ╰──────────────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772827320_coercible_newtype_hidden/Main.snap
+++ b/tests-integration/fixtures/checking/1772827320_coercible_newtype_hidden/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -10,23 +10,38 @@ coerceQualified :: Prim.Int -> Lib.HiddenAge
 Types
 
 Diagnostics
-error[CoercibleConstructorNotInScope]: Constructor not in scope for Coercible
-  --> 7:1..7:33
-  |
-7 | coerceHidden :: Int -> HiddenAge
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: Coercible @Type Int HiddenAge
-  --> 7:1..7:33
-  |
-7 | coerceHidden :: Int -> HiddenAge
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CoercibleConstructorNotInScope]: Constructor not in scope for Coercible
-  --> 10:1..10:38
-   |
-10 | coerceQualified :: Int -> L.HiddenAge
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: Coercible @Type Int HiddenAge
-  --> 10:1..10:38
-   |
-10 | coerceQualified :: Int -> L.HiddenAge
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CoercibleConstructorNotInScope] · Main.purs:7:1
+  •
+  │
+  • Constructor not in scope for Coercible
+  │
+  │   coerceHidden :: Int -> HiddenAge
+  │   ╰───────────────────────────────
+  •
+
+Error! · [NoInstanceFound] · Main.purs:7:1
+  •
+  │
+  • No instance found for: Coercible @Type Int HiddenAge
+  │
+  │   coerceHidden :: Int -> HiddenAge
+  │   ╰───────────────────────────────
+  •
+
+Error! · [CoercibleConstructorNotInScope] · Main.purs:10:1
+  •
+  │
+  • Constructor not in scope for Coercible
+  │
+  │   coerceQualified :: Int -> L.HiddenAge
+  │   ╰────────────────────────────────────
+  •
+
+Error! · [NoInstanceFound] · Main.purs:10:1
+  •
+  │
+  • No instance found for: Coercible @Type Int HiddenAge
+  │
+  │   coerceQualified :: Int -> L.HiddenAge
+  │   ╰────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772827440_coercible_newtype_open_hidden/Main.snap
+++ b/tests-integration/fixtures/checking/1772827440_coercible_newtype_open_hidden/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -9,13 +9,20 @@ coerceOpen :: Prim.Int -> Lib.HiddenAge
 Types
 
 Diagnostics
-error[CoercibleConstructorNotInScope]: Constructor not in scope for Coercible
-  --> 6:1..6:31
-  |
-6 | coerceOpen :: Int -> HiddenAge
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: Coercible @Type Int HiddenAge
-  --> 6:1..6:31
-  |
-6 | coerceOpen :: Int -> HiddenAge
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CoercibleConstructorNotInScope] · Main.purs:6:1
+  •
+  │
+  • Constructor not in scope for Coercible
+  │
+  │   coerceOpen :: Int -> HiddenAge
+  │   ╰─────────────────────────────
+  •
+
+Error! · [NoInstanceFound] · Main.purs:6:1
+  •
+  │
+  • No instance found for: Coercible @Type Int HiddenAge
+  │
+  │   coerceOpen :: Int -> HiddenAge
+  │   ╰─────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772827560_coercible_higher_kinded_error/Main.snap
+++ b/tests-integration/fixtures/checking/1772827560_coercible_higher_kinded_error/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -21,8 +21,11 @@ List = [Representational]
 Container = [Representational]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Coercible @Type (Maybe t0) (List t0)
-  --> 11:1..11:62
-   |
-11 | coerceContainerDifferent :: Container Maybe -> Container List
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:11:1
+  •
+  │
+  • No instance found for: Coercible @Type (Maybe t0) (List t0)
+  │
+  │   coerceContainerDifferent :: Container Maybe -> Container List
+  │   ╰────────────────────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772866020_derive_newtype_not_constructor/Main.snap
+++ b/tests-integration/fixtures/checking/1772866020_derive_newtype_not_constructor/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -11,8 +11,11 @@ Derived
 derive Data.Show.Show (Prim.Int -> Prim.Int)
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: Int -> Int
-  --> 5:1..5:42
-  |
-5 | derive newtype instance Show (Int -> Int)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveForType] · Main.purs:5:1
+  •
+  │
+  • Cannot derive for type: Int -> Int
+  │
+  │   derive newtype instance Show (Int -> Int)
+  │   ╰────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772866080_derive_newtype_class_not_constructor/Main.snap
+++ b/tests-integration/fixtures/checking/1772866080_derive_newtype_class_not_constructor/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -11,8 +11,11 @@ Derived
 derive forall t0. Data.Newtype.Newtype @Prim.Type (Prim.Int -> Prim.Int) t0
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: Int -> Int
-  --> 5:1..5:39
-  |
-5 | derive instance Newtype (Int -> Int) _
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveForType] · Main.purs:5:1
+  •
+  │
+  • Cannot derive for type: Int -> Int
+  │
+  │   derive instance Newtype (Int -> Int) _
+  │   ╰─────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772866140_derive_newtype_not_local/Main.snap
+++ b/tests-integration/fixtures/checking/1772866140_derive_newtype_not_local/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -11,8 +11,11 @@ Derived
 derive Data.Show.Show Lib.Wrapper
 
 Diagnostics
-error[NonLocalNewtype]: Expected a local newtype, got: Wrapper
-  --> 6:1..6:37
-  |
-6 | derive newtype instance Show Wrapper
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NonLocalNewtype] · Main.purs:6:1
+  •
+  │
+  • Expected a local newtype, got: Wrapper
+  │
+  │   derive newtype instance Show Wrapper
+  │   ╰───────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772866200_derive_newtype_class_not_local/Main.snap
+++ b/tests-integration/fixtures/checking/1772866200_derive_newtype_class_not_local/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -11,8 +11,11 @@ Derived
 derive forall t0. Data.Newtype.Newtype @Prim.Type Lib.Wrapper t0
 
 Diagnostics
-error[NonLocalNewtype]: Expected a local newtype, got: Wrapper
-  --> 6:1..6:34
-  |
-6 | derive instance Newtype Wrapper _
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NonLocalNewtype] · Main.purs:6:1
+  •
+  │
+  • Expected a local newtype, got: Wrapper
+  │
+  │   derive instance Newtype Wrapper _
+  │   ╰────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772866260_derive_newtype_insufficient_params/Main.snap
+++ b/tests-integration/fixtures/checking/1772866260_derive_newtype_insufficient_params/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -11,13 +11,20 @@ Derived
 derive Data.Show.Show
 
 Diagnostics
-error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 0
-  --> 5:1..5:29
-  |
-5 | derive newtype instance Show
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Type -> Constraint' with 'Constraint'
-  --> 5:1..5:29
-  |
-5 | derive newtype instance Show
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [DeriveInvalidArity] · Main.purs:5:1
+  •
+  │
+  • Invalid arity for derive: expected 1, got 0
+  │
+  │   derive newtype instance Show
+  │   ╰───────────────────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:5:1
+  •
+  │
+  • Cannot unify 'Type -> Constraint' with 'Constraint'
+  │
+  │   derive newtype instance Show
+  │   ╰───────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1772866320_derive_newtype_class_insufficient_params/Main.snap
+++ b/tests-integration/fixtures/checking/1772866320_derive_newtype_class_insufficient_params/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,13 +16,20 @@ Roles
 Wrapper = []
 
 Diagnostics
-error[DeriveInvalidArity]: Invalid arity for derive: expected 2, got 1
-  --> 7:1..7:32
-  |
-7 | derive instance Newtype Wrapper
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Type -> Constraint' with 'Constraint'
-  --> 7:1..7:32
-  |
-7 | derive instance Newtype Wrapper
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [DeriveInvalidArity] · Main.purs:7:1
+  •
+  │
+  • Invalid arity for derive: expected 2, got 1
+  │
+  │   derive instance Newtype Wrapper
+  │   ╰──────────────────────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:7:1
+  •
+  │
+  • Cannot unify 'Type -> Constraint' with 'Constraint'
+  │
+  │   derive instance Newtype Wrapper
+  │   ╰──────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1773152280_derive_newtype_invalid_skolem_layout/Main.snap
+++ b/tests-integration/fixtures/checking/1773152280_derive_newtype_invalid_skolem_layout/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -33,8 +33,12 @@ Vector = [Phantom, Representational]
 InvalidVector = [Representational, Phantom]
 
 Diagnostics
-error[InvalidNewtypeDeriveSkolemArguments]: Cannot derive newtype instance where skolemised arguments do not appear trailing in the inner type.
-  --> 13:1..13:50
-   |
-13 | derive newtype instance Empty (InvalidVector Int)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [InvalidNewtypeDeriveSkolemArguments] · Main.purs:13:1
+  •
+  │
+  • Cannot derive newtype instance where skolemised arguments do not appear trailing in the inner
+  │ type.
+  │
+  │   derive newtype instance Empty (InvalidVector Int)
+  │   ╰────────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1773504480_exhaustive_record/Main.snap
+++ b/tests-integration/fixtures/checking/1773504480_exhaustive_record/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -19,18 +19,29 @@ Roles
 Maybe = [Representational]
 
 Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: { x: Nothing }
-  --> 8:1..8:35
-  |
-8 | test2 :: { x :: Maybe Int } -> Int
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-warning[RedundantPattern]: Pattern match has redundant patterns: _
-  --> 11:1..11:39
-   |
-11 | test3 :: { x :: Int, y :: Int } -> Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: { a: Nothing, b: _ }
-  --> 15:1..15:54
-   |
-15 | test4 :: { a :: Maybe Int, b :: Maybe String } -> Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Warning! · [MissingPatterns] · Main.purs:8:1
+  •
+  │
+  • Pattern match is not exhaustive. Missing: { x: Nothing }
+  │
+  │   test2 :: { x :: Maybe Int } -> Int
+  │   ╰─────────────────────────────────
+  •
+
+Warning! · [RedundantPattern] · Main.purs:11:1
+  •
+  │
+  • Pattern match has redundant patterns: _
+  │
+  │   test3 :: { x :: Int, y :: Int } -> Int
+  │   ╰─────────────────────────────────────
+  •
+
+Warning! · [MissingPatterns] · Main.purs:15:1
+  •
+  │
+  • Pattern match is not exhaustive. Missing: { a: Nothing, b: _ }
+  │
+  │   test4 :: { a :: Maybe Int, b :: Maybe String } -> Int
+  │   ╰────────────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1773504540_exhaustive_array/Main.snap
+++ b/tests-integration/fixtures/checking/1773504540_exhaustive_array/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -11,13 +11,20 @@ testExhaustive :: Prim.Array Prim.Int -> Prim.Int
 Types
 
 Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: _
-  --> 3:1..3:38
-  |
-3 | testNonExhaustive :: Array Int -> Int
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-warning[RedundantPattern]: Pattern match has redundant patterns: [_]
-  --> 7:1..7:34
-  |
-7 | testRedundant :: Array Int -> Int
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Warning! · [MissingPatterns] · Main.purs:3:1
+  •
+  │
+  • Pattern match is not exhaustive. Missing: _
+  │
+  │   testNonExhaustive :: Array Int -> Int
+  │   ╰────────────────────────────────────
+  •
+
+Warning! · [RedundantPattern] · Main.purs:7:1
+  •
+  │
+  • Pattern match has redundant patterns: [_]
+  │
+  │   testRedundant :: Array Int -> Int
+  │   ╰────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1773504600_exhaustive_missing_patterns/Main.snap
+++ b/tests-integration/fixtures/checking/1773504600_exhaustive_missing_patterns/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,8 +16,11 @@ Roles
 Maybe = [Representational]
 
 Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Just _
-  --> 14:5..15:22
-   |
-14 |     loud :: Maybe a -> Int
-   |     ^~~~~~~~~~~~~~~~~~~~~~
+Warning! · [MissingPatterns] · Main.purs:14:5
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Just _
+  │
+  │       loud :: Maybe a -> Int
+  │       ╰─────────────────────
+  •

--- a/tests-integration/fixtures/checking/1773713100_visible_type_application_error/Main.snap
+++ b/tests-integration/fixtures/checking/1773713100_visible_type_application_error/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -10,13 +10,20 @@ test :: ?[invalid visible type application]
 Types
 
 Diagnostics
-error[NoVisibleTypeVariable]: No visible type variable for type application in: forall a. a -> a
-  --> 6:8..6:21
-  |
-6 | test = identity @Int
-  |        ^~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Type' with '?[invalid kind]'
-  --> 6:8..6:21
-  |
-6 | test = identity @Int
-  |        ^~~~~~~~~~~~~
+Error! · [NoVisibleTypeVariable] · Main.purs:6:8
+  •
+  │
+  • No visible type variable for type application in: forall a. a -> a
+  │
+  │   test = identity @Int
+  │          ╰────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:6:8
+  •
+  │
+  • Cannot unify 'Type' with '?[invalid kind]'
+  │
+  │   test = identity @Int
+  │          ╰────────────
+  •

--- a/tests-integration/fixtures/checking/1774024080_prim_int_given_improvement/Main.snap
+++ b/tests-integration/fixtures/checking/1774024080_prim_int_given_improvement/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -20,8 +20,11 @@ forceSolve ::
 Types
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Add 1 2 4
-  --> 12:1..15:4
-   |
-12 | forceSolve =
-   | ^~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:12:1
+  •
+  │
+  • No instance found for: Add 1 2 4
+  │
+  │   forceSolve =
+  │   ╰───────────
+  •

--- a/tests-integration/fixtures/checking/1777091040_row_union_open_duplicates/Main.snap
+++ b/tests-integration/fixtures/checking/1777091040_row_union_open_duplicates/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -44,13 +44,20 @@ Roles
 Proxy = [Phantom]
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'String' with 'Int'
-  --> 17:1..21:4
-   |
-17 | forceSolve =
-   | ^~~~~~~~~~~~
-error[CannotUnify]: Cannot unify '( a :: String )' with '( a :: Int )'
-  --> 17:1..21:4
-   |
-17 | forceSolve =
-   | ^~~~~~~~~~~~
+Error! · [CannotUnify] · Main.purs:17:1
+  •
+  │
+  • Cannot unify 'String' with 'Int'
+  │
+  │   forceSolve =
+  │   ╰───────────
+  •
+
+Error! · [CannotUnify] · Main.purs:17:1
+  •
+  │
+  • Cannot unify '( a :: String )' with '( a :: Int )'
+  │
+  │   forceSolve =
+  │   ╰───────────
+  •

--- a/tests-integration/fixtures/checking/1777489980_expression_hole/Main.snap
+++ b/tests-integration/fixtures/checking/1777489980_expression_hole/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -9,9 +9,14 @@ hole :: forall t0. t0
 Types
 
 Diagnostics
-error[TermHole]: Hole '?hole' has inferred type: t0
-  --> 3:8..3:13
-  |
-3 | hole = ?hole
-  |        ^~~~~
-  trivia: hole :: t0 is in scope
+Error! · [TermHole] · Main.purs:3:8
+  •
+  │
+  • Hole '?hole' has inferred type: t0
+  │
+  │   hole = ?hole
+  │          ╰────
+  • while
+  │
+  │   hole :: t0 is in scope
+  •

--- a/tests-integration/fixtures/checking/1777708860_local_instance_conflict/Main.snap
+++ b/tests-integration/fixtures/checking/1777708860_local_instance_conflict/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -17,13 +17,20 @@ Instances
 instance Main.Class
 
 Diagnostics
-error[InstanceHeadMismatch]: Instance head mismatch: expected 1 arguments, got 0
-  --> 1:1..9:18
-  |
-1 | module Main where
-  | ^~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Type -> Constraint' with 'Constraint'
-  --> 1:1..9:18
-  |
-1 | module Main where
-  | ^~~~~~~~~~~~~~~~~
+Error! · [InstanceHeadMismatch] · Main.purs:1:1
+  •
+  │
+  • Instance head mismatch: expected 1 arguments, got 0
+  │
+  │   module Main where
+  │   ╰────────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:1:1
+  •
+  │
+  • Cannot unify 'Type -> Constraint' with 'Constraint'
+  │
+  │   module Main where
+  │   ╰────────────────
+  •

--- a/tests-integration/fixtures/checking/1777825440_irrefutable_variable_pattern/Main.snap
+++ b/tests-integration/fixtures/checking/1777825440_irrefutable_variable_pattern/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -12,13 +12,20 @@ arrayLength :: forall a. Prim.Array a -> Prim.Int
 Types
 
 Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: _
-  --> 14:13..16:24
-   |
-14 | refutable = case _ of
-   |             ^~~~~~~~~
-error[NoInstanceFound]: No instance found for: Partial
-  --> 13:1..13:30
-   |
-13 | refutable :: Array Int -> Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Warning! · [MissingPatterns] · Main.purs:14:13
+  •
+  │
+  • Pattern match is not exhaustive. Missing: _
+  │
+  │   refutable = case _ of
+  │               ╰────────
+  •
+
+Error! · [NoInstanceFound] · Main.purs:13:1
+  •
+  │
+  • No instance found for: Partial
+  │
+  │   refutable :: Array Int -> Int
+  │   ╰────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1778051580_match_type_semantics/Main.snap
+++ b/tests-integration/fixtures/checking/1778051580_match_type_semantics/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -41,23 +41,38 @@ Unit = []
 Output = []
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: IsEq x Unit Output
-  --> 17:1..17:41
-   |
-17 | testSkolemRight :: forall x. x -> Output
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: IsEq Unit x1 Output
-  --> 20:1..20:40
-   |
-20 | testSkolemLeft :: forall x. x -> Output
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: IsEq y x2 Output
-  --> 23:1..23:47
-   |
-23 | testSkolemIsEq :: forall x y. x -> y -> Output
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: RowSame @Type { params :: Unit | ?47 } { query :: Unit | ?50 }
-  --> 44:1..44:25
-   |
-44 | testOpenRowsNoFd :: Unit
-   | ^~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:17:1
+  •
+  │
+  • No instance found for: IsEq x Unit Output
+  │
+  │   testSkolemRight :: forall x. x -> Output
+  │   ╰───────────────────────────────────────
+  •
+
+Error! · [NoInstanceFound] · Main.purs:20:1
+  •
+  │
+  • No instance found for: IsEq Unit x1 Output
+  │
+  │   testSkolemLeft :: forall x. x -> Output
+  │   ╰──────────────────────────────────────
+  •
+
+Error! · [NoInstanceFound] · Main.purs:23:1
+  •
+  │
+  • No instance found for: IsEq y x2 Output
+  │
+  │   testSkolemIsEq :: forall x y. x -> y -> Output
+  │   ╰─────────────────────────────────────────────
+  •
+
+Error! · [NoInstanceFound] · Main.purs:44:1
+  •
+  │
+  • No instance found for: RowSame @Type { params :: Unit | ?47 } { query :: Unit | ?50 }
+  │
+  │   testOpenRowsNoFd :: Unit
+  │   ╰───────────────────────
+  •

--- a/tests-integration/fixtures/checking/1778856960_instance_member_signature_weakening/Main.snap
+++ b/tests-integration/fixtures/checking/1778856960_instance_member_signature_weakening/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -60,9 +60,14 @@ Roles
 Wrap = [Representational, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Functor (f :: Type -> Type)
-  --> 30:1..32:19
-   |
-30 | instance TransformPlain Wrap where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Functor (f1 :: Type -> Type) is in scope
+Error! · [NoInstanceFound] · Main.purs:30:1
+  •
+  │
+  • No instance found for: Functor (f :: Type -> Type)
+  │
+  │   instance TransformPlain Wrap where
+  │   ╰─────────────────────────────────
+  • while
+  │
+  │   Functor (f1 :: Type -> Type) is in scope
+  •

--- a/tests-integration/fixtures/checking/1779044580_binderless_guard_predicate_boolean/Main.snap
+++ b/tests-integration/fixtures/checking/1779044580_binderless_guard_predicate_boolean/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -9,8 +9,11 @@ test :: Prim.Int -> Prim.Int
 Types
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'Int' with 'Boolean'
-  --> 6:7..6:8
-  |
-6 |     | n -> 0
-  |       ^
+Error! · [CannotUnify] · Main.purs:6:7
+  •
+  │
+  • Cannot unify 'Int' with 'Boolean'
+  │
+  │       | n -> 0
+  │         ╰
+  •

--- a/tests-integration/fixtures/checking/1779903960_overlapping/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -19,10 +19,15 @@ instance forall a. Main.Test a
 instance Main.Test Prim.Int
 
 Diagnostics
-error[OverlappingInstances]: Overlapping type class instances found for: Test Int
-  --> 9:1..10:13
-  |
-9 | instance testInt :: Test Int where
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: forall a. Test a is matching
-  trivia: Test Int is matching
+Error! · [OverlappingInstances] · Main.purs:9:1
+  •
+  │
+  • Overlapping type class instances found for: Test Int
+  │
+  │   instance testInt :: Test Int where
+  │   ╰─────────────────────────────────
+  • while
+  │
+  │   forall a. Test a is matching
+  │   Test Int is matching
+  •

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -17,16 +17,27 @@ Roles
 Y = []
 
 Diagnostics
-error[OverlappingInstances]: Overlapping type class instances found for: C X Y
-  --> 7:1..7:22
-  |
-7 | instance cxy :: C X Y
-  | ^~~~~~~~~~~~~~~~~~~~~
-  trivia: forall t0. C X t0 is matching
-  trivia: C X Y is matching
-warning[MissingInstanceMembers]: Instance is missing class members
-  --> 7:1..7:22
-  |
-7 | instance cxy :: C X Y
-  | ^~~~~~~~~~~~~~~~~~~~~
-  trivia: test is not implemented
+Error! · [OverlappingInstances] · Main.purs:7:1
+  •
+  │
+  • Overlapping type class instances found for: C X Y
+  │
+  │   instance cxy :: C X Y
+  │   ╰────────────────────
+  • while
+  │
+  │   forall t0. C X t0 is matching
+  │   C X Y is matching
+  •
+
+Warning! · [MissingInstanceMembers] · Main.purs:7:1
+  •
+  │
+  • Instance is missing class members
+  │
+  │   instance cxy :: C X Y
+  │   ╰────────────────────
+  • while
+  │
+  │   test is not implemented
+  •

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_no_use/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_no_use/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -18,10 +18,15 @@ instance forall a. Main.Test a
 instance Main.Test Prim.Int
 
 Diagnostics
-error[OverlappingInstances]: Overlapping type class instances found for: Test Int
-  --> 9:1..10:13
-  |
-9 | instance testInt :: Test Int where
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: forall a. Test a is matching
-  trivia: Test Int is matching
+Error! · [OverlappingInstances] · Main.purs:9:1
+  •
+  │
+  • Overlapping type class instances found for: Test Int
+  │
+  │   instance testInt :: Test Int where
+  │   ╰─────────────────────────────────
+  • while
+  │
+  │   forall a. Test a is matching
+  │   Test Int is matching
+  •

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_polymorphic/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_polymorphic/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -24,10 +24,15 @@ Roles
 Proxy = [Phantom]
 
 Diagnostics
-error[OverlappingInstances]: Overlapping type class instances found for: ShowP @k (a :: k)
-  --> 13:1..14:21
-   |
-13 | instance showPSecond :: ShowP a where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: forall k1 (a1 :: k1). ShowP @k1 (a1 :: k1) is matching
-  trivia: forall k (a :: k). ShowP @k (a :: k) is matching
+Error! · [OverlappingInstances] · Main.purs:13:1
+  •
+  │
+  • Overlapping type class instances found for: ShowP @k (a :: k)
+  │
+  │   instance showPSecond :: ShowP a where
+  │   ╰────────────────────────────────────
+  • while
+  │
+  │   forall k1 (a1 :: k1). ShowP @k1 (a1 :: k1) is matching
+  │   forall k (a :: k). ShowP @k (a :: k) is matching
+  •

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_synonym/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_synonym/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -23,10 +23,15 @@ instance Main.Convert Prim.String Main.Bar
 instance Main.Convert Prim.String Prim.String
 
 Diagnostics
-error[OverlappingInstances]: Overlapping type class instances found for: Convert String String
-  --> 11:1..12:16
-   |
-11 | instance convertSS :: Convert String String where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Convert String Bar is matching
-  trivia: Convert String String is matching
+Error! · [OverlappingInstances] · Main.purs:11:1
+  •
+  │
+  • Overlapping type class instances found for: Convert String String
+  │
+  │   instance convertSS :: Convert String String where
+  │   ╰────────────────────────────────────────────────
+  • while
+  │
+  │   Convert String Bar is matching
+  │   Convert String String is matching
+  •

--- a/tests-integration/fixtures/checking/1779972240_overlapping_instances_derive_no_use/Main.snap
+++ b/tests-integration/fixtures/checking/1779972240_overlapping_instances_derive_no_use/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -19,10 +19,15 @@ Roles
 Box = []
 
 Diagnostics
-error[OverlappingInstances]: Overlapping type class instances found for: Eq Box
-  --> 9:1..10:16
-  |
-9 | instance eqBox :: Eq Box where
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq Box is matching
-  trivia: Eq Box is matching
+Error! · [OverlappingInstances] · Main.purs:9:1
+  •
+  │
+  • Overlapping type class instances found for: Eq Box
+  │
+  │   instance eqBox :: Eq Box where
+  │   ╰─────────────────────────────
+  • while
+  │
+  │   Eq Box is matching
+  │   Eq Box is matching
+  •

--- a/tests-integration/fixtures/checking/1779972240_overlapping_instances_partial_no_use/Main.snap
+++ b/tests-integration/fixtures/checking/1779972240_overlapping_instances_partial_no_use/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -23,10 +23,15 @@ Roles
 Pair = [Representational, Representational]
 
 Diagnostics
-error[OverlappingInstances]: Overlapping type class instances found for: Test (Pair String b)
-  --> 11:1..12:13
-   |
-11 | instance testRight :: Test (Pair String b) where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: forall a. Test (Pair a Int) is matching
-  trivia: forall b. Test (Pair String b) is matching
+Error! · [OverlappingInstances] · Main.purs:11:1
+  •
+  │
+  • Overlapping type class instances found for: Test (Pair String b)
+  │
+  │   instance testRight :: Test (Pair String b) where
+  │   ╰───────────────────────────────────────────────
+  • while
+  │
+  │   forall a. Test (Pair a Int) is matching
+  │   forall b. Test (Pair String b) is matching
+  •

--- a/tests-integration/fixtures/checking/1780673760_do_final_let/Main.snap
+++ b/tests-integration/fixtures/checking/1780673760_do_final_let/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,13 +16,20 @@ Roles
 Effect = [Nominal]
 
 Diagnostics
-error[InvalidFinalLet]: Invalid final let statement in do expression
-  --> 11:3..11:36
-   |
-11 |   let _ = expectString record.field
-   |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Int' with 'String'
-  --> 11:24..11:36
-   |
-11 |   let _ = expectString record.field
-   |                        ^~~~~~~~~~~~
+Error! · [InvalidFinalLet] · Main.purs:11:3
+  •
+  │
+  • Invalid final let statement in do expression
+  │
+  │     let _ = expectString record.field
+  │     ╰────────────────────────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:11:24
+  •
+  │
+  • Cannot unify 'Int' with 'String'
+  │
+  │     let _ = expectString record.field
+  │                          ╰───────────
+  •

--- a/tests-integration/fixtures/checking/1781171580_typed_holes/Main.snap
+++ b/tests-integration/fixtures/checking/1781171580_typed_holes/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -23,28 +23,51 @@ Instances
 instance forall implicit. Main.InstanceTypeHole implicit
 
 Diagnostics
-error[TypeHole]: Type hole '?type' has inferred type: ?3 :: Type
-  --> 14:19..14:24
-   |
-14 | type TypeHole a = ?type :: Type
-   |                   ^~~~~
-  trivia: a :: t0 is in scope
-error[TermHole]: Hole '?term' has inferred type: Int
-  --> 12:5..12:10
-   |
-12 |     ?term
-   |     ^~~~~
-  trivia: argument :: Int is in scope
-  trivia: localInt :: Int is in scope
-error[TermHole]: Hole '?pun' has inferred type: Int
-  --> 17:39..17:43
-   |
-17 | recordPunHole { punInt, punString } = ?pun
-   |                                       ^~~~
-  trivia: punInt :: Int is in scope
-error[TypeHole]: Type hole '?implicit' has inferred type: implicit :: Type
-  --> 23:29..23:38
-   |
-23 |   instanceTypeHoleMember :: ?implicit -> implicit
-   |                             ^~~~~~~~~
-  trivia: implicit :: Type is in scope
+Error! · [TypeHole] · Main.purs:14:19
+  •
+  │
+  • Type hole '?type' has inferred type: ?3 :: Type
+  │
+  │   type TypeHole a = ?type :: Type
+  │                     ╰────
+  • while
+  │
+  │   a :: t0 is in scope
+  •
+
+Error! · [TermHole] · Main.purs:12:5
+  •
+  │
+  • Hole '?term' has inferred type: Int
+  │
+  │       ?term
+  │       ╰────
+  • while
+  │
+  │   argument :: Int is in scope
+  │   localInt :: Int is in scope
+  •
+
+Error! · [TermHole] · Main.purs:17:39
+  •
+  │
+  • Hole '?pun' has inferred type: Int
+  │
+  │   recordPunHole { punInt, punString } = ?pun
+  │                                         ╰───
+  • while
+  │
+  │   punInt :: Int is in scope
+  •
+
+Error! · [TypeHole] · Main.purs:23:29
+  •
+  │
+  • Type hole '?implicit' has inferred type: implicit :: Type
+  │
+  │     instanceTypeHoleMember :: ?implicit -> implicit
+  │                               ╰────────
+  • while
+  │
+  │   implicit :: Type is in scope
+  •

--- a/tests-integration/fixtures/checking/1781587680_typed_holes_constructors/Main.snap
+++ b/tests-integration/fixtures/checking/1781587680_typed_holes_constructors/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -24,28 +24,45 @@ Roles
 Option = []
 
 Diagnostics
-error[TermHole]: Hole '?help' has inferred type: Option
-  --> 11:10..11:15
-   |
-11 | option = ?help
-   |          ^~~~~
-  trivia: No :: Option is in scope
-  trivia: Yes :: Option is in scope
-  trivia: localOption :: Option is in scope
-  trivia: option :: Option is in scope
-error[TermHole]: Hole '?imported' has inferred type: ImportedOption
-  --> 14:12..14:21
-   |
-14 | imported = ?imported
-   |            ^~~~~~~~~
-  trivia: ImportedNo :: ImportedOption is in scope
-  trivia: ImportedYes :: ImportedOption is in scope
-  trivia: imported :: ImportedOption is in scope
-  trivia: importedOption :: ImportedOption is in scope
-error[TermHole]: Hole '?method' has inferred type: a -> Option
-  --> 20:10..20:17
-   |
-20 | method = ?method
-   |          ^~~~~~~
-  trivia: method :: forall a1. Select a1 => a1 -> Option is in scope
-  trivia: select :: forall @a2. Select a2 => a2 -> Option is in scope
+Error! · [TermHole] · Main.purs:11:10
+  •
+  │
+  • Hole '?help' has inferred type: Option
+  │
+  │   option = ?help
+  │            ╰────
+  • while
+  │
+  │   No :: Option is in scope
+  │   Yes :: Option is in scope
+  │   localOption :: Option is in scope
+  │   option :: Option is in scope
+  •
+
+Error! · [TermHole] · Main.purs:14:12
+  •
+  │
+  • Hole '?imported' has inferred type: ImportedOption
+  │
+  │   imported = ?imported
+  │              ╰────────
+  • while
+  │
+  │   ImportedNo :: ImportedOption is in scope
+  │   ImportedYes :: ImportedOption is in scope
+  │   imported :: ImportedOption is in scope
+  │   importedOption :: ImportedOption is in scope
+  •
+
+Error! · [TermHole] · Main.purs:20:10
+  •
+  │
+  • Hole '?method' has inferred type: a -> Option
+  │
+  │   method = ?method
+  │            ╰──────
+  • while
+  │
+  │   method :: forall a1. Select a1 => a1 -> Option is in scope
+  │   select :: forall @a2. Select a2 => a2 -> Option is in scope
+  •

--- a/tests-integration/fixtures/checking/1781589300_typed_holes_constructor_resolution/Main.snap
+++ b/tests-integration/fixtures/checking/1781589300_typed_holes_constructor_resolution/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -19,28 +19,45 @@ Roles
 Local = []
 
 Diagnostics
-error[TermHole]: Hole '?local' has inferred type: Local
-  --> 14:9..14:15
-   |
-14 | local = ?local
-   |         ^~~~~~
-  trivia: LocalOnly :: Local is in scope
-  trivia: Shared :: Local is in scope
-  trivia: local :: Local is in scope
-  trivia: localValue :: Local is in scope
-  trivia: shadowedValue :: Local is in scope
-error[TermHole]: Hole '?remote' has inferred type: Remote
-  --> 17:10..17:17
-   |
-17 | remote = ?remote
-   |          ^~~~~~~
-  trivia: RemoteOnly :: Remote is in scope
-  trivia: remote :: Remote is in scope
-  trivia: remoteValue :: Remote is in scope
-error[TermHole]: Hole '?binder' has inferred type: Remote
-  --> 20:28..20:35
-   |
-20 | binderShadow remoteValue = ?binder
-   |                            ^~~~~~~
-  trivia: RemoteOnly :: Remote is in scope
-  trivia: remote :: Remote is in scope
+Error! · [TermHole] · Main.purs:14:9
+  •
+  │
+  • Hole '?local' has inferred type: Local
+  │
+  │   local = ?local
+  │           ╰─────
+  • while
+  │
+  │   LocalOnly :: Local is in scope
+  │   Shared :: Local is in scope
+  │   local :: Local is in scope
+  │   localValue :: Local is in scope
+  │   shadowedValue :: Local is in scope
+  •
+
+Error! · [TermHole] · Main.purs:17:10
+  •
+  │
+  • Hole '?remote' has inferred type: Remote
+  │
+  │   remote = ?remote
+  │            ╰──────
+  • while
+  │
+  │   RemoteOnly :: Remote is in scope
+  │   remote :: Remote is in scope
+  │   remoteValue :: Remote is in scope
+  •
+
+Error! · [TermHole] · Main.purs:20:28
+  •
+  │
+  • Hole '?binder' has inferred type: Remote
+  │
+  │   binderShadow remoteValue = ?binder
+  │                              ╰──────
+  • while
+  │
+  │   RemoteOnly :: Remote is in scope
+  │   remote :: Remote is in scope
+  •

--- a/tests-integration/fixtures/checking/1781629500_instance_matching_kind_unification/Main.snap
+++ b/tests-integration/fixtures/checking/1781629500_instance_matching_kind_unification/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -25,8 +25,11 @@ instance forall (a :: Prim.Int).
 instance forall t0 t1 (a :: t0) (b :: t1). Main.Pick @t0 @t1 @t1 (a :: t0) (b :: t1) (b :: t1)
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'Type' with 'Int'
-  --> 15:1..15:37
-   |
-15 | x = choose (Proxy @Int) (Proxy @Int)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotUnify] · Main.purs:15:1
+  •
+  │
+  • Cannot unify 'Type' with 'Int'
+  │
+  │   x = choose (Proxy @Int) (Proxy @Int)
+  │   ╰───────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1781827200_overlapping_instances_functional_dependency/Main.snap
+++ b/tests-integration/fixtures/checking/1781827200_overlapping_instances_functional_dependency/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -18,10 +18,15 @@ instance Main.Convert Prim.String Prim.Int
 instance Main.Convert Prim.String Prim.Boolean
 
 Diagnostics
-error[OverlappingInstances]: Overlapping type class instances found for: Convert String Boolean
-  --> 9:1..10:19
-  |
-9 | instance convertSB :: Convert String Boolean where
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Convert String Int is matching
-  trivia: Convert String Boolean is matching
+Error! · [OverlappingInstances] · Main.purs:9:1
+  •
+  │
+  • Overlapping type class instances found for: Convert String Boolean
+  │
+  │   instance convertSB :: Convert String Boolean where
+  │   ╰─────────────────────────────────────────────────
+  • while
+  │
+  │   Convert String Int is matching
+  │   Convert String Boolean is matching
+  •

--- a/tests-integration/fixtures/checking/1784393160_defer_type_error_given_diagnostics/Main.snap
+++ b/tests-integration/fixtures/checking/1784393160_defer_type_error_given_diagnostics/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -21,13 +21,20 @@ Instances
 instance Main.Value Prim.Int
 
 Diagnostics
-error[CustomFailure]: failure was demanded
-  --> 14:1..14:18
-   |
-14 | useFailure :: Int
-   | ^~~~~~~~~~~~~~~~~
-warning[CustomWarning]: warning was demanded
-  --> 20:1..20:18
-   |
-20 | useWarning :: Int
-   | ^~~~~~~~~~~~~~~~~
+Error! · [CustomFailure] · Main.purs:14:1
+  •
+  │
+  • failure was demanded
+  │
+  │   useFailure :: Int
+  │   ╰────────────────
+  •
+
+Warning! · [CustomWarning] · Main.purs:20:1
+  •
+  │
+  • warning was demanded
+  │
+  │   useWarning :: Int
+  │   ╰────────────────
+  •

--- a/tests-integration/fixtures/checking/1784457540_value_mutual_infer_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_mutual_infer_constraint/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,17 +16,28 @@ class forall (a :: Prim.Type). Main.Semigroup a
   append :: forall @a. Main.Semigroup a => a -> a -> a
 
 Diagnostics
-error[CannotGeneraliseRecursiveFunction]: Unable to generalise the type of this recursive function.
-  --> 8:1..8:42
-  |
-8 | second value = append value (first value)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: The inferred type was: forall t0. Semigroup t0 => t0 -> t0
-  trivia: Try adding a type signature.
-error[CannotGeneraliseRecursiveFunction]: Unable to generalise the type of this recursive function.
-  --> 6:1..6:42
-  |
-6 | first value = append value (second value)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: The inferred type was: forall t0. Semigroup t0 => t0 -> t0
-  trivia: Try adding a type signature.
+Error! · [CannotGeneraliseRecursiveFunction] · Main.purs:8:1
+  •
+  │
+  • Unable to generalise the type of this recursive function.
+  │
+  │   second value = append value (first value)
+  │   ╰────────────────────────────────────────
+  • while
+  │
+  │   The inferred type was: forall t0. Semigroup t0 => t0 -> t0
+  │   Try adding a type signature.
+  •
+
+Error! · [CannotGeneraliseRecursiveFunction] · Main.purs:6:1
+  •
+  │
+  • Unable to generalise the type of this recursive function.
+  │
+  │   first value = append value (second value)
+  │   ╰────────────────────────────────────────
+  • while
+  │
+  │   The inferred type was: forall t0. Semigroup t0 => t0 -> t0
+  │   Try adding a type signature.
+  •

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_infer_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_infer_constraint/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -15,10 +15,15 @@ class forall (a :: Prim.Type). Main.Semigroup a
   append :: forall @a. Main.Semigroup a => a -> a -> a
 
 Diagnostics
-error[CannotGeneraliseRecursiveFunction]: Unable to generalise the type of this recursive function.
-  --> 6:1..6:39
-  |
-6 | test value = append value (test value)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: The inferred type was: forall t0. Semigroup t0 => t0 -> t0
-  trivia: Try adding a type signature.
+Error! · [CannotGeneraliseRecursiveFunction] · Main.purs:6:1
+  •
+  │
+  • Unable to generalise the type of this recursive function.
+  │
+  │   test value = append value (test value)
+  │   ╰─────────────────────────────────────
+  • while
+  │
+  │   The inferred type was: forall t0. Semigroup t0 => t0 -> t0
+  │   Try adding a type signature.
+  •

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_infer_partial/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_infer_partial/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -10,10 +10,15 @@ test :: Prim.Partial => Prim.Int
 Types
 
 Diagnostics
-error[CannotGeneraliseRecursiveFunction]: Unable to generalise the type of this recursive function.
-  --> 6:1..6:43
-  |
-6 | test = if true then test else partialValue
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: The inferred type was: Partial => Int
-  trivia: Try adding a type signature.
+Error! · [CannotGeneraliseRecursiveFunction] · Main.purs:6:1
+  •
+  │
+  • Unable to generalise the type of this recursive function.
+  │
+  │   test = if true then test else partialValue
+  │   ╰─────────────────────────────────────────
+  • while
+  │
+  │   The inferred type was: Partial => Int
+  │   Try adding a type signature.
+  •

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_inferred_fail/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_inferred_fail/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -10,8 +10,11 @@ test :: Prim.Int
 Types
 
 Diagnostics
-error[CustomFailure]: failure was demanded
-  --> 8:1..8:45
-  |
-8 | test = if true then test else guardedFailure
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CustomFailure] · Main.purs:8:1
+  •
+  │
+  • failure was demanded
+  │
+  │   test = if true then test else guardedFailure
+  │   ╰───────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1784740680_instance_superclass_missing/Main.snap
+++ b/tests-integration/fixtures/checking/1784740680_instance_superclass_missing/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -22,8 +22,11 @@ Roles
 Missing = []
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Parent Missing
-  --> 11:1..11:23
-   |
-11 | instance Child Missing
-   | ^~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:11:1
+  •
+  │
+  • No instance found for: Parent Missing
+  │
+  │   instance Child Missing
+  │   ╰─────────────────────
+  •

--- a/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Main.snap
+++ b/tests-integration/fixtures/checking/1784807160_derive_class_arity_validation/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -31,63 +31,110 @@ Roles
 Pair = [Representational, Representational]
 
 Diagnostics
-error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
-  --> 16:1..16:28
-   |
-16 | derive instance Eq Pair Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
-  --> 17:1..17:29
-   |
-17 | derive instance Ord Pair Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
-  --> 18:1..18:33
-   |
-18 | derive instance Functor Pair Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
-  --> 19:1..19:35
-   |
-19 | derive instance Bifunctor Pair Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
-  --> 20:1..20:34
-   |
-20 | derive instance Foldable Pair Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
-  --> 21:1..21:36
-   |
-21 | derive instance Bifoldable Pair Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
-  --> 22:1..22:37
-   |
-22 | derive instance Traversable Pair Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
-  --> 23:1..23:39
-   |
-23 | derive instance Bitraversable Pair Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
-  --> 24:1..24:39
-   |
-24 | derive instance Contravariant Pair Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
-  --> 25:1..25:36
-   |
-25 | derive instance Profunctor Pair Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
-  --> 26:1..26:29
-   |
-26 | derive instance Eq1 Pair Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 2
-  --> 27:1..27:30
-   |
-27 | derive instance Ord1 Pair Int
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [DeriveInvalidArity] · Main.purs:16:1
+  •
+  │
+  • Invalid arity for derive: expected 1, got 2
+  │
+  │   derive instance Eq Pair Int
+  │   ╰──────────────────────────
+  •
+
+Error! · [DeriveInvalidArity] · Main.purs:17:1
+  •
+  │
+  • Invalid arity for derive: expected 1, got 2
+  │
+  │   derive instance Ord Pair Int
+  │   ╰───────────────────────────
+  •
+
+Error! · [DeriveInvalidArity] · Main.purs:18:1
+  •
+  │
+  • Invalid arity for derive: expected 1, got 2
+  │
+  │   derive instance Functor Pair Int
+  │   ╰───────────────────────────────
+  •
+
+Error! · [DeriveInvalidArity] · Main.purs:19:1
+  •
+  │
+  • Invalid arity for derive: expected 1, got 2
+  │
+  │   derive instance Bifunctor Pair Int
+  │   ╰─────────────────────────────────
+  •
+
+Error! · [DeriveInvalidArity] · Main.purs:20:1
+  •
+  │
+  • Invalid arity for derive: expected 1, got 2
+  │
+  │   derive instance Foldable Pair Int
+  │   ╰────────────────────────────────
+  •
+
+Error! · [DeriveInvalidArity] · Main.purs:21:1
+  •
+  │
+  • Invalid arity for derive: expected 1, got 2
+  │
+  │   derive instance Bifoldable Pair Int
+  │   ╰──────────────────────────────────
+  •
+
+Error! · [DeriveInvalidArity] · Main.purs:22:1
+  •
+  │
+  • Invalid arity for derive: expected 1, got 2
+  │
+  │   derive instance Traversable Pair Int
+  │   ╰───────────────────────────────────
+  •
+
+Error! · [DeriveInvalidArity] · Main.purs:23:1
+  •
+  │
+  • Invalid arity for derive: expected 1, got 2
+  │
+  │   derive instance Bitraversable Pair Int
+  │   ╰─────────────────────────────────────
+  •
+
+Error! · [DeriveInvalidArity] · Main.purs:24:1
+  •
+  │
+  • Invalid arity for derive: expected 1, got 2
+  │
+  │   derive instance Contravariant Pair Int
+  │   ╰─────────────────────────────────────
+  •
+
+Error! · [DeriveInvalidArity] · Main.purs:25:1
+  •
+  │
+  • Invalid arity for derive: expected 1, got 2
+  │
+  │   derive instance Profunctor Pair Int
+  │   ╰──────────────────────────────────
+  •
+
+Error! · [DeriveInvalidArity] · Main.purs:26:1
+  •
+  │
+  • Invalid arity for derive: expected 1, got 2
+  │
+  │   derive instance Eq1 Pair Int
+  │   ╰───────────────────────────
+  •
+
+Error! · [DeriveInvalidArity] · Main.purs:27:1
+  •
+  │
+  • Invalid arity for derive: expected 1, got 2
+  │
+  │   derive instance Ord1 Pair Int
+  │   ╰────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1785133080_reject_eq_derive_for_foreign_data/Main.snap
+++ b/tests-integration/fixtures/checking/1785133080_reject_eq_derive_for_foreign_data/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,13 +16,20 @@ Roles
 Opaque = []
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: Opaque
-  --> 8:1..8:26
-  |
-8 | derive instance Eq Opaque
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: Opaque
-  --> 9:1..9:27
-  |
-9 | derive instance Ord Opaque
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveForType] · Main.purs:8:1
+  •
+  │
+  • Cannot derive for type: Opaque
+  │
+  │   derive instance Eq Opaque
+  │   ╰────────────────────────
+  •
+
+Error! · [CannotDeriveForType] · Main.purs:9:1
+  •
+  │
+  • Cannot derive for type: Opaque
+  │
+  │   derive instance Ord Opaque
+  │   ╰─────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.snap
+++ b/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,33 +16,56 @@ derive Data.Eq.Eq1 Library.ImportedOpaque
 derive Data.Ord.Ord1 Library.ImportedOpaque
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: ImportedStructural a
-  --> 7:1..7:50
-  |
-7 | derive instance Eq a => Eq (ImportedStructural a)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: ImportedStructural a1
-  --> 8:1..8:52
-  |
-8 | derive instance Ord a => Ord (ImportedStructural a)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: ImportedLifted
-  --> 10:1..10:35
-   |
-10 | derive instance Eq1 ImportedLifted
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: ImportedLifted
-  --> 11:1..11:36
-   |
-11 | derive instance Ord1 ImportedLifted
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: ImportedOpaque
-  --> 13:1..13:35
-   |
-13 | derive instance Eq1 ImportedOpaque
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: ImportedOpaque
-  --> 14:1..14:36
-   |
-14 | derive instance Ord1 ImportedOpaque
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveForType] · Main.purs:7:1
+  •
+  │
+  • Cannot derive for type: ImportedStructural a
+  │
+  │   derive instance Eq a => Eq (ImportedStructural a)
+  │   ╰────────────────────────────────────────────────
+  •
+
+Error! · [CannotDeriveForType] · Main.purs:8:1
+  •
+  │
+  • Cannot derive for type: ImportedStructural a1
+  │
+  │   derive instance Ord a => Ord (ImportedStructural a)
+  │   ╰──────────────────────────────────────────────────
+  •
+
+Error! · [CannotDeriveForType] · Main.purs:10:1
+  •
+  │
+  • Cannot derive for type: ImportedLifted
+  │
+  │   derive instance Eq1 ImportedLifted
+  │   ╰─────────────────────────────────
+  •
+
+Error! · [CannotDeriveForType] · Main.purs:11:1
+  •
+  │
+  • Cannot derive for type: ImportedLifted
+  │
+  │   derive instance Ord1 ImportedLifted
+  │   ╰──────────────────────────────────
+  •
+
+Error! · [CannotDeriveForType] · Main.purs:13:1
+  •
+  │
+  • Cannot derive for type: ImportedOpaque
+  │
+  │   derive instance Eq1 ImportedOpaque
+  │   ╰─────────────────────────────────
+  •
+
+Error! · [CannotDeriveForType] · Main.purs:14:1
+  •
+  │
+  • Cannot derive for type: ImportedOpaque
+  │
+  │   derive instance Ord1 ImportedOpaque
+  │   ╰──────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1785319620_derive_bifunctor_captured_application_argument/Main.snap
+++ b/tests-integration/fixtures/checking/1785319620_derive_bifunctor_captured_application_argument/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -27,13 +27,20 @@ Outer = [Representational, Representational]
 NestedCaptured = [Representational, Representational]
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: Triple t0 Int t1
-  --> 8:1..8:35
-  |
-8 | derive instance Bifunctor Captured
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: Outer (Triple t2 Int Boolean) t3
-  --> 13:1..13:41
-   |
-13 | derive instance Bifunctor NestedCaptured
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveForType] · Main.purs:8:1
+  •
+  │
+  • Cannot derive for type: Triple t0 Int t1
+  │
+  │   derive instance Bifunctor Captured
+  │   ╰─────────────────────────────────
+  •
+
+Error! · [CannotDeriveForType] · Main.purs:13:1
+  •
+  │
+  • Cannot derive for type: Outer (Triple t2 Int Boolean) t3
+  │
+  │   derive instance Bifunctor NestedCaptured
+  │   ╰───────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1785319620_derive_bifunctor_explicit_function_variance/Main.snap
+++ b/tests-integration/fixtures/checking/1785319620_derive_bifunctor_explicit_function_variance/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -20,13 +20,20 @@ ArrowSyntax = [Representational, Representational]
 ArrowConstructor = [Representational, Representational]
 
 Diagnostics
-error[ContravariantOccurrence]: Type variable occurs in contravariant position: t0
-  --> 6:1..6:38
-  |
-6 | derive instance Bifunctor ArrowSyntax
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[ContravariantOccurrence]: Type variable occurs in contravariant position: t1
-  --> 9:1..9:43
-  |
-9 | derive instance Bifunctor ArrowConstructor
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [ContravariantOccurrence] · Main.purs:6:1
+  •
+  │
+  • Type variable occurs in contravariant position: t0
+  │
+  │   derive instance Bifunctor ArrowSyntax
+  │   ╰────────────────────────────────────
+  •
+
+Error! · [ContravariantOccurrence] · Main.purs:9:1
+  •
+  │
+  • Type variable occurs in contravariant position: t1
+  │
+  │   derive instance Bifunctor ArrowConstructor
+  │   ╰─────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1785319980_preserve_unary_variance_application_checks/Main.snap
+++ b/tests-integration/fixtures/checking/1785319980_preserve_unary_variance_application_checks/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -27,13 +27,20 @@ Wrapped = [Representational, Representational]
 Wrong = [Representational, Nominal, Phantom]
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: (f :: Type -> Type) (t0 -> Int)
-  --> 7:1..7:42
-  |
-7 | derive instance Contravariant (Wrapped f)
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: (f1 :: Type -> Type) t1
-  --> 10:1..10:37
-   |
-10 | derive instance Profunctor (Wrong f)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveForType] · Main.purs:7:1
+  •
+  │
+  • Cannot derive for type: (f :: Type -> Type) (t0 -> Int)
+  │
+  │   derive instance Contravariant (Wrapped f)
+  │   ╰────────────────────────────────────────
+  •
+
+Error! · [CannotDeriveForType] · Main.purs:10:1
+  •
+  │
+  • Cannot derive for type: (f1 :: Type -> Type) t1
+  │
+  │   derive instance Profunctor (Wrong f)
+  │   ╰───────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1785484200_derive_traversable_function_rejection/Main.snap
+++ b/tests-integration/fixtures/checking/1785484200_derive_traversable_function_rejection/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -20,8 +20,11 @@ Roles
 Reader = [Representational]
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: Int -> t0
-  --> 16:1..16:35
-   |
-16 | derive instance Traversable Reader
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveForType] · Main.purs:16:1
+  •
+  │
+  • Cannot derive for type: Int -> t0
+  │
+  │   derive instance Traversable Reader
+  │   ╰─────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1785518760_derive_bifoldable_function_rejection/Main.snap
+++ b/tests-integration/fixtures/checking/1785518760_derive_bifoldable_function_rejection/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,8 +16,11 @@ Roles
 ReaderPair = [Representational, Representational]
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: Int -> t0
-  --> 6:1..6:38
-  |
-6 | derive instance Bifoldable ReaderPair
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveForType] · Main.purs:6:1
+  •
+  │
+  • Cannot derive for type: Int -> t0
+  │
+  │   derive instance Bifoldable ReaderPair
+  │   ╰────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1785518760_derive_foldable_function_rejection/Main.snap
+++ b/tests-integration/fixtures/checking/1785518760_derive_foldable_function_rejection/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,8 +16,11 @@ Roles
 Reader = [Representational]
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: Int -> t0
-  --> 6:1..6:32
-  |
-6 | derive instance Foldable Reader
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveForType] · Main.purs:6:1
+  •
+  │
+  • Cannot derive for type: Int -> t0
+  │
+  │   derive instance Foldable Reader
+  │   ╰──────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1785598200_derive_contravariant_captured_application_head/Main.snap
+++ b/tests-integration/fixtures/checking/1785598200_derive_contravariant_captured_application_head/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -24,8 +24,11 @@ Triple = [Phantom, Phantom, Phantom]
 Captured = [Representational]
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: Triple @Type @Type @Type t0 Int String
-  --> 8:1..8:39
-  |
-8 | derive instance Contravariant Captured
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveForType] · Main.purs:8:1
+  •
+  │
+  • Cannot derive for type: Triple @Type @Type @Type t0 Int String
+  │
+  │   derive instance Contravariant Captured
+  │   ╰─────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1785598200_derive_contravariant_missing_traversal_instance/Main.snap
+++ b/tests-integration/fixtures/checking/1785598200_derive_contravariant_missing_traversal_instance/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -19,8 +19,11 @@ Opaque = [Representational]
 Wrapped = [Representational]
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: Opaque (t0 -> Int)
-  --> 8:1..8:38
-  |
-8 | derive instance Contravariant Wrapped
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotDeriveForType] · Main.purs:8:1
+  •
+  │
+  • Cannot derive for type: Opaque (t0 -> Int)
+  │
+  │   derive instance Contravariant Wrapped
+  │   ╰────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1785598200_derive_contravariant_nested_parity_rejection/Main.snap
+++ b/tests-integration/fixtures/checking/1785598200_derive_contravariant_nested_parity_rejection/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -20,8 +20,11 @@ Predicate = [Representational]
 DoubleNegative = [Representational]
 
 Diagnostics
-error[CovariantOccurrence]: Type variable occurs in covariant position: t0
-  --> 9:1..9:45
-  |
-9 | derive instance Contravariant DoubleNegative
-  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CovariantOccurrence] · Main.purs:9:1
+  •
+  │
+  • Type variable occurs in covariant position: t0
+  │
+  │   derive instance Contravariant DoubleNegative
+  │   ╰───────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1785598200_derive_profunctor_bifunctor_priority_rejection/Main.snap
+++ b/tests-integration/fixtures/checking/1785598200_derive_profunctor_bifunctor_priority_rejection/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -20,8 +20,11 @@ Pair = [Representational, Representational]
 Nested = [Representational, Representational]
 
 Diagnostics
-error[CovariantOccurrence]: Type variable occurs in covariant position: t0
-  --> 10:1..10:34
-   |
-10 | derive instance Profunctor Nested
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [CovariantOccurrence] · Main.purs:10:1
+  •
+  │
+  • Type variable occurs in covariant position: t0
+  │
+  │   derive instance Profunctor Nested
+  │   ╰────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1786015260_missing_instance_members/Main.snap
+++ b/tests-integration/fixtures/checking/1786015260_missing_instance_members/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -21,16 +21,27 @@ instance Prim.TypeError.Fail (Prim.TypeError.Text "empty") => Main.Render Prim.B
 instance Prim.TypeError.Fail (Prim.TypeError.Text "partial") => Main.Render Prim.String
 
 Diagnostics
-warning[MissingInstanceMembers]: Instance is missing class members
-  --> 9:1..9:20
-  |
-9 | instance Render Int
-  | ^~~~~~~~~~~~~~~~~~~
-  trivia: render is not implemented
-  trivia: renderWithIndent is not implemented
-warning[MissingInstanceMembers]: Instance is missing class members
-  --> 13:1..14:23
-   |
-13 | instance Fail (Text "partial") => Render String where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: renderWithIndent is not implemented
+Warning! · [MissingInstanceMembers] · Main.purs:9:1
+  •
+  │
+  • Instance is missing class members
+  │
+  │   instance Render Int
+  │   ╰──────────────────
+  • while
+  │
+  │   render is not implemented
+  │   renderWithIndent is not implemented
+  •
+
+Warning! · [MissingInstanceMembers] · Main.purs:13:1
+  •
+  │
+  • Instance is missing class members
+  │
+  │   instance Fail (Text "partial") => Render String where
+  │   ╰────────────────────────────────────────────────────
+  • while
+  │
+  │   renderWithIndent is not implemented
+  •

--- a/tests-integration/fixtures/checking/1786028940_unresolved_instance_class/Main.snap
+++ b/tests-integration/fixtures/checking/1786028940_unresolved_instance_class/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -8,13 +8,20 @@ Terms
 Types
 
 Diagnostics
-error[NotInScope]: 'Functor' is not in scope
-  --> 3:10..3:17
-  |
-3 | instance Functor Array where
-  |          ^~~~~~~
-error[NotInScope]: 'Missing.Functor' is not in scope
-  --> 5:10..5:25
-  |
-5 | instance Missing.Functor Array where
-  |          ^~~~~~~~~~~~~~~
+Error! · [NotInScope] · Main.purs:3:10
+  •
+  │
+  • 'Functor' is not in scope
+  │
+  │   instance Functor Array where
+  │            ╰──────
+  •
+
+Error! · [NotInScope] · Main.purs:5:10
+  •
+  │
+  • 'Missing.Functor' is not in scope
+  │
+  │   instance Missing.Functor Array where
+  │            ╰──────────────
+  •

--- a/tests-integration/fixtures/checking/1786297500_nested_abstraction_scoping/Main.snap
+++ b/tests-integration/fixtures/checking/1786297500_nested_abstraction_scoping/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -18,13 +18,20 @@ class forall (a :: Prim.Type). Main.Eq a
   show :: forall @a. Main.Eq a => a -> Prim.String
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Eq a
-  --> 7:1..11:7
-  |
-7 | evidenceDoesNotEscape
-  | ^~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable 'a1' has escaped its scope, appearing in type 'a1'
-  --> 19:1..19:55
-   |
-19 | typeDoesNotEscape = consume { value: \value -> value }
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:7:1
+  •
+  │
+  • No instance found for: Eq a
+  │
+  │   evidenceDoesNotEscape
+  │   ╰────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:19:1
+  •
+  │
+  • Type variable 'a1' has escaped its scope, appearing in type 'a1'
+  │
+  │   typeDoesNotEscape = consume { value: \value -> value }
+  │   ╰─────────────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1786461240_lambda_against_non_function_expected_type/Main.snap
+++ b/tests-integration/fixtures/checking/1786461240_lambda_against_non_function_expected_type/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -15,8 +15,11 @@ Roles
 Unit = []
 
 Diagnostics
-error[CannotUnify]: Cannot unify '?0 -> Int' with 'Int'
-  --> 8:17..8:28
-  |
-8 | test = consume (\value -> 0)
-  |                 ^~~~~~~~~~~
+Error! · [CannotUnify] · Main.purs:8:17
+  •
+  │
+  • Cannot unify '?0 -> Int' with 'Int'
+  │
+  │   test = consume (\value -> 0)
+  │                   ╰──────────
+  •

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_constraint/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -19,8 +19,11 @@ Roles
 Unit = []
 
 Diagnostics
-error[CannotUnify]: Cannot unify '?0 -> Int' with 'Int'
-  --> 11:16..11:29
-   |
-11 | test = consume \_ extra -> 0
-   |                ^~~~~~~~~~~~~
+Error! · [CannotUnify] · Main.purs:11:16
+  •
+  │
+  • Cannot unify '?0 -> Int' with 'Int'
+  │
+  │   test = consume \_ extra -> 0
+  │                  ╰────────────
+  •

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_forall/Main.snap
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_forall/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -18,18 +18,29 @@ Unit = []
 Proxy = [Phantom]
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'Function ?1' with 'Proxy'
-  --> 11:16..11:33
-   |
-11 | test = consume \_ extra -> Proxy
-   |                ^~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Function ?1 (Proxy ?3)' with 'Proxy value'
-  --> 11:16..11:33
-   |
-11 | test = consume \_ extra -> Proxy
-   |                ^~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify '?1 -> Proxy ?3' with 'Proxy value'
-  --> 11:16..11:33
-   |
-11 | test = consume \_ extra -> Proxy
-   |                ^~~~~~~~~~~~~~~~~
+Error! · [CannotUnify] · Main.purs:11:16
+  •
+  │
+  • Cannot unify 'Function ?1' with 'Proxy'
+  │
+  │   test = consume \_ extra -> Proxy
+  │                  ╰────────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:11:16
+  •
+  │
+  • Cannot unify 'Function ?1 (Proxy ?3)' with 'Proxy value'
+  │
+  │   test = consume \_ extra -> Proxy
+  │                  ╰────────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:11:16
+  •
+  │
+  • Cannot unify '?1 -> Proxy ?3' with 'Proxy value'
+  │
+  │   test = consume \_ extra -> Proxy
+  │                  ╰────────────────
+  •

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_function/Main.snap
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_function/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -15,8 +15,11 @@ Roles
 Unit = []
 
 Diagnostics
-error[CannotUnify]: Cannot unify '?0 -> Int' with 'Int'
-  --> 8:16..8:37
-  |
-8 | test = consume \value extra -> value
-  |                ^~~~~~~~~~~~~~~~~~~~~
+Error! · [CannotUnify] · Main.purs:8:16
+  •
+  │
+  • Cannot unify '?0 -> Int' with 'Int'
+  │
+  │   test = consume \value extra -> value
+  │                  ╰────────────────────
+  •

--- a/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_interleaved_forall_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1786461240_lambda_excess_binder_after_interleaved_forall_constraint/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -22,18 +22,29 @@ Unit = []
 Proxy = [Phantom]
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'Function ?1' with 'Proxy'
-  --> 15:16..15:33
-   |
-15 | test = consume \_ extra -> Proxy
-   |                ^~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Function ?1 (Proxy ?3)' with 'Proxy value'
-  --> 15:16..15:33
-   |
-15 | test = consume \_ extra -> Proxy
-   |                ^~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify '?1 -> Proxy ?3' with 'Proxy value'
-  --> 15:16..15:33
-   |
-15 | test = consume \_ extra -> Proxy
-   |                ^~~~~~~~~~~~~~~~~
+Error! · [CannotUnify] · Main.purs:15:16
+  •
+  │
+  • Cannot unify 'Function ?1' with 'Proxy'
+  │
+  │   test = consume \_ extra -> Proxy
+  │                  ╰────────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:15:16
+  •
+  │
+  • Cannot unify 'Function ?1 (Proxy ?3)' with 'Proxy value'
+  │
+  │   test = consume \_ extra -> Proxy
+  │                  ╰────────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:15:16
+  •
+  │
+  • Cannot unify '?1 -> Proxy ?3' with 'Proxy value'
+  │
+  │   test = consume \_ extra -> Proxy
+  │                  ╰────────────────
+  •

--- a/tests-integration/fixtures/checking/1786504980_derive_newtype_missing_delegated_subclass/Main.snap
+++ b/tests-integration/fixtures/checking/1786504980_derive_newtype_missing_delegated_subclass/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -29,8 +29,11 @@ Representation = []
 Wrapper = []
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Child @Type Representation
-  --> 15:1..15:38
-   |
-15 | derive newtype instance Child Wrapper
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:15:1
+  •
+  │
+  • No instance found for: Child @Type Representation
+  │
+  │   derive newtype instance Child Wrapper
+  │   ╰────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1786505040_derive_lifted_foreign_ownership_boundaries/Main.snap
+++ b/tests-integration/fixtures/checking/1786505040_derive_lifted_foreign_ownership_boundaries/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -34,29 +34,50 @@ NoBase = [Nominal]
 Product = [Representational, Representational]
 
 Diagnostics
-error[CannotDeriveForType]: Cannot derive for type: ImportedAlias
-  --> 17:1..17:34
-   |
-17 | derive instance Eq1 ImportedAlias
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[PartialSynonymApplication]: Partial type synonym application
-  --> 27:21..27:31
-   |
-27 | derive instance Eq1 ProductInt
-   |                     ^~~~~~~~~~
-error[CannotUnify]: Cannot unify '?[partial synonym application]' with 'Type -> Type'
-  --> 27:21..27:31
-   |
-27 | derive instance Eq1 ProductInt
-   |                     ^~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: ?[partial synonym application]
-  --> 27:1..27:31
-   |
-27 | derive instance Eq1 ProductInt
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: Eq (NoBase t0)
-  --> 21:1..21:27
-   |
-21 | derive instance Eq1 NoBase
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq t0 is in scope
+Error! · [CannotDeriveForType] · Main.purs:17:1
+  •
+  │
+  • Cannot derive for type: ImportedAlias
+  │
+  │   derive instance Eq1 ImportedAlias
+  │   ╰────────────────────────────────
+  •
+
+Error! · [PartialSynonymApplication] · Main.purs:27:21
+  •
+  │
+  • Partial type synonym application
+  │
+  │   derive instance Eq1 ProductInt
+  │                       ╰─────────
+  •
+
+Error! · [CannotUnify] · Main.purs:27:21
+  •
+  │
+  • Cannot unify '?[partial synonym application]' with 'Type -> Type'
+  │
+  │   derive instance Eq1 ProductInt
+  │                       ╰─────────
+  •
+
+Error! · [CannotDeriveForType] · Main.purs:27:1
+  •
+  │
+  • Cannot derive for type: ?[partial synonym application]
+  │
+  │   derive instance Eq1 ProductInt
+  │   ╰─────────────────────────────
+  •
+
+Error! · [NoInstanceFound] · Main.purs:21:1
+  •
+  │
+  • No instance found for: Eq (NoBase t0)
+  │
+  │   derive instance Eq1 NoBase
+  │   ╰─────────────────────────
+  • while
+  │
+  │   Eq t0 is in scope
+  •

--- a/tests-integration/fixtures/checking/1786550220_expression_operator_constraint_scope_isolation/Main.snap
+++ b/tests-integration/fixtures/checking/1786550220_expression_operator_constraint_scope_isolation/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -17,8 +17,11 @@ Classes
 class forall (t0 :: Prim.Type) (a :: t0). Main.First @t0 (a :: t0)
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: First @Type Int
-  --> 16:1..16:12
-   |
-16 | test :: Int
-   | ^~~~~~~~~~~
+Error! · [NoInstanceFound] · Main.purs:16:1
+  •
+  │
+  • No instance found for: First @Type Int
+  │
+  │   test :: Int
+  │   ╰──────────
+  •

--- a/tests-integration/fixtures/checking/1786636800_expected_forall_skolem_escape/Main.snap
+++ b/tests-integration/fixtures/checking/1786636800_expected_forall_skolem_escape/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -85,33 +85,61 @@ Proxy = [Phantom]
 Map = [Phantom, Phantom]
 
 Diagnostics
-error[EscapedSkolem]: Type variable '(scope :: t0)' has escaped its scope, appearing in type 'forall t0. Token @t0 (scope :: t0)'
-  --> 99:1..99:28
-   |
-99 | escapedResult = leak modify
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable 'value' has escaped its scope, appearing in type '(value -> value) -> Unit'
-  --> 101:1..101:54
-    |
-101 | escapedBinder = \callback -> consumeIdentity callback
-    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope1 :: t1)' has escaped its scope, appearing in type 'forall t1. Token @t1 (scope1 :: t1)'
-  --> 103:1..103:42
-    |
-103 | escapedNestedUse = identity (leak modify)
-    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope2 :: t2)' has escaped its scope, appearing in type 'forall t3 t2. t3 -> Token @t2 (scope2 :: t2)'
-  --> 105:1..105:46
-    |
-105 | escapedDiscardedOuterArgument _ = leak modify
-    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope3 :: ?111)' has escaped its scope, appearing in type 'Token @?111 (scope3 :: ?111)'
-  --> 107:1..107:33
-    |
-107 | escapedDiscardedArgument :: Unit
-    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope4 :: t4)' has escaped its scope, appearing in type 'forall t4 t5 (t6 :: t5). EscapingEvidence @t4 @t5 (scope4 :: t4) (t6 :: t5) => Proxy @t5 (t6 :: t5)'
-  --> 110:1..110:46
-    |
-110 | escapedEvidenceOnly = leak pokeWithoutWitness
-    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [EscapedSkolem] · Main.purs:99:1
+  •
+  │
+  • Type variable '(scope :: t0)' has escaped its scope, appearing in type 'forall t0. Token @t0
+  │ (scope :: t0)'
+  │
+  │   escapedResult = leak modify
+  │   ╰──────────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:101:1
+  •
+  │
+  • Type variable 'value' has escaped its scope, appearing in type '(value -> value) -> Unit'
+  │
+  │   escapedBinder = \callback -> consumeIdentity callback
+  │   ╰────────────────────────────────────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:103:1
+  •
+  │
+  • Type variable '(scope1 :: t1)' has escaped its scope, appearing in type 'forall t1. Token @t1
+  │ (scope1 :: t1)'
+  │
+  │   escapedNestedUse = identity (leak modify)
+  │   ╰────────────────────────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:105:1
+  •
+  │
+  • Type variable '(scope2 :: t2)' has escaped its scope, appearing in type 'forall t3 t2. t3 ->
+  │ Token @t2 (scope2 :: t2)'
+  │
+  │   escapedDiscardedOuterArgument _ = leak modify
+  │   ╰────────────────────────────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:107:1
+  •
+  │
+  • Type variable '(scope3 :: ?111)' has escaped its scope, appearing in type 'Token @?111
+  │ (scope3 :: ?111)'
+  │
+  │   escapedDiscardedArgument :: Unit
+  │   ╰───────────────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:110:1
+  •
+  │
+  • Type variable '(scope4 :: t4)' has escaped its scope, appearing in type 'forall t4 t5 (t6 ::
+  │ t5). EscapingEvidence @t4 @t5 (scope4 :: t4) (t6 :: t5) => Proxy @t5 (t6 :: t5)'
+  │
+  │   escapedEvidenceOnly = leak pokeWithoutWitness
+  │   ╰────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1786636860_expected_forall_local_bindings/Main.snap
+++ b/tests-integration/fixtures/checking/1786636860_expected_forall_local_bindings/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -41,38 +41,70 @@ Spec = []
 Token = [Phantom]
 
 Diagnostics
-error[EscapedSkolem]: Type variable '(scope :: t0)' has escaped its scope, appearing in type 'Token @t0 (scope :: t0)'
-  --> 54:3..54:24
-   |
-54 |   escaped = leak modify
-   |   ^~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope1 :: ?61)' has escaped its scope, appearing in type 'Token @?61 (scope1 :: ?61)'
-  --> 67:3..67:24
-   |
-67 |   escaped = leak modify
-   |   ^~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable 'value' has escaped its scope, appearing in type 'Witness @Type value'
-  --> 50:3..50:30
-   |
-50 |   eval = constrainedEval Spec
-   |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope2 :: t1)' has escaped its scope, appearing in type 'forall t1. Token @t1 (scope2 :: t1)'
-  --> 56:1..56:52
-   |
-56 | escapedEtaExpansion = leak (\token -> modify token)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope3 :: t2)' has escaped its scope, appearing in type 'forall t2. Token @t2 (scope3 :: t2)'
-  --> 58:1..58:48
-   |
-58 | escapedIdentityWrapper = identity (leak modify)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope4 :: t3)' has escaped its scope, appearing in type 'forall t3. Array (Token @t3 (scope4 :: t3))'
-  --> 60:1..60:36
-   |
-60 | escapedArrayWrapper = [leak modify]
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope5 :: t4)' has escaped its scope, appearing in type 'forall t4. Token @t4 (scope5 :: t4)'
-  --> 62:1..62:89
-   |
-62 | escapedConditionalWrapper = leak (\token -> if true then modify token else modify token)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [EscapedSkolem] · Main.purs:54:3
+  •
+  │
+  • Type variable '(scope :: t0)' has escaped its scope, appearing in type 'Token @t0 (scope :: t0)'
+  │
+  │     escaped = leak modify
+  │     ╰────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:67:3
+  •
+  │
+  • Type variable '(scope1 :: ?61)' has escaped its scope, appearing in type 'Token @?61
+  │ (scope1 :: ?61)'
+  │
+  │     escaped = leak modify
+  │     ╰────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:50:3
+  •
+  │
+  • Type variable 'value' has escaped its scope, appearing in type 'Witness @Type value'
+  │
+  │     eval = constrainedEval Spec
+  │     ╰──────────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:56:1
+  •
+  │
+  • Type variable '(scope2 :: t1)' has escaped its scope, appearing in type 'forall t1. Token @t1
+  │ (scope2 :: t1)'
+  │
+  │   escapedEtaExpansion = leak (\token -> modify token)
+  │   ╰──────────────────────────────────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:58:1
+  •
+  │
+  • Type variable '(scope3 :: t2)' has escaped its scope, appearing in type 'forall t2. Token @t2
+  │ (scope3 :: t2)'
+  │
+  │   escapedIdentityWrapper = identity (leak modify)
+  │   ╰──────────────────────────────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:60:1
+  •
+  │
+  • Type variable '(scope4 :: t3)' has escaped its scope, appearing in type 'forall t3. Array (Token
+  │ @t3 (scope4 :: t3))'
+  │
+  │   escapedArrayWrapper = [leak modify]
+  │   ╰──────────────────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:62:1
+  •
+  │
+  • Type variable '(scope5 :: t4)' has escaped its scope, appearing in type 'forall t4. Token @t4
+  │ (scope5 :: t4)'
+  │
+  │   escapedConditionalWrapper = leak (\token -> if true then modify token else modify token)
+  │   ╰───────────────────────────────────────────────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1786636920_expected_forall_expression_forms/Main.snap
+++ b/tests-integration/fixtures/checking/1786636920_expected_forall_expression_forms/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -40,44 +40,84 @@ Token = [Phantom]
 Effect = [Representational]
 
 Diagnostics
-error[EscapedSkolem]: Type variable '(scope :: t0)' has escaped its scope, appearing in type 'forall t0. Token @t0 (scope :: t0)'
-  --> 49:1..49:41
-   |
-49 | escapedOperator = leak modify # identity
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope1 :: t1)' has escaped its scope, appearing in type 'forall t1 t2. (Token @t1 (scope1 :: t1) -> t2) -> t2'
-  --> 51:1..51:35
-   |
-51 | escapedSection = (leak modify # _)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope2 :: t3)' has escaped its scope, appearing in type 'forall t3. Effect (Token @t3 (scope2 :: t3))'
-  --> 53:1..55:13
-   |
-53 | escapedDo = do
-   | ^~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope3 :: t4)' has escaped its scope, appearing in type 'forall t4. Effect (Token @t4 (scope3 :: t4))'
-  --> 57:1..59:11
-   |
-57 | escapedAdo = ado
-   | ^~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope4 :: t5)' has escaped its scope, appearing in type 'forall t5. { token :: Token @t5 (scope4 :: t5) }'
-  --> 61:1..61:39
-   |
-61 | escapedRecord = { token: leak modify }
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope5 :: t6)' has escaped its scope, appearing in type 'forall t7 (t8 :: Row Type) t6.
-  { token :: t7 | (t8 :: Row Type) } -> { token :: Token @t6 (scope5 :: t6) | (t8 :: Row Type) }'
-  --> 63:1..63:60
-   |
-63 | escapedRecordUpdate record = record { token = leak modify }
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope6 :: ?83)' has escaped its scope, appearing in type 'Token @?83 (scope6 :: ?83)'
-  --> 65:1..66:33
-   |
-65 | escapedPatternGuard value
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~
-error[EscapedSkolem]: Type variable '(scope7 :: t9)' has escaped its scope, appearing in type 'forall t10 t9. t10 -> { token :: Token @t9 (scope7 :: t9) }'
-  --> 68:1..69:34
-   |
-68 | escapedCase value = case value of
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error! · [EscapedSkolem] · Main.purs:49:1
+  •
+  │
+  • Type variable '(scope :: t0)' has escaped its scope, appearing in type 'forall t0. Token @t0
+  │ (scope :: t0)'
+  │
+  │   escapedOperator = leak modify # identity
+  │   ╰───────────────────────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:51:1
+  •
+  │
+  • Type variable '(scope1 :: t1)' has escaped its scope, appearing in type 'forall t1 t2. (Token
+  │ @t1 (scope1 :: t1) -> t2) -> t2'
+  │
+  │   escapedSection = (leak modify # _)
+  │   ╰─────────────────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:53:1
+  •
+  │
+  • Type variable '(scope2 :: t3)' has escaped its scope, appearing in type 'forall t3. Effect
+  │ (Token @t3 (scope2 :: t3))'
+  │
+  │   escapedDo = do
+  │   ╰─────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:57:1
+  •
+  │
+  • Type variable '(scope3 :: t4)' has escaped its scope, appearing in type 'forall t4. Effect
+  │ (Token @t4 (scope3 :: t4))'
+  │
+  │   escapedAdo = ado
+  │   ╰───────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:61:1
+  •
+  │
+  • Type variable '(scope4 :: t5)' has escaped its scope, appearing in type 'forall t5. { token ::
+  │ Token @t5 (scope4 :: t5) }'
+  │
+  │   escapedRecord = { token: leak modify }
+  │   ╰─────────────────────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:63:1
+  •
+  │
+  • Type variable '(scope5 :: t6)' has escaped its scope, appearing in type 'forall t7 (t8 :: Row
+  │ Type) t6.
+  │   { token :: t7 | (t8 :: Row Type) } -> { token :: Token @t6 (scope5 :: t6) | (t8 :: Row
+  │ Type) }'
+  │
+  │   escapedRecordUpdate record = record { token = leak modify }
+  │   ╰──────────────────────────────────────────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:65:1
+  •
+  │
+  • Type variable '(scope6 :: ?83)' has escaped its scope, appearing in type 'Token @?83
+  │ (scope6 :: ?83)'
+  │
+  │   escapedPatternGuard value
+  │   ╰────────────────────────
+  •
+
+Error! · [EscapedSkolem] · Main.purs:68:1
+  •
+  │
+  • Type variable '(scope7 :: t9)' has escaped its scope, appearing in type 'forall t10 t9. t10 ->
+  │ { token :: Token @t9 (scope7 :: t9) }'
+  │
+  │   escapedCase value = case value of
+  │   ╰────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1786686300_exhaustive_recovered_constructor_arity/Main.snap
+++ b/tests-integration/fixtures/checking/1786686300_exhaustive_recovered_constructor_arity/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -16,53 +16,92 @@ Roles
 Box = [Representational]
 
 Diagnostics
-error[CannotUnify]: Cannot unify 'Box' with 'Function ?4'
-  --> 5:1..5:17
-  |
-5 | test (Box _) = 0
-  | ^~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Box t0' with 'Function ?4 (Box ?4)'
-  --> 5:1..5:17
-  |
-5 | test (Box _) = 0
-  | ^~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Box t0' with '?4 -> Box ?4'
-  --> 5:1..5:17
-  |
-5 | test (Box _) = 0
-  | ^~~~~~~~~~~~~~~~
-warning[RedundantPattern]: Pattern match has redundant patterns: Box
-  --> 5:1..5:17
-  |
-5 | test (Box _) = 0
-  | ^~~~~~~~~~~~~~~~
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Other
-  --> 5:1..5:17
-  |
-5 | test (Box _) = 0
-  | ^~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Function t1' with 'Box'
-  --> 8:1..8:14
-  |
-8 | test2 Box = 0
-  | ^~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Function t1 (Box t1)' with 'Box ?8'
-  --> 8:1..8:14
-  |
-8 | test2 Box = 0
-  | ^~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 't1 -> Box t1' with 'Box ?8'
-  --> 8:1..8:14
-  |
-8 | test2 Box = 0
-  | ^~~~~~~~~~~~~
-warning[RedundantPattern]: Pattern match has redundant patterns: Box _
-  --> 8:1..8:14
-  |
-8 | test2 Box = 0
-  | ^~~~~~~~~~~~~
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: Other
-  --> 8:1..8:14
-  |
-8 | test2 Box = 0
-  | ^~~~~~~~~~~~~
+Error! · [CannotUnify] · Main.purs:5:1
+  •
+  │
+  • Cannot unify 'Box' with 'Function ?4'
+  │
+  │   test (Box _) = 0
+  │   ╰───────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:5:1
+  •
+  │
+  • Cannot unify 'Box t0' with 'Function ?4 (Box ?4)'
+  │
+  │   test (Box _) = 0
+  │   ╰───────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:5:1
+  •
+  │
+  • Cannot unify 'Box t0' with '?4 -> Box ?4'
+  │
+  │   test (Box _) = 0
+  │   ╰───────────────
+  •
+
+Warning! · [RedundantPattern] · Main.purs:5:1
+  •
+  │
+  • Pattern match has redundant patterns: Box
+  │
+  │   test (Box _) = 0
+  │   ╰───────────────
+  •
+
+Warning! · [MissingPatterns] · Main.purs:5:1
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Other
+  │
+  │   test (Box _) = 0
+  │   ╰───────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:8:1
+  •
+  │
+  • Cannot unify 'Function t1' with 'Box'
+  │
+  │   test2 Box = 0
+  │   ╰────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:8:1
+  •
+  │
+  • Cannot unify 'Function t1 (Box t1)' with 'Box ?8'
+  │
+  │   test2 Box = 0
+  │   ╰────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:8:1
+  •
+  │
+  • Cannot unify 't1 -> Box t1' with 'Box ?8'
+  │
+  │   test2 Box = 0
+  │   ╰────────────
+  •
+
+Warning! · [RedundantPattern] · Main.purs:8:1
+  •
+  │
+  • Pattern match has redundant patterns: Box _
+  │
+  │   test2 Box = 0
+  │   ╰────────────
+  •
+
+Warning! · [MissingPatterns] · Main.purs:8:1
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Other
+  │
+  │   test2 Box = 0
+  │   ╰────────────
+  •

--- a/tests-integration/fixtures/checking/1786810320_not_in_scope_diagnostic_rendering/Main.snap
+++ b/tests-integration/fixtures/checking/1786810320_not_in_scope_diagnostic_rendering/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 286
 expression: report
 ---
 Terms
@@ -21,138 +21,245 @@ Synonyms
 type MissingTypeOperator = ?[invalid operator chain]
 
 Diagnostics
-error[NotInScope]: 'absent' is not in scope
-  --> 4:19..4:25
-  |
-4 | missingVariable = absent
-  |                   ^~~~~~
-error[NotInScope]: 'Missing' is not in scope
-  --> 5:22..5:29
-  |
-5 | missingConstructor = Missing
-  |                      ^~~~~~~
-error[NotInScope]: '+' is not in scope
-  --> 6:21..6:22
-  |
-6 | missingOperator = 1 + 2
-  |                     ^
-error[NotInScope]: 'negate' is not in scope
-  --> 7:17..7:19
-  |
-7 | missingNegate = -1
-  |                 ^~
-error[NotInScope]: 'bind' is not in scope
-  --> 9:13..11:8
-  |
-9 | missingDo = do
-  |             ^~
-error[NotInScope]: 'absent' is not in scope
-  --> 10:12..10:18
-   |
-10 |   value <- absent
-   |            ^~~~~~
-error[NotInScope]: 'discard' is not in scope
-  --> 13:18..15:9
-   |
-13 | missingDiscard = do
-   |                  ^~
-error[NotInScope]: 'absent' is not in scope
-  --> 14:3..14:9
-   |
-14 |   absent
-   |   ^~~~~~
-error[NotInScope]: 'absent' is not in scope
-  --> 15:3..15:9
-   |
-15 |   absent
-   |   ^~~~~~
-error[NotInScope]: 'map' is not in scope
-  --> 17:14..20:11
-   |
-17 | missingAdo = ado
-   |              ^~~
-error[NotInScope]: 'apply' is not in scope
-  --> 17:14..20:11
-   |
-17 | missingAdo = ado
-   |              ^~~
-error[NotInScope]: 'absent' is not in scope
-  --> 18:12..18:18
-   |
-18 |   value <- absent
-   |            ^~~~~~
-error[NotInScope]: 'absent' is not in scope
-  --> 19:13..19:19
-   |
-19 |   second <- absent
-   |             ^~~~~~
-error[NotInScope]: 'pure' is not in scope
-  --> 22:15..23:7
-   |
-22 | missingPure = ado
-   |               ^~~
-error[NotInScope]: 'MissingType' is not in scope
-  --> 25:16..25:27
-   |
-25 | missingType :: MissingType
-   |                ^~~~~~~~~~~
-error[NotInScope]: 'absent' is not in scope
-  --> 26:15..26:21
-   |
-26 | missingType = absent
-   |               ^~~~~~
-error[CannotUnify]: Cannot unify 'Type' with '?[invalid kind]'
-  --> 28:28..28:40
-   |
-28 | type MissingTypeOperator = Int + String
-   |                            ^~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Type' with '?[invalid kind]'
-  --> 4:19..4:25
-  |
-4 | missingVariable = absent
-  |                   ^~~~~~
-error[CannotUnify]: Cannot unify 'Type' with '?[invalid kind]'
-  --> 5:22..5:29
-  |
-5 | missingConstructor = Missing
-  |                      ^~~~~~~
-error[CannotUnify]: Cannot unify 'Type' with '?[invalid kind]'
-  --> 7:17..7:19
-  |
-7 | missingNegate = -1
-  |                 ^~
-error[CannotUnify]: Cannot unify '?[missing expression]' with '(t0 :: Type -> Type) ((t0 :: Type -> Type) t1)'
-  --> 10:3..10:18
-   |
-10 |   value <- absent
-   |   ^~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify '?[missing expression]' with '(t2 :: Type -> Type) ?24'
-  --> 14:3..14:9
-   |
-14 |   absent
-   |   ^~~~~~
-error[CannotUnify]: Cannot unify '?[missing expression]' with '(t2 :: Type -> Type) t3'
-  --> 15:3..15:9
-   |
-15 |   absent
-   |   ^~~~~~
-error[CannotUnify]: Cannot unify '?[missing expression]' with '(t4 :: Type -> Type) t5'
-  --> 18:3..18:18
-   |
-18 |   value <- absent
-   |   ^~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify '?[missing expression]' with '(t4 :: Type -> Type) ?34'
-  --> 19:3..19:19
-   |
-19 |   second <- absent
-   |   ^~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify '?[missing constructor]' with 'Type'
-  --> 25:16..25:27
-   |
-25 | missingType :: MissingType
-   |                ^~~~~~~~~~~
-error[CannotUnify]: Cannot unify '?[missing expression]' with '?[missing constructor]'
-  --> 26:15..26:21
-   |
-26 | missingType = absent
-   |               ^~~~~~
+Error! · [NotInScope] · Main.purs:4:19
+  •
+  │
+  • 'absent' is not in scope
+  │
+  │   missingVariable = absent
+  │                     ╰─────
+  •
+
+Error! · [NotInScope] · Main.purs:5:22
+  •
+  │
+  • 'Missing' is not in scope
+  │
+  │   missingConstructor = Missing
+  │                        ╰──────
+  •
+
+Error! · [NotInScope] · Main.purs:6:21
+  •
+  │
+  • '+' is not in scope
+  │
+  │   missingOperator = 1 + 2
+  │                       ╰
+  •
+
+Error! · [NotInScope] · Main.purs:7:17
+  •
+  │
+  • 'negate' is not in scope
+  │
+  │   missingNegate = -1
+  │                   ╰─
+  •
+
+Error! · [NotInScope] · Main.purs:9:13
+  •
+  │
+  • 'bind' is not in scope
+  │
+  │   missingDo = do
+  │               ╰─
+  •
+
+Error! · [NotInScope] · Main.purs:10:12
+  •
+  │
+  • 'absent' is not in scope
+  │
+  │     value <- absent
+  │              ╰─────
+  •
+
+Error! · [NotInScope] · Main.purs:13:18
+  •
+  │
+  • 'discard' is not in scope
+  │
+  │   missingDiscard = do
+  │                    ╰─
+  •
+
+Error! · [NotInScope] · Main.purs:14:3
+  •
+  │
+  • 'absent' is not in scope
+  │
+  │     absent
+  │     ╰─────
+  •
+
+Error! · [NotInScope] · Main.purs:15:3
+  •
+  │
+  • 'absent' is not in scope
+  │
+  │     absent
+  │     ╰─────
+  •
+
+Error! · [NotInScope] · Main.purs:17:14
+  •
+  │
+  • 'map' is not in scope
+  │
+  │   missingAdo = ado
+  │                ╰──
+  •
+
+Error! · [NotInScope] · Main.purs:17:14
+  •
+  │
+  • 'apply' is not in scope
+  │
+  │   missingAdo = ado
+  │                ╰──
+  •
+
+Error! · [NotInScope] · Main.purs:18:12
+  •
+  │
+  • 'absent' is not in scope
+  │
+  │     value <- absent
+  │              ╰─────
+  •
+
+Error! · [NotInScope] · Main.purs:19:13
+  •
+  │
+  • 'absent' is not in scope
+  │
+  │     second <- absent
+  │               ╰─────
+  •
+
+Error! · [NotInScope] · Main.purs:22:15
+  •
+  │
+  • 'pure' is not in scope
+  │
+  │   missingPure = ado
+  │                 ╰──
+  •
+
+Error! · [NotInScope] · Main.purs:25:16
+  •
+  │
+  • 'MissingType' is not in scope
+  │
+  │   missingType :: MissingType
+  │                  ╰──────────
+  •
+
+Error! · [NotInScope] · Main.purs:26:15
+  •
+  │
+  • 'absent' is not in scope
+  │
+  │   missingType = absent
+  │                 ╰─────
+  •
+
+Error! · [CannotUnify] · Main.purs:28:28
+  •
+  │
+  • Cannot unify 'Type' with '?[invalid kind]'
+  │
+  │   type MissingTypeOperator = Int + String
+  │                              ╰───────────
+  •
+
+Error! · [CannotUnify] · Main.purs:4:19
+  •
+  │
+  • Cannot unify 'Type' with '?[invalid kind]'
+  │
+  │   missingVariable = absent
+  │                     ╰─────
+  •
+
+Error! · [CannotUnify] · Main.purs:5:22
+  •
+  │
+  • Cannot unify 'Type' with '?[invalid kind]'
+  │
+  │   missingConstructor = Missing
+  │                        ╰──────
+  •
+
+Error! · [CannotUnify] · Main.purs:7:17
+  •
+  │
+  • Cannot unify 'Type' with '?[invalid kind]'
+  │
+  │   missingNegate = -1
+  │                   ╰─
+  •
+
+Error! · [CannotUnify] · Main.purs:10:3
+  •
+  │
+  • Cannot unify '?[missing expression]' with '(t0 :: Type -> Type) ((t0 :: Type -> Type) t1)'
+  │
+  │     value <- absent
+  │     ╰──────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:14:3
+  •
+  │
+  • Cannot unify '?[missing expression]' with '(t2 :: Type -> Type) ?24'
+  │
+  │     absent
+  │     ╰─────
+  •
+
+Error! · [CannotUnify] · Main.purs:15:3
+  •
+  │
+  • Cannot unify '?[missing expression]' with '(t2 :: Type -> Type) t3'
+  │
+  │     absent
+  │     ╰─────
+  •
+
+Error! · [CannotUnify] · Main.purs:18:3
+  •
+  │
+  • Cannot unify '?[missing expression]' with '(t4 :: Type -> Type) t5'
+  │
+  │     value <- absent
+  │     ╰──────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:19:3
+  •
+  │
+  • Cannot unify '?[missing expression]' with '(t4 :: Type -> Type) ?34'
+  │
+  │     second <- absent
+  │     ╰───────────────
+  •
+
+Error! · [CannotUnify] · Main.purs:25:16
+  •
+  │
+  • Cannot unify '?[missing constructor]' with 'Type'
+  │
+  │   missingType :: MissingType
+  │                  ╰──────────
+  •
+
+Error! · [CannotUnify] · Main.purs:26:15
+  •
+  │
+  • Cannot unify '?[missing expression]' with '?[missing constructor]'
+  │
+  │   missingType = absent
+  │                 ╰─────
+  •

--- a/tests-integration/src/fixtures.rs
+++ b/tests-integration/src/fixtures.rs
@@ -240,13 +240,16 @@ pub fn backend(path: &Path) -> FixtureResult {
     let folder = fixture_folder(path)?;
     let fixture = snapshot_path(folder);
     let file = module_name(path)?;
+    let display_path = path.file_name().and_then(|name| name.to_str()).ok_or_else(|| {
+        invalid_data(format!("invariant violated: invalid fixture file name: {}", path.display()))
+    })?;
     let (engine, files) = crate::load_compiler(folder);
     let Some(id) = engine.module_file(&file) else {
         return Err(missing_module(path, &file).into());
     };
 
-    let checking_report = crate::generated::basic::report_checked(&engine, id);
-    let foreign_report = crate::generated::basic::report_foreign(&engine, id);
+    let checking_report = crate::generated::basic::report_checked(&engine, id, display_path);
+    let foreign_report = crate::generated::basic::report_foreign(&engine, id, display_path);
     let diagnostics_report = format!("{checking_report}{foreign_report}");
     let generated = tempfile::tempdir()?;
     match javascript_modules(&engine, id)? {
@@ -267,12 +270,15 @@ pub fn backend(path: &Path) -> FixtureResult {
 pub fn checking(path: &Path) -> FixtureResult {
     let folder = fixture_folder(path)?;
     let file = module_name(path)?;
+    let display_path = path.file_name().and_then(|name| name.to_str()).ok_or_else(|| {
+        invalid_data(format!("invariant violated: invalid fixture file name: {}", path.display()))
+    })?;
     let (engine, _) = crate::load_compiler(folder);
     let Some(id) = engine.module_file(&file) else {
         return Err(missing_module(path, &file).into());
     };
 
-    let report = crate::generated::basic::report_checked(&engine, id);
+    let report = crate::generated::basic::report_checked(&engine, id, display_path);
 
     let mut settings = insta::Settings::clone_current();
     settings.set_snapshot_path(snapshot_path(folder));

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -4,7 +4,7 @@ use analyzer::position;
 use building::QueryEngine;
 use checking::core::pretty;
 use checking::{PrettyQueries, core};
-use diagnostics::{DiagnosticsContext, ToDiagnostics, format_rustc};
+use diagnostics::{DiagnosticsContext, ToDiagnostics, format_rich_with_path};
 use files::FileId;
 use indexing::{ImportKind, IndexedTermItem, IndexedTypeItem, IndexedTypeItemKind, TypeItemId};
 use itertools::Itertools;
@@ -226,7 +226,7 @@ pub fn report_lowered(engine: &QueryEngine, id: FileId, name: &str) -> String {
     out
 }
 
-pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
+pub fn report_checked(engine: &QueryEngine, id: FileId, path: &str) -> String {
     let indexed = engine.indexed(id).unwrap();
     let checked = engine.checked(id).unwrap();
     let config = pretty::PrettyConfig::new().fully_qualified_names();
@@ -356,12 +356,12 @@ pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
         writeln!(out, "{name} = [{}]", roles_str.join(", ")).unwrap();
     }
 
-    write_checked_diagnostics(&mut out, engine, id, &indexed, &checked);
+    write_checked_diagnostics(&mut out, engine, id, path, &indexed, &checked);
 
     out
 }
 
-pub fn report_foreign(engine: &QueryEngine, id: FileId) -> String {
+pub fn report_foreign(engine: &QueryEngine, id: FileId, path: &str) -> String {
     let validation = engine.foreign_validation(id).unwrap();
     if validation.errors.is_empty() {
         return String::new();
@@ -384,7 +384,7 @@ pub fn report_foreign(engine: &QueryEngine, id: FileId) -> String {
 
     let mut out = String::new();
     heading(&mut out, "Diagnostics");
-    out.push_str(&format_rustc(&diagnostics, &content));
+    out.push_str(&format_rich_with_path(&diagnostics, &content, path, false));
     out
 }
 
@@ -494,6 +494,7 @@ fn write_checked_diagnostics(
     out: &mut String,
     engine: &QueryEngine,
     id: FileId,
+    path: &str,
     indexed: &indexing::IndexedModule,
     checked: &checking::CheckedModule,
 ) {
@@ -523,7 +524,7 @@ fn write_checked_diagnostics(
 
     if !all_diagnostics.is_empty() {
         writeln!(out, "\nDiagnostics").unwrap();
-        out.push_str(&format_rustc(&all_diagnostics, &content));
+        out.push_str(&format_rich_with_path(&all_diagnostics, &content, path, false));
     }
 }
 


### PR DESCRIPTION
## Summary

Test fixtures should exercise the same rich diagnostic presentation used by the command line rather than preserving a separate rustc-style renderer solely for snapshots.

This change:
- renders checking, backend, and compatibility diagnostics with the rich renderer in uncoloured mode
- removes the rustc renderer and its public API
- records stable fixture file names in rich diagnostic locations
- regenerates all 152 affected checking and backend snapshots

## Verification

- `just t checking`
- `just t backend`
- `cargo nextest run -p tests-compatibility`
- `cargo check -p diagnostics --tests`
- `cargo check -p tests-integration --tests`
- `cargo check -p tests-compatibility --tests`
- `git diff --check`

All checks pass. The regenerated snapshots contain no ANSI escapes or rustc-style diagnostic headers.