### PR TITLE
[backend] Expand backend integration coverage

### DIFF
--- a/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/Effect.js
+++ b/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/Effect.js
@@ -1,0 +1,4 @@
+export const mapE = transform => action => () => transform(action());
+export const applyE = functionAction => valueAction => () => functionAction()(valueAction());
+export const pureE = value => () => value;
+export const bindE = action => continuation => () => continuation(action())();

--- a/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/Effect.purs
+++ b/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/Effect.purs
@@ -1,0 +1,28 @@
+module Effect where
+
+import Control.Applicative (class Applicative)
+import Control.Apply (class Apply)
+import Control.Bind (class Bind)
+import Control.Monad (class Monad)
+import Data.Functor (class Functor)
+
+foreign import data Effect :: Type -> Type
+
+foreign import mapE :: forall value result. (value -> result) -> Effect value -> Effect result
+foreign import applyE :: forall value result. Effect (value -> result) -> Effect value -> Effect result
+foreign import pureE :: forall value. value -> Effect value
+foreign import bindE :: forall value result. Effect value -> (value -> Effect result) -> Effect result
+
+instance Functor Effect where
+  map = mapE
+
+instance Apply Effect where
+  apply = applyE
+
+instance Applicative Effect where
+  pure = pureE
+
+instance Bind Effect where
+  bind = bindE
+
+instance Monad Effect

--- a/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/Main.functional.snap
@@ -1,0 +1,32 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export constructor First/0
+
+@export constructor Second/0
+
+@export foreign constructEffect
+
+@export branchResult = \condition%0 seed%1 ->
+  effect.bind (if condition%0
+    then constructEffect "branch-then" seed%1
+    else constructEffect "branch-else" seed%1)
+    \selected%2 -> constructEffect "branch-after" selected%2
+
+@export caseResult = \choice%3 seed%4 ->
+  effect.bind (case choice%3 of
+    First ->
+      constructEffect "case-first" seed%4
+    Second ->
+      constructEffect "case-second" seed%4)
+    \selected%5 -> constructEffect "case-after" selected%5
+
+@export guardResult = \condition%8 seed%6 ->
+  effect.bind (case seed%6 of
+    value%7 ->
+      | condition%8 -> constructEffect "guard-true" value%7
+    value%9 ->
+      constructEffect "guard-false" value%9)
+    \selected%10 -> constructEffect "guard-after" selected%10

--- a/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/Main.js
+++ b/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/Main.js
@@ -1,0 +1,15 @@
+const trace = [];
+
+export const resetTrace = () => {
+  trace.length = 0;
+};
+
+export const readTrace = () => trace.slice();
+
+export const constructEffect = label => value => {
+  trace.push(`construct:${label}`);
+  return () => {
+    trace.push(`run:${label}`);
+    return value;
+  };
+};

--- a/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/Main.purs
+++ b/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/Main.purs
@@ -1,0 +1,30 @@
+module Main where
+
+import Control.Applicative (pure)
+import Control.Bind (bind)
+import Effect (Effect)
+
+data Choice = First | Second
+
+foreign import constructEffect :: forall value. String -> value -> Effect value
+
+branchResult :: Boolean -> String -> Effect String
+branchResult condition seed = do
+  selected <-
+    if condition then constructEffect "branch-then" seed
+    else constructEffect "branch-else" seed
+  constructEffect "branch-after" selected
+
+caseResult :: Choice -> String -> Effect String
+caseResult choice seed = do
+  selected <- case choice of
+    First -> constructEffect "case-first" seed
+    Second -> constructEffect "case-second" seed
+  constructEffect "case-after" selected
+
+guardResult :: Boolean -> String -> Effect String
+guardResult condition seed = do
+  selected <- case seed of
+    value | condition -> constructEffect "guard-true" value
+    value -> constructEffect "guard-false" value
+  constructEffect "guard-after" selected

--- a/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/Main.snap
+++ b/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 275
+expression: diagnostics_report
+---
+Terms
+First :: Main.Choice
+Second :: Main.Choice
+constructEffect :: forall value. Prim.String -> value -> Effect.Effect value
+branchResult :: Prim.Boolean -> Prim.String -> Effect.Effect Prim.String
+caseResult :: Main.Choice -> Prim.String -> Effect.Effect Prim.String
+guardResult :: Prim.Boolean -> Prim.String -> Effect.Effect Prim.String
+
+Types
+Choice :: Prim.Type
+
+Roles
+Choice = []

--- a/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/output/Control.Bind/index.js
+++ b/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/output/Control.Bind/index.js
@@ -1,0 +1,7 @@
+export function bind(dictionary) {
+  return dictionary.bind;
+}
+export function discard(dictionary) {
+  return dictionary.discard;
+}
+export const discardUnit = { discard: (bindFDict) => /* @__PURE__ */ bind(bindFDict) };

--- a/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/output/Effect/foreign.js
+++ b/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/output/Effect/foreign.js
@@ -1,0 +1,4 @@
+export const mapE = transform => action => () => transform(action());
+export const applyE = functionAction => valueAction => () => functionAction()(valueAction());
+export const pureE = value => () => value;
+export const bindE = action => continuation => () => continuation(action())();

--- a/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/output/Effect/index.js
+++ b/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/output/Effect/index.js
@@ -1,0 +1,22 @@
+import * as $foreign from "./foreign.js";
+export const mapE = $foreign["mapE"];
+export const applyE = $foreign["applyE"];
+export const pureE = $foreign["pureE"];
+export const bindE = $foreign["bindE"];
+export const functorEffect = { map: mapE };
+export const applyEffect = {
+  Functor0: () => functorEffect,
+  apply: applyE
+};
+export const applicativeEffect = {
+  Apply0: () => applyEffect,
+  pure: pureE
+};
+export const bindEffect = {
+  Apply0: () => applyEffect,
+  bind: bindE
+};
+export const monadEffect = {
+  Applicative0: () => applicativeEffect,
+  Bind1: () => bindEffect
+};

--- a/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/output/Main/foreign.js
@@ -1,0 +1,15 @@
+const trace = [];
+
+export const resetTrace = () => {
+  trace.length = 0;
+};
+
+export const readTrace = () => trace.slice();
+
+export const constructEffect = label => value => {
+  trace.push(`construct:${label}`);
+  return () => {
+    trace.push(`run:${label}`);
+    return value;
+  };
+};

--- a/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/output/Main/index.js
@@ -1,0 +1,59 @@
+import * as $foreign from "./foreign.js";
+export const First = "First";
+export const Second = "Second";
+export function branchResult(condition) {
+  return (seed) => {
+    let $result;
+    if (condition) {
+      $result = constructEffect("branch-then")(seed);
+    } else {
+      $result = constructEffect("branch-else")(seed);
+    }
+    return () => {
+      const selected = $result();
+      return constructEffect("branch-after")(selected)();
+    };
+  };
+}
+export function caseResult(choice) {
+  return (seed) => {
+    let $result;
+    $case: {
+      if (choice === "First") {
+        $result = constructEffect("case-first")(seed);
+        break $case;
+      }
+      if (choice === "Second") {
+        $result = constructEffect("case-second")(seed);
+        break $case;
+      }
+      throw new Error("Pattern match failure");
+    }
+    return () => {
+      const selected = $result();
+      return constructEffect("case-after")(selected)();
+    };
+  };
+}
+export function guardResult(condition) {
+  return (seed) => {
+    let $result;
+    $case: {
+      {
+        const value = seed;
+        if (condition) {
+          $result = constructEffect("guard-true")(value);
+          break $case;
+        }
+      }
+      const value$1 = seed;
+      $result = constructEffect("guard-false")(value$1);
+      break $case;
+    }
+    return () => {
+      const selected = $result();
+      return constructEffect("guard-after")(selected)();
+    };
+  };
+}
+export const constructEffect = $foreign["constructEffect"];

--- a/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/package.json
+++ b/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/verify.mjs
+++ b/tests-integration/fixtures/backend/1787790540_effect_branch_result_sequencing/verify.mjs
@@ -1,0 +1,21 @@
+import { deepStrictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+import { readTrace, resetTrace } from "./output/Main/foreign.js";
+
+const scenarios = [
+  ["branch then", () => Main.branchResult(true)("branch"), "branch", ["branch-then", "branch-after"]],
+  ["branch else", () => Main.branchResult(false)("branch"), "branch", ["branch-else", "branch-after"]],
+  ["case first", () => Main.caseResult(Main.First)("case"), "case", ["case-first", "case-after"]],
+  ["case second", () => Main.caseResult(Main.Second)("case"), "case", ["case-second", "case-after"]],
+  ["guard true", () => Main.guardResult(true)("guard"), "guard", ["guard-true", "guard-after"]],
+  ["guard false", () => Main.guardResult(false)("guard"), "guard", ["guard-false", "guard-after"]],
+];
+
+for (const [name, makeEffect, expectedValue, labels] of scenarios) {
+  resetTrace();
+  const effect = makeEffect();
+  deepStrictEqual(readTrace(), [`construct:${labels[0]}`], `${name} construction`);
+  deepStrictEqual(effect(), expectedValue, `${name} result`);
+  const expectedTrace = labels.flatMap(label => [`construct:${label}`, `run:${label}`]);
+  deepStrictEqual(readTrace(), expectedTrace, `${name} sequencing`);
+}

--- a/tests-integration/fixtures/backend/1787790540_ffi_default_export_validation/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787790540_ffi_default_export_validation/Main.functional.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign requested

--- a/tests-integration/fixtures/backend/1787790540_ffi_default_export_validation/Main.js
+++ b/tests-integration/fixtures/backend/1787790540_ffi_default_export_validation/Main.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/tests-integration/fixtures/backend/1787790540_ffi_default_export_validation/Main.purs
+++ b/tests-integration/fixtures/backend/1787790540_ffi_default_export_validation/Main.purs
@@ -1,0 +1,3 @@
+module Main where
+
+foreign import requested :: Int

--- a/tests-integration/fixtures/backend/1787790540_ffi_default_export_validation/Main.snap
+++ b/tests-integration/fixtures/backend/1787790540_ffi_default_export_validation/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 275
+expression: diagnostics_report
+---
+Terms
+requested :: Prim.Int
+
+Types
+
+Diagnostics
+Error! · [MissingFFIImplementation] · Main.purs:3:1
+  •
+  │
+  • JavaScript FFI module does not export 'requested'
+  │
+  │   foreign import requested :: Int
+  │   ╰──────────────────────────────
+  •

--- a/tests-integration/fixtures/backend/1787790540_ffi_default_export_validation/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787790540_ffi_default_export_validation/output/Main/foreign.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/tests-integration/fixtures/backend/1787790540_ffi_default_export_validation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787790540_ffi_default_export_validation/output/Main/index.js
@@ -1,0 +1,2 @@
+import * as $foreign from "./foreign.js";
+export const requested = $foreign["requested"];

--- a/tests-integration/fixtures/backend/1787790540_higher_rank_constrained_callback_runtime/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787790540_higher_rank_constrained_callback_runtime/Main.functional.snap
@@ -1,0 +1,25 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export before = \dictionary%0 -> dictionary%0.before
+
+@export constructor Left/0
+
+@export constructor Right/0
+
+@export instance beforeMarker = {
+  before:
+    \$marker%1 $marker%2 ->
+      case $marker%1, $marker%2 of
+        Left, Right ->
+          true
+        _, _ ->
+          false
+}
+
+@export runComparison = \comparison%3 -> comparison%3 beforeMarker "Left" "Right"
+
+@export result = runComparison
+  (\beforeValueDict%4 -> \left%5 right%6 -> before beforeValueDict%4 left%5 right%6)

--- a/tests-integration/fixtures/backend/1787790540_higher_rank_constrained_callback_runtime/Main.purs
+++ b/tests-integration/fixtures/backend/1787790540_higher_rank_constrained_callback_runtime/Main.purs
@@ -1,0 +1,18 @@
+module Main where
+
+class Before value where
+  before :: value -> value -> Boolean
+
+data Marker = Left | Right
+
+instance Before Marker where
+  before Left Right = true
+  before _ _ = false
+
+runComparison
+  :: (forall value. Before value => value -> value -> Boolean)
+  -> Boolean
+runComparison comparison = comparison Left Right
+
+result :: Boolean
+result = runComparison \left right -> before left right

--- a/tests-integration/fixtures/backend/1787790540_higher_rank_constrained_callback_runtime/Main.snap
+++ b/tests-integration/fixtures/backend/1787790540_higher_rank_constrained_callback_runtime/Main.snap
@@ -1,0 +1,25 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 275
+expression: diagnostics_report
+---
+Terms
+before :: forall @value. Main.Before value => value -> value -> Prim.Boolean
+Left :: Main.Marker
+Right :: Main.Marker
+runComparison :: (forall value. Main.Before value => value -> value -> Prim.Boolean) -> Prim.Boolean
+result :: Prim.Boolean
+
+Types
+Before :: Prim.Type -> Prim.Constraint
+Marker :: Prim.Type
+
+Classes
+class forall (value :: Prim.Type). Main.Before value
+  before :: forall @value. Main.Before value => value -> value -> Prim.Boolean
+
+Instances
+instance Main.Before Main.Marker
+
+Roles
+Marker = []

--- a/tests-integration/fixtures/backend/1787790540_higher_rank_constrained_callback_runtime/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787790540_higher_rank_constrained_callback_runtime/output/Main/index.js
@@ -1,0 +1,20 @@
+export const Left = "Left";
+export const Right = "Right";
+export function before(dictionary) {
+  return dictionary.before;
+}
+export function runComparison(comparison) {
+  return /* @__PURE__ */ comparison(beforeMarker)("Left")("Right");
+}
+export const beforeMarker = /* @__PURE__ */ (() => {
+  const $closure = ($marker) => {
+    return ($marker$1) => {
+      if ($marker === "Left" && $marker$1 === "Right") {
+        return true;
+      }
+      return false;
+    };
+  };
+  return { before: $closure };
+})();
+export const result = runComparison((beforeValueDict) => (left) => (right) => /* @__PURE__ */ before(beforeValueDict)(left)(right));

--- a/tests-integration/fixtures/backend/1787790540_higher_rank_constrained_callback_runtime/package.json
+++ b/tests-integration/fixtures/backend/1787790540_higher_rank_constrained_callback_runtime/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests-integration/fixtures/backend/1787790540_higher_rank_constrained_callback_runtime/verify.mjs
+++ b/tests-integration/fixtures/backend/1787790540_higher_rank_constrained_callback_runtime/verify.mjs
@@ -1,0 +1,4 @@
+import { strictEqual } from "node:assert/strict";
+import { result } from "./output/Main/index.js";
+
+strictEqual(result, true);


### PR DESCRIPTION
## Summary

Add focused backend integration fixtures for substantive behavior not covered by the existing canonical suite:

- diagnose a named PureScript FFI import when the foreign module exports only a JavaScript default
- lower and execute a higher-rank constrained callback while preserving its dictionary and asymmetric argument order
- generate and execute effectful `if`, `case`, and guarded results whose values feed a continuation, including labeled assignment-and-break control flow

All snapshots and JavaScript outputs were generated through the fixture runner. Runtime fixtures verify the emitted modules with Node.

## Coverage

Canonical `just coverage` line coverage changes:

- `foreign-javascript`: 60/62 (96.77%) → 61/62 (98.39%)
- `functional`: 2463/2634 (93.51%) → 2469/2634 (93.74%)
- `javascript`: 2833/3155 (89.79%) → 2865/3155 (90.81%)

## Validation

- `just t backend`
- `just coverage` (633 workspace tests and 881 integration tests)