### PR TITLE
[tests] Cover compiler tool workflows end to end

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -294,7 +294,7 @@ jobs:
       - name: Install tools
         uses: taiki-e/install-action@v2.85.4
         with:
-          tool: cargo-nextest,cargo-llvm-cov,just
+          tool: cargo-nextest,cargo-llvm-cov,cargo-insta,just
 
       - name: Build and Test
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,6 +514,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar 3.1.2",
+ "tempfile",
 ]
 
 [[package]]

--- a/compiler-bin/tests/compile.rs
+++ b/compiler-bin/tests/compile.rs
@@ -1,0 +1,71 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn compiler() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_purescript-alexandrite"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures").join(name)
+}
+
+fn compile(fixture: &Path, output: &Path, extra_arguments: &[&str]) -> Output {
+    let sources = fixture.join("src/**/*.purs");
+    compiler()
+        .arg("compile")
+        .arg("--output")
+        .arg(output)
+        .args(extra_arguments)
+        .arg(sources)
+        .output()
+        .expect("compiler should run")
+}
+
+#[test]
+fn compiles_a_project_with_dependencies_and_foreign_javascript() {
+    let fixture = fixture("compile-project");
+    let temporary = tempfile::tempdir().unwrap();
+    let output = temporary.path().join("output");
+
+    let result = compile(&fixture, &output, &["--json-errors", "--color", "never"]);
+
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    let report: serde_json::Value = serde_json::from_slice(&result.stdout).unwrap();
+    assert_eq!(report["warnings"], serde_json::json!([]));
+    assert_eq!(report["errors"], serde_json::json!([]));
+    assert!(output.join("Library/index.js").is_file());
+    assert!(output.join("Main/foreign.js").is_file());
+
+    std::fs::write(output.join("package.json"), r#"{"type":"module"}"#).unwrap();
+    let module = url::Url::from_file_path(output.join("Main/index.js")).unwrap();
+    let javascript =
+        format!("const module = await import({:?}); console.log(module.result);", module.as_str());
+    let execution = Command::new("node")
+        .arg("--input-type=module")
+        .arg("--eval")
+        .arg(javascript)
+        .output()
+        .expect("generated JavaScript should run");
+
+    assert!(execution.status.success(), "{}", String::from_utf8_lossy(&execution.stderr));
+    assert_eq!(String::from_utf8_lossy(&execution.stdout).trim(), "42");
+}
+
+#[test]
+fn reports_compilation_errors_through_the_json_cli_contract() {
+    let fixture = fixture("compile-error");
+    let temporary = tempfile::tempdir().unwrap();
+    let output = temporary.path().join("output");
+
+    let result = compile(
+        &fixture,
+        &output,
+        &["--json-errors", "--diagnostic-limit", "0", "--color", "never"],
+    );
+
+    assert!(!result.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&result.stdout).unwrap();
+    assert_eq!(report["warnings"], serde_json::json!([]));
+    assert_eq!(report["errors"][0]["message"], "compilation failed");
+    assert!(!output.exists());
+}

--- a/compiler-bin/tests/fixtures/compile-error/src/Main.purs
+++ b/compiler-bin/tests/fixtures/compile-error/src/Main.purs
@@ -1,0 +1,4 @@
+module Main where
+
+answer :: Int
+answer = "forty-two"

--- a/compiler-bin/tests/fixtures/compile-project/src/Library.purs
+++ b/compiler-bin/tests/fixtures/compile-project/src/Library.purs
@@ -1,0 +1,4 @@
+module Library where
+
+answer :: Int
+answer = 41

--- a/compiler-bin/tests/fixtures/compile-project/src/Main.js
+++ b/compiler-bin/tests/fixtures/compile-project/src/Main.js
@@ -1,0 +1,1 @@
+export const increment = value => (value + 1) | 0;

--- a/compiler-bin/tests/fixtures/compile-project/src/Main.purs
+++ b/compiler-bin/tests/fixtures/compile-project/src/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+import Library (answer)
+
+foreign import increment :: Int -> Int
+
+result :: Int
+result = increment answer

--- a/compiler-scripts/Cargo.toml
+++ b/compiler-scripts/Cargo.toml
@@ -11,3 +11,6 @@ heck = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 similar = { version = "3", features = ["inline"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/compiler-scripts/src/test_runner/pending.rs
+++ b/compiler-scripts/src/test_runner/pending.rs
@@ -1,8 +1,8 @@
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::{env, fs};
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 use console::style;
 use serde::Deserialize;
 
@@ -45,9 +45,12 @@ pub fn collect_pending_snapshots(
         .arg("insta")
         .arg("pending-snapshots")
         .arg("--as-json")
-        .stderr(Stdio::null())
         .output()
         .context("failed to run cargo insta")?;
+    if !pending_output.status.success() {
+        let stderr = String::from_utf8_lossy(&pending_output.stderr);
+        bail!("cargo insta pending-snapshots failed: {}", stderr.trim());
+    }
 
     let pending = String::from_utf8_lossy(&pending_output.stdout);
     let pending = pending.trim();

--- a/compiler-scripts/tests/cli.rs
+++ b/compiler-scripts/tests/cli.rs
@@ -1,0 +1,67 @@
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn scripts() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_compiler-scripts"))
+}
+
+fn run(current_directory: &Path, arguments: &[&str]) -> Output {
+    scripts()
+        .current_dir(current_directory)
+        .args(arguments)
+        .output()
+        .expect("compiler scripts should run")
+}
+
+#[test]
+fn creates_previews_and_deletes_a_fixture_through_the_cli() {
+    let temporary = tempfile::tempdir().unwrap();
+    let fixtures = temporary.path().join("tests-integration/fixtures/backend");
+    std::fs::create_dir_all(&fixtures).unwrap();
+
+    let created = run(temporary.path(), &["backend", "--create", "CLI lifecycle"]);
+    assert!(created.status.success(), "{}", String::from_utf8_lossy(&created.stderr));
+
+    let fixture_entries = std::fs::read_dir(&fixtures).unwrap();
+    let fixture_entries = fixture_entries.collect::<Result<Vec<_>, _>>().unwrap();
+    assert_eq!(fixture_entries.len(), 1);
+    let fixture = fixture_entries[0].path();
+    assert!(fixture.file_name().unwrap().to_string_lossy().ends_with("_cli_lifecycle"));
+    let main = fixture.join("Main.purs");
+    assert_eq!(std::fs::read_to_string(&main).unwrap(), "module Main where\n\n");
+
+    let preview = run(temporary.path(), &["backend", "--delete", "CLI lifecycle"]);
+    assert!(preview.status.success(), "{}", String::from_utf8_lossy(&preview.stderr));
+    assert!(String::from_utf8_lossy(&preview.stdout).contains("1 pending deletion(s) in backend"));
+    assert_eq!(std::fs::read_to_string(&main).unwrap(), "module Main where\n\n");
+
+    let deleted = run(temporary.path(), &["backend", "--delete", "CLI lifecycle", "--confirm"]);
+    assert!(deleted.status.success(), "{}", String::from_utf8_lossy(&deleted.stderr));
+    assert_eq!(std::fs::read_dir(&fixtures).unwrap().count(), 0);
+}
+
+#[test]
+fn runs_a_fixture_category_end_to_end() {
+    let temporary = tempfile::tempdir().unwrap();
+    let package = temporary.path().join("tests-integration");
+    std::fs::create_dir_all(package.join("tests")).unwrap();
+    std::fs::write(
+        temporary.path().join("Cargo.toml"),
+        "[workspace]\nmembers = [\"tests-integration\"]\nresolver = \"3\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        package.join("Cargo.toml"),
+        "[package]\nname = \"tests-integration\"\nversion = \"0.0.0\"\nedition = \"2024\"\n",
+    )
+    .unwrap();
+    std::fs::write(package.join("tests/docs.rs"), "#[test]\nfn documentation_baseline() {}\n")
+        .unwrap();
+
+    let result = run(temporary.path(), &["docs", "documentation_baseline"]);
+
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    assert!(
+        String::from_utf8_lossy(&result.stdout).contains("All tests passed, no pending snapshots.")
+    );
+}

--- a/compiler-scripts/tests/cli.rs
+++ b/compiler-scripts/tests/cli.rs
@@ -13,27 +13,17 @@ fn run(current_directory: &Path, arguments: &[&str]) -> Output {
         .expect("compiler scripts should run")
 }
 
-#[cfg(unix)]
-fn write_failing_snapshot_cargo(path: &Path) {
-    use std::os::unix::fs::PermissionsExt;
-
-    std::fs::write(
-        path,
-        "#!/bin/sh\nif [ \"$1\" = \"nextest\" ]; then exit 0; fi\necho snapshot inspection failed >&2\nexit 19\n",
-    )
-    .unwrap();
-    let mut permissions = std::fs::metadata(path).unwrap().permissions();
-    permissions.set_mode(0o755);
-    std::fs::set_permissions(path, permissions).unwrap();
-}
-
-#[cfg(windows)]
-fn write_failing_snapshot_cargo(path: &Path) {
-    std::fs::write(
-        path.with_extension("cmd"),
-        "@echo off\r\nif \"%1\"==\"nextest\" exit /b 0\r\necho snapshot inspection failed 1>&2\r\nexit /b 19\r\n",
-    )
-    .unwrap();
+fn build_failing_snapshot_cargo(path: &Path) {
+    let source =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/failing_snapshot_cargo.rs");
+    let executable = path.with_extension(std::env::consts::EXE_EXTENSION);
+    let status = Command::new("rustc")
+        .arg(source)
+        .arg("-o")
+        .arg(executable)
+        .status()
+        .expect("rustc should run");
+    assert!(status.success(), "fake cargo should compile");
 }
 
 #[test]
@@ -94,7 +84,7 @@ fn reports_failed_pending_snapshot_inspection() {
     let temporary = tempfile::tempdir().unwrap();
     let binaries = temporary.path().join("bin");
     std::fs::create_dir(&binaries).unwrap();
-    write_failing_snapshot_cargo(&binaries.join("cargo"));
+    build_failing_snapshot_cargo(&binaries.join("cargo"));
 
     let result = scripts()
         .current_dir(temporary.path())

--- a/compiler-scripts/tests/cli.rs
+++ b/compiler-scripts/tests/cli.rs
@@ -13,6 +13,29 @@ fn run(current_directory: &Path, arguments: &[&str]) -> Output {
         .expect("compiler scripts should run")
 }
 
+#[cfg(unix)]
+fn write_failing_snapshot_cargo(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::write(
+        path,
+        "#!/bin/sh\nif [ \"$1\" = \"nextest\" ]; then exit 0; fi\necho snapshot inspection failed >&2\nexit 19\n",
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).unwrap();
+}
+
+#[cfg(windows)]
+fn write_failing_snapshot_cargo(path: &Path) {
+    std::fs::write(
+        path.with_extension("cmd"),
+        "@echo off\r\nif \"%1\"==\"nextest\" exit /b 0\r\necho snapshot inspection failed 1>&2\r\nexit /b 19\r\n",
+    )
+    .unwrap();
+}
+
 #[test]
 fn creates_previews_and_deletes_a_fixture_through_the_cli() {
     let temporary = tempfile::tempdir().unwrap();
@@ -63,5 +86,26 @@ fn runs_a_fixture_category_end_to_end() {
     assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
     assert!(
         String::from_utf8_lossy(&result.stdout).contains("All tests passed, no pending snapshots.")
+    );
+}
+
+#[test]
+fn reports_failed_pending_snapshot_inspection() {
+    let temporary = tempfile::tempdir().unwrap();
+    let binaries = temporary.path().join("bin");
+    std::fs::create_dir(&binaries).unwrap();
+    write_failing_snapshot_cargo(&binaries.join("cargo"));
+
+    let result = scripts()
+        .current_dir(temporary.path())
+        .env("PATH", binaries)
+        .args(["docs", "snapshot_failure"])
+        .output()
+        .expect("compiler scripts should run");
+
+    assert!(!result.status.success());
+    assert!(
+        String::from_utf8_lossy(&result.stderr)
+            .contains("cargo insta pending-snapshots failed: snapshot inspection failed")
     );
 }

--- a/compiler-scripts/tests/fixtures/failing_snapshot_cargo.rs
+++ b/compiler-scripts/tests/fixtures/failing_snapshot_cargo.rs
@@ -1,0 +1,8 @@
+fn main() {
+    if std::env::args().nth(1).as_deref() == Some("nextest") {
+        return;
+    }
+
+    eprintln!("snapshot inspection failed");
+    std::process::exit(19);
+}

--- a/justfile
+++ b/justfile
@@ -7,6 +7,7 @@ set positional-arguments
 coverage:
   cargo llvm-cov clean --workspace
   cargo llvm-cov nextest --no-report
+  cargo llvm-cov nextest --no-report -p purescript-alexandrite -p compiler-scripts
   cargo llvm-cov nextest --no-report -p tests-integration
 
 [doc("Generate coverage with the package set")]


### PR DESCRIPTION
## Summary

The standard coverage job did not execute the `purescript-alexandrite` or `compiler-scripts` packages, leaving their command-line workflows effectively unmeasured. This adds end-to-end coverage at the process boundary rather than extending crate-local unit coverage.

- run both compiler-tool packages in the coverage recipe
- exercise successful and failing `purescript-alexandrite compile` workflows through the real binary
- exercise fixture creation/deletion and category orchestration through the real `compiler-scripts` binary
- fail fixture runs when pending-snapshot inspection itself fails, rather than treating failure as a clean snapshot set
- install `cargo-insta` in the coverage job, where the fixture-runner integration test executes

The successful compiler fixture discovers modules through a glob, compiles an imported module, copies foreign JavaScript, checks the JSON contract, and executes generated JavaScript with Node. The failure fixture checks the JSON error contract and confirms that compilation does not emit output. Compiler-scripts scenarios use isolated temporary workspaces to avoid mutating or racing repository fixtures.

## Coverage

Line coverage from an explicit package baseline:

| Package | Before | After | Change |
| --- | ---: | ---: | ---: |
| `compiler-bin` | 1,064/2,434 (43.71%) | 1,423/2,434 (58.46%) | +359 lines, +14.75 pp |
| `compiler-scripts` | 155/851 (18.21%) | 441/854 (51.64%) | +286 lines, +33.43 pp |

`compiler-bin/src/compile.rs` moves from 0% to 81.12% line coverage.

## Validation

- `cargo nextest run -p purescript-alexandrite` — 47 passed
- `cargo nextest run -p compiler-scripts` — 17 passed
- `cargo check -p purescript-alexandrite --tests`
- `cargo check -p compiler-scripts --tests`
- `just t backend` — full category passed, no pending snapshots
- `just t docs` — full category passed, no pending snapshots
- `just coverage` — passed, including all 875 `tests-integration` tests

Each new integration scenario received an independent subagent review. Valid findings were addressed by using semantic JSON assertions, proving dry-run preservation and cleanup, isolating fixture-runner execution, and propagating failed `cargo-insta` inspection.
