### PR TITLE
[tests] Exercise support crate integration surfaces

### DIFF
--- a/docs/src/wasm/tests/web.rs
+++ b/docs/src/wasm/tests/web.rs
@@ -92,7 +92,8 @@ fn check_uses_registered_packages_until_they_are_cleared() {
     assert!(checked.types.is_empty());
     assert!(checked.synonyms.is_empty());
     assert!(checked.errors.is_empty());
-    assert!(checked.timing.all().into_iter().all(|timing| timing >= 0.0));
+    let mut timings = checked.timing.all().into_iter();
+    assert!(timings.all(|timing| timing >= 0.0));
 
     let synonym_source =
         "module Main where\n\ntype Identity a = a\n\nidentity :: forall a. Identity a -> a\nidentity value = value";

--- a/docs/src/wasm/tests/web.rs
+++ b/docs/src/wasm/tests/web.rs
@@ -2,12 +2,114 @@
 
 #![cfg(target_arch = "wasm32")]
 
-extern crate wasm_bindgen_test;
-use wasm_bindgen_test::*;
+use serde::Deserialize;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
 wasm_bindgen_test_configure!(run_in_browser);
 
+#[derive(Deserialize)]
+struct CheckResult {
+    terms: Vec<String>,
+    types: Vec<String>,
+    synonyms: Vec<SynonymExpansion>,
+    errors: Vec<CheckError>,
+    timing: CheckTiming,
+}
+
+#[derive(Deserialize)]
+struct SynonymExpansion {
+    name: String,
+    expansion: String,
+    quantified_variables: u32,
+    kind_variables: u32,
+    type_variables: u32,
+}
+
+#[derive(Deserialize)]
+struct CheckError {
+    kind: String,
+    message: String,
+    location: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CheckTiming {
+    lex: f64,
+    layout: f64,
+    parse: f64,
+    stabilize: f64,
+    index: f64,
+    resolve: f64,
+    lower: f64,
+    check: f64,
+    total: f64,
+}
+
+impl CheckTiming {
+    fn all(&self) -> [f64; 9] {
+        [
+            self.lex,
+            self.layout,
+            self.parse,
+            self.stabilize,
+            self.index,
+            self.resolve,
+            self.lower,
+            self.check,
+            self.total,
+        ]
+    }
+}
+
+fn check(source: &str) -> CheckResult {
+    serde_wasm_bindgen::from_value(docs_lib::check(source)).unwrap()
+}
+
 #[wasm_bindgen_test]
-fn pass() {
-    assert_eq!(1 + 1, 2);
+fn parse_returns_the_syntax_tree_and_timings() {
+    let result = docs_lib::parse("module Main where\n\nvalue = 42");
+    let empty_module = docs_lib::parse("module Main where");
+
+    assert!(result.output().contains("Module"));
+    assert_ne!(result.output(), empty_module.output());
+    assert!(result.lex >= 0.0);
+    assert!(result.layout >= 0.0);
+    assert!(result.parse >= 0.0);
+}
+
+#[wasm_bindgen_test]
+fn check_uses_registered_packages_until_they_are_cleared() {
+    docs_lib::clear_packages();
+    let library = "module Library where\n\ntype Identity a = a\n\nidentity :: forall a. Identity a -> a\nidentity value = value";
+    assert_eq!(
+        docs_lib::register_source("library/src/Library.purs", library).as_deref(),
+        Some("Library")
+    );
+
+    let source = "module Main where\n\nimport Library (identity)\n\nanswer = identity 42";
+    let checked = check(source);
+    assert_eq!(checked.terms, ["answer :: Int"]);
+    assert!(checked.types.is_empty());
+    assert!(checked.synonyms.is_empty());
+    assert!(checked.errors.is_empty());
+    assert!(checked.timing.all().into_iter().all(|timing| timing >= 0.0));
+
+    let synonym_source =
+        "module Main where\n\ntype Identity a = a\n\nidentity :: forall a. Identity a -> a\nidentity value = value";
+    let checked = check(synonym_source);
+    assert!(checked.terms.iter().any(|term| term.starts_with("identity ::")));
+    assert_eq!(checked.synonyms.len(), 1);
+    assert_eq!(checked.synonyms[0].name, "Identity");
+    assert!(checked.synonyms[0].expansion.starts_with("forall a."));
+    assert!(checked.synonyms[0].expansion.contains("a"));
+    assert_eq!(checked.synonyms[0].quantified_variables, 1);
+    assert_eq!(checked.synonyms[0].kind_variables, 0);
+    assert_eq!(checked.synonyms[0].type_variables, 1);
+    assert!(checked.errors.is_empty());
+
+    docs_lib::clear_packages();
+    let checked = check(source);
+    let error = checked.errors.iter().find(|error| error.kind == "NotInScope").unwrap();
+    assert!(!error.message.is_empty());
+    assert!(error.location.as_deref().is_some_and(|location| location.contains("..")));
 }

--- a/tests-compatibility/fixtures/cli/registry-index/pr/el/prelude
+++ b/tests-compatibility/fixtures/cli/registry-index/pr/el/prelude
@@ -1,0 +1,1 @@
+{"name":"prelude","version":"1.0.0","license":"BSD-3-Clause","location":{"gitUrl":"https://example.test/prelude.git","subdir":null},"dependencies":{}}

--- a/tests-compatibility/fixtures/cli/registry/package-sets/1.0.0.json
+++ b/tests-compatibility/fixtures/cli/registry/package-sets/1.0.0.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.0",
+  "compiler": "0.15.15",
+  "published": "2026-08-27",
+  "packages": {
+    "prelude": "1.0.0"
+  }
+}

--- a/tests-compatibility/fixtures/cli/regression/Prelude.purs
+++ b/tests-compatibility/fixtures/cli/regression/Prelude.purs
@@ -1,0 +1,6 @@
+module Prelude where
+
+identity :: forall a. a -> a
+identity value = value
+
+broken = missing

--- a/tests-compatibility/fixtures/cli/valid/Prelude.purs
+++ b/tests-compatibility/fixtures/cli/valid/Prelude.purs
@@ -1,0 +1,4 @@
+module Prelude where
+
+identity :: forall a. a -> a
+identity value = value

--- a/tests-compatibility/tests/cli.rs
+++ b/tests-compatibility/tests/cli.rs
@@ -1,0 +1,153 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use serde_json::Value;
+use tar::Builder;
+use tempfile::TempDir;
+
+const PACKAGE: &str = "prelude";
+const VERSION: &str = "1.0.0";
+
+struct VerifierFixture {
+    temporary: TempDir,
+    registry: PathBuf,
+    index: PathBuf,
+    cache: PathBuf,
+}
+
+impl VerifierFixture {
+    fn new() -> VerifierFixture {
+        let temporary = tempfile::tempdir().unwrap();
+        let fixtures = Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/cli");
+        let registry = fixtures.join("registry");
+        let index = fixtures.join("registry-index");
+        let cache = temporary.path().join("cache");
+        fs::create_dir_all(cache.join("downloads")).unwrap();
+
+        VerifierFixture { temporary, registry, index, cache }
+    }
+
+    fn install_tarball(&self, source_directory: &Path) {
+        let tarball = self.cache.join("downloads").join(format!("{PACKAGE}-{VERSION}.tar.gz"));
+        let file = fs::File::create(tarball).unwrap();
+        let encoder = GzEncoder::new(file, Compression::default());
+        let mut archive = Builder::new(encoder);
+        archive.append_dir_all("package/src", source_directory).unwrap();
+        archive.finish().unwrap();
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_tests-compatibility"));
+        command.current_dir(self.temporary.path());
+        command
+    }
+
+    fn registry_arguments(&self) -> [String; 6] {
+        [
+            "--registry-dir".to_string(),
+            self.registry.display().to_string(),
+            "--index-dir".to_string(),
+            self.index.display().to_string(),
+            "--cache-dir".to_string(),
+            self.cache.display().to_string(),
+        ]
+    }
+
+    fn report(&self, name: &str) -> PathBuf {
+        self.temporary.path().join(name)
+    }
+}
+
+fn run(mut command: Command) -> Output {
+    command.output().unwrap()
+}
+
+fn output_text(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn read_json(path: &Path) -> Value {
+    serde_json::from_slice(&fs::read(path).unwrap()).unwrap()
+}
+
+#[test]
+fn prepare_verify_and_compare_reports_a_compiler_regression() {
+    let fixture = VerifierFixture::new();
+    let fixtures = Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/cli");
+    fixture.install_tarball(&fixtures.join("valid"));
+
+    let mut prepare = fixture.command();
+    prepare.arg("prepare").args(fixture.registry_arguments()).args([
+        "--package-set",
+        "1.0.0",
+        "--preset",
+        "core",
+    ]);
+    let prepared = run(prepare);
+    assert!(prepared.status.success(), "{}", output_text(&prepared));
+    assert!(String::from_utf8_lossy(&prepared.stdout).contains("Prepared 1 packages"));
+    let extracted_source = fixture.cache.join("sources/prelude/1.0.0/src/Prelude.purs");
+    assert_eq!(
+        fs::read_to_string(&extracted_source).unwrap(),
+        fs::read_to_string(fixtures.join("valid/Prelude.purs")).unwrap()
+    );
+    assert!(fixture.cache.join("sources/prelude/1.0.0/.tarball-size").is_file());
+
+    let base_report = fixture.report("base.json");
+    let mut verify_base = fixture.command();
+    verify_base
+        .arg("verify")
+        .args(fixture.registry_arguments())
+        .args(["--package-set", "1.0.0", "--package", PACKAGE, "--json-output"])
+        .arg(&base_report);
+    let base = run(verify_base);
+    assert!(base.status.success(), "{}", output_text(&base));
+    let base_json = read_json(&base_report);
+    assert_eq!(base_json["summary"]["sourceFiles"], 1);
+    assert_eq!(base_json["summary"]["compilerErrors"], 0);
+
+    fs::copy(fixtures.join("regression/Prelude.purs"), extracted_source).unwrap();
+
+    let candidate_report = fixture.report("candidate.json");
+    let mut verify_candidate = fixture.command();
+    verify_candidate
+        .arg("verify")
+        .args(fixture.registry_arguments())
+        .args(["--package-set", "1.0.0", "--package", PACKAGE, "--json-output"])
+        .arg(&candidate_report);
+    let candidate = run(verify_candidate);
+    assert_eq!(candidate.status.code(), Some(1), "{}", output_text(&candidate));
+    let candidate_json = read_json(&candidate_report);
+    assert!(candidate_json["summary"]["compilerErrors"].as_u64().unwrap() > 0);
+    let diagnostics = candidate_json["diagnostics"].as_array().unwrap();
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic["package"] == PACKAGE && diagnostic["code"] == "NotInScope"
+    }));
+
+    let comparison_report = fixture.report("comparison.json");
+    let summary = fixture.report("summary.md");
+    let mut compare = fixture.command();
+    compare
+        .arg("compare")
+        .args(["--base-report", base_report.to_str().unwrap()])
+        .args(["--candidate-report", candidate_report.to_str().unwrap()])
+        .args(["--json-output", comparison_report.to_str().unwrap()])
+        .args(["--summary-output", summary.to_str().unwrap()])
+        .arg("--github-annotations");
+    let comparison = run(compare);
+    assert_eq!(comparison.status.code(), Some(1), "{}", output_text(&comparison));
+
+    let comparison_json = read_json(&comparison_report);
+    assert!(comparison_json["summary"]["introducedCompilerErrors"].as_u64().unwrap() > 0);
+    let markdown = fs::read_to_string(summary).unwrap();
+    assert!(markdown.contains("The candidate introduces compatibility errors"));
+    assert!(markdown.contains("NotInScope"));
+    assert!(String::from_utf8_lossy(&comparison.stdout).contains("::error title="));
+}


### PR DESCRIPTION
## Summary

Add end-to-end coverage for the workspace support crates that expose responsible consumer-facing behavior:

- exercise the compatibility verifier through its actual `prepare`, `verify`, and `compare` subprocess workflows using a local registry, package tarball, cache, and valid/regressed PureScript sources
- replace the placeholder docs Wasm browser test with coverage for `parse`, `check`, `register_source`, and `clear_packages`, including serialized results, package imports, source replacement, cache invalidation, and diagnostics

`tests-integration` intentionally has no new self-tests. It is fixture infrastructure already exercised by every compiler integration category; directly testing its loaders and snapshot reporters would test the harness merely to move metrics rather than cover a responsible external surface.

## Verification

- `cargo check -p tests-compatibility --tests`
- `cargo nextest run -p tests-compatibility` (28 passed)
- `cargo check -p docs-lib --tests --target wasm32-unknown-unknown`
- `cargo test -p docs-lib --target wasm32-unknown-unknown` with wasm-bindgen-test-runner and headless Chrome (2 browser tests passed)
- `just format`
- `git diff --check origin/main..HEAD`

Each added fixture/scenario received an independent review. The resulting findings were addressed by proving extraction immediately after `prepare`, avoiding exact diagnostic fan-out, validating the complete serialized Wasm result shape, strengthening parse-output coverage, and avoiding generated-name brittleness.
