### PR TITLE
[lsp] Cover derived docs and symbol caching

### DIFF
--- a/tests-integration/fixtures/docs/1787790540_derived_instance_documentation/Main.purs
+++ b/tests-integration/fixtures/docs/1787790540_derived_instance_documentation/Main.purs
@@ -1,0 +1,16 @@
+module Main where
+
+import Remote (Remote)
+import Wrapping (class Wrap)
+
+-- | A local class used by a derived instance.
+class LocalWrap a
+
+-- | A local type used by derived instances.
+data Box = Box
+
+-- | A derived instance associated with both local declarations.
+derive instance localWrapBox :: LocalWrap Box
+
+-- | A derived instance for an imported class and type.
+derive instance wrapRemote :: Wrap Remote

--- a/tests-integration/fixtures/docs/1787790540_derived_instance_documentation/Main.snap
+++ b/tests-integration/fixtures/docs/1787790540_derived_instance_documentation/Main.snap
@@ -1,0 +1,357 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 363
+expression: report
+---
+{
+  "manifest": {
+    "dependencies": {},
+    "description": null,
+    "license": null,
+    "location": null,
+    "modules": [
+      "Main",
+      "Remote",
+      "Wrapping"
+    ],
+    "name": "docs-fixture",
+    "version": "0.0.0"
+  },
+  "modules": [
+    {
+      "documentation": null,
+      "name": "Main",
+      "terms": [
+        {
+          "documentation": "A derived instance for an imported class and type.",
+          "kind": "Derive",
+          "name": "wrapRemote",
+          "signature": {
+            "argument": {
+              "reference": {
+                "module": "Remote",
+                "name": "Remote",
+                "package": "docs-fixture"
+              },
+              "tag": "constructor"
+            },
+            "function": {
+              "argument": {
+                "reference": {
+                  "module": "Prim",
+                  "name": "Type",
+                  "package": null
+                },
+                "tag": "constructor"
+              },
+              "function": {
+                "reference": {
+                  "module": "Wrapping",
+                  "name": "Wrap",
+                  "package": "docs-fixture"
+                },
+                "tag": "constructor"
+              },
+              "tag": "kindApplication"
+            },
+            "tag": "application"
+          }
+        }
+      ],
+      "types": [
+        {
+          "documentation": "A local class used by a derived instance.",
+          "form": {
+            "declaration": {
+              "binders": [
+                {
+                  "kind": {
+                    "kind": {
+                      "reference": {
+                        "module": "Prim",
+                        "name": "Type",
+                        "package": null
+                      },
+                      "tag": "constructor"
+                    },
+                    "name": "t0",
+                    "tag": "rigid"
+                  },
+                  "name": "a",
+                  "visible": true
+                }
+              ]
+            },
+            "functionalDependencies": [],
+            "instances": [
+              {
+                "documentation": "A derived instance associated with both local declarations.",
+                "kind": "Derive",
+                "name": "localWrapBox",
+                "signature": {
+                  "argument": {
+                    "reference": {
+                      "module": "Main",
+                      "name": "Box",
+                      "package": "docs-fixture"
+                    },
+                    "tag": "constructor"
+                  },
+                  "function": {
+                    "argument": {
+                      "reference": {
+                        "module": "Prim",
+                        "name": "Type",
+                        "package": null
+                      },
+                      "tag": "constructor"
+                    },
+                    "function": {
+                      "reference": {
+                        "module": "Main",
+                        "name": "LocalWrap",
+                        "package": "docs-fixture"
+                      },
+                      "tag": "constructor"
+                    },
+                    "tag": "kindApplication"
+                  },
+                  "tag": "application"
+                }
+              }
+            ],
+            "members": [],
+            "signature": {
+              "binder": {
+                "kind": {
+                  "reference": {
+                    "module": "Prim",
+                    "name": "Type",
+                    "package": null
+                  },
+                  "tag": "constructor"
+                },
+                "name": "t0",
+                "visible": false
+              },
+              "body": {
+                "argument": {
+                  "kind": {
+                    "reference": {
+                      "module": "Prim",
+                      "name": "Type",
+                      "package": null
+                    },
+                    "tag": "constructor"
+                  },
+                  "name": "t0",
+                  "tag": "rigid"
+                },
+                "result": {
+                  "reference": {
+                    "module": "Prim",
+                    "name": "Constraint",
+                    "package": null
+                  },
+                  "tag": "constructor"
+                },
+                "tag": "function"
+              },
+              "tag": "forall"
+            },
+            "superclasses": [],
+            "tag": "class"
+          },
+          "name": "LocalWrap"
+        },
+        {
+          "documentation": "A local type used by derived instances.",
+          "form": {
+            "constructors": [
+              {
+                "documentation": null,
+                "kind": "Constructor",
+                "name": "Box",
+                "signature": {
+                  "reference": {
+                    "module": "Main",
+                    "name": "Box",
+                    "package": "docs-fixture"
+                  },
+                  "tag": "constructor"
+                }
+              }
+            ],
+            "declaration": {
+              "binders": []
+            },
+            "instances": [
+              {
+                "documentation": "A derived instance associated with both local declarations.",
+                "kind": "Derive",
+                "name": "localWrapBox",
+                "signature": {
+                  "argument": {
+                    "reference": {
+                      "module": "Main",
+                      "name": "Box",
+                      "package": "docs-fixture"
+                    },
+                    "tag": "constructor"
+                  },
+                  "function": {
+                    "argument": {
+                      "reference": {
+                        "module": "Prim",
+                        "name": "Type",
+                        "package": null
+                      },
+                      "tag": "constructor"
+                    },
+                    "function": {
+                      "reference": {
+                        "module": "Main",
+                        "name": "LocalWrap",
+                        "package": "docs-fixture"
+                      },
+                      "tag": "constructor"
+                    },
+                    "tag": "kindApplication"
+                  },
+                  "tag": "application"
+                }
+              }
+            ],
+            "signature": {
+              "reference": {
+                "module": "Prim",
+                "name": "Type",
+                "package": null
+              },
+              "tag": "constructor"
+            },
+            "tag": "data"
+          },
+          "name": "Box"
+        }
+      ]
+    },
+    {
+      "documentation": null,
+      "name": "Remote",
+      "terms": [],
+      "types": [
+        {
+          "documentation": "A remotely defined type.",
+          "form": {
+            "constructors": [
+              {
+                "documentation": null,
+                "kind": "Constructor",
+                "name": "Remote",
+                "signature": {
+                  "reference": {
+                    "module": "Remote",
+                    "name": "Remote",
+                    "package": "docs-fixture"
+                  },
+                  "tag": "constructor"
+                }
+              }
+            ],
+            "declaration": {
+              "binders": []
+            },
+            "instances": [],
+            "signature": {
+              "reference": {
+                "module": "Prim",
+                "name": "Type",
+                "package": null
+              },
+              "tag": "constructor"
+            },
+            "tag": "data"
+          },
+          "name": "Remote"
+        }
+      ]
+    },
+    {
+      "documentation": null,
+      "name": "Wrapping",
+      "terms": [],
+      "types": [
+        {
+          "documentation": "A remotely defined class.",
+          "form": {
+            "declaration": {
+              "binders": [
+                {
+                  "kind": {
+                    "kind": {
+                      "reference": {
+                        "module": "Prim",
+                        "name": "Type",
+                        "package": null
+                      },
+                      "tag": "constructor"
+                    },
+                    "name": "t0",
+                    "tag": "rigid"
+                  },
+                  "name": "a",
+                  "visible": true
+                }
+              ]
+            },
+            "functionalDependencies": [],
+            "instances": [],
+            "members": [],
+            "signature": {
+              "binder": {
+                "kind": {
+                  "reference": {
+                    "module": "Prim",
+                    "name": "Type",
+                    "package": null
+                  },
+                  "tag": "constructor"
+                },
+                "name": "t0",
+                "visible": false
+              },
+              "body": {
+                "argument": {
+                  "kind": {
+                    "reference": {
+                      "module": "Prim",
+                      "name": "Type",
+                      "package": null
+                    },
+                    "tag": "constructor"
+                  },
+                  "name": "t0",
+                  "tag": "rigid"
+                },
+                "result": {
+                  "reference": {
+                    "module": "Prim",
+                    "name": "Constraint",
+                    "package": null
+                  },
+                  "tag": "constructor"
+                },
+                "tag": "function"
+              },
+              "tag": "forall"
+            },
+            "superclasses": [],
+            "tag": "class"
+          },
+          "name": "Wrap"
+        }
+      ]
+    }
+  ]
+}

--- a/tests-integration/fixtures/docs/1787790540_derived_instance_documentation/Remote.purs
+++ b/tests-integration/fixtures/docs/1787790540_derived_instance_documentation/Remote.purs
@@ -1,0 +1,4 @@
+module Remote where
+
+-- | A remotely defined type.
+data Remote = Remote

--- a/tests-integration/fixtures/docs/1787790540_derived_instance_documentation/Wrapping.purs
+++ b/tests-integration/fixtures/docs/1787790540_derived_instance_documentation/Wrapping.purs
@@ -1,0 +1,4 @@
+module Wrapping where
+
+-- | A remotely defined class.
+class Wrap a

--- a/tests-integration/fixtures/lsp/1787790540_workspace_symbol_cache_consistency/Main.purs
+++ b/tests-integration/fixtures/lsp/1787790540_workspace_symbol_cache_consistency/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+cacheAlpha :: Int
+cacheAlpha = 1
+
+cacheAlpine :: Int
+cacheAlpine = 2
+
+cacheBeta :: Int
+cacheBeta = 3
+
+-- # cache
+-- # cache
+-- # cachea
+-- # cacheal

--- a/tests-integration/fixtures/lsp/1787790540_workspace_symbol_cache_consistency/Main.snap
+++ b/tests-integration/fixtures/lsp/1787790540_workspace_symbol_cache_consistency/Main.snap
@@ -1,0 +1,29 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 380
+expression: report
+---
+WorkspaceSymbols query "cache"
+
+cacheAlpha Function file:///tests-integration/fixtures/lsp/1787790540_workspace_symbol_cache_consistency/Main.purs @ 2:0..3:14
+cacheAlpine Function file:///tests-integration/fixtures/lsp/1787790540_workspace_symbol_cache_consistency/Main.purs @ 5:0..6:15
+cacheBeta Function file:///tests-integration/fixtures/lsp/1787790540_workspace_symbol_cache_consistency/Main.purs @ 8:0..9:13
+
+
+WorkspaceSymbols query "cache"
+
+cacheAlpha Function file:///tests-integration/fixtures/lsp/1787790540_workspace_symbol_cache_consistency/Main.purs @ 2:0..3:14
+cacheAlpine Function file:///tests-integration/fixtures/lsp/1787790540_workspace_symbol_cache_consistency/Main.purs @ 5:0..6:15
+cacheBeta Function file:///tests-integration/fixtures/lsp/1787790540_workspace_symbol_cache_consistency/Main.purs @ 8:0..9:13
+
+
+WorkspaceSymbols query "cachea"
+
+cacheAlpha Function file:///tests-integration/fixtures/lsp/1787790540_workspace_symbol_cache_consistency/Main.purs @ 2:0..3:14
+cacheAlpine Function file:///tests-integration/fixtures/lsp/1787790540_workspace_symbol_cache_consistency/Main.purs @ 5:0..6:15
+
+
+WorkspaceSymbols query "cacheal"
+
+cacheAlpha Function file:///tests-integration/fixtures/lsp/1787790540_workspace_symbol_cache_consistency/Main.purs @ 2:0..3:14
+cacheAlpine Function file:///tests-integration/fixtures/lsp/1787790540_workspace_symbol_cache_consistency/Main.purs @ 5:0..6:15


### PR DESCRIPTION
## Summary

Improve integration coverage for editor and generated-documentation behavior without adding crate-local tests.

- verify workspace symbol results remain stable across exact cache hits and successive prefix narrowing
- verify named derived instances are associated with local class and type documentation
- verify derived instances for imported classes and types remain top-level module terms

The `spago` crate has no responsible path through the current integration fixture harness: `tests-integration` does not depend on `spago`, and the LSP/docs fixtures operate on compiler files rather than lockfile-backed workspace discovery. This change therefore leaves `spago` to its existing lockfile tests instead of adding an artificial fixture.

## Coverage

Integration-only line coverage from `cargo llvm-cov nextest --no-report -p tests-integration`:

- `analyzer`: 6260/6545 (95.6455%) → 6261/6545 (95.6608%)
- `documentation`: 442/516 (85.6589%) → 459/516 (88.9535%)

## Verification

- `just t lsp`
- `just t docs`
- `cargo llvm-cov nextest --no-report -p tests-integration --test lsp --test docs` (123 passed)
