### PR TITLE
[checking] Expand non-expression integration coverage

### DIFF
--- a/tests-integration/fixtures/checking/1774024140_given_deep_name_improvement/Main.purs
+++ b/tests-integration/fixtures/checking/1774024140_given_deep_name_improvement/Main.purs
@@ -7,6 +7,12 @@ import Type.Proxy (Proxy(..))
 needsAdd :: forall x. Add 1 x 3 => Proxy x
 needsAdd = Proxy
 
+class IsInt value
+instance IsInt Int
+
+needsInt :: forall value. IsInt value => Proxy value
+needsInt = Proxy
+
 nonHeadGivenImprovement
   :: forall n
    . Row.Union (a :: Proxy n) () (a :: Proxy 2)
@@ -17,23 +23,9 @@ functionGivenImprovement
   :: forall value
    . Row.Union (a :: value -> String) () (a :: Int -> String)
   => Proxy value
-functionGivenImprovement = Proxy
-
-leftOpenRowGivenImprovement
-  :: forall row
-   . Row.Union (a :: Record (x :: Int | row)) () (a :: Record (x :: Int, y :: String))
-  => Proxy row
-leftOpenRowGivenImprovement = Proxy
-
-rightOpenRowGivenImprovement
-  :: forall row
-   . Row.Union (a :: Record (x :: Int, y :: String)) () (a :: Record (x :: Int | row))
-  => Proxy row
-rightOpenRowGivenImprovement = Proxy
+functionGivenImprovement = needsInt
 
 forceSolve =
   { nonHeadGivenImprovement
   , functionGivenImprovement
-  , leftOpenRowGivenImprovement
-  , rightOpenRowGivenImprovement
   }

--- a/tests-integration/fixtures/checking/1774024140_given_deep_name_improvement/Main.purs
+++ b/tests-integration/fixtures/checking/1774024140_given_deep_name_improvement/Main.purs
@@ -13,5 +13,27 @@ nonHeadGivenImprovement
   => Proxy n
 nonHeadGivenImprovement = needsAdd
 
+functionGivenImprovement
+  :: forall value
+   . Row.Union (a :: value -> String) () (a :: Int -> String)
+  => Proxy value
+functionGivenImprovement = Proxy
+
+leftOpenRowGivenImprovement
+  :: forall row
+   . Row.Union (a :: Record (x :: Int | row)) () (a :: Record (x :: Int, y :: String))
+  => Proxy row
+leftOpenRowGivenImprovement = Proxy
+
+rightOpenRowGivenImprovement
+  :: forall row
+   . Row.Union (a :: Record (x :: Int, y :: String)) () (a :: Record (x :: Int | row))
+  => Proxy row
+rightOpenRowGivenImprovement = Proxy
+
 forceSolve =
-  { nonHeadGivenImprovement }
+  { nonHeadGivenImprovement
+  , functionGivenImprovement
+  , leftOpenRowGivenImprovement
+  , rightOpenRowGivenImprovement
+  }

--- a/tests-integration/fixtures/checking/1774024140_given_deep_name_improvement/Main.snap
+++ b/tests-integration/fixtures/checking/1774024140_given_deep_name_improvement/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 50
+assertion_line: 296
 expression: report
 ---
 Terms
@@ -14,6 +14,29 @@ nonHeadGivenImprovement ::
       ()
       ( a :: Type.Proxy.Proxy @Prim.Int 2 ) =>
     Type.Proxy.Proxy @Prim.Int (n :: Prim.Int)
-forceSolve :: { nonHeadGivenImprovement :: Type.Proxy.Proxy @Prim.Int 2 }
+functionGivenImprovement ::
+  forall value.
+    Prim.Row.Union @Prim.Type ( a :: value -> Prim.String ) () ( a :: Prim.Int -> Prim.String ) =>
+    Type.Proxy.Proxy @Prim.Type value
+leftOpenRowGivenImprovement ::
+  forall (row :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      ( a :: { x :: Prim.Int | (row :: Prim.Row Prim.Type) } )
+      ()
+      ( a :: { x :: Prim.Int, y :: Prim.String } ) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (row :: Prim.Row Prim.Type)
+rightOpenRowGivenImprovement ::
+  forall (row :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      ( a :: { x :: Prim.Int, y :: Prim.String } )
+      ()
+      ( a :: { x :: Prim.Int | (row :: Prim.Row Prim.Type) } ) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (row :: Prim.Row Prim.Type)
+forceSolve ::
+  { functionGivenImprovement :: Type.Proxy.Proxy @Prim.Type Prim.Int
+  , leftOpenRowGivenImprovement :: Type.Proxy.Proxy @(Prim.Row Prim.Type) ( y :: Prim.String )
+  , nonHeadGivenImprovement :: Type.Proxy.Proxy @Prim.Int 2
+  , rightOpenRowGivenImprovement :: Type.Proxy.Proxy @(Prim.Row Prim.Type) ( y :: Prim.String )
+  }
 
 Types

--- a/tests-integration/fixtures/checking/1774024140_given_deep_name_improvement/Main.snap
+++ b/tests-integration/fixtures/checking/1774024140_given_deep_name_improvement/Main.snap
@@ -7,6 +7,8 @@ Terms
 needsAdd ::
   forall (x :: Prim.Int).
     Prim.Int.Add 1 (x :: Prim.Int) 3 => Type.Proxy.Proxy @Prim.Int (x :: Prim.Int)
+needsInt ::
+  forall t0 (value :: t0). Main.IsInt @t0 (value :: t0) => Type.Proxy.Proxy @t0 (value :: t0)
 nonHeadGivenImprovement ::
   forall (n :: Prim.Int).
     Prim.Row.Union @Prim.Type
@@ -18,25 +20,16 @@ functionGivenImprovement ::
   forall value.
     Prim.Row.Union @Prim.Type ( a :: value -> Prim.String ) () ( a :: Prim.Int -> Prim.String ) =>
     Type.Proxy.Proxy @Prim.Type value
-leftOpenRowGivenImprovement ::
-  forall (row :: Prim.Row Prim.Type).
-    Prim.Row.Union @Prim.Type
-      ( a :: { x :: Prim.Int | (row :: Prim.Row Prim.Type) } )
-      ()
-      ( a :: { x :: Prim.Int, y :: Prim.String } ) =>
-    Type.Proxy.Proxy @(Prim.Row Prim.Type) (row :: Prim.Row Prim.Type)
-rightOpenRowGivenImprovement ::
-  forall (row :: Prim.Row Prim.Type).
-    Prim.Row.Union @Prim.Type
-      ( a :: { x :: Prim.Int, y :: Prim.String } )
-      ()
-      ( a :: { x :: Prim.Int | (row :: Prim.Row Prim.Type) } ) =>
-    Type.Proxy.Proxy @(Prim.Row Prim.Type) (row :: Prim.Row Prim.Type)
 forceSolve ::
   { functionGivenImprovement :: Type.Proxy.Proxy @Prim.Type Prim.Int
-  , leftOpenRowGivenImprovement :: Type.Proxy.Proxy @(Prim.Row Prim.Type) ( y :: Prim.String )
   , nonHeadGivenImprovement :: Type.Proxy.Proxy @Prim.Int 2
-  , rightOpenRowGivenImprovement :: Type.Proxy.Proxy @(Prim.Row Prim.Type) ( y :: Prim.String )
   }
 
 Types
+IsInt :: forall t0. t0 -> Prim.Constraint
+
+Classes
+class forall (t0 :: Prim.Type) (value :: t0). Main.IsInt @t0 (value :: t0)
+
+Instances
+instance Main.IsInt @Prim.Type Prim.Int

--- a/tests-integration/fixtures/checking/1787786880_derive_variance_records/Main.purs
+++ b/tests-integration/fixtures/checking/1787786880_derive_variance_records/Main.purs
@@ -1,0 +1,22 @@
+module Main where
+
+import Data.Bifunctor (class Bifunctor)
+import Data.Foldable (class Foldable)
+import Data.Functor (class Functor)
+import Data.Functor.Contravariant (class Contravariant)
+import Data.Profunctor (class Profunctor)
+import Data.Traversable (class Traversable)
+
+data CovariantRecord a = CovariantRecord { value :: a }
+derive instance Functor CovariantRecord
+derive instance Foldable CovariantRecord
+derive instance Traversable CovariantRecord
+
+data BivariantRecord a b = BivariantRecord { first :: a, second :: b }
+derive instance Bifunctor BivariantRecord
+
+data ContravariantRecord a = ContravariantRecord { predicate :: a -> Boolean }
+derive instance Contravariant ContravariantRecord
+
+data ProfunctorRecord a b = ProfunctorRecord { run :: a -> b }
+derive instance Profunctor ProfunctorRecord

--- a/tests-integration/fixtures/checking/1787786880_derive_variance_records/Main.snap
+++ b/tests-integration/fixtures/checking/1787786880_derive_variance_records/Main.snap
@@ -1,0 +1,30 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 296
+expression: report
+---
+Terms
+CovariantRecord :: forall @a. { value :: a } -> Main.CovariantRecord a
+BivariantRecord :: forall @a @b. { first :: a, second :: b } -> Main.BivariantRecord a b
+ContravariantRecord :: forall @a. { predicate :: a -> Prim.Boolean } -> Main.ContravariantRecord a
+ProfunctorRecord :: forall @a @b. { run :: a -> b } -> Main.ProfunctorRecord a b
+
+Types
+CovariantRecord :: Prim.Type -> Prim.Type
+BivariantRecord :: Prim.Type -> Prim.Type -> Prim.Type
+ContravariantRecord :: Prim.Type -> Prim.Type
+ProfunctorRecord :: Prim.Type -> Prim.Type -> Prim.Type
+
+Derived
+derive Data.Functor.Functor Main.CovariantRecord
+derive Data.Foldable.Foldable Main.CovariantRecord
+derive Data.Traversable.Traversable Main.CovariantRecord
+derive Data.Bifunctor.Bifunctor Main.BivariantRecord
+derive Data.Functor.Contravariant.Contravariant Main.ContravariantRecord
+derive Data.Profunctor.Profunctor Main.ProfunctorRecord
+
+Roles
+CovariantRecord = [Representational]
+BivariantRecord = [Representational, Representational]
+ContravariantRecord = [Representational]
+ProfunctorRecord = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1787787600_derive_nested_variance_applications/Main.purs
+++ b/tests-integration/fixtures/checking/1787787600_derive_nested_variance_applications/Main.purs
@@ -1,0 +1,37 @@
+module Main where
+
+import Data.Bifunctor (class Bifunctor)
+import Data.Functor (class Functor)
+import Data.Functor.Contravariant (class Contravariant)
+import Data.Profunctor (class Profunctor)
+
+data Predicate a = Predicate (a -> Boolean)
+derive instance Contravariant Predicate
+
+data UnaryContravariant a = UnaryContravariant (Predicate a)
+derive instance Contravariant UnaryContravariant
+
+data Box a = Box a
+derive instance Functor Box
+
+data UnaryCovariant a = UnaryCovariant (Box (a -> Boolean))
+derive instance Contravariant UnaryCovariant
+
+data Pair a b = Pair a b
+derive instance Bifunctor Pair
+derive instance Functor (Pair a)
+
+data BinaryFirst a = BinaryFirst (Pair (a -> Boolean) Int)
+derive instance Contravariant BinaryFirst
+
+data BinarySecond a = BinarySecond (Pair Int (a -> Boolean))
+derive instance Contravariant BinarySecond
+
+data BinaryBoth a = BinaryBoth (Pair (a -> Boolean) (a -> String))
+derive instance Contravariant BinaryBoth
+
+data FunctionLike a b = FunctionLike (a -> b)
+derive instance Profunctor FunctionLike
+
+data NestedProfunctor a b = NestedProfunctor (FunctionLike a b)
+derive instance Profunctor NestedProfunctor

--- a/tests-integration/fixtures/checking/1787787600_derive_nested_variance_applications/Main.snap
+++ b/tests-integration/fixtures/checking/1787787600_derive_nested_variance_applications/Main.snap
@@ -1,0 +1,53 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 296
+expression: report
+---
+Terms
+Predicate :: forall @a. (a -> Prim.Boolean) -> Main.Predicate a
+UnaryContravariant :: forall @a. Main.Predicate a -> Main.UnaryContravariant a
+Box :: forall @a. a -> Main.Box a
+UnaryCovariant :: forall @a. Main.Box (a -> Prim.Boolean) -> Main.UnaryCovariant a
+Pair :: forall @a @b. a -> b -> Main.Pair a b
+BinaryFirst :: forall @a. Main.Pair (a -> Prim.Boolean) Prim.Int -> Main.BinaryFirst a
+BinarySecond :: forall @a. Main.Pair Prim.Int (a -> Prim.Boolean) -> Main.BinarySecond a
+BinaryBoth :: forall @a. Main.Pair (a -> Prim.Boolean) (a -> Prim.String) -> Main.BinaryBoth a
+FunctionLike :: forall @a @b. (a -> b) -> Main.FunctionLike a b
+NestedProfunctor :: forall @a @b. Main.FunctionLike a b -> Main.NestedProfunctor a b
+
+Types
+Predicate :: Prim.Type -> Prim.Type
+UnaryContravariant :: Prim.Type -> Prim.Type
+Box :: Prim.Type -> Prim.Type
+UnaryCovariant :: Prim.Type -> Prim.Type
+Pair :: Prim.Type -> Prim.Type -> Prim.Type
+BinaryFirst :: Prim.Type -> Prim.Type
+BinarySecond :: Prim.Type -> Prim.Type
+BinaryBoth :: Prim.Type -> Prim.Type
+FunctionLike :: Prim.Type -> Prim.Type -> Prim.Type
+NestedProfunctor :: Prim.Type -> Prim.Type -> Prim.Type
+
+Derived
+derive Data.Functor.Contravariant.Contravariant Main.Predicate
+derive Data.Functor.Contravariant.Contravariant Main.UnaryContravariant
+derive Data.Functor.Functor Main.Box
+derive Data.Functor.Contravariant.Contravariant Main.UnaryCovariant
+derive Data.Bifunctor.Bifunctor Main.Pair
+derive forall a. Data.Functor.Functor (Main.Pair a)
+derive Data.Functor.Contravariant.Contravariant Main.BinaryFirst
+derive Data.Functor.Contravariant.Contravariant Main.BinarySecond
+derive Data.Functor.Contravariant.Contravariant Main.BinaryBoth
+derive Data.Profunctor.Profunctor Main.FunctionLike
+derive Data.Profunctor.Profunctor Main.NestedProfunctor
+
+Roles
+Predicate = [Representational]
+UnaryContravariant = [Representational]
+Box = [Representational]
+UnaryCovariant = [Representational]
+Pair = [Representational, Representational]
+BinaryFirst = [Representational]
+BinarySecond = [Representational]
+BinaryBoth = [Representational]
+FunctionLike = [Representational, Representational]
+NestedProfunctor = [Representational, Representational]

--- a/tests-integration/fixtures/semantic/1787787780_derive_contravariant_fixed_function_field/Main.purs
+++ b/tests-integration/fixtures/semantic/1787787780_derive_contravariant_fixed_function_field/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Functor.Contravariant (class Contravariant)
+
+data PredicateWithFormatter a = PredicateWithFormatter (a -> Boolean) (Int -> String)
+derive instance Contravariant PredicateWithFormatter

--- a/tests-integration/fixtures/semantic/1787787780_derive_contravariant_fixed_function_field/Main.snap
+++ b/tests-integration/fixtures/semantic/1787787780_derive_contravariant_fixed_function_field/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 314
+expression: report
+---
+data PredicateWithFormatter :: Prim.Type -> Prim.Type
+data PredicateWithFormatter @a
+  | PredicateWithFormatter ::
+    (a -> Prim.Boolean) -> (Prim.Int -> Prim.String) -> Main.PredicateWithFormatter a
+
+dictionary contravariantPredicateWithFormatter ::
+  Data.Functor.Contravariant.Contravariant Main.PredicateWithFormatter
+  where
+  cmap :: forall a b. (b -> a) -> Main.PredicateWithFormatter a -> Main.PredicateWithFormatter b
+  cmap = \function value ->
+    case value of
+      (PredicateWithFormatter field0 field1) -> PredicateWithFormatter
+        (\argument -> field0 (function argument))
+        field1

--- a/tests-integration/fixtures/semantic/1787788560_derive_generic_generated_bodies/Main.purs
+++ b/tests-integration/fixtures/semantic/1787788560_derive_generic_generated_bodies/Main.purs
@@ -1,0 +1,21 @@
+module Main where
+
+import Data.Generic.Rep (class Generic)
+
+data Void
+derive instance Generic Void _
+
+data Unit = Unit
+derive instance Generic Unit _
+
+data Identity a = Identity a
+derive instance Generic (Identity a) _
+
+data Pair a b = Pair a b
+derive instance Generic (Pair a b) _
+
+data Either a b = Left a | Right b
+derive instance Generic (Either a b) _
+
+newtype Wrapper a = Wrapper a
+derive instance Generic (Wrapper a) _

--- a/tests-integration/fixtures/semantic/1787788560_derive_generic_generated_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1787788560_derive_generic_generated_bodies/Main.snap
@@ -1,0 +1,132 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 314
+expression: report
+---
+data Void :: Prim.Type
+data Void
+
+data Unit :: Prim.Type
+data Unit
+  | Unit :: Main.Unit
+
+data Identity :: Prim.Type -> Prim.Type
+data Identity @a
+  | Identity :: a -> Main.Identity a
+
+data Pair :: Prim.Type -> Prim.Type -> Prim.Type
+data Pair @a @b
+  | Pair :: a -> b -> Main.Pair a b
+
+data Either :: Prim.Type -> Prim.Type -> Prim.Type
+data Either @a @b
+  | Left :: a -> Main.Either a b
+  | Right :: b -> Main.Either a b
+
+newtype Wrapper :: Prim.Type -> Prim.Type
+newtype Wrapper @a
+  | Wrapper :: a -> Main.Wrapper a
+
+dictionary genericVoidNoConstructors ::
+  Data.Generic.Rep.Generic Main.Void Data.Generic.Rep.NoConstructors
+  where
+  to :: Data.Generic.Rep.NoConstructors -> Main.Void
+  to = \value ->
+    case value of
+      _ -> to {genericVoidNoConstructors} value
+  from :: Main.Void -> Data.Generic.Rep.NoConstructors
+  from = \value ->
+    case value of
+      _ -> from {genericVoidNoConstructors} value
+
+dictionary genericUnitConstructorNoArguments ::
+  Data.Generic.Rep.Generic
+  Main.Unit
+  (Data.Generic.Rep.Constructor "Unit" Data.Generic.Rep.NoArguments)
+  where
+  to :: Data.Generic.Rep.Constructor "Unit" Data.Generic.Rep.NoArguments -> Main.Unit
+  to = \representation ->
+    case representation of
+      (Constructor NoArguments) -> Unit
+  from :: Main.Unit -> Data.Generic.Rep.Constructor "Unit" Data.Generic.Rep.NoArguments
+  from = \value ->
+    case value of
+      Unit -> Constructor NoArguments
+
+dictionary genericIdentityConstructorArgument ::
+  forall a.
+  Data.Generic.Rep.Generic
+  (Main.Identity a)
+  (Data.Generic.Rep.Constructor "Identity" (Data.Generic.Rep.Argument a))
+  where
+  to :: Data.Generic.Rep.Constructor "Identity" (Data.Generic.Rep.Argument a) -> Main.Identity a
+  to = \representation ->
+    case representation of
+      (Constructor (Argument field0)) -> Identity field0
+  from :: Main.Identity a -> Data.Generic.Rep.Constructor "Identity" (Data.Generic.Rep.Argument a)
+  from = \value ->
+    case value of
+      (Identity field0) -> Constructor (Argument field0)
+
+dictionary genericPairConstructorProductArgumentArgument ::
+  forall a b.
+  Data.Generic.Rep.Generic
+  (Main.Pair a b)
+  (Data.Generic.Rep.Constructor
+    "Pair"
+    (Data.Generic.Rep.Product (Data.Generic.Rep.Argument a) (Data.Generic.Rep.Argument b)))
+  where
+  to :: Data.Generic.Rep.Constructor
+  "Pair"
+  (Data.Generic.Rep.Product (Data.Generic.Rep.Argument a) (Data.Generic.Rep.Argument b)) ->
+Main.Pair a b
+  to = \representation ->
+    case representation of
+      (Constructor (Product (Argument field0) (Argument field1))) -> Pair field0 field1
+  from :: Main.Pair a b ->
+Data.Generic.Rep.Constructor
+  "Pair"
+  (Data.Generic.Rep.Product (Data.Generic.Rep.Argument a) (Data.Generic.Rep.Argument b))
+  from = \value ->
+    case value of
+      (Pair field0 field1) -> Constructor (Product (Argument field0) (Argument field1))
+
+dictionary genericEitherSumConstructorArgumentConstructorArgument ::
+  forall a b.
+  Data.Generic.Rep.Generic
+  (Main.Either a b)
+  (Data.Generic.Rep.Sum
+    (Data.Generic.Rep.Constructor "Left" (Data.Generic.Rep.Argument a))
+    (Data.Generic.Rep.Constructor "Right" (Data.Generic.Rep.Argument b)))
+  where
+  to :: Data.Generic.Rep.Sum
+  (Data.Generic.Rep.Constructor "Left" (Data.Generic.Rep.Argument a))
+  (Data.Generic.Rep.Constructor "Right" (Data.Generic.Rep.Argument b)) ->
+Main.Either a b
+  to = \representation ->
+    case representation of
+      (Inl (Constructor (Argument field0))) -> Left field0
+      (Inr (Constructor (Argument field0))) -> Right field0
+  from :: Main.Either a b ->
+Data.Generic.Rep.Sum
+  (Data.Generic.Rep.Constructor "Left" (Data.Generic.Rep.Argument a))
+  (Data.Generic.Rep.Constructor "Right" (Data.Generic.Rep.Argument b))
+  from = \value ->
+    case value of
+      (Left field0) -> Inl (Constructor (Argument field0))
+      (Right field0) -> Inr (Constructor (Argument field0))
+
+dictionary genericWrapperConstructorArgument ::
+  forall a.
+  Data.Generic.Rep.Generic
+  (Main.Wrapper a)
+  (Data.Generic.Rep.Constructor "Wrapper" (Data.Generic.Rep.Argument a))
+  where
+  to :: Data.Generic.Rep.Constructor "Wrapper" (Data.Generic.Rep.Argument a) -> Main.Wrapper a
+  to = \representation ->
+    case representation of
+      (Constructor (Argument field0)) -> Wrapper field0
+  from :: Main.Wrapper a -> Data.Generic.Rep.Constructor "Wrapper" (Data.Generic.Rep.Argument a)
+  from = \value ->
+    case value of
+      (Wrapper field0) -> Constructor (Argument field0)

--- a/tests-integration/fixtures/semantic/1787788980_derive_bifunctor_right_only_nested_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1787788980_derive_bifunctor_right_only_nested_body/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Data.Bifunctor (class Bifunctor)
+
+data RightOnly a b = RightOnly b
+
+derive instance Bifunctor RightOnly
+
+data NestedRightOnly a b = NestedRightOnly (RightOnly Int b)
+
+derive instance Bifunctor NestedRightOnly

--- a/tests-integration/fixtures/semantic/1787788980_derive_bifunctor_right_only_nested_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1787788980_derive_bifunctor_right_only_nested_body/Main.snap
@@ -1,0 +1,31 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 314
+expression: report
+---
+data RightOnly :: forall k0. k0 -> Prim.Type -> Prim.Type
+data RightOnly @a @b
+  | RightOnly :: b -> Main.RightOnly a b
+
+data NestedRightOnly :: forall k0. k0 -> Prim.Type -> Prim.Type
+data NestedRightOnly @a @b
+  | NestedRightOnly :: Main.RightOnly @Prim.Type Prim.Int b -> Main.NestedRightOnly a b
+
+dictionary bifunctorRightOnlyType :: Data.Bifunctor.Bifunctor (Main.RightOnly @Prim.Type) where
+  bimap :: forall a b c d.
+  (a -> b) -> (c -> d) -> Main.RightOnly @Prim.Type a c -> Main.RightOnly @Prim.Type b d
+  bimap = \firstFunction secondFunction value ->
+    case value of
+      (RightOnly field0) -> RightOnly (secondFunction field0)
+
+dictionary bifunctorNestedRightOnlyType ::
+  Data.Bifunctor.Bifunctor (Main.NestedRightOnly @Prim.Type)
+  where
+  bimap :: forall a b c d.
+  (a -> b) -> (c -> d) -> Main.NestedRightOnly @Prim.Type a c -> Main.NestedRightOnly @Prim.Type b d
+  bimap = \firstFunction secondFunction value ->
+    case value of
+      (NestedRightOnly field0) -> NestedRightOnly
+        (bimap {bifunctorRightOnlyType} (\unchanged -> unchanged)
+          (\element -> secondFunction element)
+          field0)


### PR DESCRIPTION
## Summary

Improve checking coverage through focused integration fixtures, without adding unit tests or broad expression-shape coverage.

The fixtures exercise:

- deep given-constraint improvements, including function and open-row structure
- deriving through record fields and nested variance applications
- generated `Contravariant`, `Bifunctor`, and `Generic` instance bodies
- identity preservation for fixed function fields and unused binary parameters

Semantic snapshots are used where the generated tree is the behavior under test. Each fixture was independently reviewed after acceptance.

## Verification

- `just t checking`
- `just t semantic`
- `just coverage` (879 tests passed before rebasing; affected categories rerun after rebasing)
