### PR TITLE
[building] Cover compiler module loading lifecycle

### DIFF
--- a/compiler-bin/tests/compile.rs
+++ b/compiler-bin/tests/compile.rs
@@ -1,0 +1,38 @@
+use std::fs;
+use std::process::Command;
+
+use purescript_alexandrite::cli::ColorChoice;
+use purescript_alexandrite::compile::{self, CompileConfig};
+
+#[test]
+fn compiles_module_graph_with_foreign_dependency() {
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let fixture = manifest.join("tests/fixtures/compile_module_graph");
+    let output = tempfile::tempdir().expect("failed to create compiler output directory");
+
+    compile::start(CompileConfig {
+        output: output.path().to_path_buf(),
+        inputs: vec![fixture.join("*.purs")],
+        json_errors: false,
+        diagnostic_limit: None,
+        color: ColorChoice::Never,
+    });
+
+    let main = output.path().join("Main/index.js");
+    let foreign = output.path().join("Main/foreign.js");
+    let library = output.path().join("Library/index.js");
+    assert!(main.is_file(), "compiler did not emit Main");
+    assert!(foreign.is_file(), "compiler did not copy Main's foreign module");
+    assert!(library.is_file(), "compiler did not emit Library");
+
+    fs::write(output.path().join("package.json"), r#"{"type":"module"}"#)
+        .expect("failed to configure generated JavaScript as ES modules");
+    let verification = Command::new("node")
+        .arg("--input-type=module")
+        .arg("--eval")
+        .arg("import('./Main/index.js').then(({ result }) => { if (result !== 43) process.exit(1); })")
+        .current_dir(output.path())
+        .status()
+        .expect("failed to run generated JavaScript");
+    assert!(verification.success(), "generated JavaScript returned the wrong result");
+}

--- a/compiler-bin/tests/fixtures/compile_module_graph/Library.purs
+++ b/compiler-bin/tests/fixtures/compile_module_graph/Library.purs
@@ -1,0 +1,4 @@
+module Library where
+
+answer :: Int
+answer = 42

--- a/compiler-bin/tests/fixtures/compile_module_graph/Main.js
+++ b/compiler-bin/tests/fixtures/compile_module_graph/Main.js
@@ -1,0 +1,1 @@
+export const increment = value => value + 1;

--- a/compiler-bin/tests/fixtures/compile_module_graph/Main.purs
+++ b/compiler-bin/tests/fixtures/compile_module_graph/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+import Library (answer)
+
+foreign import increment :: Int -> Int
+
+result :: Int
+result = increment answer


### PR DESCRIPTION
## Summary

Add an end-to-end compile integration fixture that exercises the production module-loading lifecycle instead of constructing compiler inputs directly in the fixture harness.

The fixture compiles a two-module graph with a foreign implementation, verifies that both modules are emitted and the foreign module is copied, then executes the generated ES modules with Node. This covers source discovery, primitive and source lifecycle insertion, foreign association and validation, parallel query snapshots, module linking, and output writing.

## Coverage

Measured from integration tests only, before and after adding the compile fixture:

- `files`: 62/103 lines (60.19%) → 65/103 (63.11%)
- `building`: 529/1,415 lines (37.39%) → 820/1,471 (55.74%)
  - `engine.rs`: 520/798 (65.16%) → 571/798 (71.55%)
  - `graph.rs`: 0/14 → 13/14
  - `promise.rs`: 0/38 → 35/38
  - lifecycle entry: 0/168 → 63/168
  - source lifecycle: 0/193 → 50/193
  - foreign lifecycle: 0/156 → 44/156

The `building` denominator increases because the integration path instantiates generic lifecycle code that the existing fixture harness never links into its exercised path.

No fixtures were added for `interner`, `prim-constants`, or `building-types`: their remaining gaps are invariant/hash-collision paths, have no executable coverage regions, or require lifecycle mutation not legitimately owned by a one-shot source fixture. Adding cases there would pad coverage rather than test observable compiler behavior.

## Validation

- `just coverage` — 633 workspace tests and 875 integration tests passed
- `cargo nextest run -p purescript-alexandrite` — 46 tests passed
- Independent review covered every fixture file and the harness; its assertion-wording finding was addressed
