### PR TITLE
[diagnostics] Report indexing errors in checking fixtures

### DIFF
--- a/tests-integration/fixtures/checking/1787790540_import_diagnostics/Library.purs
+++ b/tests-integration/fixtures/checking/1787790540_import_diagnostics/Library.purs
@@ -1,0 +1,3 @@
+module Library where
+
+value = 42

--- a/tests-integration/fixtures/checking/1787790540_import_diagnostics/Main.purs
+++ b/tests-integration/fixtures/checking/1787790540_import_diagnostics/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+import Library
+  ( value
+  , value
+  , missing
+  )
+import Missing

--- a/tests-integration/fixtures/checking/1787790540_import_diagnostics/Main.snap
+++ b/tests-integration/fixtures/checking/1787790540_import_diagnostics/Main.snap
@@ -1,0 +1,41 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 296
+expression: report
+---
+Terms
+
+Types
+
+Diagnostics
+Warning! · [DuplicateImport] · Main.purs:5:5
+  •
+  │
+  • Import list contains multiple references to 'value'
+  │
+  │     , value
+  │       ╰────
+  •
+  │ First imported here
+  │
+  │     ( value
+  │       ╰────
+  •
+
+Error! · [InvalidImportStatement] · Main.purs:8:1
+  •
+  │
+  • Cannot import module 'Missing'
+  │
+  │   import Missing
+  │   ╰─────────────
+  •
+
+Error! · [InvalidImportItem] · Main.purs:6:5
+  •
+  │
+  • Cannot import item 'missing'
+  │
+  │     , missing
+  │       ╰──────
+  •

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -510,6 +510,10 @@ fn write_checked_diagnostics(
 
     let mut all_diagnostics = vec![];
 
+    for error in &indexed.errors {
+        all_diagnostics.extend(error.to_diagnostics(&context));
+    }
+
     for error in &lowered.errors {
         all_diagnostics.extend(error.to_diagnostics(&context));
     }


### PR DESCRIPTION
## Intent

Establish the user-visible diagnostics contract for indexing and resolving import errors through the integration harness rather than adding unit-level coverage or fixtures for recovery-only branches.

The derived-instance documentation coverage originally included in this branch is now provided by the broader fixture merged in PR #419, so the redundant commit was dropped while rebasing.

## Changes

- include indexing errors in checking fixture diagnostics in frontend phase order
- snapshot a duplicate import warning with its related first-import span
- snapshot invalid imported-item and missing-module errors

## Coverage

The fixture exercises indexing, resolving, diagnostics conversion, diagnostic context, and rich rendering. Codecov reports all modified coverable lines covered and a +0.13 percentage-point project coverage change against current main.

## Verification

- just t checking
- just t docs
- refreshed GitHub formatting, compilation, coverage, Codecov, and compatibility checks