### PR TITLE
[frontend] Cover syntax pipeline language behavior

### DIFF
--- a/tests-integration/fixtures/lowering/1787790600_escaped_multiline_string_gaps/Main.purs
+++ b/tests-integration/fixtures/lowering/1787790600_escaped_multiline_string_gaps/Main.purs
@@ -1,0 +1,4 @@
+module Main where
+
+message = "hello \
+  \world"

--- a/tests-integration/fixtures/lowering/1787790600_escaped_multiline_string_gaps/Main.snap
+++ b/tests-integration/fixtures/lowering/1787790600_escaped_multiline_string_gaps/Main.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 331
+expression: report
+---
+module Main
+
+Expressions:
+
+"hello \
+  \world"@2:9
+  -> string String "hello \\\n  \\world"
+
+Types:

--- a/tests-integration/fixtures/semantic/1787790600_ambiguous_operator_associativity/Main.purs
+++ b/tests-integration/fixtures/semantic/1787790600_ambiguous_operator_associativity/Main.purs
@@ -1,0 +1,31 @@
+module Main where
+
+nonAssociative left right = left
+
+infix 5 nonAssociative as <=>
+
+singleNonAssociative :: Int
+singleNonAssociative = 1 <=> 2
+
+ambiguousNonAssociative :: Int
+ambiguousNonAssociative = 1 <=> 2 <=> 3
+
+leftAssociative left right = left
+rightAssociative left right = right
+
+infixl 6 leftAssociative as <+>
+infixr 6 rightAssociative as <*>
+
+infixr 7 rightAssociative as <**>
+
+validLeftAssociative :: Int
+validLeftAssociative = 1 <+> 2 <+> 3
+
+validRightAssociative :: Int
+validRightAssociative = 1 <*> 2 <*> 3
+
+validMixedPrecedence :: Int
+validMixedPrecedence = 1 <+> 2 <**> 3
+
+ambiguousMixedAssociativity :: Int
+ambiguousMixedAssociativity = 1 <+> 2 <*> 3

--- a/tests-integration/fixtures/semantic/1787790600_ambiguous_operator_associativity/Main.snap
+++ b/tests-integration/fixtures/semantic/1787790600_ambiguous_operator_associativity/Main.snap
@@ -1,0 +1,31 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 314
+expression: report
+---
+nonAssociative :: forall t0 t1. t0 -> t1 -> t0
+nonAssociative = \left -> \right -> left
+
+singleNonAssociative :: Prim.Int
+singleNonAssociative = nonAssociative 1 2
+
+ambiguousNonAssociative :: Prim.Int
+ambiguousNonAssociative = <error>
+
+leftAssociative :: forall t0 t1. t0 -> t1 -> t0
+leftAssociative = \left -> \right -> left
+
+rightAssociative :: forall t0 t1. t0 -> t1 -> t1
+rightAssociative = \left -> \right -> right
+
+validLeftAssociative :: Prim.Int
+validLeftAssociative = leftAssociative (leftAssociative 1 2) 3
+
+validRightAssociative :: Prim.Int
+validRightAssociative = rightAssociative 1 (rightAssociative 2 3)
+
+validMixedPrecedence :: Prim.Int
+validMixedPrecedence = leftAssociative 1 (rightAssociative 2 3)
+
+ambiguousMixedAssociativity :: Prim.Int
+ambiguousMixedAssociativity = <error>

--- a/tests-integration/fixtures/semantic/1787790600_qualified_rebindable_do_notation/Control.purs
+++ b/tests-integration/fixtures/semantic/1787790600_qualified_rebindable_do_notation/Control.purs
@@ -1,0 +1,31 @@
+module Control where
+
+foreign import data Box :: Type -> Type
+
+foreign import action :: forall value. Box value
+
+foreign import bind ::
+  forall value result.
+  Box value ->
+  (value -> Box result) ->
+  Box result
+
+foreign import discard ::
+  forall value result.
+  Box value ->
+  (value -> Box result) ->
+  Box result
+
+foreign import map ::
+  forall value result.
+  (value -> result) ->
+  Box value ->
+  Box result
+
+foreign import apply ::
+  forall value result.
+  Box (value -> result) ->
+  Box value ->
+  Box result
+
+foreign import pure :: forall value. value -> Box value

--- a/tests-integration/fixtures/semantic/1787790600_qualified_rebindable_do_notation/Main.purs
+++ b/tests-integration/fixtures/semantic/1787790600_qualified_rebindable_do_notation/Main.purs
@@ -1,0 +1,19 @@
+module Main where
+
+import Control as Control
+
+qualifiedDo :: Control.Box Int
+qualifiedDo = Control.do
+  value <- Control.action
+  Control.action
+  Control.pure value
+
+qualifiedAdo :: Control.Box Int
+qualifiedAdo = Control.ado
+  left <- Control.action
+  right <- Control.action
+  in left
+
+qualifiedPure :: Control.Box Int
+qualifiedPure = Control.ado
+  in 1

--- a/tests-integration/fixtures/semantic/1787790600_qualified_rebindable_do_notation/Main.snap
+++ b/tests-integration/fixtures/semantic/1787790600_qualified_rebindable_do_notation/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 314
+expression: report
+---
+qualifiedDo :: Control.Box Prim.Int
+qualifiedDo = bind action \value -> discard action \_ -> pure value
+
+qualifiedAdo :: Control.Box Prim.Int
+qualifiedAdo = apply (map (\left right -> left) action) action
+
+qualifiedPure :: Control.Box Prim.Int
+qualifiedPure = pure 1


### PR DESCRIPTION
## Summary

Add focused integration fixtures for language behavior that was missing from the frontend pipeline coverage:

- module-qualified rebindable `do` and `ado`, including `bind`, `discard`, `map`, `apply`, and zero-action `pure`
- valid escaped multiline string gaps
- rejection of consecutive non-associative operators and same-precedence mixed associativity, with valid controls

The fixtures use generated lowering and semantic snapshots as their oracles. They are independent of the checking coverage work in #418.

## Coverage

Integration-only line coverage changes:

- lexing: 860/935 (91.98%) → 865/935 (92.51%)
- lowering: 2191/2254 (97.20%) → 2201/2254 (97.65%)
- sugar: 216/223 (96.86%) → 221/223 (99.10%)

Syntax, parsing, and stabilizing remain unchanged because their remaining uncovered lines are API, invariant, or malformed-recovery paths without a useful fixture-owned route.

## Verification

- `just t lowering`
- `just t semantic`
- `cargo llvm-cov nextest --no-report -p tests-integration` (878 passed)