### PR TITLE
[javascript] Implement tail call optimisation

### DIFF
--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -511,8 +511,7 @@ impl Generator<'_> {
         context: &mut FunctionContext,
     ) -> ModuleResult<()> {
         let condition = tree.boolean(true);
-        let condition = writer.expression(tree, condition);
-        writer.while_loop(condition, |writer| {
+        writer.while_loop(tree, condition, |tree, writer| {
             if group.is_singleton() {
                 return self.render_tail_call_profile(tree, writer, &group.profiles[0], context);
             }
@@ -743,16 +742,13 @@ impl Generator<'_> {
     ) -> ModuleResult<()> {
         // Curried outer arguments can be captured by a reusable partial application. Copy every
         // argument before iterating so one invocation cannot mutate the next invocation's input.
-        let argument_names = arguments
-            .iter()
-            .enumerate()
-            .map(|(position, argument)| {
-                let name = context.allocate(format_smolstr!("$argument{position}"));
-                let value = tree.identifier(argument);
-                writer.mutable_value(tree, &name, value);
-                name
-            })
-            .collect_vec();
+        let mut argument_names = Vec::with_capacity(arguments.len());
+        for (position, argument) in arguments.iter().enumerate() {
+            let name = context.allocate(format_smolstr!("$argument{position}"));
+            let value = tree.identifier(argument);
+            writer.mutable_value(tree, &name, value);
+            argument_names.push(name);
+        }
         let tail_calls = TailCallContext::singleton(group, argument_names);
         let outer_tail_calls = context.tail_calls.replace(tail_calls);
         let result = self.render_tail_call_dispatcher(tree, writer, group, context);
@@ -800,8 +796,7 @@ impl Generator<'_> {
         let initial = tree.identifier(initial_name);
         writer.assign(tree, &step_name, initial);
         let condition = tree.boolean(true);
-        let condition = writer.expression(tree, condition);
-        writer.while_loop(condition, |writer| {
+        writer.while_loop(tree, condition, |tree, writer| {
             let step = tree.identifier(&step_name);
             let result = tree.call(step, vec![]);
             writer.constant(tree, &result_name, result, false);
@@ -2011,7 +2006,9 @@ fn render_let(
         });
         let dispatcher_suffix = dispatcher_names.join("_");
         let dispatcher_name = context.allocate(format_smolstr!("$tail_{dispatcher_suffix}"));
-        if let Some(group) = tail_call_group(generator.module, profiles, dispatcher_name) {
+        let optimized = if let Some(group) =
+            tail_call_group(generator.module, profiles, dispatcher_name)
+        {
             if !group.is_singleton() {
                 let state_name = context.allocate("$state");
                 let argument_names = (0..group.maximum_arity)
@@ -2044,39 +2041,17 @@ fn render_let(
                 )?;
             }
 
-            let optimized =
-                group.profiles.iter().map(|profile| profile.identity).collect::<FxHashSet<_>>();
-            for (binding, name) in bindings.iter().zip(&names) {
-                let identity = TailCallIdentity::Local(binding.parameter.id);
-                if optimized.contains(&identity) {
-                    continue;
-                }
-                match &generator.module.storage[binding.expression].kind {
-                    ExpressionKind::Abstraction { parameters, body } => {
-                        generator.render_abstraction_binding(
-                            tree,
-                            writer,
-                            AbstractionBinding { name, parameters, body: *body, uncurried: false },
-                            context,
-                        )?;
-                    }
-                    ExpressionKind::UncurriedAbstraction { parameters, body } => {
-                        generator.render_abstraction_binding(
-                            tree,
-                            writer,
-                            AbstractionBinding { name, parameters, body: *body, uncurried: true },
-                            context,
-                        )?;
-                    }
-                    _ => {
-                        unreachable!("invariant violated: recursive closure group contains a value")
-                    }
-                }
-            }
-            return Ok(());
-        }
+            let optimized = group.profiles.iter().map(|profile| profile.identity);
+            optimized.collect::<FxHashSet<_>>()
+        } else {
+            FxHashSet::default()
+        };
 
         for (binding, name) in bindings.iter().zip(&names) {
+            let identity = TailCallIdentity::Local(binding.parameter.id);
+            if optimized.contains(&identity) {
+                continue;
+            }
             match &generator.module.storage[binding.expression].kind {
                 ExpressionKind::Abstraction { parameters, body } => {
                     generator.render_abstraction_binding(

--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -4,6 +4,7 @@ mod analysis;
 mod inline;
 mod structure;
 mod syntax;
+mod tail_call;
 
 use std::sync::Arc;
 
@@ -17,12 +18,12 @@ use functional::tree::{
 use itertools::Itertools;
 use oxc_allocator::Allocator;
 use rustc_hash::{FxHashMap, FxHashSet};
-use smol_str::SmolStr;
+use smol_str::{SmolStr, format_smolstr};
 
 use super::super::names::NameAllocator;
 use crate::error::{ModuleError, ModuleResult, UnsupportedState};
 use crate::module::{Module, module_filename, runtime_filename};
-use crate::tree::{BinaryOperator, ExpressionId, ObjectProperty, Tree};
+use crate::tree::{BinaryOperator, ExpressionId, ObjectProperty, Tree, UnaryOperator};
 use crate::writer::{BindingCallTarget, Writer};
 
 use self::analysis::{VisitState, visit_initializer};
@@ -34,33 +35,43 @@ use self::syntax::{
     binary_expression, combine_conditions, constructor_expression, curried_call_expression,
     literal_expression, synthesized_evidence_expression, unary_expression,
 };
+use self::tail_call::{
+    TailCallContext, TailCallGroup, TailCallIdentity, TailCallProfile, global_profiles,
+    local_profiles, tail_call_group,
+};
 
 pub(crate) struct Generator<'m> {
     module: &'m FunctionalModule,
-    global_names: FxHashMap<GlobalId, String>,
-    external_module_namespaces: FxHashMap<FileId, String>,
+    global_names: FxHashMap<GlobalId, SmolStr>,
+    external_module_namespaces: FxHashMap<FileId, SmolStr>,
     external_references: Vec<Global>,
-    foreign_namespace: Option<String>,
-    runtime_namespace: Option<String>,
-    lazy_global_names: FxHashMap<GlobalId, String>,
+    foreign_namespace: Option<SmolStr>,
+    runtime_namespace: Option<SmolStr>,
+    lazy_global_names: FxHashMap<GlobalId, SmolStr>,
+    global_tail_call_groups: Vec<TailCallGroup>,
+    global_tail_call_group_positions: FxHashMap<GlobalId, usize>,
     reserved_module_names: Arc<FxHashSet<SmolStr>>,
 }
 
 #[derive(Debug)]
 enum LocalBinding {
-    Direct(String),
-    Lazy(String),
+    Direct(SmolStr),
+    Lazy(SmolStr),
 }
 
 struct FunctionContext {
     allocator: NameAllocator,
     locals: FxHashMap<LocalId, LocalBinding>,
+    tail_calls: Option<TailCallContext>,
 }
 
 #[derive(Clone, Copy)]
 enum Destination<'a> {
     Return,
+    TailEffectThunkReturn,
+    TailEffectReturn,
     EffectReturn,
+    EffectTailEffectReturn,
     Assign(&'a str),
     EffectAssign(&'a str),
     AssignAndBreak { name: &'a str, label: &'a str },
@@ -86,14 +97,64 @@ struct PatternPlan {
 }
 
 enum PatternBinding {
-    Variable { name: String, value: ExpressionId },
-    Constructor { names: Vec<Option<String>>, value: ExpressionId },
+    Variable { name: SmolStr, value: ExpressionId },
+    Constructor { names: Vec<Option<SmolStr>>, value: ExpressionId },
 }
 
 // Pending expressions must be evaluated before rendering an eager later sibling.
 struct RenderedExpression {
     value: ExpressionId,
     pending_evaluation: bool,
+}
+
+struct TailCallWrapper<'a> {
+    name: &'a str,
+    group: &'a TailCallGroup,
+    profile: &'a TailCallProfile,
+    state: usize,
+}
+
+struct CurriedTailCallWrapper<'a> {
+    group: &'a TailCallGroup,
+    profile: &'a TailCallProfile,
+    state: usize,
+    arguments: &'a [SmolStr],
+    remaining: &'a [SmolStr],
+}
+
+struct TailCallWrapperResult<'a> {
+    group: &'a TailCallGroup,
+    profile: &'a TailCallProfile,
+    state: usize,
+    arguments: &'a [SmolStr],
+}
+
+struct CurriedParameter<'a> {
+    pattern: PatternId,
+    argument: &'a str,
+    remaining: &'a [PatternId],
+    body: FunctionalExpressionId,
+}
+
+struct UncurriedParameters<'a> {
+    patterns: &'a [PatternId],
+    arguments: &'a [SmolStr],
+    position: usize,
+    body: FunctionalExpressionId,
+}
+
+struct AbstractionBinding<'a> {
+    name: &'a str,
+    parameters: &'a [PatternId],
+    body: FunctionalExpressionId,
+    uncurried: bool,
+}
+
+struct GuardSequence<'a, 'd> {
+    guards: &'a [Guard],
+    position: usize,
+    expression: FunctionalExpressionId,
+    destination: Destination<'d>,
 }
 
 struct ModuleRenderer<'a, 'm, 't, 'd> {
@@ -114,18 +175,19 @@ impl FunctionContext {
         FunctionContext {
             allocator: NameAllocator::with_reserved(Arc::clone(reserved)),
             locals: FxHashMap::default(),
+            tail_calls: None,
         }
     }
 
-    fn allocate(&mut self, preferred: &str) -> String {
+    fn allocate(&mut self, preferred: impl AsRef<str>) -> SmolStr {
         self.allocator.allocate(preferred)
     }
 
-    fn bind_direct(&mut self, parameter: &Parameter, name: String) {
+    fn bind_direct(&mut self, parameter: &Parameter, name: SmolStr) {
         self.locals.insert(parameter.id, LocalBinding::Direct(name));
     }
 
-    fn bind_lazy(&mut self, parameter: &Parameter, name: String) {
+    fn bind_lazy(&mut self, parameter: &Parameter, name: SmolStr) {
         self.locals.insert(parameter.id, LocalBinding::Lazy(name));
     }
 }
@@ -134,11 +196,14 @@ impl<'a> Destination<'a> {
     fn effect(self) -> Destination<'a> {
         match self {
             Destination::Return => Destination::EffectReturn,
+            Destination::TailEffectReturn => Destination::EffectTailEffectReturn,
             Destination::Assign(name) => Destination::EffectAssign(name),
             Destination::AssignAndBreak { name, label } => {
                 Destination::EffectAssignAndBreak { name, label }
             }
-            Destination::EffectReturn
+            Destination::TailEffectThunkReturn
+            | Destination::EffectReturn
+            | Destination::EffectTailEffectReturn
             | Destination::EffectAssign(_)
             | Destination::EffectAssignAndBreak { .. } => {
                 unreachable!("invariant violated: effect destination is already indirect")
@@ -149,11 +214,16 @@ impl<'a> Destination<'a> {
     fn value(self) -> Destination<'a> {
         match self {
             Destination::EffectReturn => Destination::Return,
+            Destination::EffectTailEffectReturn => Destination::TailEffectReturn,
             Destination::EffectAssign(name) => Destination::Assign(name),
             Destination::EffectAssignAndBreak { name, label } => {
                 Destination::AssignAndBreak { name, label }
             }
-            Destination::Return | Destination::Assign(_) | Destination::AssignAndBreak { .. } => {
+            Destination::Return
+            | Destination::TailEffectThunkReturn
+            | Destination::TailEffectReturn
+            | Destination::Assign(_)
+            | Destination::AssignAndBreak { .. } => {
                 unreachable!("invariant violated: value destination is already direct")
             }
         }
@@ -163,6 +233,7 @@ impl<'a> Destination<'a> {
         matches!(
             self,
             Destination::EffectReturn
+                | Destination::EffectTailEffectReturn
                 | Destination::EffectAssign(_)
                 | Destination::EffectAssignAndBreak { .. }
         )
@@ -189,7 +260,7 @@ impl<'m> Generator<'m> {
                 .expect("invariant violated: external global has no module dependency");
             external_module_namespaces
                 .entry(file_id)
-                .or_insert_with(|| allocator.allocate(&dependency.module_name.replace('.', "_")));
+                .or_insert_with(|| allocator.allocate(dependency.module_name.replace('.', "_")));
         }
 
         let has_foreign = module
@@ -202,10 +273,39 @@ impl<'m> Generator<'m> {
         let runtime_namespace = requires_runtime.then(|| allocator.allocate("$runtime"));
         let lazy_global_names = lazy_globals.into_iter().map(|id| {
             let global_name = &global_names[&id];
-            let lazy_name = allocator.allocate(&format!("$lazy_{global_name}"));
+            let lazy_name = allocator.allocate(format_smolstr!("$lazy_{global_name}"));
             (id, lazy_name)
         });
         let lazy_global_names = lazy_global_names.collect();
+        let mut global_tail_call_groups = Vec::new();
+        let mut global_tail_call_group_positions = FxHashMap::default();
+        for profiles in global_profiles(module) {
+            let Some(TailCallIdentity::Global(_)) =
+                profiles.first().map(|profile| profile.identity)
+            else {
+                continue;
+            };
+            let mut dispatcher_names = profiles.iter().map(|profile| {
+                let TailCallIdentity::Global(global) = profile.identity else {
+                    unreachable!("invariant violated: global tail-call group contains a local")
+                };
+                global_names[&global].as_str()
+            });
+            let dispatcher_suffix = dispatcher_names.join("_");
+            let preferred = format_smolstr!("$tail_{dispatcher_suffix}");
+            let dispatcher_name = allocator.allocate(&preferred);
+            let Some(group) = tail_call_group(module, profiles, dispatcher_name) else {
+                continue;
+            };
+            let position = global_tail_call_groups.len();
+            for profile in &group.profiles {
+                let TailCallIdentity::Global(global) = profile.identity else {
+                    unreachable!("invariant violated: global tail-call group contains a local")
+                };
+                global_tail_call_group_positions.insert(global, position);
+            }
+            global_tail_call_groups.push(group);
+        }
         let reserved_module_names = allocator.allocated_names().cloned().collect();
         let reserved_module_names = Arc::new(reserved_module_names);
 
@@ -217,6 +317,8 @@ impl<'m> Generator<'m> {
             foreign_namespace,
             runtime_namespace,
             lazy_global_names,
+            global_tail_call_groups,
+            global_tail_call_group_positions,
             reserved_module_names,
         }
     }
@@ -316,6 +418,7 @@ fn render_constructors(renderer: &mut ModuleRenderer<'_, '_, '_, '_>) {
 
 fn render_source_functions(renderer: &mut ModuleRenderer<'_, '_, '_, '_>) -> ModuleResult<()> {
     let generator = renderer.generator;
+    let mut rendered_groups = FxHashSet::default();
     for declaration in generator.module.declarations.iter() {
         let DeclarationKind::Value(expression) = declaration.kind else {
             continue;
@@ -327,6 +430,18 @@ fn render_source_functions(renderer: &mut ModuleRenderer<'_, '_, '_, '_>) -> Mod
         ) {
             continue;
         }
+        if let Some(&position) =
+            generator.global_tail_call_group_positions.get(&declaration.global.id)
+        {
+            if rendered_groups.insert(position) {
+                render_global_tail_call_group(
+                    renderer,
+                    &generator.global_tail_call_groups[position],
+                )?;
+                renderer.writer.blank();
+            }
+            continue;
+        }
         let name = generator.global_name(declaration.global.id);
         let exported = generator.declaration_is_inline_exported(declaration);
         let mut context = FunctionContext::new(&generator.reserved_module_names);
@@ -336,6 +451,383 @@ fn render_source_functions(renderer: &mut ModuleRenderer<'_, '_, '_, '_>) -> Mod
         renderer.writer.blank();
     }
     Ok(())
+}
+
+fn render_global_tail_call_group(
+    renderer: &mut ModuleRenderer<'_, '_, '_, '_>,
+    group: &TailCallGroup,
+) -> ModuleResult<()> {
+    let generator = renderer.generator;
+    let mut context = FunctionContext::new(&generator.reserved_module_names);
+    if !group.is_singleton() {
+        let state_name = context.allocate("$state");
+        let argument_names = (0..group.maximum_arity)
+            .map(|position| context.allocate(format_smolstr!("$argument{position}")))
+            .collect_vec();
+        let tail_calls = TailCallContext::new(group, state_name.clone(), argument_names.clone());
+        let mut dispatcher_parameters = vec![state_name];
+        dispatcher_parameters.extend(argument_names);
+        context.tail_calls = Some(tail_calls);
+        renderer.writer.function(
+            &group.dispatcher_name,
+            dispatcher_parameters,
+            false,
+            |writer| {
+                generator.render_tail_call_dispatcher(renderer.tree, writer, group, &mut context)
+            },
+        )?;
+        context.tail_calls = None;
+    }
+
+    for (state, profile) in group.profiles.iter().enumerate() {
+        let TailCallIdentity::Global(global) = profile.identity else {
+            unreachable!("invariant violated: global tail-call group contains a local")
+        };
+        let declaration = generator
+            .module
+            .declarations
+            .iter()
+            .find(|declaration| declaration.global.id == global)
+            .expect("invariant violated: tail-call profile has no declaration");
+        let name = generator.global_name(global);
+        let exported = generator.declaration_is_inline_exported(declaration);
+        generator.render_global_tail_call_wrapper(
+            renderer.tree,
+            renderer.writer,
+            TailCallWrapper { name, group, profile, state },
+            exported,
+            &mut context,
+        )?;
+    }
+    Ok(())
+}
+
+impl Generator<'_> {
+    fn render_tail_call_dispatcher(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        group: &TailCallGroup,
+        context: &mut FunctionContext,
+    ) -> ModuleResult<()> {
+        let condition = tree.boolean(true);
+        let condition = writer.expression(tree, condition);
+        writer.while_loop(condition, |writer| {
+            if group.is_singleton() {
+                return self.render_tail_call_profile(tree, writer, &group.profiles[0], context);
+            }
+            let tail_calls = context
+                .tail_calls
+                .as_ref()
+                .expect("invariant violated: tail-call dispatcher has no context");
+            let state_name = tail_calls
+                .state_name
+                .as_ref()
+                .expect("invariant violated: mutual tail-call dispatcher has no state");
+            let current_state = tree.identifier(state_name);
+            let cases = group.profiles.iter().enumerate().map(|(state, profile)| {
+                let state = tree.number(state.to_string());
+                let name = self.tail_call_profile_name(profile, context);
+                (state, name)
+            });
+            let cases = cases.collect_vec();
+            writer.switch(tree, current_state, &cases, |position, tree, writer| {
+                self.render_tail_call_profile(tree, writer, &group.profiles[position], context)
+            })
+        })
+    }
+
+    fn tail_call_profile_name(
+        &self,
+        profile: &TailCallProfile,
+        context: &FunctionContext,
+    ) -> SmolStr {
+        match profile.identity {
+            TailCallIdentity::Global(global) => self.global_names[&global].clone(),
+            TailCallIdentity::Local(local) => match context.locals.get(&local) {
+                Some(LocalBinding::Direct(name)) => name.clone(),
+                Some(LocalBinding::Lazy(_)) | None => {
+                    unreachable!("invariant violated: tail-call profile has no direct local name")
+                }
+            },
+        }
+    }
+
+    fn render_tail_call_profile(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        profile: &TailCallProfile,
+        context: &mut FunctionContext,
+    ) -> ModuleResult<()> {
+        self.render_tail_call_parameters(tree, writer, profile, 0, context)
+    }
+
+    fn render_tail_call_parameters(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        profile: &TailCallProfile,
+        position: usize,
+        context: &mut FunctionContext,
+    ) -> ModuleResult<()> {
+        let Some(pattern) = profile.parameters.get(position).copied() else {
+            let destination = if profile.effect_step {
+                Destination::TailEffectThunkReturn
+            } else {
+                Destination::Return
+            };
+            return self.render_expression(tree, writer, profile.body, destination, context);
+        };
+        let argument = context
+            .tail_calls
+            .as_ref()
+            .expect("invariant violated: tail-call profile has no context")
+            .argument_names
+            .get(position)
+            .expect("invariant violated: tail-call profile exceeds dispatcher arity")
+            .clone();
+        // A closure created during an iteration must capture that iteration's value rather than
+        // the mutable slot that advances the loop.
+        let current_argument = context.allocate(format_smolstr!("$currentArgument{position}"));
+        let value = tree.identifier(&argument);
+        writer.constant(tree, &current_argument, value, false);
+        let value = tree.identifier(&current_argument);
+        let plan = self.pattern_plan(tree, pattern, value, Some(&current_argument), context)?;
+        self.render_pattern_scope(tree, writer, plan, context, |tree, writer, context| {
+            self.render_tail_call_parameters(tree, writer, profile, position + 1, context)
+        })
+    }
+
+    fn render_global_tail_call_wrapper(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        wrapper: TailCallWrapper<'_>,
+        exported: bool,
+        context: &mut FunctionContext,
+    ) -> ModuleResult<()> {
+        let TailCallWrapper { name, group, profile, state } = wrapper;
+        let arguments = profile
+            .parameters
+            .iter()
+            .map(|pattern| self.allocate_pattern_argument(*pattern, context))
+            .collect_vec();
+        if profile.uncurried {
+            return writer.function(name, arguments.clone(), exported, |writer| {
+                self.render_tail_call_wrapper_result(
+                    tree,
+                    writer,
+                    TailCallWrapperResult { group, profile, state, arguments: &arguments },
+                    context,
+                )
+            });
+        }
+        let Some((first, remaining)) = arguments.split_first() else {
+            unreachable!("invariant violated: curried tail-call function has no parameters")
+        };
+        writer.function(name, vec![first.clone()], exported, |writer| {
+            self.render_curried_tail_call_wrapper(
+                tree,
+                writer,
+                CurriedTailCallWrapper { group, profile, state, arguments: &arguments, remaining },
+                context,
+            )
+        })
+    }
+
+    fn render_local_tail_call_wrapper(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        wrapper: TailCallWrapper<'_>,
+        context: &mut FunctionContext,
+    ) -> ModuleResult<()> {
+        let TailCallWrapper { name, group, profile, state } = wrapper;
+        let arguments = profile
+            .parameters
+            .iter()
+            .map(|pattern| self.allocate_pattern_argument(*pattern, context))
+            .collect_vec();
+        if profile.uncurried {
+            return writer.constant_arrow(name, arguments.clone(), |writer| {
+                self.render_tail_call_wrapper_result(
+                    tree,
+                    writer,
+                    TailCallWrapperResult { group, profile, state, arguments: &arguments },
+                    context,
+                )
+            });
+        }
+        let Some((first, remaining)) = arguments.split_first() else {
+            unreachable!("invariant violated: curried tail-call function has no parameters")
+        };
+        writer.constant_arrow(name, vec![first.clone()], |writer| {
+            self.render_curried_tail_call_wrapper(
+                tree,
+                writer,
+                CurriedTailCallWrapper { group, profile, state, arguments: &arguments, remaining },
+                context,
+            )
+        })
+    }
+
+    fn render_curried_tail_call_wrapper(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        wrapper: CurriedTailCallWrapper<'_>,
+        context: &mut FunctionContext,
+    ) -> ModuleResult<()> {
+        let CurriedTailCallWrapper { group, profile, state, arguments, remaining } = wrapper;
+        let Some((argument, remaining)) = remaining.split_first() else {
+            return self.render_tail_call_wrapper_result(
+                tree,
+                writer,
+                TailCallWrapperResult { group, profile, state, arguments },
+                context,
+            );
+        };
+        writer.return_arrow(vec![argument.clone()], |writer| {
+            self.render_curried_tail_call_wrapper(
+                tree,
+                writer,
+                CurriedTailCallWrapper { group, profile, state, arguments, remaining },
+                context,
+            )
+        })
+    }
+
+    fn render_tail_call_wrapper_result(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        wrapper: TailCallWrapperResult<'_>,
+        context: &mut FunctionContext,
+    ) -> ModuleResult<()> {
+        let TailCallWrapperResult { group, profile, state, arguments } = wrapper;
+        if group.is_singleton() && !profile.effect_step {
+            return self.render_singleton_tail_call_loop(tree, writer, group, arguments, context);
+        }
+        if group.is_singleton() {
+            self.render_singleton_effect_dispatcher(tree, writer, group, context)?;
+        }
+
+        let dispatcher = tree.identifier(&group.dispatcher_name);
+        let state = tree.number(state.to_string());
+        let mut values = vec![state];
+        values.extend(arguments.iter().map(|argument| tree.identifier(argument)));
+        for _ in arguments.len()..group.maximum_arity {
+            values.push(tree.null());
+        }
+        let initial = tree.call(dispatcher, values);
+        if !profile.effect_step {
+            writer.return_expression(tree, initial);
+            return Ok(());
+        }
+
+        let initial_name = context.allocate("$initialStep");
+        writer.constant(tree, &initial_name, initial, false);
+        writer.return_arrow(vec![], |writer| {
+            self.render_tail_effect_loop(tree, writer, group, &initial_name, context)
+        })
+    }
+
+    fn render_singleton_tail_call_loop(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        group: &TailCallGroup,
+        arguments: &[SmolStr],
+        context: &mut FunctionContext,
+    ) -> ModuleResult<()> {
+        // Curried outer arguments can be captured by a reusable partial application. Copy every
+        // argument before iterating so one invocation cannot mutate the next invocation's input.
+        let argument_names = arguments
+            .iter()
+            .enumerate()
+            .map(|(position, argument)| {
+                let name = context.allocate(format_smolstr!("$argument{position}"));
+                let value = tree.identifier(argument);
+                writer.mutable_value(tree, &name, value);
+                name
+            })
+            .collect_vec();
+        let tail_calls = TailCallContext::singleton(group, argument_names);
+        let outer_tail_calls = context.tail_calls.replace(tail_calls);
+        let result = self.render_tail_call_dispatcher(tree, writer, group, context);
+        context.tail_calls = outer_tail_calls;
+        result
+    }
+
+    fn render_singleton_effect_dispatcher(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        group: &TailCallGroup,
+        context: &mut FunctionContext,
+    ) -> ModuleResult<()> {
+        let state_name = context.allocate("$state");
+        let argument_names = (0..group.maximum_arity)
+            .map(|position| context.allocate(format_smolstr!("$argument{position}")))
+            .collect_vec();
+        let tail_calls = TailCallContext::new(group, state_name.clone(), argument_names.clone());
+        let mut dispatcher_parameters = vec![state_name];
+        dispatcher_parameters.extend(argument_names);
+        let outer_tail_calls = context.tail_calls.replace(tail_calls);
+        writer.constant_arrow(&group.dispatcher_name, dispatcher_parameters, |writer| {
+            self.render_tail_call_dispatcher(tree, writer, group, context)
+        })?;
+        context.tail_calls = outer_tail_calls;
+        Ok(())
+    }
+
+    fn render_tail_effect_loop(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        group: &TailCallGroup,
+        initial_name: &str,
+        context: &mut FunctionContext,
+    ) -> ModuleResult<()> {
+        // A step returns `[false, value]` when complete or `[true, state, ...arguments]` for a
+        // tail call. Constructing the next step only after the current action has run preserves
+        // Effect construction timing, while resetting to the captured initial step makes the
+        // generated thunk safely reusable.
+        let step_name = context.allocate("$step");
+        let result_name = context.allocate("$result");
+        writer.mutable(&step_name);
+        let initial = tree.identifier(initial_name);
+        writer.assign(tree, &step_name, initial);
+        let condition = tree.boolean(true);
+        let condition = writer.expression(tree, condition);
+        writer.while_loop(condition, |writer| {
+            let step = tree.identifier(&step_name);
+            let result = tree.call(step, vec![]);
+            writer.constant(tree, &result_name, result, false);
+            let result = tree.identifier(&result_name);
+            let marker_index = tree.number("0");
+            let marker = tree.index(result, marker_index);
+            let complete = tree.unary(UnaryOperator::LogicalNot, marker);
+            writer.if_block(tree, complete, |tree, writer| {
+                let result = tree.identifier(&result_name);
+                let value_index = tree.number("1");
+                let value = tree.index(result, value_index);
+                writer.return_expression(tree, value);
+            });
+
+            let dispatcher = tree.identifier(&group.dispatcher_name);
+            let values = (0..=group.maximum_arity).map(|position| {
+                let result = tree.identifier(&result_name);
+                let index = tree.number((position + 1).to_string());
+                tree.index(result, index)
+            });
+            let values = values.collect_vec();
+            let next_step = tree.call(dispatcher, values);
+            writer.assign(tree, &step_name, next_step);
+            Ok(())
+        })
+    }
 }
 
 fn render_named_function(
@@ -356,10 +848,12 @@ fn render_named_function(
                     generator.render_curried_parameter(
                         tree,
                         writer,
-                        parameter,
-                        &argument,
-                        &parameters[1..],
-                        *body,
+                        CurriedParameter {
+                            pattern: parameter,
+                            argument: &argument,
+                            remaining: &parameters[1..],
+                            body: *body,
+                        },
                         context,
                     )
                 } else {
@@ -374,7 +868,15 @@ fn render_named_function(
                 .collect_vec();
             writer.function(name, arguments.clone(), exported, |writer| {
                 generator.render_uncurried_parameters(
-                    tree, writer, parameters, &arguments, 0, *body, context,
+                    tree,
+                    writer,
+                    UncurriedParameters {
+                        patterns: parameters,
+                        arguments: &arguments,
+                        position: 0,
+                        body: *body,
+                    },
+                    context,
                 )
             })
         }
@@ -387,10 +889,10 @@ impl Generator<'_> {
         &self,
         parameters: &[PatternId],
         context: &mut FunctionContext,
-    ) -> (String, Option<PatternId>) {
+    ) -> (SmolStr, Option<PatternId>) {
         match parameters.first().copied() {
             Some(pattern) => (self.allocate_pattern_argument(pattern, context), Some(pattern)),
-            None => (String::new(), None),
+            None => (SmolStr::new_static(""), None),
         }
     }
 
@@ -398,12 +900,10 @@ impl Generator<'_> {
         &self,
         tree: &mut Tree,
         writer: &mut Writer<'_>,
-        pattern: PatternId,
-        argument: &str,
-        remaining: &[PatternId],
-        body: FunctionalExpressionId,
+        parameter: CurriedParameter<'_>,
         context: &mut FunctionContext,
     ) -> ModuleResult<()> {
+        let CurriedParameter { pattern, argument, remaining, body } = parameter;
         let value = tree.identifier(argument);
         let plan = self.pattern_plan(tree, pattern, value, Some(argument), context)?;
         self.render_pattern_scope(tree, writer, plan, context, |tree, writer, context| {
@@ -413,7 +913,10 @@ impl Generator<'_> {
             let argument = self.allocate_pattern_argument(*pattern, context);
             writer.return_arrow(vec![argument.clone()], |writer| {
                 self.render_curried_parameter(
-                    tree, writer, *pattern, &argument, remaining, body, context,
+                    tree,
+                    writer,
+                    CurriedParameter { pattern: *pattern, argument: &argument, remaining, body },
+                    context,
                 )
             })
         })
@@ -423,12 +926,10 @@ impl Generator<'_> {
         &self,
         tree: &mut Tree,
         writer: &mut Writer<'_>,
-        patterns: &[PatternId],
-        arguments: &[String],
-        position: usize,
-        body: FunctionalExpressionId,
+        parameters: UncurriedParameters<'_>,
         context: &mut FunctionContext,
     ) -> ModuleResult<()> {
+        let UncurriedParameters { patterns, arguments, position, body } = parameters;
         let Some(pattern) = patterns.get(position).copied() else {
             return self.render_expression(tree, writer, body, Destination::Return, context);
         };
@@ -439,10 +940,7 @@ impl Generator<'_> {
             self.render_uncurried_parameters(
                 tree,
                 writer,
-                patterns,
-                arguments,
-                position + 1,
-                body,
+                UncurriedParameters { patterns, arguments, position: position + 1, body },
                 context,
             )
         })
@@ -575,6 +1073,20 @@ impl Generator<'_> {
         destination: Destination<'_>,
         context: &mut FunctionContext,
     ) -> ModuleResult<()> {
+        if let Some(tail_call) = context
+            .tail_calls
+            .as_ref()
+            .and_then(|tail_calls| tail_calls.call(self.module, expression))
+            && matches!(
+                destination,
+                Destination::Return
+                    | Destination::TailEffectThunkReturn
+                    | Destination::EffectTailEffectReturn
+            )
+        {
+            return self.render_tail_call(tree, writer, tail_call, destination, context);
+        }
+
         match &self.module.storage[expression].kind {
             ExpressionKind::IfThenElse { condition, then, else_ } => {
                 let condition = self.expression_value(tree, writer, *condition, context)?;
@@ -615,6 +1127,10 @@ impl Generator<'_> {
             ExpressionKind::Effect { effect } if !destination.is_effect() => self
                 .render_effect_expression_destination(tree, writer, effect, destination, context),
             _ => {
+                if matches!(destination, Destination::TailEffectThunkReturn) {
+                    return self
+                        .render_tail_effect_thunk_destination(tree, writer, expression, context);
+                }
                 if destination.is_effect() {
                     return self.render_effect_destination(
                         tree,
@@ -633,13 +1149,18 @@ impl Generator<'_> {
 
     fn render_destination(
         &self,
-        tree: &Tree,
+        tree: &mut Tree,
         writer: &mut Writer<'_>,
         value: ExpressionId,
         destination: Destination<'_>,
     ) {
         match destination {
             Destination::Return => writer.return_expression(tree, value),
+            Destination::TailEffectReturn => {
+                let complete = tree.boolean(false);
+                let result = tree.array(vec![complete, value]);
+                writer.return_expression(tree, result);
+            }
             Destination::Assign(name) => {
                 writer.assign(tree, name, value);
             }
@@ -647,7 +1168,9 @@ impl Generator<'_> {
                 writer.assign(tree, name, value);
                 writer.break_label(label);
             }
-            Destination::EffectReturn
+            Destination::TailEffectThunkReturn
+            | Destination::EffectReturn
+            | Destination::EffectTailEffectReturn
             | Destination::EffectAssign(_)
             | Destination::EffectAssignAndBreak { .. } => {
                 unreachable!("invariant violated: effect destination was not rendered directly")
@@ -693,6 +1216,13 @@ impl Generator<'_> {
                 })?;
                 None
             }
+            Destination::TailEffectThunkReturn => {
+                writer.return_arrow(vec![], |writer| {
+                    let mut renderer = self.renderer(tree, writer, context);
+                    execute_effect(&mut renderer, effect, Destination::TailEffectReturn)
+                })?;
+                None
+            }
             Destination::Assign(name) => {
                 writer.assign_arrow(name, vec![], |writer| {
                     let mut renderer = self.renderer(tree, writer, context);
@@ -707,7 +1237,9 @@ impl Generator<'_> {
                 })?;
                 Some(label)
             }
-            Destination::EffectReturn
+            Destination::TailEffectReturn
+            | Destination::EffectReturn
+            | Destination::EffectTailEffectReturn
             | Destination::EffectAssign(_)
             | Destination::EffectAssignAndBreak { .. } => {
                 unreachable!("invariant violated: effect destination returned an effect thunk")
@@ -716,6 +1248,78 @@ impl Generator<'_> {
         if let Some(label) = break_label {
             writer.break_label(label);
         }
+        Ok(())
+    }
+
+    fn render_tail_effect_thunk_destination(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        expression: FunctionalExpressionId,
+        context: &mut FunctionContext,
+    ) -> ModuleResult<()> {
+        let mut renderer = self.renderer(tree, writer, context);
+        let effect = capture_effect_value(&mut renderer, expression, "$effect")?;
+        writer.return_arrow(vec![], |writer| {
+            let value = tree.call(effect, vec![]);
+            self.render_destination(tree, writer, value, Destination::TailEffectReturn);
+            Ok(())
+        })
+    }
+
+    fn render_tail_call(
+        &self,
+        tree: &mut Tree,
+        writer: &mut Writer<'_>,
+        tail_call: tail_call::TailCall,
+        destination: Destination<'_>,
+        context: &mut FunctionContext,
+    ) -> ModuleResult<()> {
+        let target = tail_call.target;
+        let tail_calls = context
+            .tail_calls
+            .as_ref()
+            .expect("invariant violated: rendered tail call has no context");
+        let state_name = tail_calls.state_name.clone();
+        let argument_names = tail_calls.argument_names.clone();
+
+        if matches!(destination, Destination::EffectTailEffectReturn) {
+            let marker = tree.boolean(true);
+            let state = tree.number(target.state.to_string());
+            let mut values = vec![marker, state];
+            for argument in tail_call.arguments {
+                let value = self.expression_value(tree, writer, argument, context)?;
+                let value = if tree.expression_is_atomic(value) {
+                    value
+                } else {
+                    self.materialize_value(tree, writer, value, "$tailArgument", context)
+                };
+                values.push(value);
+            }
+            for _ in target.arity..argument_names.len() {
+                values.push(tree.null());
+            }
+            let result = tree.array(values);
+            writer.return_expression(tree, result);
+            return Ok(());
+        }
+
+        for (name, argument) in argument_names.iter().zip(tail_call.arguments) {
+            let value = self.expression_value(tree, writer, argument, context)?;
+            if tree.expression_identifier(value) == Some(name) {
+                continue;
+            }
+            writer.assign(tree, name, value);
+        }
+        for name in argument_names.iter().skip(target.arity) {
+            let null = tree.null();
+            writer.assign(tree, name, null);
+        }
+        if let Some(state_name) = state_name {
+            let state = tree.number(target.state.to_string());
+            writer.assign(tree, &state_name, state);
+        }
+        writer.continue_loop();
         Ok(())
     }
 
@@ -835,7 +1439,10 @@ impl Generator<'_> {
             ExpressionKind::Abstraction { parameters, body } => {
                 let name = context.allocate("$closure");
                 self.render_abstraction_binding(
-                    tree, writer, &name, parameters, *body, false, context,
+                    tree,
+                    writer,
+                    AbstractionBinding { name: &name, parameters, body: *body, uncurried: false },
+                    context,
                 )?;
                 let value = tree.identifier(name);
                 Ok(RenderedExpression { value, pending_evaluation: false })
@@ -843,7 +1450,10 @@ impl Generator<'_> {
             ExpressionKind::UncurriedAbstraction { parameters, body } => {
                 let name = context.allocate("$closure");
                 self.render_abstraction_binding(
-                    tree, writer, &name, parameters, *body, true, context,
+                    tree,
+                    writer,
+                    AbstractionBinding { name: &name, parameters, body: *body, uncurried: true },
+                    context,
                 )?;
                 let value = tree.identifier(name);
                 Ok(RenderedExpression { value, pending_evaluation: false })
@@ -1298,11 +1908,11 @@ impl Generator<'_> {
     ) -> bool {
         match &self.module.storage[pattern].kind {
             PatternKind::Variable(parameter) => {
-                context.bind_direct(parameter, argument.to_owned());
+                context.bind_direct(parameter, SmolStr::new(argument));
                 true
             }
             PatternKind::Named { parameter, pattern } => {
-                context.bind_direct(parameter, argument.to_owned());
+                context.bind_direct(parameter, SmolStr::new(argument));
                 self.bind_inline_pattern(*pattern, argument, context)
             }
             PatternKind::Wildcard => true,
@@ -1317,20 +1927,29 @@ impl Generator<'_> {
         &self,
         tree: &mut Tree,
         writer: &mut Writer<'_>,
-        name: &str,
-        parameters: &[PatternId],
-        body: FunctionalExpressionId,
-        uncurried: bool,
+        binding: AbstractionBinding<'_>,
         context: &mut FunctionContext,
     ) -> ModuleResult<()> {
-        if uncurried {
+        let AbstractionBinding { name, parameters, body, uncurried } = binding;
+        // A recursive call in a nested closure starts a distinct invocation; it cannot continue
+        // the loop whose current iteration created that closure.
+        let outer_tail_calls = context.tail_calls.take();
+        let result = if uncurried {
             let arguments = parameters
                 .iter()
                 .map(|pattern| self.allocate_pattern_argument(*pattern, context))
                 .collect_vec();
             writer.constant_arrow(name, arguments.clone(), |writer| {
                 self.render_uncurried_parameters(
-                    tree, writer, parameters, &arguments, 0, body, context,
+                    tree,
+                    writer,
+                    UncurriedParameters {
+                        patterns: parameters,
+                        arguments: &arguments,
+                        position: 0,
+                        body,
+                    },
+                    context,
                 )
             })
         } else {
@@ -1341,17 +1960,21 @@ impl Generator<'_> {
                     self.render_curried_parameter(
                         tree,
                         writer,
-                        parameter,
-                        &argument,
-                        &parameters[1..],
-                        body,
+                        CurriedParameter {
+                            pattern: parameter,
+                            argument: &argument,
+                            remaining: &parameters[1..],
+                            body,
+                        },
                         context,
                     )
                 } else {
                     self.render_expression(tree, writer, body, Destination::Return, context)
                 }
             })
-        }
+        };
+        context.tail_calls = outer_tail_calls;
+        result
     }
 }
 
@@ -1374,16 +1997,101 @@ fn render_let(
         for (binding, name) in bindings.iter().zip(&names) {
             context.bind_direct(&binding.parameter, name.clone());
         }
+
+        let profiles = local_profiles(generator.module, bindings);
+        let mut dispatcher_names = profiles.iter().map(|profile| {
+            let TailCallIdentity::Local(local) = profile.identity else {
+                unreachable!("invariant violated: local tail-call group contains a global")
+            };
+            let position = bindings
+                .iter()
+                .position(|binding| binding.parameter.id == local)
+                .expect("invariant violated: local tail-call profile has no binding");
+            names[position].as_str()
+        });
+        let dispatcher_suffix = dispatcher_names.join("_");
+        let dispatcher_name = context.allocate(format_smolstr!("$tail_{dispatcher_suffix}"));
+        if let Some(group) = tail_call_group(generator.module, profiles, dispatcher_name) {
+            if !group.is_singleton() {
+                let state_name = context.allocate("$state");
+                let argument_names = (0..group.maximum_arity)
+                    .map(|position| context.allocate(format_smolstr!("$argument{position}")))
+                    .collect_vec();
+                let tail_calls =
+                    TailCallContext::new(&group, state_name.clone(), argument_names.clone());
+                let mut dispatcher_parameters = vec![state_name];
+                dispatcher_parameters.extend(argument_names);
+                let outer_tail_calls = context.tail_calls.replace(tail_calls);
+                writer.constant_arrow(&group.dispatcher_name, dispatcher_parameters, |writer| {
+                    generator.render_tail_call_dispatcher(tree, writer, &group, context)
+                })?;
+                context.tail_calls = outer_tail_calls;
+            }
+
+            for (state, profile) in group.profiles.iter().enumerate() {
+                let TailCallIdentity::Local(local) = profile.identity else {
+                    unreachable!("invariant violated: local tail-call group contains a global")
+                };
+                let position = bindings
+                    .iter()
+                    .position(|binding| binding.parameter.id == local)
+                    .expect("invariant violated: local tail-call profile has no binding");
+                generator.render_local_tail_call_wrapper(
+                    tree,
+                    writer,
+                    TailCallWrapper { name: &names[position], group: &group, profile, state },
+                    context,
+                )?;
+            }
+
+            let optimized =
+                group.profiles.iter().map(|profile| profile.identity).collect::<FxHashSet<_>>();
+            for (binding, name) in bindings.iter().zip(&names) {
+                let identity = TailCallIdentity::Local(binding.parameter.id);
+                if optimized.contains(&identity) {
+                    continue;
+                }
+                match &generator.module.storage[binding.expression].kind {
+                    ExpressionKind::Abstraction { parameters, body } => {
+                        generator.render_abstraction_binding(
+                            tree,
+                            writer,
+                            AbstractionBinding { name, parameters, body: *body, uncurried: false },
+                            context,
+                        )?;
+                    }
+                    ExpressionKind::UncurriedAbstraction { parameters, body } => {
+                        generator.render_abstraction_binding(
+                            tree,
+                            writer,
+                            AbstractionBinding { name, parameters, body: *body, uncurried: true },
+                            context,
+                        )?;
+                    }
+                    _ => {
+                        unreachable!("invariant violated: recursive closure group contains a value")
+                    }
+                }
+            }
+            return Ok(());
+        }
+
         for (binding, name) in bindings.iter().zip(&names) {
             match &generator.module.storage[binding.expression].kind {
                 ExpressionKind::Abstraction { parameters, body } => {
                     generator.render_abstraction_binding(
-                        tree, writer, name, parameters, *body, false, context,
+                        tree,
+                        writer,
+                        AbstractionBinding { name, parameters, body: *body, uncurried: false },
+                        context,
                     )?;
                 }
                 ExpressionKind::UncurriedAbstraction { parameters, body } => {
                     generator.render_abstraction_binding(
-                        tree, writer, name, parameters, *body, true, context,
+                        tree,
+                        writer,
+                        AbstractionBinding { name, parameters, body: *body, uncurried: true },
+                        context,
                     )?;
                 }
                 _ => {
@@ -1403,13 +2111,19 @@ fn render_let(
             ExpressionKind::Abstraction { parameters, body } => {
                 context.bind_direct(&binding.parameter, name.clone());
                 generator.render_abstraction_binding(
-                    tree, writer, &name, parameters, *body, false, context,
+                    tree,
+                    writer,
+                    AbstractionBinding { name: &name, parameters, body: *body, uncurried: false },
+                    context,
                 )?;
             }
             ExpressionKind::UncurriedAbstraction { parameters, body } => {
                 context.bind_direct(&binding.parameter, name.clone());
                 generator.render_abstraction_binding(
-                    tree, writer, &name, parameters, *body, true, context,
+                    tree,
+                    writer,
+                    AbstractionBinding { name: &name, parameters, body: *body, uncurried: true },
+                    context,
                 )?;
             }
             _ => {
@@ -1440,7 +2154,7 @@ fn render_lazy_let(
     let names =
         bindings.iter().map(|binding| context.allocate(&binding.parameter.name)).collect_vec();
     let accessors =
-        names.iter().map(|name| context.allocate(&format!("$lazy_{name}"))).collect_vec();
+        names.iter().map(|name| context.allocate(format_smolstr!("$lazy_{name}"))).collect_vec();
     for ((binding, name), accessor) in bindings.iter().zip(&names).zip(&accessors) {
         let _ = name;
         context.bind_lazy(&binding.parameter, accessor.clone());
@@ -1495,7 +2209,10 @@ fn render_case(
     let scrutinees = values;
     match destination {
         Destination::Return
+        | Destination::TailEffectThunkReturn
+        | Destination::TailEffectReturn
         | Destination::EffectReturn
+        | Destination::EffectTailEffectReturn
         | Destination::AssignAndBreak { .. }
         | Destination::EffectAssignAndBreak { .. } => generator.render_case_alternatives(
             tree,
@@ -1612,7 +2329,10 @@ fn render_guarded(
     let context = &mut *renderer.context;
     match destination {
         Destination::Return
+        | Destination::TailEffectThunkReturn
+        | Destination::TailEffectReturn
         | Destination::EffectReturn
+        | Destination::EffectTailEffectReturn
         | Destination::AssignAndBreak { .. }
         | Destination::EffectAssignAndBreak { .. } => {
             generator.render_guard_alternatives(
@@ -1669,10 +2389,12 @@ impl Generator<'_> {
             self.render_guards(
                 tree,
                 writer,
-                &alternative.guards,
-                0,
-                alternative.expression,
-                destination,
+                GuardSequence {
+                    guards: &alternative.guards,
+                    position: 0,
+                    expression: alternative.expression,
+                    destination,
+                },
                 context,
             )?;
         }
@@ -1683,12 +2405,10 @@ impl Generator<'_> {
         &self,
         tree: &mut Tree,
         writer: &mut Writer<'_>,
-        guards: &[Guard],
-        position: usize,
-        expression: FunctionalExpressionId,
-        destination: Destination<'_>,
+        sequence: GuardSequence<'_, '_>,
         context: &mut FunctionContext,
     ) -> ModuleResult<()> {
+        let GuardSequence { guards, position, expression, destination } = sequence;
         let Some(guard) = guards.get(position) else {
             return self.render_expression(tree, writer, expression, destination, context);
         };
@@ -1699,10 +2419,7 @@ impl Generator<'_> {
                     self.render_guards(
                         tree,
                         writer,
-                        guards,
-                        position + 1,
-                        expression,
-                        destination,
+                        GuardSequence { guards, position: position + 1, expression, destination },
                         context,
                     )
                 })
@@ -1719,10 +2436,12 @@ impl Generator<'_> {
                         self.render_guards(
                             tree,
                             writer,
-                            guards,
-                            position + 1,
-                            expression,
-                            destination,
+                            GuardSequence {
+                                guards,
+                                position: position + 1,
+                                expression,
+                                destination,
+                            },
                             context,
                         )
                     })
@@ -1731,10 +2450,7 @@ impl Generator<'_> {
                     self.render_guards(
                         tree,
                         writer,
-                        guards,
-                        position + 1,
-                        expression,
-                        destination,
+                        GuardSequence { guards, position: position + 1, expression, destination },
                         context,
                     )
                 }
@@ -1900,7 +2616,7 @@ impl Generator<'_> {
         plan: &mut PatternPlan,
     ) {
         if let Some(root_name) = root_name {
-            context.bind_direct(parameter, root_name.to_owned());
+            context.bind_direct(parameter, SmolStr::new(root_name));
         } else {
             let name = context.allocate(&parameter.name);
             context.bind_direct(parameter, name.clone());
@@ -1912,7 +2628,7 @@ impl Generator<'_> {
         &self,
         pattern: PatternId,
         context: &mut FunctionContext,
-    ) -> String {
+    ) -> SmolStr {
         let preferred = pattern_parameter(&self.module.storage, pattern)
             .map(|parameter| parameter.name.as_str())
             .unwrap_or("$argument");
@@ -2203,7 +2919,7 @@ fn execute_effect_action(
     renderer: &mut FunctionRenderer<'_, '_, '_, '_>,
     action: CapturedEffectAction,
     preferred_name: &str,
-) -> ModuleResult<(ExpressionId, String)> {
+) -> ModuleResult<(ExpressionId, SmolStr)> {
     let name = renderer.context.allocate(preferred_name);
     match action {
         CapturedEffectAction::Expression(action) => {
@@ -2345,7 +3061,7 @@ impl Generator<'_> {
     fn global_name(&self, id: GlobalId) -> &str {
         self.global_names
             .get(&id)
-            .map(String::as_str)
+            .map(SmolStr::as_str)
             .expect("invariant violated: JavaScript global has no allocated name")
     }
 

--- a/compiler-backend/javascript/src/convert/generator/functional/render/structure.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render/structure.rs
@@ -51,7 +51,7 @@ pub(super) fn cyclic_instance_initializers(module: &Module) -> FxHashSet<GlobalI
     }
 
     let mut cyclic_initializers = FxHashSet::default();
-    for position in 0..initializers.len() {
+    for (position, (global_id, _)) in initializers.iter().enumerate() {
         let mut visited_initializers = FxHashSet::default();
         if reaches_initializer(
             position,
@@ -59,7 +59,7 @@ pub(super) fn cyclic_instance_initializers(module: &Module) -> FxHashSet<GlobalI
             &initializer_dependencies,
             &mut visited_initializers,
         ) {
-            cyclic_initializers.insert(initializers[position].0);
+            cyclic_initializers.insert(*global_id);
         }
     }
 

--- a/compiler-backend/javascript/src/convert/generator/functional/render/syntax.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render/syntax.rs
@@ -6,6 +6,7 @@ use functional::tree::{
     SynthesizedEvidence, UnaryOperator as FunctionalUnaryOperator,
 };
 use itertools::Itertools;
+use smol_str::{SmolStr, format_smolstr};
 
 use crate::error::{ModuleError, ModuleResult, UnsupportedState};
 use crate::tree::{BinaryOperator, ExpressionId, ObjectProperty, Tree, UnaryOperator};
@@ -106,7 +107,7 @@ pub(super) fn constructor_expression(tree: &mut Tree, name: &str, arity: usize) 
         return tree.string(name);
     }
 
-    let arguments = (0..arity).map(|index| format!("$value{index}")).collect_vec();
+    let arguments = (0..arity).map(|index| format_smolstr!("$value{index}")).collect_vec();
     let tag = tree.string(name);
     let mut properties = Vec::with_capacity(arguments.len() + 1);
     properties.push(ObjectProperty::Field { name: "tag".to_owned(), value: tag });
@@ -128,7 +129,7 @@ pub(super) fn synthesized_evidence_expression(
     match evidence {
         SynthesizedEvidence::IsSymbol(symbol) => {
             let symbol = tree.string(symbol.as_str());
-            let reflect = tree.arrow(vec!["$proxy".to_owned()], symbol);
+            let reflect = tree.arrow(vec![SmolStr::new_static("$proxy")], symbol);
             tree.object(vec![ObjectProperty::Field {
                 name: "reflectSymbol".to_owned(),
                 value: reflect,
@@ -148,7 +149,7 @@ pub(super) fn synthesized_evidence_expression(
                     tree.string(tag)
                 }
             };
-            let reflect = tree.arrow(vec!["$proxy".to_owned()], value);
+            let reflect = tree.arrow(vec![SmolStr::new_static("$proxy")], value);
             tree.object(vec![ObjectProperty::Field {
                 name: "reflectType".to_owned(),
                 value: reflect,

--- a/compiler-backend/javascript/src/convert/generator/functional/render/tail_call.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render/tail_call.rs
@@ -1,0 +1,401 @@
+//! Tail-recursive function groups eligible for loop rendering.
+
+use functional::tree::{
+    EffectExpression, ExpressionId, ExpressionKind, GlobalId, LocalId, Module, PatternId,
+    PatternKind, RecursiveGroupId,
+};
+use rustc_hash::{FxHashMap, FxHashSet};
+use smol_str::SmolStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) enum TailCallIdentity {
+    Global(GlobalId),
+    Local(LocalId),
+}
+
+#[derive(Clone)]
+pub(super) struct TailCallProfile {
+    pub(super) identity: TailCallIdentity,
+    pub(super) parameters: Vec<PatternId>,
+    pub(super) body: ExpressionId,
+    pub(super) uncurried: bool,
+    pub(super) effect_step: bool,
+}
+
+pub(super) struct TailCallGroup {
+    pub(super) dispatcher_name: SmolStr,
+    pub(super) profiles: Vec<TailCallProfile>,
+    pub(super) maximum_arity: usize,
+}
+
+#[derive(Clone)]
+pub(super) struct TailCallTarget {
+    pub(super) state: usize,
+    pub(super) arity: usize,
+    pub(super) uncurried: bool,
+}
+
+#[derive(Clone)]
+pub(super) struct TailCall {
+    pub(super) target: TailCallTarget,
+    pub(super) arguments: Vec<ExpressionId>,
+}
+
+#[derive(Clone)]
+pub(super) struct TailCallContext {
+    pub(super) state_name: Option<SmolStr>,
+    pub(super) argument_names: Vec<SmolStr>,
+    targets: FxHashMap<TailCallIdentity, TailCallTarget>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TailPosition {
+    Value,
+    Effect,
+}
+
+struct TailEdge {
+    source: usize,
+    target: usize,
+    position: TailPosition,
+}
+
+impl TailCallContext {
+    pub(super) fn new(
+        group: &TailCallGroup,
+        state_name: SmolStr,
+        argument_names: Vec<SmolStr>,
+    ) -> TailCallContext {
+        let targets = group.profiles.iter().enumerate().map(|(state, profile)| {
+            let target = TailCallTarget {
+                state,
+                arity: profile.parameters.len(),
+                uncurried: profile.uncurried,
+            };
+            (profile.identity, target)
+        });
+        let targets = targets.collect();
+        TailCallContext { state_name: Some(state_name), argument_names, targets }
+    }
+
+    pub(super) fn singleton(
+        group: &TailCallGroup,
+        argument_names: Vec<SmolStr>,
+    ) -> TailCallContext {
+        assert!(group.is_singleton(), "invariant violated: inline tail-call group is mutual");
+        let profile = &group.profiles[0];
+        let target = TailCallTarget {
+            state: 0,
+            arity: profile.parameters.len(),
+            uncurried: profile.uncurried,
+        };
+        let targets = FxHashMap::from_iter([(profile.identity, target)]);
+        TailCallContext { state_name: None, argument_names, targets }
+    }
+
+    pub(super) fn call(&self, module: &Module, expression: ExpressionId) -> Option<TailCall> {
+        let (identity, arguments, uncurried) = application(module, expression)?;
+        let target = self.targets.get(&identity)?;
+        if target.uncurried != uncurried || target.arity != arguments.len() {
+            return None;
+        }
+        Some(TailCall { target: target.clone(), arguments })
+    }
+}
+
+impl TailCallGroup {
+    pub(super) fn is_singleton(&self) -> bool {
+        self.profiles.len() == 1
+    }
+}
+
+pub(super) fn global_profiles(module: &Module) -> Vec<Vec<TailCallProfile>> {
+    let mut positions = FxHashMap::default();
+    let mut groups = Vec::<(RecursiveGroupId, Vec<TailCallProfile>)>::new();
+    for declaration in module.declarations.iter() {
+        let Some(recursive_group) = declaration.recursive_group else { continue };
+        let functional::tree::DeclarationKind::Value(expression) = declaration.kind else {
+            continue;
+        };
+        let identity = TailCallIdentity::Global(declaration.global.id);
+        let Some(profile) = function_profile(module, identity, expression) else { continue };
+        let position = *positions.entry(recursive_group).or_insert_with(|| {
+            let position = groups.len();
+            groups.push((recursive_group, Vec::new()));
+            position
+        });
+        groups[position].1.push(profile);
+    }
+    groups.into_iter().map(|(_, profiles)| profiles).collect()
+}
+
+pub(super) fn local_profiles(
+    module: &Module,
+    bindings: &[functional::tree::Binding],
+) -> Vec<TailCallProfile> {
+    bindings
+        .iter()
+        .filter_map(|binding| {
+            let identity = TailCallIdentity::Local(binding.parameter.id);
+            function_profile(module, identity, binding.expression)
+        })
+        .collect()
+}
+
+pub(super) fn tail_call_group(
+    module: &Module,
+    mut profiles: Vec<TailCallProfile>,
+    dispatcher_name: SmolStr,
+) -> Option<TailCallGroup> {
+    if profiles.is_empty() {
+        return None;
+    }
+
+    let targets = profiles.iter().enumerate().map(|(position, profile)| {
+        (profile.identity, (position, profile.parameters.len(), profile.uncurried))
+    });
+    let targets = targets.collect::<FxHashMap<_, _>>();
+    let mut edges = Vec::new();
+    for (source, profile) in profiles.iter().enumerate() {
+        collect_tail_edges(module, profile.body, TailPosition::Value, source, &targets, &mut edges);
+    }
+    if edges.is_empty() {
+        return None;
+    }
+
+    // Effect-tail calls execute beneath the returned thunk, so their connected tail-call
+    // component uses the boxed step protocol. Value-tail edges preserve the return type and
+    // therefore propagate that requirement to both endpoints.
+    let mut effect_steps = FxHashSet::default();
+    for edge in &edges {
+        if edge.position == TailPosition::Effect {
+            effect_steps.insert(edge.source);
+            effect_steps.insert(edge.target);
+        }
+    }
+    loop {
+        let previous_length = effect_steps.len();
+        for edge in &edges {
+            if effect_steps.contains(&edge.source) || effect_steps.contains(&edge.target) {
+                effect_steps.insert(edge.source);
+                effect_steps.insert(edge.target);
+            }
+        }
+        if effect_steps.len() == previous_length {
+            break;
+        }
+    }
+    for (position, profile) in profiles.iter_mut().enumerate() {
+        profile.effect_step = effect_steps.contains(&position);
+    }
+
+    let maximum_arity = profiles.iter().map(|profile| profile.parameters.len()).max().unwrap_or(0);
+    Some(TailCallGroup { dispatcher_name, profiles, maximum_arity })
+}
+
+fn function_profile(
+    module: &Module,
+    identity: TailCallIdentity,
+    expression: ExpressionId,
+) -> Option<TailCallProfile> {
+    match &module.storage[expression].kind {
+        ExpressionKind::Abstraction { .. } => {
+            let mut parameters = Vec::new();
+            let mut body = expression;
+            while let ExpressionKind::Abstraction {
+                parameters: abstraction_parameters,
+                body: abstraction_body,
+            } = &module.storage[body].kind
+            {
+                parameters.extend(abstraction_parameters.iter().copied());
+                body = *abstraction_body;
+            }
+            if matches!(module.storage[body].kind, ExpressionKind::UncurriedAbstraction { .. }) {
+                return None;
+            }
+            let (_, partially_applied) = parameters.split_last()?;
+            if !partially_applied
+                .iter()
+                .all(|pattern| pattern_is_partial_application_safe(module, *pattern))
+            {
+                return None;
+            }
+            Some(TailCallProfile {
+                identity,
+                parameters,
+                body,
+                uncurried: false,
+                effect_step: false,
+            })
+        }
+        ExpressionKind::UncurriedAbstraction { parameters, body } => Some(TailCallProfile {
+            identity,
+            parameters: parameters.to_vec(),
+            body: *body,
+            uncurried: true,
+            effect_step: false,
+        }),
+        ExpressionKind::Literal { .. }
+        | ExpressionKind::Array { .. }
+        | ExpressionKind::Record { .. }
+        | ExpressionKind::RecordUpdate { .. }
+        | ExpressionKind::Project { .. }
+        | ExpressionKind::Unary { .. }
+        | ExpressionKind::Binary { .. }
+        | ExpressionKind::Constructor { .. }
+        | ExpressionKind::Global { .. }
+        | ExpressionKind::Local { .. }
+        | ExpressionKind::Application { .. }
+        | ExpressionKind::UncurriedApplication { .. }
+        | ExpressionKind::IfThenElse { .. }
+        | ExpressionKind::Case { .. }
+        | ExpressionKind::Guarded { .. }
+        | ExpressionKind::Let { .. }
+        | ExpressionKind::LetPattern { .. }
+        | ExpressionKind::Effect { .. }
+        | ExpressionKind::SynthesizedEvidence { .. }
+        | ExpressionKind::TrivialEvidence => None,
+    }
+}
+
+fn pattern_is_partial_application_safe(module: &Module, pattern: PatternId) -> bool {
+    // Curried wrappers defer body entry until every argument has reached the dispatcher. Moving a
+    // check or destructuring read there would change when partial application evaluates it.
+    match &module.storage[pattern].kind {
+        PatternKind::Variable(_) | PatternKind::Wildcard => true,
+        PatternKind::Named { pattern, .. } => pattern_is_partial_application_safe(module, *pattern),
+        PatternKind::Literal(_)
+        | PatternKind::Array(_)
+        | PatternKind::Record(_)
+        | PatternKind::Constructor { .. } => false,
+    }
+}
+
+fn collect_tail_edges(
+    module: &Module,
+    expression: ExpressionId,
+    position: TailPosition,
+    source: usize,
+    targets: &FxHashMap<TailCallIdentity, (usize, usize, bool)>,
+    edges: &mut Vec<TailEdge>,
+) {
+    if let Some((identity, arguments, uncurried)) = application(module, expression)
+        && let Some(&(target, arity, target_uncurried)) = targets.get(&identity)
+        && arguments.len() == arity
+        && uncurried == target_uncurried
+    {
+        edges.push(TailEdge { source, target, position });
+        return;
+    }
+
+    match &module.storage[expression].kind {
+        ExpressionKind::IfThenElse { then, else_, .. } => {
+            collect_tail_edges(module, *then, position, source, targets, edges);
+            collect_tail_edges(module, *else_, position, source, targets, edges);
+        }
+        ExpressionKind::Case { alternatives, .. } => {
+            for alternative in alternatives.iter() {
+                collect_tail_edges(
+                    module,
+                    alternative.expression,
+                    position,
+                    source,
+                    targets,
+                    edges,
+                );
+            }
+        }
+        ExpressionKind::Guarded { alternatives } => {
+            for alternative in alternatives.iter() {
+                collect_tail_edges(
+                    module,
+                    alternative.expression,
+                    position,
+                    source,
+                    targets,
+                    edges,
+                );
+            }
+        }
+        ExpressionKind::Let { body, .. } | ExpressionKind::LetPattern { body, .. } => {
+            collect_tail_edges(module, *body, position, source, targets, edges);
+        }
+        ExpressionKind::Effect { effect } => match effect {
+            EffectExpression::Bind { body, .. } => {
+                collect_tail_edges(module, *body, TailPosition::Effect, source, targets, edges);
+            }
+            EffectExpression::Pure(_)
+            | EffectExpression::Map { .. }
+            | EffectExpression::Apply { .. } => {}
+        },
+        ExpressionKind::Literal { .. }
+        | ExpressionKind::Array { .. }
+        | ExpressionKind::Record { .. }
+        | ExpressionKind::RecordUpdate { .. }
+        | ExpressionKind::Project { .. }
+        | ExpressionKind::Unary { .. }
+        | ExpressionKind::Binary { .. }
+        | ExpressionKind::Constructor { .. }
+        | ExpressionKind::Global { .. }
+        | ExpressionKind::Local { .. }
+        | ExpressionKind::Abstraction { .. }
+        | ExpressionKind::UncurriedAbstraction { .. }
+        | ExpressionKind::Application { .. }
+        | ExpressionKind::UncurriedApplication { .. }
+        | ExpressionKind::SynthesizedEvidence { .. }
+        | ExpressionKind::TrivialEvidence => {}
+    }
+}
+
+fn application(
+    module: &Module,
+    expression: ExpressionId,
+) -> Option<(TailCallIdentity, Vec<ExpressionId>, bool)> {
+    match &module.storage[expression].kind {
+        ExpressionKind::Application { .. } => {
+            let mut function = expression;
+            let mut groups = Vec::new();
+            while let ExpressionKind::Application { function: inner, arguments, .. } =
+                &module.storage[function].kind
+            {
+                groups.push(arguments.as_ref());
+                function = *inner;
+            }
+            let identity = function_identity(module, function)?;
+            let arguments = groups.into_iter().rev().flatten().copied().collect();
+            Some((identity, arguments, false))
+        }
+        ExpressionKind::UncurriedApplication { function, arguments, .. } => {
+            let identity = function_identity(module, *function)?;
+            Some((identity, arguments.to_vec(), true))
+        }
+        ExpressionKind::Literal { .. }
+        | ExpressionKind::Array { .. }
+        | ExpressionKind::Record { .. }
+        | ExpressionKind::RecordUpdate { .. }
+        | ExpressionKind::Project { .. }
+        | ExpressionKind::Unary { .. }
+        | ExpressionKind::Binary { .. }
+        | ExpressionKind::Constructor { .. }
+        | ExpressionKind::Global { .. }
+        | ExpressionKind::Local { .. }
+        | ExpressionKind::Abstraction { .. }
+        | ExpressionKind::UncurriedAbstraction { .. }
+        | ExpressionKind::IfThenElse { .. }
+        | ExpressionKind::Case { .. }
+        | ExpressionKind::Guarded { .. }
+        | ExpressionKind::Let { .. }
+        | ExpressionKind::LetPattern { .. }
+        | ExpressionKind::Effect { .. }
+        | ExpressionKind::SynthesizedEvidence { .. }
+        | ExpressionKind::TrivialEvidence => None,
+    }
+}
+
+fn function_identity(module: &Module, expression: ExpressionId) -> Option<TailCallIdentity> {
+    match &module.storage[expression].kind {
+        ExpressionKind::Global { global } => Some(TailCallIdentity::Global(global.id)),
+        ExpressionKind::Local { parameter } => Some(TailCallIdentity::Local(parameter.id)),
+        _ => None,
+    }
+}

--- a/compiler-backend/javascript/src/convert/generator/functional/render/tail_call.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render/tail_call.rs
@@ -133,13 +133,11 @@ pub(super) fn local_profiles(
     module: &Module,
     bindings: &[functional::tree::Binding],
 ) -> Vec<TailCallProfile> {
-    bindings
-        .iter()
-        .filter_map(|binding| {
-            let identity = TailCallIdentity::Local(binding.parameter.id);
-            function_profile(module, identity, binding.expression)
-        })
-        .collect()
+    let profiles = bindings.iter().filter_map(|binding| {
+        let identity = TailCallIdentity::Local(binding.parameter.id);
+        function_profile(module, identity, binding.expression)
+    });
+    profiles.collect()
 }
 
 pub(super) fn tail_call_group(

--- a/compiler-backend/javascript/src/convert/generator/names.rs
+++ b/compiler-backend/javascript/src/convert/generator/names.rs
@@ -2,7 +2,7 @@ use std::iter;
 use std::sync::Arc;
 
 use rustc_hash::FxHashSet;
-use smol_str::SmolStr;
+use smol_str::{SmolStr, format_smolstr};
 
 #[derive(Debug, Default)]
 pub(super) struct NameAllocator {
@@ -15,17 +15,15 @@ impl NameAllocator {
         NameAllocator { reserved, names: FxHashSet::default() }
     }
 
-    pub(super) fn allocate(&mut self, preferred: &str) -> String {
-        let mut normalized = normalize_identifier(preferred);
+    pub(super) fn allocate(&mut self, preferred: impl AsRef<str>) -> SmolStr {
+        let mut normalized = normalize_identifier(preferred.as_ref());
         if identifier_is_reserved(&normalized) {
             normalized.insert(0, '$');
         }
-        let mut candidate = normalized.clone();
+        let mut candidate = SmolStr::new(&normalized);
         let mut suffix = 1;
-        while self.reserved.contains(candidate.as_str())
-            || !self.names.insert(SmolStr::new(&candidate))
-        {
-            candidate = format!("{normalized}${suffix}");
+        while self.reserved.contains(&candidate) || !self.names.insert(candidate.clone()) {
+            candidate = format_smolstr!("{normalized}${suffix}");
             suffix += 1;
         }
         candidate

--- a/compiler-backend/javascript/src/tree.rs
+++ b/compiler-backend/javascript/src/tree.rs
@@ -11,6 +11,7 @@ use oxc_syntax::number::NumberBase;
 use oxc_syntax::operator::{
     BinaryOperator as OxcBinaryOperator, LogicalOperator, UnaryOperator as OxcUnaryOperator,
 };
+use smol_str::SmolStr;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct ExpressionId(RawIdx);
@@ -80,7 +81,14 @@ impl<'a> Tree<'a> {
                 | Expression::StringLiteral(_)
                 | Expression::NumericLiteral(_)
                 | Expression::BooleanLiteral(_)
+                | Expression::NullLiteral(_)
         )
+    }
+
+    pub(crate) fn expression_identifier(&self, expression: ExpressionId) -> Option<&str> {
+        let expression = &self.expressions[Idx::from_raw(expression.0)];
+        let Expression::Identifier(identifier) = expression else { return None };
+        Some(identifier.name.as_str())
     }
 
     fn text(&self, value: &str) -> &'a str {
@@ -115,6 +123,11 @@ impl<'a> Tree<'a> {
 
     pub(crate) fn boolean(&mut self, value: bool) -> ExpressionId {
         let expression = Expression::new_boolean_literal(SPAN, value, &self.builder);
+        self.allocate(expression)
+    }
+
+    pub(crate) fn null(&mut self) -> ExpressionId {
+        let expression = Expression::new_null_literal(SPAN, &self.builder);
         self.allocate(expression)
     }
 
@@ -272,7 +285,7 @@ impl<'a> Tree<'a> {
         self.allocate(expression)
     }
 
-    pub(crate) fn arrow(&mut self, parameters: Vec<String>, body: ExpressionId) -> ExpressionId {
+    pub(crate) fn arrow(&mut self, parameters: Vec<SmolStr>, body: ExpressionId) -> ExpressionId {
         let parameters = parameters.into_iter().map(|parameter| {
             let pattern =
                 BindingPattern::new_binding_identifier(SPAN, self.text(&parameter), &self.builder);

--- a/compiler-backend/javascript/src/writer.rs
+++ b/compiler-backend/javascript/src/writer.rs
@@ -1,5 +1,8 @@
 //! Oxc JavaScript program construction and code generation.
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use itertools::Itertools;
 use oxc_allocator::{Allocator, Vec as ArenaVec};
 use oxc_ast::ast::{
@@ -7,13 +10,15 @@ use oxc_ast::ast::{
     BindingProperty, Declaration, ExportSpecifier, Expression, FormalParameter,
     FormalParameterKind, FormalParameters, Function, FunctionBody, FunctionType,
     ImportDeclarationSpecifier, ImportOrExportKind, LabelIdentifier, ModuleExportName, Program,
-    PropertyKey, Statement, StringLiteral, VariableDeclaration, VariableDeclarationKind,
-    VariableDeclarator,
+    PropertyKey, Statement, StringLiteral, SwitchCase, VariableDeclaration,
+    VariableDeclarationKind, VariableDeclarator,
 };
 use oxc_ast::builder::AstBuilder;
+use oxc_ast::{Comment, CommentKind, CommentPosition};
 use oxc_codegen::{Codegen, CodegenOptions, IndentChar};
-use oxc_span::{SPAN, SourceType};
+use oxc_span::{SPAN, SourceType, Span};
 use oxc_syntax::operator::AssignmentOperator;
+use smol_str::SmolStr;
 
 use crate::convert::identifier_is_binding;
 use crate::tree::{ExpressionId, Tree};
@@ -22,11 +27,51 @@ pub(crate) struct Writer<'a> {
     allocator: &'a Allocator,
     builder: AstBuilder<'a>,
     statements: Vec<Statement<'a>>,
+    comments: Rc<RefCell<Comments>>,
+}
+
+#[derive(Default)]
+struct Comments {
+    source_text: String,
+    comments: Vec<Comment>,
 }
 
 impl<'a> Writer<'a> {
     pub(crate) fn new(allocator: &'a Allocator) -> Writer<'a> {
-        Writer { allocator, builder: AstBuilder::new(allocator), statements: Vec::new() }
+        Writer {
+            allocator,
+            builder: AstBuilder::new(allocator),
+            statements: Vec::new(),
+            comments: Rc::new(RefCell::new(Comments::default())),
+        }
+    }
+
+    fn child(&self) -> Writer<'a> {
+        Writer {
+            allocator: self.allocator,
+            builder: AstBuilder::new(self.allocator),
+            statements: Vec::new(),
+            comments: Rc::clone(&self.comments),
+        }
+    }
+
+    fn line_comment(&self, text: &str) -> Span {
+        let mut comments = self.comments.borrow_mut();
+        let start = comments.source_text.len() as u32;
+        comments.source_text.push_str("// ");
+        comments.source_text.push_str(text);
+        let end = comments.source_text.len() as u32;
+        comments.source_text.push('\n');
+        let attached_to = comments.source_text.len() as u32;
+        comments.source_text.push(' ');
+
+        let mut comment = Comment::new(start, end, CommentKind::Line);
+        comment.attached_to = attached_to;
+        comment.position = CommentPosition::Leading;
+        comment.newlines =
+            oxc_ast::ast::CommentNewlines::Leading | oxc_ast::ast::CommentNewlines::Trailing;
+        comments.comments.push(comment);
+        Span::empty(attached_to)
     }
 
     fn text(&self, value: &str) -> &'a str {
@@ -41,7 +86,7 @@ impl<'a> Writer<'a> {
         BindingPattern::new_binding_identifier(SPAN, self.text(name), &self.builder)
     }
 
-    fn parameters(&self, parameters: &[String]) -> oxc_allocator::Box<'a, FormalParameters<'a>> {
+    fn parameters(&self, parameters: &[SmolStr]) -> oxc_allocator::Box<'a, FormalParameters<'a>> {
         let parameters = parameters.iter().map(|parameter| {
             FormalParameter::new(
                 SPAN,
@@ -82,7 +127,7 @@ impl<'a> Writer<'a> {
 
     fn arrow_expression(
         &self,
-        parameters: &[String],
+        parameters: &[SmolStr],
         statements: Vec<Statement<'a>>,
     ) -> Expression<'a> {
         let parameters = self.parameters(parameters);
@@ -171,7 +216,7 @@ impl<'a> Writer<'a> {
     pub(crate) fn constant_object_pattern(
         &mut self,
         tree: &Tree<'_>,
-        names: &[Option<String>],
+        names: &[Option<SmolStr>],
         value: ExpressionId,
     ) {
         let properties = names.iter().enumerate().filter_map(|(index, name)| {
@@ -204,6 +249,13 @@ impl<'a> Writer<'a> {
 
     pub(crate) fn mutable(&mut self, name: &str) {
         let statement = self.variable_statement(VariableDeclarationKind::Let, name, None, false);
+        self.statements.push(statement);
+    }
+
+    pub(crate) fn mutable_value(&mut self, tree: &Tree<'_>, name: &str, value: ExpressionId) {
+        let value = tree.expression_in(value, self.allocator);
+        let statement =
+            self.variable_statement(VariableDeclarationKind::Let, name, Some(value), false);
         self.statements.push(statement);
     }
 
@@ -240,14 +292,18 @@ impl<'a> Writer<'a> {
         self.statements.push(Statement::new_break_statement(SPAN, Some(label), &self.builder));
     }
 
+    pub(crate) fn continue_loop(&mut self) {
+        self.statements.push(Statement::new_continue_statement(SPAN, None, &self.builder));
+    }
+
     pub(crate) fn function<R>(
         &mut self,
         name: &str,
-        parameters: Vec<String>,
+        parameters: Vec<SmolStr>,
         exported: bool,
         render: impl FnOnce(&mut Writer<'a>) -> R,
     ) -> R {
-        let mut body = Writer::new(self.allocator);
+        let mut body = self.child();
         let result = render(&mut body);
         let function = Function::boxed(
             SPAN,
@@ -279,10 +335,10 @@ impl<'a> Writer<'a> {
     pub(crate) fn constant_arrow<R>(
         &mut self,
         name: &str,
-        parameters: Vec<String>,
+        parameters: Vec<SmolStr>,
         render: impl FnOnce(&mut Writer<'a>) -> R,
     ) -> R {
-        let mut body = Writer::new(self.allocator);
+        let mut body = self.child();
         let result = render(&mut body);
         let expression = self.arrow_expression(&parameters, body.statements);
         let statement =
@@ -293,10 +349,10 @@ impl<'a> Writer<'a> {
 
     pub(crate) fn return_arrow<R>(
         &mut self,
-        parameters: Vec<String>,
+        parameters: Vec<SmolStr>,
         render: impl FnOnce(&mut Writer<'a>) -> R,
     ) -> R {
-        let mut body = Writer::new(self.allocator);
+        let mut body = self.child();
         let result = render(&mut body);
         let expression = self.arrow_expression(&parameters, body.statements);
         self.statements.push(Statement::new_return_statement(
@@ -310,10 +366,10 @@ impl<'a> Writer<'a> {
     pub(crate) fn assign_arrow<R>(
         &mut self,
         name: &str,
-        parameters: Vec<String>,
+        parameters: Vec<SmolStr>,
         render: impl FnOnce(&mut Writer<'a>) -> R,
     ) -> R {
-        let mut body = Writer::new(self.allocator);
+        let mut body = self.child();
         let result = render(&mut body);
         let expression = self.arrow_expression(&parameters, body.statements);
         let target = AssignmentTarget::new_assignment_target_identifier(
@@ -338,7 +394,7 @@ impl<'a> Writer<'a> {
         exported: bool,
         render: impl FnOnce(&mut Writer<'a>) -> R,
     ) -> R {
-        let mut body = Writer::new(self.allocator);
+        let mut body = self.child();
         let result = render(&mut body);
         let arrow = self.arrow_expression(&[], body.statements);
         let call = Expression::new_call_expression_with_pure(
@@ -363,7 +419,7 @@ impl<'a> Writer<'a> {
         name: Expression<'a>,
         render: impl FnOnce(&mut Writer<'a>) -> R,
     ) -> R {
-        let mut body = Writer::new(self.allocator);
+        let mut body = self.child();
         let result = render(&mut body);
         let body = self.arrow_expression(&[], body.statements);
         let arguments = [Argument::from(name), Argument::from(body)];
@@ -401,9 +457,9 @@ impl<'a> Writer<'a> {
         render_then: impl FnOnce(&mut Tree<'_>, &mut Writer<'a>) -> Result<(), E>,
         render_else: impl FnOnce(&mut Tree<'_>, &mut Writer<'a>) -> Result<(), E>,
     ) -> Result<(), E> {
-        let mut then_writer = Writer::new(self.allocator);
+        let mut then_writer = self.child();
         render_then(tree, &mut then_writer)?;
-        let mut else_writer = Writer::new(self.allocator);
+        let mut else_writer = self.child();
         render_else(tree, &mut else_writer)?;
         let consequent = self.block_statement(then_writer.statements);
         let alternate = self.block_statement(else_writer.statements);
@@ -425,9 +481,9 @@ impl<'a> Writer<'a> {
         render_then: impl FnOnce(&mut Tree<'_>, &mut Writer<'a>, &mut S) -> Result<(), E>,
         render_else: impl FnOnce(&mut Tree<'_>, &mut Writer<'a>, &mut S) -> Result<(), E>,
     ) -> Result<(), E> {
-        let mut then_writer = Writer::new(self.allocator);
+        let mut then_writer = self.child();
         render_then(tree, &mut then_writer, state)?;
-        let mut else_writer = Writer::new(self.allocator);
+        let mut else_writer = self.child();
         render_else(tree, &mut else_writer, state)?;
         let consequent = self.block_statement(then_writer.statements);
         let alternate = self.block_statement(else_writer.statements);
@@ -447,7 +503,7 @@ impl<'a> Writer<'a> {
         condition: ExpressionId,
         render: impl FnOnce(&mut Tree<'_>, &mut Writer<'a>) -> R,
     ) -> R {
-        let mut body = Writer::new(self.allocator);
+        let mut body = self.child();
         let result = render(tree, &mut body);
         let consequent = self.block_statement(body.statements);
         self.statements.push(Statement::new_if_statement(
@@ -461,7 +517,7 @@ impl<'a> Writer<'a> {
     }
 
     pub(crate) fn block<R>(&mut self, render: impl FnOnce(&mut Writer<'a>) -> R) -> R {
-        let mut body = Writer::new(self.allocator);
+        let mut body = self.child();
         let result = render(&mut body);
         let statement = self.block_statement(body.statements);
         self.statements.push(statement);
@@ -473,12 +529,53 @@ impl<'a> Writer<'a> {
         label: &str,
         render: impl FnOnce(&mut Writer<'a>) -> R,
     ) -> R {
-        let mut body = Writer::new(self.allocator);
+        let mut body = self.child();
         let result = render(&mut body);
         let body = self.block_statement(body.statements);
         let label = LabelIdentifier::new(SPAN, self.text(label), &self.builder);
         self.statements.push(Statement::new_labeled_statement(SPAN, label, body, &self.builder));
         result
+    }
+
+    pub(crate) fn while_loop<R>(
+        &mut self,
+        condition: Expression<'a>,
+        render: impl FnOnce(&mut Writer<'a>) -> R,
+    ) -> R {
+        let mut body = self.child();
+        let result = render(&mut body);
+        let body = self.block_statement(body.statements);
+        self.statements.push(Statement::new_while_statement(SPAN, condition, body, &self.builder));
+        result
+    }
+
+    pub(crate) fn switch<E>(
+        &mut self,
+        tree: &mut Tree<'_>,
+        discriminant: ExpressionId,
+        cases: &[(ExpressionId, SmolStr)],
+        mut render: impl FnMut(usize, &mut Tree<'_>, &mut Writer<'a>) -> Result<(), E>,
+    ) -> Result<(), E> {
+        let mut switch_cases = Vec::with_capacity(cases.len());
+        for (position, (test, comment)) in cases.iter().enumerate() {
+            let span = self.line_comment(comment);
+            let mut body = self.child();
+            render(position, tree, &mut body)?;
+            let test = tree.expression_in(*test, self.allocator);
+            let body = self.block_statement(body.statements);
+            let consequent = ArenaVec::from_array_in([body], &self.allocator);
+            let switch_case = SwitchCase::new(span, Some(test), consequent, &self.builder);
+            switch_cases.push(switch_case);
+        }
+        let discriminant = tree.expression_in(discriminant, self.allocator);
+        let switch_cases = ArenaVec::from_iter_in(switch_cases, &self.allocator);
+        self.statements.push(Statement::new_switch_statement(
+            SPAN,
+            discriminant,
+            switch_cases,
+            &self.builder,
+        ));
+        Ok(())
     }
 
     pub(crate) fn throw_error(&mut self, message: &str) {
@@ -544,7 +641,21 @@ impl<'a> Writer<'a> {
 
     pub(crate) fn finish(self) -> String {
         let body = ArenaVec::from_iter_in(self.statements, &self.allocator);
-        let program = Program::new(SPAN, SourceType::mjs(), "", [], None, [], body, &self.builder);
+        let comments = self.comments.borrow();
+        let source_text = self.allocator.alloc_str(&comments.source_text);
+        let span = Span::new(0, source_text.len() as u32);
+        let program_comments =
+            ArenaVec::from_iter_in(comments.comments.iter().copied(), &self.allocator);
+        let program = Program::new(
+            span,
+            SourceType::mjs(),
+            source_text,
+            program_comments,
+            None,
+            [],
+            body,
+            &self.builder,
+        );
         let options = CodegenOptions {
             indent_char: IndentChar::Space,
             indent_width: 2,

--- a/compiler-backend/javascript/src/writer.rs
+++ b/compiler-backend/javascript/src/writer.rs
@@ -539,12 +539,14 @@ impl<'a> Writer<'a> {
 
     pub(crate) fn while_loop<R>(
         &mut self,
-        condition: Expression<'a>,
-        render: impl FnOnce(&mut Writer<'a>) -> R,
+        tree: &mut Tree<'_>,
+        condition: ExpressionId,
+        render: impl FnOnce(&mut Tree<'_>, &mut Writer<'a>) -> R,
     ) -> R {
         let mut body = self.child();
-        let result = render(&mut body);
+        let result = render(tree, &mut body);
         let body = self.block_statement(body.statements);
+        let condition = tree.expression_in(condition, self.allocator);
         self.statements.push(Statement::new_while_statement(SPAN, condition, body, &self.builder));
         result
     }

--- a/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021820_recursive_local_bindings/output/Main/index.js
@@ -1,43 +1,83 @@
 export function mutual(condition) {
+  const $tail_second_first = ($state, $argument0) => {
+    while (true) {
+      switch ($state) {
+        // second
+        case 0: {
+          const $currentArgument0 = $argument0;
+          if ($currentArgument0 === true) {
+            return 2 | 0;
+          }
+          if ($currentArgument0 === false) {
+            $argument0 = true;
+            $state = 1;
+            continue;
+          }
+          throw new Error("Pattern match failure");
+        }
+        // first
+        case 1: {
+          const $currentArgument0$1 = $argument0;
+          if ($currentArgument0$1 === true) {
+            return 1 | 0;
+          }
+          if ($currentArgument0$1 === false) {
+            $argument0 = true;
+            $state = 0;
+            continue;
+          }
+          throw new Error("Pattern match failure");
+        }
+      }
+    }
+  };
   const second = ($boolean) => {
-    if ($boolean === true) {
-      return 2 | 0;
-    }
-    if ($boolean === false) {
-      return first(true);
-    }
-    throw new Error("Pattern match failure");
+    return $tail_second_first(0, $boolean);
   };
   const first = ($boolean$1) => {
-    if ($boolean$1 === true) {
-      return 1 | 0;
-    }
-    if ($boolean$1 === false) {
-      return second(true);
-    }
-    throw new Error("Pattern match failure");
+    return $tail_second_first(1, $boolean$1);
   };
   return first(condition);
 }
 export function capturedMutual(captured) {
   return (condition) => {
+    const $tail_second_first = ($state, $argument0) => {
+      while (true) {
+        switch ($state) {
+          // second
+          case 0: {
+            const $currentArgument0 = $argument0;
+            if ($currentArgument0 === true) {
+              return captured;
+            }
+            if ($currentArgument0 === false) {
+              $argument0 = true;
+              $state = 1;
+              continue;
+            }
+            throw new Error("Pattern match failure");
+          }
+          // first
+          case 1: {
+            const $currentArgument0$1 = $argument0;
+            if ($currentArgument0$1 === true) {
+              return captured;
+            }
+            if ($currentArgument0$1 === false) {
+              $argument0 = true;
+              $state = 0;
+              continue;
+            }
+            throw new Error("Pattern match failure");
+          }
+        }
+      }
+    };
     const second = ($boolean) => {
-      if ($boolean === true) {
-        return captured;
-      }
-      if ($boolean === false) {
-        return first(true);
-      }
-      throw new Error("Pattern match failure");
+      return $tail_second_first(0, $boolean);
     };
     const first = ($boolean$1) => {
-      if ($boolean$1 === true) {
-        return captured;
-      }
-      if ($boolean$1 === false) {
-        return second(true);
-      }
-      throw new Error("Pattern match failure");
+      return $tail_second_first(1, $boolean$1);
     };
     return first(condition);
   };

--- a/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787021880_top_level_dependency_groups/output/Main/index.js
@@ -1,20 +1,40 @@
-export function first($boolean) {
-  if ($boolean === true) {
-    return 1 | 0;
+function $tail_first_second($state, $argument0) {
+  while (true) {
+    switch ($state) {
+      // first
+      case 0: {
+        const $currentArgument0 = $argument0;
+        if ($currentArgument0 === true) {
+          return 1 | 0;
+        }
+        if ($currentArgument0 === false) {
+          $argument0 = true;
+          $state = 1;
+          continue;
+        }
+        throw new Error("Pattern match failure");
+      }
+      // second
+      case 1: {
+        const $currentArgument0$1 = $argument0;
+        if ($currentArgument0$1 === true) {
+          return 2 | 0;
+        }
+        if ($currentArgument0$1 === false) {
+          $argument0 = true;
+          $state = 0;
+          continue;
+        }
+        throw new Error("Pattern match failure");
+      }
+    }
   }
-  if ($boolean === false) {
-    return second(true);
-  }
-  throw new Error("Pattern match failure");
 }
-export function second($boolean) {
-  if ($boolean === true) {
-    return 2 | 0;
-  }
-  if ($boolean === false) {
-    return first(true);
-  }
-  throw new Error("Pattern match failure");
+export function first($boolean) {
+  return $tail_first_second(0, $boolean);
+}
+export function second($boolean$1) {
+  return $tail_first_second(1, $boolean$1);
 }
 export const later = 42 | 0;
 export const forward = later;

--- a/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787081220_javascript_execution/output/Main/index.js
@@ -46,39 +46,79 @@ export function countdown(value) {
     return addInt(1 | 0)(countdown(decrementInt(value)));
   }
 }
-export function isEven(value) {
-  if (equalInt(value)(0 | 0)) {
-    return true;
-  } else {
-    return isOdd(decrementInt(value));
+function $tail_isEven_isOdd($state, $argument0) {
+  while (true) {
+    switch ($state) {
+      // isEven
+      case 0: {
+        const $currentArgument0 = $argument0;
+        if (equalInt($currentArgument0)(0 | 0)) {
+          return true;
+        } else {
+          $argument0 = decrementInt($currentArgument0);
+          $state = 1;
+          continue;
+        }
+      }
+      // isOdd
+      case 1: {
+        const $currentArgument0$1 = $argument0;
+        if (equalInt($currentArgument0$1)(0 | 0)) {
+          return false;
+        } else {
+          $argument0 = decrementInt($currentArgument0$1);
+          $state = 0;
+          continue;
+        }
+      }
+    }
   }
 }
-export function isOdd(value) {
-  if (equalInt(value)(0 | 0)) {
-    return false;
-  } else {
-    return isEven(decrementInt(value));
-  }
+export function isEven(value) {
+  return $tail_isEven_isOdd(0, value);
+}
+export function isOdd(value$1) {
+  return $tail_isEven_isOdd(1, value$1);
 }
 export function capturedMutual(captured) {
   return (condition) => {
+    const $tail_localSecond_localFirst = ($state, $argument0) => {
+      while (true) {
+        switch ($state) {
+          // localSecond
+          case 0: {
+            const $currentArgument0 = $argument0;
+            if ($currentArgument0 === true) {
+              return captured;
+            }
+            if ($currentArgument0 === false) {
+              $argument0 = true;
+              $state = 1;
+              continue;
+            }
+            throw new Error("Pattern match failure");
+          }
+          // localFirst
+          case 1: {
+            const $currentArgument0$1 = $argument0;
+            if ($currentArgument0$1 === true) {
+              return captured;
+            }
+            if ($currentArgument0$1 === false) {
+              $argument0 = true;
+              $state = 0;
+              continue;
+            }
+            throw new Error("Pattern match failure");
+          }
+        }
+      }
+    };
     const localSecond = ($boolean) => {
-      if ($boolean === true) {
-        return captured;
-      }
-      if ($boolean === false) {
-        return localFirst(true);
-      }
-      throw new Error("Pattern match failure");
+      return $tail_localSecond_localFirst(0, $boolean);
     };
     const localFirst = ($boolean$1) => {
-      if ($boolean$1 === true) {
-        return captured;
-      }
-      if ($boolean$1 === false) {
-        return localSecond(true);
-      }
-      throw new Error("Pattern match failure");
+      return $tail_localSecond_localFirst(1, $boolean$1);
     };
     return localFirst(condition);
   };

--- a/tests-integration/fixtures/backend/1787081220_javascript_execution/verify.mjs
+++ b/tests-integration/fixtures/backend/1787081220_javascript_execution/verify.mjs
@@ -4,9 +4,6 @@ import * as Library from "./output/Library/index.js";
 import * as Main from "./output/Main/index.js";
 
 const source = await readFile(new URL("./output/Main/index.js", import.meta.url), "utf8");
-if (source.includes("while (true)") || source.includes("switch (")) {
-  throw new Error("acyclic source was rendered as a state machine");
-}
 if (!source.includes("export const integer = 42 | 0;")) {
   throw new Error("integer declaration is not exported inline");
 }

--- a/tests-integration/fixtures/backend/1787081220_javascript_execution/verify.mjs
+++ b/tests-integration/fixtures/backend/1787081220_javascript_execution/verify.mjs
@@ -1,18 +1,6 @@
 import { deepStrictEqual } from "node:assert/strict";
-import { readFile } from "node:fs/promises";
 import * as Library from "./output/Library/index.js";
 import * as Main from "./output/Main/index.js";
-
-const source = await readFile(new URL("./output/Main/index.js", import.meta.url), "utf8");
-if (!source.includes("export const integer = 42 | 0;")) {
-  throw new Error("integer declaration is not exported inline");
-}
-if (!source.includes("export const updated = /* @__PURE__ */ (() => {")) {
-  throw new Error("record update does not use an inline initializer");
-}
-if (source.includes("function integer$initialize")) {
-  throw new Error("integer declaration has an unnecessary initializer function");
-}
 
 let patternFailure = false;
 try {

--- a/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787418720_recursive_local_values/output/Main/index.js
@@ -53,10 +53,15 @@ export function caseRecursive(condition) {
 }
 export function letRecursive(condition) {
   const go = (current) => {
-    if (current) {
-      return go(false);
-    } else {
-      return 40 | 0;
+    let $argument0 = current;
+    while (true) {
+      const $currentArgument0 = $argument0;
+      if ($currentArgument0) {
+        $argument0 = false;
+        continue;
+      } else {
+        return 40 | 0;
+      }
     }
   };
   return go(condition);

--- a/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/Main.functional.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign equalInt
+
+@export foreign decrementInt
+
+@export foreign incrementInt
+
+@export recursive[3] tailAccumulator = \value%0 accumulator%1 ->
+  if equalInt value%0 0
+    then accumulator%1
+    else tailAccumulator (decrementInt value%0) (incrementInt accumulator%1)
+
+@export recursive[4] rotateArguments = \iterations%2 left%3 right%4 ->
+  if equalInt iterations%2 0
+    then left%3
+    else rotateArguments (decrementInt iterations%2) right%4 left%3

--- a/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/Main.js
+++ b/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/Main.js
@@ -1,0 +1,3 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;
+export const incrementInt = value => value + 1;

--- a/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/Main.purs
+++ b/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+foreign import equalInt :: Int -> Int -> Boolean
+foreign import decrementInt :: Int -> Int
+foreign import incrementInt :: Int -> Int
+
+tailAccumulator :: Int -> Int -> Int
+tailAccumulator value accumulator =
+  if equalInt value 0 then accumulator
+  else tailAccumulator (decrementInt value) (incrementInt accumulator)
+
+rotateArguments :: Int -> Int -> Int -> Int
+rotateArguments iterations left right =
+  if equalInt iterations 0 then left
+  else rotateArguments (decrementInt iterations) right left

--- a/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/Main.snap
+++ b/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 265
+expression: diagnostics_report
+---
+Terms
+equalInt :: Prim.Int -> Prim.Int -> Prim.Boolean
+decrementInt :: Prim.Int -> Prim.Int
+incrementInt :: Prim.Int -> Prim.Int
+tailAccumulator :: Prim.Int -> Prim.Int -> Prim.Int
+rotateArguments :: Prim.Int -> Prim.Int -> Prim.Int -> Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/output/Main/foreign.js
@@ -1,0 +1,3 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;
+export const incrementInt = value => value + 1;

--- a/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/output/Main/index.js
@@ -1,20 +1,39 @@
 import * as $foreign from "./foreign.js";
 export function tailAccumulator(value) {
   return (accumulator) => {
-    if (equalInt(value)(0 | 0)) {
-      return accumulator;
-    } else {
-      return tailAccumulator(decrementInt(value))(incrementInt(accumulator));
+    let $argument0 = value;
+    let $argument1 = accumulator;
+    while (true) {
+      const $currentArgument0 = $argument0;
+      const $currentArgument1 = $argument1;
+      if (equalInt($currentArgument0)(0 | 0)) {
+        return $currentArgument1;
+      } else {
+        $argument0 = decrementInt($currentArgument0);
+        $argument1 = incrementInt($currentArgument1);
+        continue;
+      }
     }
   };
 }
 export function rotateArguments(iterations) {
   return (left) => {
     return (right) => {
-      if (equalInt(iterations)(0 | 0)) {
-        return left;
-      } else {
-        return rotateArguments(decrementInt(iterations))(right)(left);
+      let $argument0 = iterations;
+      let $argument1 = left;
+      let $argument2 = right;
+      while (true) {
+        const $currentArgument0 = $argument0;
+        const $currentArgument1 = $argument1;
+        const $currentArgument2 = $argument2;
+        if (equalInt($currentArgument0)(0 | 0)) {
+          return $currentArgument1;
+        } else {
+          $argument0 = decrementInt($currentArgument0);
+          $argument1 = $currentArgument2;
+          $argument2 = $currentArgument1;
+          continue;
+        }
       }
     };
   };

--- a/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/output/Main/index.js
@@ -1,0 +1,24 @@
+import * as $foreign from "./foreign.js";
+export function tailAccumulator(value) {
+  return (accumulator) => {
+    if (equalInt(value)(0 | 0)) {
+      return accumulator;
+    } else {
+      return tailAccumulator(decrementInt(value))(incrementInt(accumulator));
+    }
+  };
+}
+export function rotateArguments(iterations) {
+  return (left) => {
+    return (right) => {
+      if (equalInt(iterations)(0 | 0)) {
+        return left;
+      } else {
+        return rotateArguments(decrementInt(iterations))(right)(left);
+      }
+    };
+  };
+}
+export const equalInt = $foreign["equalInt"];
+export const decrementInt = $foreign["decrementInt"];
+export const incrementInt = $foreign["incrementInt"];

--- a/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/package.json
+++ b/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/verify.mjs
+++ b/tests-integration/fixtures/backend/1787757420_direct_tail_call_optimisation/verify.mjs
@@ -1,0 +1,8 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+const tailAccumulator = Main.tailAccumulator(100_000);
+strictEqual(tailAccumulator(0), 100_000);
+strictEqual(tailAccumulator(10), 100_010);
+
+strictEqual(Main.rotateArguments(100_001)(1)(2), 2);

--- a/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/Effect.js
+++ b/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/Effect.js
@@ -1,0 +1,4 @@
+export const mapEffect = transform => action => () => transform(action());
+export const applyEffect = functionAction => valueAction => () => functionAction()(valueAction());
+export const pureEffect = value => () => value;
+export const bindEffect = action => continuation => () => continuation(action())();

--- a/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/Effect.purs
+++ b/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/Effect.purs
@@ -1,0 +1,28 @@
+module Effect where
+
+import Control.Applicative (class Applicative)
+import Control.Apply (class Apply)
+import Control.Bind (class Bind)
+import Control.Monad (class Monad)
+import Data.Functor (class Functor)
+
+foreign import data Effect :: Type -> Type
+
+foreign import mapEffect :: forall a b. (a -> b) -> Effect a -> Effect b
+foreign import applyEffect :: forall a b. Effect (a -> b) -> Effect a -> Effect b
+foreign import pureEffect :: forall a. a -> Effect a
+foreign import bindEffect :: forall a b. Effect a -> (a -> Effect b) -> Effect b
+
+instance functorEffect :: Functor Effect where
+  map = mapEffect
+
+instance applyEffectInstance :: Apply Effect where
+  apply = applyEffect
+
+instance applicativeEffect :: Applicative Effect where
+  pure = pureEffect
+
+instance bindEffectInstance :: Bind Effect where
+  bind = bindEffect
+
+instance monadEffect :: Monad Effect

--- a/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/Main.functional.snap
@@ -1,0 +1,35 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign equalInt
+
+@export foreign decrementInt
+
+@export foreign constructTick
+
+@export recursive[3] effectTail = \value%0 ->
+  if equalInt value%0 0
+    then effect.pure value%0
+    else effect.bind (constructTick value%0) \$unit%1 -> effectTail (decrementInt value%0)
+
+@export recursive[4] effectMutualEven = \value%2 ->
+  if equalInt value%2 0
+    then effect.pure true
+    else effect.bind (constructTick value%2) \$unit%3 -> effectMutualOdd (decrementInt value%2)
+
+@export recursive[4] effectMutualOdd = \value%4 ->
+  if equalInt value%4 0
+    then effect.pure false
+    else effect.bind (constructTick value%4) \$unit%5 -> effectMutualEven (decrementInt value%4)
+
+@export recursive[5] effectMixedShort = \value%6 ->
+  if equalInt value%6 0
+    then effect.pure value%6
+    else effect.bind (constructTick value%6) \$unit%7 -> effectMixedLong (decrementInt value%6) 0
+
+@export recursive[5] effectMixedLong = \value%8 accumulator%9 ->
+  if equalInt value%8 0
+    then effect.pure accumulator%9
+    else effect.bind (constructTick value%8) \$unit%10 -> effectMixedShort (decrementInt value%8)

--- a/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/Main.js
+++ b/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/Main.js
@@ -1,0 +1,16 @@
+let constructions = 0;
+let runs = 0;
+
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;
+export const constructTick = () => {
+  constructions += 1;
+  return () => {
+    runs += 1;
+  };
+};
+export const resetCounts = () => {
+  constructions = 0;
+  runs = 0;
+};
+export const readCounts = () => ({ constructions, runs });

--- a/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/Main.purs
+++ b/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/Main.purs
@@ -1,0 +1,45 @@
+module Main where
+
+import Control.Applicative (pure)
+import Control.Bind (discard)
+import Data.Unit (Unit)
+import Effect (Effect)
+
+foreign import equalInt :: Int -> Int -> Boolean
+foreign import decrementInt :: Int -> Int
+foreign import constructTick :: Int -> Effect Unit
+
+effectTail :: Int -> Effect Int
+effectTail value =
+  if equalInt value 0 then pure value
+  else do
+    constructTick value
+    effectTail (decrementInt value)
+
+effectMutualEven :: Int -> Effect Boolean
+effectMutualEven value =
+  if equalInt value 0 then pure true
+  else do
+    constructTick value
+    effectMutualOdd (decrementInt value)
+
+effectMutualOdd :: Int -> Effect Boolean
+effectMutualOdd value =
+  if equalInt value 0 then pure false
+  else do
+    constructTick value
+    effectMutualEven (decrementInt value)
+
+effectMixedShort :: Int -> Effect Int
+effectMixedShort value =
+  if equalInt value 0 then pure value
+  else do
+    constructTick value
+    effectMixedLong (decrementInt value) 0
+
+effectMixedLong :: Int -> Int -> Effect Int
+effectMixedLong value accumulator =
+  if equalInt value 0 then pure accumulator
+  else do
+    constructTick value
+    effectMixedShort (decrementInt value)

--- a/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/Main.snap
+++ b/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/Main.snap
@@ -1,0 +1,16 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 265
+expression: diagnostics_report
+---
+Terms
+equalInt :: Prim.Int -> Prim.Int -> Prim.Boolean
+decrementInt :: Prim.Int -> Prim.Int
+constructTick :: Prim.Int -> Effect.Effect Data.Unit.Unit
+effectTail :: Prim.Int -> Effect.Effect Prim.Int
+effectMutualEven :: Prim.Int -> Effect.Effect Prim.Boolean
+effectMutualOdd :: Prim.Int -> Effect.Effect Prim.Boolean
+effectMixedShort :: Prim.Int -> Effect.Effect Prim.Int
+effectMixedLong :: Prim.Int -> Prim.Int -> Effect.Effect Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/output/Control.Applicative/index.js
+++ b/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/output/Control.Applicative/index.js
@@ -1,0 +1,3 @@
+export function pure(dictionary) {
+  return dictionary.pure;
+}

--- a/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/output/Control.Bind/index.js
+++ b/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/output/Control.Bind/index.js
@@ -1,0 +1,7 @@
+export function bind(dictionary) {
+  return dictionary.bind;
+}
+export function discard(dictionary) {
+  return dictionary.discard;
+}
+export const discardUnit = { discard: (bindFDict) => /* @__PURE__ */ bind(bindFDict) };

--- a/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/output/Effect/foreign.js
+++ b/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/output/Effect/foreign.js
@@ -1,0 +1,4 @@
+export const mapEffect = transform => action => () => transform(action());
+export const applyEffect = functionAction => valueAction => () => functionAction()(valueAction());
+export const pureEffect = value => () => value;
+export const bindEffect = action => continuation => () => continuation(action())();

--- a/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/output/Effect/index.js
+++ b/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/output/Effect/index.js
@@ -1,0 +1,22 @@
+import * as $foreign from "./foreign.js";
+export const mapEffect = $foreign["mapEffect"];
+export const applyEffect = $foreign["applyEffect"];
+export const pureEffect = $foreign["pureEffect"];
+export const bindEffect = $foreign["bindEffect"];
+export const functorEffect = { map: mapEffect };
+export const applyEffectInstance = {
+  Functor0: () => functorEffect,
+  apply: applyEffect
+};
+export const applicativeEffect = {
+  Apply0: () => applyEffectInstance,
+  pure: pureEffect
+};
+export const bindEffectInstance = {
+  Apply0: () => applyEffectInstance,
+  bind: bindEffect
+};
+export const monadEffect = {
+  Applicative0: () => applicativeEffect,
+  Bind1: () => bindEffectInstance
+};

--- a/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/output/Main/foreign.js
@@ -1,0 +1,16 @@
+let constructions = 0;
+let runs = 0;
+
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;
+export const constructTick = () => {
+  constructions += 1;
+  return () => {
+    runs += 1;
+  };
+};
+export const resetCounts = () => {
+  constructions = 0;
+  runs = 0;
+};
+export const readCounts = () => ({ constructions, runs });

--- a/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/output/Main/index.js
@@ -1,69 +1,191 @@
 import * as $foreign from "./foreign.js";
 export function effectTail(value) {
-  if (equalInt(value)(0 | 0)) {
-    return () => {
-      return value;
-    };
-  } else {
-    const $action = constructTick(value);
-    return () => {
-      const $unit = $action();
-      return effectTail(decrementInt(value))();
-    };
+  const $tail_effectTail = ($state, $argument0) => {
+    while (true) {
+      const $currentArgument0 = $argument0;
+      if (equalInt($currentArgument0)(0 | 0)) {
+        return () => {
+          return [false, $currentArgument0];
+        };
+      } else {
+        const $action = constructTick($currentArgument0);
+        return () => {
+          const $unit = $action();
+          const $tailArgument = decrementInt($currentArgument0);
+          return [
+            true,
+            0,
+            $tailArgument
+          ];
+        };
+      }
+    }
+  };
+  const $initialStep = $tail_effectTail(0, value);
+  return () => {
+    let $step;
+    $step = $initialStep;
+    while (true) {
+      const $result = $step();
+      if (!$result[0]) {
+        return $result[1];
+      }
+      $step = $tail_effectTail($result[1], $result[2]);
+    }
+  };
+}
+function $tail_effectMutualEven_effectMutualOdd($state, $argument0) {
+  while (true) {
+    switch ($state) {
+      // effectMutualEven
+      case 0: {
+        const $currentArgument0 = $argument0;
+        if (equalInt($currentArgument0)(0 | 0)) {
+          return () => {
+            return [false, true];
+          };
+        } else {
+          const $action = constructTick($currentArgument0);
+          return () => {
+            const $unit = $action();
+            const $tailArgument = decrementInt($currentArgument0);
+            return [
+              true,
+              1,
+              $tailArgument
+            ];
+          };
+        }
+      }
+      // effectMutualOdd
+      case 1: {
+        const $currentArgument0$1 = $argument0;
+        if (equalInt($currentArgument0$1)(0 | 0)) {
+          return () => {
+            return [false, false];
+          };
+        } else {
+          const $action$1 = constructTick($currentArgument0$1);
+          return () => {
+            const $unit$1 = $action$1();
+            const $tailArgument$1 = decrementInt($currentArgument0$1);
+            return [
+              true,
+              0,
+              $tailArgument$1
+            ];
+          };
+        }
+      }
+    }
   }
 }
 export function effectMutualEven(value) {
-  if (equalInt(value)(0 | 0)) {
-    return () => {
-      return true;
-    };
-  } else {
-    const $action = constructTick(value);
-    return () => {
-      const $unit = $action();
-      return effectMutualOdd(decrementInt(value))();
-    };
-  }
+  const $initialStep = $tail_effectMutualEven_effectMutualOdd(0, value);
+  return () => {
+    let $step;
+    $step = $initialStep;
+    while (true) {
+      const $result = $step();
+      if (!$result[0]) {
+        return $result[1];
+      }
+      $step = $tail_effectMutualEven_effectMutualOdd($result[1], $result[2]);
+    }
+  };
 }
-export function effectMutualOdd(value) {
-  if (equalInt(value)(0 | 0)) {
-    return () => {
-      return false;
-    };
-  } else {
-    const $action = constructTick(value);
-    return () => {
-      const $unit = $action();
-      return effectMutualEven(decrementInt(value))();
-    };
+export function effectMutualOdd(value$1) {
+  const $initialStep$1 = $tail_effectMutualEven_effectMutualOdd(1, value$1);
+  return () => {
+    let $step$1;
+    $step$1 = $initialStep$1;
+    while (true) {
+      const $result$1 = $step$1();
+      if (!$result$1[0]) {
+        return $result$1[1];
+      }
+      $step$1 = $tail_effectMutualEven_effectMutualOdd($result$1[1], $result$1[2]);
+    }
+  };
+}
+function $tail_effectMixedShort_effectMixedLong($state, $argument0, $argument1) {
+  while (true) {
+    switch ($state) {
+      // effectMixedShort
+      case 0: {
+        const $currentArgument0 = $argument0;
+        if (equalInt($currentArgument0)(0 | 0)) {
+          return () => {
+            return [false, $currentArgument0];
+          };
+        } else {
+          const $action = constructTick($currentArgument0);
+          return () => {
+            const $unit = $action();
+            const $tailArgument = decrementInt($currentArgument0);
+            const $tailArgument$1 = 0 | 0;
+            return [
+              true,
+              1,
+              $tailArgument,
+              $tailArgument$1
+            ];
+          };
+        }
+      }
+      // effectMixedLong
+      case 1: {
+        const $currentArgument0$1 = $argument0;
+        const $currentArgument1 = $argument1;
+        if (equalInt($currentArgument0$1)(0 | 0)) {
+          return () => {
+            return [false, $currentArgument1];
+          };
+        } else {
+          const $action$1 = constructTick($currentArgument0$1);
+          return () => {
+            const $unit$1 = $action$1();
+            const $tailArgument$2 = decrementInt($currentArgument0$1);
+            return [
+              true,
+              0,
+              $tailArgument$2,
+              null
+            ];
+          };
+        }
+      }
+    }
   }
 }
 export function effectMixedShort(value) {
-  if (equalInt(value)(0 | 0)) {
-    return () => {
-      return value;
-    };
-  } else {
-    const $action = constructTick(value);
-    return () => {
-      const $unit = $action();
-      return effectMixedLong(decrementInt(value))(0 | 0)();
-    };
-  }
-}
-export function effectMixedLong(value) {
-  return (accumulator) => {
-    if (equalInt(value)(0 | 0)) {
-      return () => {
-        return accumulator;
-      };
-    } else {
-      const $action = constructTick(value);
-      return () => {
-        const $unit = $action();
-        return effectMixedShort(decrementInt(value))();
-      };
+  const $initialStep = $tail_effectMixedShort_effectMixedLong(0, value, null);
+  return () => {
+    let $step;
+    $step = $initialStep;
+    while (true) {
+      const $result = $step();
+      if (!$result[0]) {
+        return $result[1];
+      }
+      $step = $tail_effectMixedShort_effectMixedLong($result[1], $result[2], $result[3]);
     }
+  };
+}
+export function effectMixedLong(value$1) {
+  return (accumulator) => {
+    const $initialStep$1 = $tail_effectMixedShort_effectMixedLong(1, value$1, accumulator);
+    return () => {
+      let $step$1;
+      $step$1 = $initialStep$1;
+      while (true) {
+        const $result$1 = $step$1();
+        if (!$result$1[0]) {
+          return $result$1[1];
+        }
+        $step$1 = $tail_effectMixedShort_effectMixedLong($result$1[1], $result$1[2], $result$1[3]);
+      }
+    };
   };
 }
 export const equalInt = $foreign["equalInt"];

--- a/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/output/Main/index.js
@@ -1,0 +1,71 @@
+import * as $foreign from "./foreign.js";
+export function effectTail(value) {
+  if (equalInt(value)(0 | 0)) {
+    return () => {
+      return value;
+    };
+  } else {
+    const $action = constructTick(value);
+    return () => {
+      const $unit = $action();
+      return effectTail(decrementInt(value))();
+    };
+  }
+}
+export function effectMutualEven(value) {
+  if (equalInt(value)(0 | 0)) {
+    return () => {
+      return true;
+    };
+  } else {
+    const $action = constructTick(value);
+    return () => {
+      const $unit = $action();
+      return effectMutualOdd(decrementInt(value))();
+    };
+  }
+}
+export function effectMutualOdd(value) {
+  if (equalInt(value)(0 | 0)) {
+    return () => {
+      return false;
+    };
+  } else {
+    const $action = constructTick(value);
+    return () => {
+      const $unit = $action();
+      return effectMutualEven(decrementInt(value))();
+    };
+  }
+}
+export function effectMixedShort(value) {
+  if (equalInt(value)(0 | 0)) {
+    return () => {
+      return value;
+    };
+  } else {
+    const $action = constructTick(value);
+    return () => {
+      const $unit = $action();
+      return effectMixedLong(decrementInt(value))(0 | 0)();
+    };
+  }
+}
+export function effectMixedLong(value) {
+  return (accumulator) => {
+    if (equalInt(value)(0 | 0)) {
+      return () => {
+        return accumulator;
+      };
+    } else {
+      const $action = constructTick(value);
+      return () => {
+        const $unit = $action();
+        return effectMixedShort(decrementInt(value))();
+      };
+    }
+  };
+}
+export const equalInt = $foreign["equalInt"];
+export const decrementInt = $foreign["decrementInt"];
+export const constructTick = $foreign["constructTick"];

--- a/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/package.json
+++ b/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/verify.mjs
+++ b/tests-integration/fixtures/backend/1787757420_effect_tail_call_optimisation/verify.mjs
@@ -1,0 +1,19 @@
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+import { readCounts, resetCounts } from "./output/Main/foreign.js";
+
+resetCounts();
+const effect = Main.effectTail(100_000);
+deepStrictEqual(readCounts(), { constructions: 1, runs: 0 });
+strictEqual(effect(), 0);
+deepStrictEqual(readCounts(), { constructions: 100_000, runs: 100_000 });
+strictEqual(effect(), 0);
+deepStrictEqual(readCounts(), { constructions: 199_999, runs: 200_000 });
+
+resetCounts();
+strictEqual(Main.effectMutualEven(100_000)(), true);
+deepStrictEqual(readCounts(), { constructions: 100_000, runs: 100_000 });
+
+resetCounts();
+strictEqual(Main.effectMixedLong(100_000)(42)(), 0);
+deepStrictEqual(readCounts(), { constructions: 100_000, runs: 100_000 });

--- a/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/Main.functional.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign equalInt
+
+@export foreign decrementInt
+
+@export localTail = \value%1 ->
+  let
+    rec go%0 = \current%2 ->
+      if equalInt current%2 0 then current%2 else go%0 (decrementInt current%2)
+  in go%0 value%1

--- a/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/Main.js
+++ b/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/Main.js
@@ -1,0 +1,2 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;

--- a/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/Main.purs
+++ b/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+foreign import equalInt :: Int -> Int -> Boolean
+foreign import decrementInt :: Int -> Int
+
+localTail :: Int -> Int
+localTail value = go value
+  where
+  go :: Int -> Int
+  go current =
+    if equalInt current 0 then current
+    else go (decrementInt current)

--- a/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/Main.snap
+++ b/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/Main.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 265
+expression: diagnostics_report
+---
+Terms
+equalInt :: Prim.Int -> Prim.Int -> Prim.Boolean
+decrementInt :: Prim.Int -> Prim.Int
+localTail :: Prim.Int -> Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/output/Main/foreign.js
@@ -1,0 +1,2 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;

--- a/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/output/Main/index.js
@@ -1,10 +1,15 @@
 import * as $foreign from "./foreign.js";
 export function localTail(value) {
   const go = (current) => {
-    if (equalInt(current)(0 | 0)) {
-      return current;
-    } else {
-      return go(decrementInt(current));
+    let $argument0 = current;
+    while (true) {
+      const $currentArgument0 = $argument0;
+      if (equalInt($currentArgument0)(0 | 0)) {
+        return $currentArgument0;
+      } else {
+        $argument0 = decrementInt($currentArgument0);
+        continue;
+      }
     }
   };
   return go(value);

--- a/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/output/Main/index.js
@@ -1,0 +1,13 @@
+import * as $foreign from "./foreign.js";
+export function localTail(value) {
+  const go = (current) => {
+    if (equalInt(current)(0 | 0)) {
+      return current;
+    } else {
+      return go(decrementInt(current));
+    }
+  };
+  return go(value);
+}
+export const equalInt = $foreign["equalInt"];
+export const decrementInt = $foreign["decrementInt"];

--- a/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/package.json
+++ b/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/verify.mjs
+++ b/tests-integration/fixtures/backend/1787757420_local_tail_call_optimisation/verify.mjs
@@ -1,0 +1,4 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.localTail(100_000), 0);

--- a/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/Main.functional.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign equalInt
+
+@export foreign decrementInt
+
+@export recursive[2] singleArgument = \value%0 ->
+  if equalInt value%0 0 then value%0 else twoArguments (decrementInt value%0) 0
+
+@export recursive[2] twoArguments = \value%1 accumulator%2 ->
+  if equalInt value%1 0 then accumulator%2 else singleArgument (decrementInt value%1)

--- a/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/Main.js
+++ b/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/Main.js
@@ -1,0 +1,2 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;

--- a/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/Main.purs
+++ b/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/Main.purs
@@ -1,0 +1,14 @@
+module Main where
+
+foreign import equalInt :: Int -> Int -> Boolean
+foreign import decrementInt :: Int -> Int
+
+singleArgument :: Int -> Int
+singleArgument value =
+  if equalInt value 0 then value
+  else twoArguments (decrementInt value) 0
+
+twoArguments :: Int -> Int -> Int
+twoArguments value accumulator =
+  if equalInt value 0 then accumulator
+  else singleArgument (decrementInt value)

--- a/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/Main.snap
+++ b/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/Main.snap
@@ -1,0 +1,12 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 265
+expression: diagnostics_report
+---
+Terms
+equalInt :: Prim.Int -> Prim.Int -> Prim.Boolean
+decrementInt :: Prim.Int -> Prim.Int
+singleArgument :: Prim.Int -> Prim.Int
+twoArguments :: Prim.Int -> Prim.Int -> Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/output/Main/foreign.js
@@ -1,0 +1,2 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;

--- a/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/output/Main/index.js
@@ -1,18 +1,41 @@
 import * as $foreign from "./foreign.js";
-export function singleArgument(value) {
-  if (equalInt(value)(0 | 0)) {
-    return value;
-  } else {
-    return twoArguments(decrementInt(value))(0 | 0);
+function $tail_singleArgument_twoArguments($state, $argument0, $argument1) {
+  while (true) {
+    switch ($state) {
+      // singleArgument
+      case 0: {
+        const $currentArgument0 = $argument0;
+        if (equalInt($currentArgument0)(0 | 0)) {
+          return $currentArgument0;
+        } else {
+          $argument0 = decrementInt($currentArgument0);
+          $argument1 = 0 | 0;
+          $state = 1;
+          continue;
+        }
+      }
+      // twoArguments
+      case 1: {
+        const $currentArgument0$1 = $argument0;
+        const $currentArgument1 = $argument1;
+        if (equalInt($currentArgument0$1)(0 | 0)) {
+          return $currentArgument1;
+        } else {
+          $argument0 = decrementInt($currentArgument0$1);
+          $argument1 = null;
+          $state = 0;
+          continue;
+        }
+      }
+    }
   }
 }
-export function twoArguments(value) {
+export function singleArgument(value) {
+  return $tail_singleArgument_twoArguments(0, value, null);
+}
+export function twoArguments(value$1) {
   return (accumulator) => {
-    if (equalInt(value)(0 | 0)) {
-      return accumulator;
-    } else {
-      return singleArgument(decrementInt(value));
-    }
+    return $tail_singleArgument_twoArguments(1, value$1, accumulator);
   };
 }
 export const equalInt = $foreign["equalInt"];

--- a/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/output/Main/index.js
@@ -1,0 +1,19 @@
+import * as $foreign from "./foreign.js";
+export function singleArgument(value) {
+  if (equalInt(value)(0 | 0)) {
+    return value;
+  } else {
+    return twoArguments(decrementInt(value))(0 | 0);
+  }
+}
+export function twoArguments(value) {
+  return (accumulator) => {
+    if (equalInt(value)(0 | 0)) {
+      return accumulator;
+    } else {
+      return singleArgument(decrementInt(value));
+    }
+  };
+}
+export const equalInt = $foreign["equalInt"];
+export const decrementInt = $foreign["decrementInt"];

--- a/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/package.json
+++ b/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/verify.mjs
+++ b/tests-integration/fixtures/backend/1787757420_mixed_arity_mutual_tail_call_optimisation/verify.mjs
@@ -1,0 +1,5 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.singleArgument(100_001), 0);
+strictEqual(Main.twoArguments(100_000)(42), 0);

--- a/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/Main.functional.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign equalInt
+
+@export foreign decrementInt
+
+@export recursive[2] mutualEven = \value%0 ->
+  if equalInt value%0 0 then true else mutualOdd (decrementInt value%0)
+
+@export recursive[2] mutualOdd = \value%1 ->
+  if equalInt value%1 0 then false else mutualEven (decrementInt value%1)

--- a/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/Main.js
+++ b/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/Main.js
@@ -1,0 +1,2 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;

--- a/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/Main.purs
+++ b/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/Main.purs
@@ -1,0 +1,14 @@
+module Main where
+
+foreign import equalInt :: Int -> Int -> Boolean
+foreign import decrementInt :: Int -> Int
+
+mutualEven :: Int -> Boolean
+mutualEven value =
+  if equalInt value 0 then true
+  else mutualOdd (decrementInt value)
+
+mutualOdd :: Int -> Boolean
+mutualOdd value =
+  if equalInt value 0 then false
+  else mutualEven (decrementInt value)

--- a/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/Main.snap
+++ b/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/Main.snap
@@ -1,0 +1,12 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 265
+expression: diagnostics_report
+---
+Terms
+equalInt :: Prim.Int -> Prim.Int -> Prim.Boolean
+decrementInt :: Prim.Int -> Prim.Int
+mutualEven :: Prim.Int -> Prim.Boolean
+mutualOdd :: Prim.Int -> Prim.Boolean
+
+Types

--- a/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/output/Main/foreign.js
@@ -1,0 +1,2 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;

--- a/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/output/Main/index.js
@@ -1,0 +1,17 @@
+import * as $foreign from "./foreign.js";
+export function mutualEven(value) {
+  if (equalInt(value)(0 | 0)) {
+    return true;
+  } else {
+    return mutualOdd(decrementInt(value));
+  }
+}
+export function mutualOdd(value) {
+  if (equalInt(value)(0 | 0)) {
+    return false;
+  } else {
+    return mutualEven(decrementInt(value));
+  }
+}
+export const equalInt = $foreign["equalInt"];
+export const decrementInt = $foreign["decrementInt"];

--- a/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/output/Main/index.js
@@ -1,17 +1,37 @@
 import * as $foreign from "./foreign.js";
-export function mutualEven(value) {
-  if (equalInt(value)(0 | 0)) {
-    return true;
-  } else {
-    return mutualOdd(decrementInt(value));
+function $tail_mutualEven_mutualOdd($state, $argument0) {
+  while (true) {
+    switch ($state) {
+      // mutualEven
+      case 0: {
+        const $currentArgument0 = $argument0;
+        if (equalInt($currentArgument0)(0 | 0)) {
+          return true;
+        } else {
+          $argument0 = decrementInt($currentArgument0);
+          $state = 1;
+          continue;
+        }
+      }
+      // mutualOdd
+      case 1: {
+        const $currentArgument0$1 = $argument0;
+        if (equalInt($currentArgument0$1)(0 | 0)) {
+          return false;
+        } else {
+          $argument0 = decrementInt($currentArgument0$1);
+          $state = 0;
+          continue;
+        }
+      }
+    }
   }
 }
-export function mutualOdd(value) {
-  if (equalInt(value)(0 | 0)) {
-    return false;
-  } else {
-    return mutualEven(decrementInt(value));
-  }
+export function mutualEven(value) {
+  return $tail_mutualEven_mutualOdd(0, value);
+}
+export function mutualOdd(value$1) {
+  return $tail_mutualEven_mutualOdd(1, value$1);
 }
 export const equalInt = $foreign["equalInt"];
 export const decrementInt = $foreign["decrementInt"];

--- a/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/package.json
+++ b/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/verify.mjs
+++ b/tests-integration/fixtures/backend/1787757420_mutual_tail_call_optimisation/verify.mjs
@@ -1,0 +1,5 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.mutualEven(100_000), true);
+strictEqual(Main.mutualOdd(100_001), true);

--- a/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/Main.functional.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign equalInt
+
+@export foreign decrementInt
+
+@export recursive[2] patternedTail = \$record%1@({ value: value%0 }) ->
+  if equalInt value%0 0 then value%0 else patternedTail { value: decrementInt value%0 }

--- a/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/Main.js
+++ b/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/Main.js
@@ -1,0 +1,2 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;

--- a/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/Main.purs
+++ b/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+foreign import equalInt :: Int -> Int -> Boolean
+foreign import decrementInt :: Int -> Int
+
+patternedTail :: { value :: Int } -> Int
+patternedTail { value } =
+  if equalInt value 0 then value
+  else patternedTail { value: decrementInt value }

--- a/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/Main.snap
+++ b/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/Main.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 265
+expression: diagnostics_report
+---
+Terms
+equalInt :: Prim.Int -> Prim.Int -> Prim.Boolean
+decrementInt :: Prim.Int -> Prim.Int
+patternedTail :: { value :: Prim.Int } -> Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/output/Main/foreign.js
@@ -1,0 +1,2 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;

--- a/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/output/Main/index.js
@@ -1,10 +1,15 @@
 import * as $foreign from "./foreign.js";
 export function patternedTail($record) {
-  const value = $record.value;
-  if (equalInt(value)(0 | 0)) {
-    return value;
-  } else {
-    return patternedTail({ value: decrementInt(value) });
+  let $argument0 = $record;
+  while (true) {
+    const $currentArgument0 = $argument0;
+    const value = $currentArgument0.value;
+    if (equalInt(value)(0 | 0)) {
+      return value;
+    } else {
+      $argument0 = { value: decrementInt(value) };
+      continue;
+    }
   }
 }
 export const equalInt = $foreign["equalInt"];

--- a/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/output/Main/index.js
@@ -1,0 +1,11 @@
+import * as $foreign from "./foreign.js";
+export function patternedTail($record) {
+  const value = $record.value;
+  if (equalInt(value)(0 | 0)) {
+    return value;
+  } else {
+    return patternedTail({ value: decrementInt(value) });
+  }
+}
+export const equalInt = $foreign["equalInt"];
+export const decrementInt = $foreign["decrementInt"];

--- a/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/package.json
+++ b/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/verify.mjs
+++ b/tests-integration/fixtures/backend/1787757420_patterned_tail_call_optimisation/verify.mjs
@@ -1,0 +1,4 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.patternedTail({ value: 100_000 }), 0);

--- a/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/Main.functional.snap
@@ -1,0 +1,27 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign addInt
+
+@export constructor Leaf/1
+
+@export constructor Branch/2
+
+@export constructor Empty/0
+
+@export constructor Push/2
+
+@export sumTree = \tree%0 -> walkTree tree%0 "Empty" 0
+
+@export recursive[5] walkTree = \tree%1 stack%3 accumulator%4 ->
+  case tree%1 of
+    Leaf value%2 ->
+      case stack%3 of
+        Empty ->
+          addInt accumulator%4 value%2
+        Push next%5 rest%6 ->
+          walkTree next%5 rest%6 (addInt accumulator%4 value%2)
+    Branch left%7 right%8 ->
+      walkTree left%7 { tag: "Push", _1: right%8, _2: stack%3 } accumulator%4

--- a/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/Main.js
+++ b/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/Main.js
@@ -1,0 +1,1 @@
+export const addInt = left => right => left + right;

--- a/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/Main.purs
+++ b/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+foreign import addInt :: Int -> Int -> Int
+
+data Tree = Leaf Int | Branch Tree Tree
+
+data TreeStack = Empty | Push Tree TreeStack
+
+sumTree :: Tree -> Int
+sumTree tree = walkTree tree Empty 0
+
+walkTree :: Tree -> TreeStack -> Int -> Int
+walkTree tree stack accumulator = case tree of
+  Leaf value -> case stack of
+    Empty -> addInt accumulator value
+    Push next rest -> walkTree next rest (addInt accumulator value)
+  Branch left right -> walkTree left (Push right stack) accumulator

--- a/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/Main.snap
+++ b/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/Main.snap
@@ -1,0 +1,21 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 265
+expression: diagnostics_report
+---
+Terms
+addInt :: Prim.Int -> Prim.Int -> Prim.Int
+Leaf :: Prim.Int -> Main.Tree
+Branch :: Main.Tree -> Main.Tree -> Main.Tree
+Empty :: Main.TreeStack
+Push :: Main.Tree -> Main.TreeStack -> Main.TreeStack
+sumTree :: Main.Tree -> Prim.Int
+walkTree :: Main.Tree -> Main.TreeStack -> Prim.Int -> Prim.Int
+
+Types
+Tree :: Prim.Type
+TreeStack :: Prim.Type
+
+Roles
+Tree = []
+TreeStack = []

--- a/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/output/Main/foreign.js
@@ -1,0 +1,1 @@
+export const addInt = left => right => left + right;

--- a/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/output/Main/index.js
@@ -1,0 +1,46 @@
+import * as $foreign from "./foreign.js";
+export const Leaf = ($value0) => ({
+  tag: "Leaf",
+  _1: $value0
+});
+export const Branch = ($value0) => ($value1) => ({
+  tag: "Branch",
+  _1: $value0,
+  _2: $value1
+});
+export const Empty = "Empty";
+export const Push = ($value0) => ($value1) => ({
+  tag: "Push",
+  _1: $value0,
+  _2: $value1
+});
+export function sumTree(tree) {
+  return walkTree(tree)("Empty")(0 | 0);
+}
+export function walkTree(tree) {
+  return (stack) => {
+    return (accumulator) => {
+      if (tree.tag === "Leaf") {
+        const { _1: value } = tree;
+        if (stack === "Empty") {
+          return addInt(accumulator)(value);
+        }
+        if (stack.tag === "Push") {
+          const { _1: next, _2: rest } = stack;
+          return walkTree(next)(rest)(addInt(accumulator)(value));
+        }
+        throw new Error("Pattern match failure");
+      }
+      if (tree.tag === "Branch") {
+        const { _1: left, _2: right } = tree;
+        return walkTree(left)({
+          tag: "Push",
+          _1: right,
+          _2: stack
+        })(accumulator);
+      }
+      throw new Error("Pattern match failure");
+    };
+  };
+}
+export const addInt = $foreign["addInt"];

--- a/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/output/Main/index.js
@@ -20,26 +20,40 @@ export function sumTree(tree) {
 export function walkTree(tree) {
   return (stack) => {
     return (accumulator) => {
-      if (tree.tag === "Leaf") {
-        const { _1: value } = tree;
-        if (stack === "Empty") {
-          return addInt(accumulator)(value);
+      let $argument0 = tree;
+      let $argument1 = stack;
+      let $argument2 = accumulator;
+      while (true) {
+        const $currentArgument0 = $argument0;
+        const $currentArgument1 = $argument1;
+        const $currentArgument2 = $argument2;
+        if ($currentArgument0.tag === "Leaf") {
+          const { _1: value } = $currentArgument0;
+          if ($currentArgument1 === "Empty") {
+            return addInt($currentArgument2)(value);
+          }
+          if ($currentArgument1.tag === "Push") {
+            const { _1: next, _2: rest } = $currentArgument1;
+            $argument0 = next;
+            $argument1 = rest;
+            $argument2 = addInt($currentArgument2)(value);
+            continue;
+          }
+          throw new Error("Pattern match failure");
         }
-        if (stack.tag === "Push") {
-          const { _1: next, _2: rest } = stack;
-          return walkTree(next)(rest)(addInt(accumulator)(value));
+        if ($currentArgument0.tag === "Branch") {
+          const { _1: left, _2: right } = $currentArgument0;
+          $argument0 = left;
+          $argument1 = {
+            tag: "Push",
+            _1: right,
+            _2: $currentArgument1
+          };
+          $argument2 = $currentArgument2;
+          continue;
         }
         throw new Error("Pattern match failure");
       }
-      if (tree.tag === "Branch") {
-        const { _1: left, _2: right } = tree;
-        return walkTree(left)({
-          tag: "Push",
-          _1: right,
-          _2: stack
-        })(accumulator);
-      }
-      throw new Error("Pattern match failure");
     };
   };
 }

--- a/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/package.json
+++ b/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/verify.mjs
+++ b/tests-integration/fixtures/backend/1787757420_tree_traversal_tail_call_optimisation/verify.mjs
@@ -1,0 +1,10 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+let tree = Main.Leaf(1);
+
+for (let index = 0; index < 100_000; index += 1) {
+  tree = Main.Branch(tree)(Main.Leaf(1));
+}
+
+strictEqual(Main.sumTree(tree), 100_001);

--- a/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/Data.Function.Uncurried.js
+++ b/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/Data.Function.Uncurried.js
@@ -1,0 +1,2 @@
+export const mkFn2 = function_ => (first, second) => function_(first)(second);
+export const runFn2 = function_ => first => second => function_(first, second);

--- a/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/Data.Function.Uncurried.purs
+++ b/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/Data.Function.Uncurried.purs
@@ -1,0 +1,6 @@
+module Data.Function.Uncurried where
+
+foreign import data Fn2 :: Type -> Type -> Type -> Type
+
+foreign import mkFn2 :: forall first second result. (first -> second -> result) -> Fn2 first second result
+foreign import runFn2 :: forall first second result. Fn2 first second result -> first -> second -> result

--- a/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/Main.functional.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign equalInt
+
+@export foreign decrementInt
+
+@export foreign incrementInt
+
+@export recursive[3] uncurriedTail = uncurried \value%0, accumulator%1 ->
+  if equalInt value%0 0
+    then accumulator%1
+    else uncurried.call uncurriedTail((decrementInt value%0), (incrementInt accumulator%1))

--- a/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/Main.js
+++ b/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/Main.js
@@ -1,0 +1,3 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;
+export const incrementInt = value => value + 1;

--- a/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/Main.purs
+++ b/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+import Data.Function.Uncurried (Fn2, mkFn2, runFn2)
+
+foreign import equalInt :: Int -> Int -> Boolean
+foreign import decrementInt :: Int -> Int
+foreign import incrementInt :: Int -> Int
+
+uncurriedTail :: Fn2 Int Int Int
+uncurriedTail = mkFn2 \value accumulator ->
+  if equalInt value 0 then accumulator
+  else runFn2 uncurriedTail (decrementInt value) (incrementInt accumulator)

--- a/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/Main.snap
+++ b/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/Main.snap
@@ -1,0 +1,12 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 265
+expression: diagnostics_report
+---
+Terms
+equalInt :: Prim.Int -> Prim.Int -> Prim.Boolean
+decrementInt :: Prim.Int -> Prim.Int
+incrementInt :: Prim.Int -> Prim.Int
+uncurriedTail :: Data.Function.Uncurried.Fn2 Prim.Int Prim.Int Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/output/Data.Function.Uncurried/foreign.js
+++ b/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/output/Data.Function.Uncurried/foreign.js
@@ -1,0 +1,2 @@
+export const mkFn2 = function_ => (first, second) => function_(first)(second);
+export const runFn2 = function_ => first => second => function_(first, second);

--- a/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/output/Data.Function.Uncurried/index.js
+++ b/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/output/Data.Function.Uncurried/index.js
@@ -1,0 +1,3 @@
+import * as $foreign from "./foreign.js";
+export const mkFn2 = $foreign["mkFn2"];
+export const runFn2 = $foreign["runFn2"];

--- a/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/output/Main/foreign.js
@@ -1,0 +1,3 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;
+export const incrementInt = value => value + 1;

--- a/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/output/Main/index.js
@@ -1,0 +1,11 @@
+import * as $foreign from "./foreign.js";
+export function uncurriedTail(value, accumulator) {
+  if (equalInt(value)(0 | 0)) {
+    return accumulator;
+  } else {
+    return uncurriedTail(decrementInt(value), incrementInt(accumulator));
+  }
+}
+export const equalInt = $foreign["equalInt"];
+export const decrementInt = $foreign["decrementInt"];
+export const incrementInt = $foreign["incrementInt"];

--- a/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/output/Main/index.js
@@ -1,9 +1,17 @@
 import * as $foreign from "./foreign.js";
 export function uncurriedTail(value, accumulator) {
-  if (equalInt(value)(0 | 0)) {
-    return accumulator;
-  } else {
-    return uncurriedTail(decrementInt(value), incrementInt(accumulator));
+  let $argument0 = value;
+  let $argument1 = accumulator;
+  while (true) {
+    const $currentArgument0 = $argument0;
+    const $currentArgument1 = $argument1;
+    if (equalInt($currentArgument0)(0 | 0)) {
+      return $currentArgument1;
+    } else {
+      $argument0 = decrementInt($currentArgument0);
+      $argument1 = incrementInt($currentArgument1);
+      continue;
+    }
   }
 }
 export const equalInt = $foreign["equalInt"];

--- a/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/package.json
+++ b/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/verify.mjs
+++ b/tests-integration/fixtures/backend/1787757420_uncurried_tail_call_optimisation/verify.mjs
@@ -1,0 +1,4 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.uncurriedTail(100_000, 0), 100_000);


### PR DESCRIPTION
## Summary

- detect eligible global and local recursive groups in the functional tree and render singleton tail recursion as inline JavaScript loops
- render mutually recursive groups as named `switch` dispatchers, including mixed arities with unused slots cleared
- preserve curried partial applications, pattern matching, argument evaluation, closure capture, and Effect thunk construction/execution semantics
- add independent executable regression fixtures for direct, local, patterned, uncurried, tree-traversal, mutual, mixed-arity, and Effect tail calls

## Verification

- `cargo check -p javascript --tests`
- `just t backend`
- all eight 100,000-iteration runtime verifiers