### PR TITLE
[backend] Exercise pattern matching at runtime

### DIFF
--- a/tests-integration/fixtures/backend/1787021400_literal_patterns/verify.mjs
+++ b/tests-integration/fixtures/backend/1787021400_literal_patterns/verify.mjs
@@ -2,14 +2,24 @@ import { deepStrictEqual } from "node:assert/strict";
 import * as Main from "./output/Main/index.js";
 
 const actual = {
+  integer: [Main.integer(0), Main.integer(1)],
+  number: [Main.number(1.5), Main.number(2.5)],
+  character: [Main.character("a"), Main.character("b")],
   escapedDoubleQuote: Main.escapedDoubleQuote,
   matchesEscapedDoubleQuote: Main.matchesEscapedDoubleQuote(Main.escapedDoubleQuote),
   rejectsOtherCharacter: Main.matchesEscapedDoubleQuote("x"),
+  string: [Main.string("alexandrite"), Main.string("other")],
+  boolean: [Main.boolean(true), Main.boolean(false)],
 };
 const expected = {
+  integer: [true, false],
+  number: [true, false],
+  character: [true, false],
   escapedDoubleQuote: '"',
   matchesEscapedDoubleQuote: true,
   rejectsOtherCharacter: false,
+  string: [true, false],
+  boolean: [true, false],
 };
 
-deepStrictEqual(actual, expected, "unexpected escaped double-quote character behavior");
+deepStrictEqual(actual, expected, "unexpected literal pattern behavior");

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.functional.snap
@@ -43,3 +43,6 @@ expression: report
 @export bind = \value%12 continuation%11 -> continuation%11 value%12
 
 @export ordinaryBind = \identity%13 -> bind identity%13 (\value%14 -> value%14)
+
+@export partialBind = \partialDict%18 ->
+  \choice%15 -> bind choice%15 (\$choice%17@(One value%16) -> value%16)

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.purs
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.purs
@@ -29,3 +29,6 @@ bind value continuation = continuation value
 
 ordinaryBind :: Identity Int -> Int
 ordinaryBind identity = bind identity (\(Identity value) -> value)
+
+partialBind :: Partial => Choice Int -> Int
+partialBind choice = bind choice (\(One value) -> value)

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.snap
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/Main.snap
@@ -15,6 +15,7 @@ unwrap :: forall a. Main.Identity a -> a
 nested :: forall a. Main.Nested a -> Main.Choice a
 bind :: forall a b. a -> (a -> b) -> b
 ordinaryBind :: Main.Identity Prim.Int -> Prim.Int
+partialBind :: Prim.Partial => Main.Choice Prim.Int -> Prim.Int
 
 Types
 Choice :: Prim.Type -> Prim.Type

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/output/Main/index.js
@@ -69,3 +69,17 @@ export function bind(value) {
 export function ordinaryBind(identity) {
   return bind(identity)((value) => value);
 }
+export function partialBind(partialDict) {
+  const $closure = (choice) => {
+    const $closure$1 = ($choice) => {
+      if ($choice.tag === "One") {
+        const { _1: value } = $choice;
+        return value;
+      } else {
+        throw new Error("Pattern match failure");
+      }
+    };
+    return bind(choice)($closure$1);
+  };
+  return $closure;
+}

--- a/tests-integration/fixtures/backend/1787021460_constructor_patterns/verify.mjs
+++ b/tests-integration/fixtures/backend/1787021460_constructor_patterns/verify.mjs
@@ -1,0 +1,29 @@
+import { deepStrictEqual, strictEqual, throws } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.first(Main.Empty), Main.Empty);
+deepStrictEqual(Main.first(Main.One(1)), Main.One(1));
+deepStrictEqual(Main.first(Main.Pair(2)(3)), Main.One(2));
+deepStrictEqual(Main.pair(Main.Pair(4)(5)), Main.Pair(4)(5));
+deepStrictEqual(Main.pair(Main.One(6)), Main.One(6));
+strictEqual(Main.unwrap(7), 7);
+deepStrictEqual(Main.nested(Main.Outer(Main.One(8))), Main.One(8));
+strictEqual(Main.nested(Main.Outer(Main.Empty)), Main.Empty);
+strictEqual(Main.ordinaryBind(9), 9);
+
+const partialBind = Main.partialBind({});
+strictEqual(partialBind(Main.One(10)), 10);
+throws(() => partialBind(Main.Empty), { message: "Pattern match failure" });
+
+const inapplicableOuterPattern = new Proxy(
+  { tag: "One" },
+  {
+    get(target, property) {
+      if (property === "_1") {
+        throw new Error("extracted a constructor field before matching its tag");
+      }
+      return Reflect.get(target, property);
+    },
+  },
+);
+strictEqual(Main.nested(inapplicableOuterPattern), Main.Empty);

--- a/tests-integration/fixtures/backend/1787021520_array_patterns/verify.mjs
+++ b/tests-integration/fixtures/backend/1787021520_array_patterns/verify.mjs
@@ -1,0 +1,20 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.describe([]), 0);
+strictEqual(Main.describe([42]), 42);
+strictEqual(Main.describe([1, 2]), 1);
+strictEqual(Main.describe([1, 2, 3]), 3);
+
+const nonArray = new Proxy(
+  {},
+  {
+    get(target, property) {
+      if (property === "length" || property === "0") {
+        throw new Error("extracted an array field before checking its shape");
+      }
+      return Reflect.get(target, property);
+    },
+  },
+);
+strictEqual(Main.describe(nonArray), 3);

--- a/tests-integration/fixtures/backend/1787021580_record_patterns/verify.mjs
+++ b/tests-integration/fixtures/backend/1787021580_record_patterns/verify.mjs
@@ -1,0 +1,4 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.select({ first: 1, nested: { second: "selected" } }), "selected");

--- a/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/verify.mjs
+++ b/tests-integration/fixtures/backend/1787021640_multiple_case_scrutinees/verify.mjs
@@ -1,0 +1,7 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.choose(true)(true), 2);
+strictEqual(Main.choose(true)(false), 1);
+strictEqual(Main.choose(false)(true), 0);
+strictEqual(Main.choose(false)(false), 0);

--- a/tests-integration/fixtures/backend/1787021700_guards/verify.mjs
+++ b/tests-integration/fixtures/backend/1787021700_guards/verify.mjs
@@ -1,0 +1,12 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.booleanGuard(true), 1);
+strictEqual(Main.booleanGuard(false), 0);
+strictEqual(Main.patternGuard(Main.One(42)), 42);
+strictEqual(Main.patternGuard(Main.Empty), 0);
+strictEqual(Main.caseBooleanGuard(true), 2);
+strictEqual(Main.casePatternGuard(Main.One(43)), 43);
+strictEqual(Main.casePatternGuard(Main.Empty), 0);
+strictEqual(Main.nestedCaseGuard(true), 2);
+strictEqual(Main.nestedCaseGuard(false), 3);

--- a/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.functional.snap
@@ -1,7 +1,12 @@
 ---
 source: tests-integration/tests/functional.rs
+assertion_line: 14
 expression: report
 ---
+@export constructor Empty/0
+
+@export constructor One/1
+
 @export unwrap = \wrapped%1 ->
   let
     value%0 = wrapped%1
@@ -11,3 +16,9 @@ expression: report
   let
     { first: first%4, second: second%2 } = record%3
   in second%2
+
+@export unwrapOne = \partialDict%7 ->
+  \choice%6 ->
+    let
+      One value%5 = choice%6
+    in value%5

--- a/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.purs
+++ b/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.purs
@@ -2,6 +2,8 @@ module Main where
 
 newtype Identity a = Identity a
 
+data Choice a = Empty | One a
+
 unwrap :: forall a. Identity a -> a
 unwrap wrapped =
   let
@@ -15,3 +17,10 @@ select record =
     { first, second } = record
   in
     second
+
+unwrapOne :: forall a. Partial => Choice a -> a
+unwrapOne choice =
+  let
+    One value = choice
+  in
+    value

--- a/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.snap
+++ b/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/Main.snap
@@ -1,14 +1,20 @@
 ---
 source: tests-integration/src/fixtures.rs
+assertion_line: 262
 expression: diagnostics_report
 ---
 Terms
 Identity :: forall @a. a -> Main.Identity a
+Empty :: forall @a. Main.Choice a
+One :: forall @a. a -> Main.Choice a
 unwrap :: forall a. Main.Identity a -> a
 select :: { first :: Prim.Int, second :: Prim.String } -> Prim.String
+unwrapOne :: forall a. Prim.Partial => Main.Choice a -> a
 
 Types
 Identity :: Prim.Type -> Prim.Type
+Choice :: Prim.Type -> Prim.Type
 
 Roles
 Identity = [Representational]
+Choice = [Representational]

--- a/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/output/Main/index.js
@@ -1,3 +1,8 @@
+export const Empty = "Empty";
+export const One = ($value0) => ({
+  tag: "One",
+  _1: $value0
+});
 export function unwrap(wrapped) {
   const value = wrapped;
   return value;
@@ -6,4 +11,15 @@ export function select(record) {
   const first = record.first;
   const second = record.second;
   return second;
+}
+export function unwrapOne(partialDict) {
+  const $closure = (choice) => {
+    if (choice.tag === "One") {
+      const { _1: value } = choice;
+      return value;
+    } else {
+      throw new Error("Pattern match failure");
+    }
+  };
+  return $closure;
 }

--- a/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/verify.mjs
+++ b/tests-integration/fixtures/backend/1787021760_pattern_let_bindings/verify.mjs
@@ -1,0 +1,9 @@
+import { strictEqual, throws } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.unwrap(42), 42);
+strictEqual(Main.select({ first: 1, second: "selected" }), "selected");
+
+const unwrapOne = Main.unwrapOne({});
+strictEqual(unwrapOne(Main.One(43)), 43);
+throws(() => unwrapOne(Main.Empty), { message: "Pattern match failure" });


### PR DESCRIPTION
## Summary

The pattern backend already emits functional and JavaScript output for every supported pattern family, but most of those fixtures did not execute the generated modules. This adds runtime assertions to the existing focused fixtures so regressions in matching, binding, ordering, or failure behavior are observable.

The coverage exercises literal, constructor, array, record, named, wildcard, and variable patterns, along with multiple scrutinees, guards, pattern parameters, and pattern lets. Refutable parameters and lets cover both successful extraction and the shared pattern-match failure policy.

Proxy-based assertions verify that array length/index extraction waits for the array shape test and nested constructor extraction waits for the outer constructor tag. Record patterns continue to rely on static typing rather than adding redundant runtime shape checks.

This addresses the remaining executable-coverage gap tracked in #337 without changing backend generation behavior.

## Verification

- All tests passed, no pending snapshots.
- No pending snapshots