### PR TITLE
[compiler-bin] Add persistent watch compilation mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,7 @@ dependencies = [
 name = "diagnostics"
 version = "0.1.0"
 dependencies = [
+ "building-types",
  "checking",
  "files",
  "foreign-javascript",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,6 +911,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "functional"
 version = "0.1.0"
 dependencies = [
@@ -1364,6 +1373,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
+dependencies = [
+ "bitflags 2.13.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "insta"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1519,6 +1548,26 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
 ]
 
 [[package]]
@@ -1715,6 +1764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1739,6 +1789,33 @@ name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.1",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2361,6 +2438,7 @@ dependencies = [
  "javascript",
  "lowering",
  "lsp-types",
+ "notify",
  "parking_lot",
  "path-absolutize",
  "prim-constants",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "diagnostics"
 version = "0.1.0"
 dependencies = [
@@ -1478,6 +1509,59 @@ dependencies = [
  "rustc-hash",
  "smol_str",
  "thiserror",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -2351,6 +2435,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2436,6 +2529,7 @@ dependencies = [
  "insta",
  "itertools 0.15.0",
  "javascript",
+ "jiff",
  "lowering",
  "lsp-types",
  "notify",

--- a/compiler-bin/Cargo.toml
+++ b/compiler-bin/Cargo.toml
@@ -40,6 +40,7 @@ itertools = "0.15.0"
 javascript = { version = "0.1.0", path = "../compiler-backend/javascript" }
 lowering = { version = "0.1.0", path = "../compiler-frontend/lowering" }
 lsp-types.workspace = true
+notify = "8.2.0"
 parking_lot = "0.12.5"
 path-absolutize = "4.0.1"
 prim-constants = { version = "0.1.0", path = "../compiler-core/prim-constants" }

--- a/compiler-bin/Cargo.toml
+++ b/compiler-bin/Cargo.toml
@@ -38,6 +38,7 @@ indicatif = "0.18.6"
 indexing = { version = "0.1.0", path = "../compiler-frontend/indexing" }
 itertools = "0.15.0"
 javascript = { version = "0.1.0", path = "../compiler-backend/javascript" }
+jiff = "0.2.35"
 lowering = { version = "0.1.0", path = "../compiler-frontend/lowering" }
 lsp-types.workspace = true
 notify = "8.2.0"

--- a/compiler-bin/src/cli.rs
+++ b/compiler-bin/src/cli.rs
@@ -41,6 +41,8 @@ pub enum Command {
     Lsp(LspOptions),
     /// Compile PureScript modules to JavaScript (experimental).
     Compile(CompileOptions),
+    /// Compile PureScript modules and rebuild when inputs change (experimental).
+    Watch(WatchOptions),
     /// Documentation utilities.
     Docs(DocsOptions),
 }
@@ -90,11 +92,7 @@ pub struct LspOptions {
 #[derive(Debug, Args)]
 pub struct CompileOptions {
     #[command(flatten)]
-    pub logging: LoggingOptions,
-
-    /// Output directory for compiled modules.
-    #[arg(short, long, value_name("DIR"), default_value("output"), value_parser = absolute_path_parser())]
-    pub output: PathBuf,
+    pub build: BuildOptions,
 
     /// Code generation targets requested by build tools.
     #[arg(long, value_name("TARGETS"))]
@@ -105,6 +103,22 @@ pub struct CompileOptions {
     /// Full structured JSON diagnostics are not yet supported.
     #[arg(long)]
     pub json_errors: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct WatchOptions {
+    #[command(flatten)]
+    pub build: BuildOptions,
+}
+
+#[derive(Debug, Args)]
+pub struct BuildOptions {
+    #[command(flatten)]
+    pub logging: LoggingOptions,
+
+    /// Output directory for compiled modules.
+    #[arg(short, long, value_name("DIR"), default_value("output"), value_parser = absolute_path_parser())]
+    pub output: PathBuf,
 
     /// Maximum number of human-readable diagnostics to print.
     #[arg(long, value_name("COUNT"))]
@@ -223,6 +237,16 @@ mod tests {
         }
     }
 
+    fn watch(args: &[&str]) -> WatchOptions {
+        let mut argv = vec!["alexandrite", "watch"];
+        argv.extend(args);
+        let cli = Cli::parse_from(argv);
+        match cli.command {
+            Some(Command::Watch(options)) => options,
+            _ => unreachable!("parsed command was not `watch`"),
+        }
+    }
+
     fn docs_error_kind(args: &[&str]) -> ErrorKind {
         let mut argv = vec!["alexandrite", "docs"];
         argv.extend(args);
@@ -266,18 +290,36 @@ mod tests {
             ".spago/p/prelude-6.0.2/src/**/*.purs",
         ]);
 
-        assert_eq!(options.output, current_directory_path("output"));
+        assert_eq!(options.build.output, current_directory_path("output"));
         assert_eq!(options.codegen.as_deref(), Some("corefn,docs,js,sourcemaps"));
         assert!(options.json_errors);
-        assert_eq!(options.diagnostic_limit, Some(20));
-        assert_eq!(options.color, ColorChoice::Always);
+        assert_eq!(options.build.diagnostic_limit, Some(20));
+        assert_eq!(options.build.color, ColorChoice::Always);
         assert_eq!(
-            options.inputs,
+            options.build.inputs,
             vec![
                 PathBuf::from("src/**/*.purs"),
                 PathBuf::from(".spago/p/prelude-6.0.2/src/**/*.purs"),
             ]
         );
+    }
+
+    #[test]
+    fn watch_accepts_compile_arguments() {
+        let options = watch(&[
+            "--output",
+            "dist",
+            "--diagnostic-limit",
+            "10",
+            "--color",
+            "never",
+            "src/**/*.purs",
+        ]);
+
+        assert_eq!(options.build.output, current_directory_path("dist"));
+        assert_eq!(options.build.diagnostic_limit, Some(10));
+        assert_eq!(options.build.color, ColorChoice::Never);
+        assert_eq!(options.build.inputs, vec![PathBuf::from("src/**/*.purs")]);
     }
 
     #[test]

--- a/compiler-bin/src/cli.rs
+++ b/compiler-bin/src/cli.rs
@@ -120,9 +120,9 @@ pub struct BuildOptions {
     #[arg(short, long, value_name("DIR"), default_value("output"), value_parser = absolute_path_parser())]
     pub output: PathBuf,
 
-    /// Maximum number of human-readable diagnostics to print.
-    #[arg(long, value_name("COUNT"))]
-    pub diagnostic_limit: Option<usize>,
+    /// Suppress build progress output.
+    #[arg(short, long)]
+    pub quiet: bool,
 
     /// When to use colors in human-readable diagnostics.
     #[arg(long, value_enum, default_value_t = ColorChoice::Auto)]
@@ -282,8 +282,7 @@ mod tests {
             "--codegen",
             "corefn,docs,js,sourcemaps",
             "--json-errors",
-            "--diagnostic-limit",
-            "20",
+            "--quiet",
             "--color",
             "always",
             "src/**/*.purs",
@@ -293,7 +292,7 @@ mod tests {
         assert_eq!(options.build.output, current_directory_path("output"));
         assert_eq!(options.codegen.as_deref(), Some("corefn,docs,js,sourcemaps"));
         assert!(options.json_errors);
-        assert_eq!(options.build.diagnostic_limit, Some(20));
+        assert!(options.build.quiet);
         assert_eq!(options.build.color, ColorChoice::Always);
         assert_eq!(
             options.build.inputs,
@@ -306,18 +305,10 @@ mod tests {
 
     #[test]
     fn watch_accepts_compile_arguments() {
-        let options = watch(&[
-            "--output",
-            "dist",
-            "--diagnostic-limit",
-            "10",
-            "--color",
-            "never",
-            "src/**/*.purs",
-        ]);
+        let options = watch(&["--output", "dist", "--quiet", "--color", "never", "src/**/*.purs"]);
 
         assert_eq!(options.build.output, current_directory_path("dist"));
-        assert_eq!(options.build.diagnostic_limit, Some(10));
+        assert!(options.build.quiet);
         assert_eq!(options.build.color, ColorChoice::Never);
         assert_eq!(options.build.inputs, vec![PathBuf::from("src/**/*.purs")]);
     }

--- a/compiler-bin/src/compilation.rs
+++ b/compiler-bin/src/compilation.rs
@@ -1,0 +1,135 @@
+use std::sync::Arc;
+
+use building::{
+    DiskObservation, FileLifecycle, ForeignEvent, LifecycleChange, LifecycleEvent, QueryEngine,
+    SourceEvent, SourceUnitKey,
+};
+use files::FileId;
+use prim_constants::MODULE_MAP;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SourceRole {
+    Prim,
+    Input,
+}
+
+pub struct CompilationState {
+    engine: QueryEngine,
+    files: FileLifecycle<(), SourceRole>,
+}
+
+impl CompilationState {
+    pub fn new() -> CompilationState {
+        let engine = QueryEngine::default();
+        let mut files = FileLifecycle::default();
+
+        for (name, content) in MODULE_MAP {
+            let source = format!("prim://localhost/{name}.purs");
+            let foreign = format!("prim://localhost/{name}.js");
+            let event = LifecycleEvent::Source {
+                unit: SourceUnitKey::new(source, foreign),
+                event: SourceEvent::DiskObserved {
+                    disk: DiskObservation::Found(Arc::from(*content)),
+                    metadata: SourceRole::Prim,
+                },
+            };
+
+            let change = files.apply(&engine, event);
+            let id = change
+                .changed_sources()
+                .next()
+                .expect("invariant violated: Prim source lifecycle did not insert a source");
+            engine.set_module_file(name, id);
+        }
+
+        CompilationState { engine, files }
+    }
+
+    pub fn observe_source(
+        &mut self,
+        unit: SourceUnitKey,
+        disk: DiskObservation,
+    ) -> LifecycleChange {
+        let event = LifecycleEvent::Source {
+            unit,
+            event: SourceEvent::DiskObserved { disk, metadata: SourceRole::Input },
+        };
+        self.files.apply(&self.engine, event)
+    }
+
+    pub fn observe_foreign(
+        &mut self,
+        unit: SourceUnitKey,
+        disk: DiskObservation,
+    ) -> LifecycleChange {
+        let event = LifecycleEvent::Foreign { unit, event: ForeignEvent::DiskObserved { disk } };
+        self.files.apply(&self.engine, event)
+    }
+
+    pub fn input_source_ids(&self) -> Vec<FileId> {
+        self.files
+            .source_ids()
+            .filter(|&file_id| self.files.source_metadata(file_id) == Some(&SourceRole::Input))
+            .collect()
+    }
+
+    pub fn snapshot(&self) -> QueryEngine {
+        self.engine.snapshot()
+    }
+
+    pub fn source_path(&self, file_id: FileId) -> Option<Arc<str>> {
+        self.files.source_path(file_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unit(name: &str) -> SourceUnitKey {
+        SourceUnitKey::new(format!("file:///src/{name}.purs"), format!("file:///src/{name}.js"))
+    }
+
+    #[test]
+    fn prim_modules_are_not_input_sources() {
+        let compilation = CompilationState::new();
+
+        assert!(compilation.input_source_ids().is_empty());
+        assert!(compilation.snapshot().module_file("Prim").is_some());
+    }
+
+    #[test]
+    fn source_observations_preserve_identity_until_deletion() {
+        let mut compilation = CompilationState::new();
+        let unit = unit("Main");
+        let content = DiskObservation::Found(Arc::from("module Main where\n"));
+        compilation.observe_source(SourceUnitKey::clone(&unit), content);
+        let original = compilation.input_source_ids()[0];
+
+        let content = DiskObservation::Found(Arc::from("module Main where\n\nvalue = 1\n"));
+        compilation.observe_source(SourceUnitKey::clone(&unit), content);
+        assert_eq!(compilation.input_source_ids(), vec![original]);
+
+        compilation.observe_source(SourceUnitKey::clone(&unit), DiskObservation::NotFound);
+        assert!(compilation.input_source_ids().is_empty());
+
+        let content = DiskObservation::Found(Arc::from("module Main where\n"));
+        compilation.observe_source(unit, content);
+        assert_ne!(compilation.input_source_ids(), vec![original]);
+    }
+
+    #[test]
+    fn foreign_observations_are_associated_with_the_input_source() {
+        let mut compilation = CompilationState::new();
+        let unit = unit("Main");
+        let content = DiskObservation::Found(Arc::from("module Main where\n"));
+        compilation.observe_source(SourceUnitKey::clone(&unit), content);
+        let source_id = compilation.input_source_ids()[0];
+
+        let content = DiskObservation::Found(Arc::from("export const value = 1;\n"));
+        let change = compilation.observe_foreign(unit, content);
+
+        assert_eq!(change.changed_sources().collect::<Vec<_>>(), vec![source_id]);
+        assert!(compilation.snapshot().foreign_file(source_id).is_some());
+    }
+}

--- a/compiler-bin/src/compilation.rs
+++ b/compiler-bin/src/compilation.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use building::{
     DiskObservation, FileLifecycle, ForeignEvent, LifecycleChange, LifecycleEvent, QueryEngine,
-    SourceEvent, SourceUnitKey,
+    QueryError, SourceEvent, SourceUnitKey,
 };
 use files::FileId;
 use prim_constants::MODULE_MAP;
@@ -81,22 +81,30 @@ impl CompilationState {
         self.files.source_path(file_id)
     }
 
-    pub fn source_content(&self, locator: &str) -> Option<Arc<str>> {
-        let file_id = self.files.source_id(locator)?;
-        self.engine.content(file_id).ok()
+    pub fn source_content(&self, locator: &str) -> Result<Option<Arc<str>>, QueryError> {
+        let Some(file_id) = self.files.source_id(locator) else {
+            return Ok(None);
+        };
+        self.engine.content(file_id).map(Some)
     }
 
     pub fn foreign_content(&self, locator: &str) -> Option<Arc<str>> {
         let foreign_id = self.files.foreign_id(locator)?;
-        self.engine.foreign_content(foreign_id)
+        let content = self
+            .engine
+            .foreign_content(foreign_id)
+            .expect("invariant violated: lifecycle foreign file has no engine content");
+        Some(content)
     }
 
-    pub fn module_name(&self, locator: &str) -> Option<String> {
-        let file_id = self.files.source_id(locator)?;
+    pub fn module_name(&self, locator: &str) -> Result<Option<String>, QueryError> {
+        let Some(file_id) = self.files.source_id(locator) else {
+            return Ok(None);
+        };
         let engine = self.engine.snapshot();
-        let content = engine.content(file_id).ok()?;
-        let (parsed, _) = engine.parsed(file_id).ok()?;
-        parsed.module_name(&content).map(|name| name.to_string())
+        let content = engine.content(file_id)?;
+        let (parsed, _) = engine.parsed(file_id)?;
+        Ok(parsed.module_name(&content).map(|name| name.to_string()))
     }
 }
 
@@ -149,5 +157,24 @@ mod tests {
 
         assert_eq!(change.changed_sources().collect::<Vec<_>>(), vec![source_id]);
         assert!(compilation.snapshot().foreign_file(source_id).is_some());
+    }
+
+    #[test]
+    fn source_queries_preserve_missing_engine_content_errors() {
+        let mut compilation = CompilationState::new();
+        let unit = unit("Main");
+        let content = DiskObservation::Found(Arc::from("module Main where\n"));
+        compilation.observe_source(SourceUnitKey::clone(&unit), content);
+        let source_id = compilation.input_source_ids()[0];
+        compilation.engine.remove_file(source_id);
+
+        assert_eq!(
+            compilation.source_content(unit.source()),
+            Err(QueryError::MissingContent { file_id: source_id })
+        );
+        assert_eq!(
+            compilation.module_name(unit.source()),
+            Err(QueryError::MissingContent { file_id: source_id })
+        );
     }
 }

--- a/compiler-bin/src/compilation.rs
+++ b/compiler-bin/src/compilation.rs
@@ -80,6 +80,24 @@ impl CompilationState {
     pub fn source_path(&self, file_id: FileId) -> Option<Arc<str>> {
         self.files.source_path(file_id)
     }
+
+    pub fn source_content(&self, locator: &str) -> Option<Arc<str>> {
+        let file_id = self.files.source_id(locator)?;
+        self.engine.content(file_id).ok()
+    }
+
+    pub fn foreign_content(&self, locator: &str) -> Option<Arc<str>> {
+        let foreign_id = self.files.foreign_id(locator)?;
+        self.engine.foreign_content(foreign_id)
+    }
+
+    pub fn module_name(&self, locator: &str) -> Option<String> {
+        let file_id = self.files.source_id(locator)?;
+        let engine = self.engine.snapshot();
+        let content = engine.content(file_id).ok()?;
+        let (parsed, _) = engine.parsed(file_id).ok()?;
+        parsed.module_name(&content).map(|name| name.to_string())
+    }
 }
 
 #[cfg(test)]

--- a/compiler-bin/src/compilation.rs
+++ b/compiler-bin/src/compilation.rs
@@ -97,6 +97,15 @@ impl CompilationState {
         Some(content)
     }
 
+    pub fn source_foreign_content(&self, source_id: FileId) -> Option<Arc<str>> {
+        let foreign_id = self.engine.foreign_file(source_id)?;
+        let content = self
+            .engine
+            .foreign_content(foreign_id)
+            .expect("invariant violated: associated foreign file has no engine content");
+        Some(content)
+    }
+
     pub fn module_name(&self, locator: &str) -> Result<Option<String>, QueryError> {
         let Some(file_id) = self.files.source_id(locator) else {
             return Ok(None);
@@ -157,6 +166,10 @@ mod tests {
 
         assert_eq!(change.changed_sources().collect::<Vec<_>>(), vec![source_id]);
         assert!(compilation.snapshot().foreign_file(source_id).is_some());
+        assert_eq!(
+            compilation.source_foreign_content(source_id).as_deref(),
+            Some("export const value = 1;\n")
+        );
     }
 
     #[test]

--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -255,7 +255,6 @@ fn report_diagnostics(
     let mut remaining = config.diagnostic_limit.unwrap_or(usize::MAX);
     let mut omitted = 0;
     let mut rendered_any = false;
-    let separate_diagnostics = !config.progress || io::stderr().is_terminal();
     for (file_has_errors, all, content, display_path) in diagnostics {
         has_errors |= file_has_errors;
         let rendered_count = remaining.min(all.len());
@@ -263,8 +262,10 @@ fn report_diagnostics(
         remaining -= rendered_count;
 
         if rendered_count > 0 {
-            if !rendered_any && separate_diagnostics {
+            if !rendered_any && config.progress && io::stderr().is_terminal() {
                 eprint!("\n\n");
+            } else if !rendered_any && !config.progress {
+                eprintln!();
             }
             rendered_any = true;
             let display_path =
@@ -281,10 +282,6 @@ fn report_diagnostics(
     if omitted > 0 && config.diagnostic_limit != Some(0) {
         eprintln!("note: {omitted} additional diagnostics omitted by --diagnostic-limit");
     }
-    if rendered_any && !config.progress {
-        eprintln!();
-    }
-
     Ok(has_errors)
 }
 

--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -365,19 +365,11 @@ fn write_modules(
             return Ok(outputs);
         }
 
-        let source_locator = compilation
-            .source_path(module.file_id())
-            .expect("invariant violated: generated module has no lifecycle path");
-        let source_url = Url::parse(&source_locator)
-            .map_err(|_| CompileError::InvalidPath(PathBuf::from(source_locator.as_ref())))?;
-        let source_path = source_url
-            .to_file_path()
-            .map_err(|()| CompileError::InvalidPath(PathBuf::from(source_locator.as_ref())))?;
-
-        let foreign_path = source_path.with_extension("js");
         let output_path = output.join(module.foreign_filename());
-        let foreign = fs::read(foreign_path)?;
-        write_if_changed(&output_path, &foreign)?;
+        let foreign = compilation
+            .source_foreign_content(module.file_id())
+            .expect("invariant violated: generated module requires missing foreign content");
+        write_if_changed(&output_path, foreign.as_bytes())?;
         outputs.push(output_path);
         progress.inc(1);
         Ok(outputs)

--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -255,7 +255,7 @@ fn report_diagnostics(
     let mut remaining = config.diagnostic_limit.unwrap_or(usize::MAX);
     let mut omitted = 0;
     let mut rendered_any = false;
-    let separate_from_progress = io::stderr().is_terminal();
+    let separate_diagnostics = !config.progress || io::stderr().is_terminal();
     for (file_has_errors, all, content, display_path) in diagnostics {
         has_errors |= file_has_errors;
         let rendered_count = remaining.min(all.len());
@@ -263,7 +263,7 @@ fn report_diagnostics(
         remaining -= rendered_count;
 
         if rendered_count > 0 {
-            if !rendered_any && separate_from_progress {
+            if !rendered_any && separate_diagnostics {
                 eprint!("\n\n");
             }
             rendered_any = true;
@@ -280,6 +280,9 @@ fn report_diagnostics(
     }
     if omitted > 0 && config.diagnostic_limit != Some(0) {
         eprintln!("note: {omitted} additional diagnostics omitted by --diagnostic-limit");
+    }
+    if rendered_any && !config.progress {
+        eprintln!();
     }
 
     Ok(has_errors)
@@ -454,8 +457,10 @@ fn phase_progress(
     phase: &'static str,
     show: bool,
 ) -> ProgressBar {
-    let phase_progress = if show { ProgressBar::new(total as u64) } else { ProgressBar::hidden() };
-    let phase_progress = progress.add(phase_progress);
+    if !show {
+        return ProgressBar::hidden();
+    }
+    let phase_progress = progress.add(ProgressBar::new(total as u64));
     configure_progress(&phase_progress, phase);
     phase_progress
 }

--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -38,9 +38,9 @@ pub(crate) struct BuildConfig<'a> {
     pub progress: bool,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum BuildOutcome {
-    Succeeded,
+    Succeeded(BTreeSet<PathBuf>),
     Diagnostics,
 }
 
@@ -111,7 +111,7 @@ fn compile(config: CompileConfig) -> Result<(), CompileError> {
         color: use_color(config.color),
         progress: true,
     };
-    if build(&compilation, &build_config)? == BuildOutcome::Diagnostics {
+    if matches!(build(&compilation, &build_config)?, BuildOutcome::Diagnostics) {
         return Err(CompileError::Diagnostics);
     }
 
@@ -131,8 +131,8 @@ pub(crate) fn build(
     }
 
     let modules = generate_modules(compilation, &source_ids, config.progress)?;
-    write_modules(compilation, &modules, config.output, config.progress)?;
-    Ok(BuildOutcome::Succeeded)
+    let outputs = write_modules(compilation, &modules, config.output, config.progress)?;
+    Ok(BuildOutcome::Succeeded(outputs))
 }
 
 pub(crate) fn load_source(
@@ -340,26 +340,29 @@ fn write_modules(
     modules: &[Arc<javascript::Module>],
     output: &Path,
     show_progress: bool,
-) -> Result<(), CompileError> {
+) -> Result<BTreeSet<PathBuf>, CompileError> {
+    let mut outputs = BTreeSet::new();
     if modules.iter().any(|module| module.requires_runtime()) {
         let runtime = output.join(javascript::runtime_filename());
         fs::create_dir_all(output)?;
-        fs::write(runtime, javascript::runtime_source())?;
+        write_if_changed(&runtime, javascript::runtime_source().as_bytes())?;
+        outputs.insert(runtime);
     }
 
     let progress = compilation_progress(modules.len(), "Output", show_progress);
-    modules.par_iter().try_for_each(|module| -> Result<(), CompileError> {
+    let module_outputs = modules.par_iter().map(|module| -> Result<Vec<PathBuf>, CompileError> {
         set_progress_module(&progress, module.name());
         let output_path = output.join(module.filename());
         let output_parent =
             output_path.parent().expect("invariant violated: module filename has no parent");
 
         fs::create_dir_all(output_parent)?;
-        fs::write(output_path, module.source())?;
+        write_if_changed(&output_path, module.source().as_bytes())?;
+        let mut outputs = vec![output_path];
 
         if !module.requires_foreign() {
             progress.inc(1);
-            return Ok(());
+            return Ok(outputs);
         }
 
         let source_locator = compilation
@@ -373,12 +376,25 @@ fn write_modules(
 
         let foreign_path = source_path.with_extension("js");
         let output_path = output.join(module.foreign_filename());
-        fs::copy(foreign_path, output_path)?;
+        let foreign = fs::read(foreign_path)?;
+        write_if_changed(&output_path, &foreign)?;
+        outputs.push(output_path);
         progress.inc(1);
-        Ok(())
-    })?;
+        Ok(outputs)
+    });
+    let module_outputs = module_outputs.collect::<Result<Vec<_>, _>>()?;
+    outputs.extend(module_outputs.into_iter().flatten());
     finish_progress(&progress);
-    Ok(())
+    Ok(outputs)
+}
+
+fn write_if_changed(path: &Path, content: &[u8]) -> io::Result<()> {
+    match fs::read(path) {
+        Ok(previous) if previous == content => Ok(()),
+        Ok(_) => fs::write(path, content),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => fs::write(path, content),
+        Err(error) => Err(error),
+    }
 }
 
 fn compilation_progress(total: usize, phase: &'static str, show: bool) -> ProgressBar {

--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -30,8 +30,22 @@ pub struct CompileConfig {
     pub color: ColorChoice,
 }
 
+pub(crate) struct BuildConfig<'a> {
+    pub output: &'a Path,
+    pub current_directory: &'a Path,
+    pub diagnostic_limit: Option<usize>,
+    pub color: bool,
+    pub progress: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BuildOutcome {
+    Succeeded,
+    Diagnostics,
+}
+
 #[derive(Debug, Error)]
-enum CompileError {
+pub(crate) enum CompileError {
     #[error("compilation failed")]
     Diagnostics,
     #[error("failed to convert path to a file URL: {0}")]
@@ -73,7 +87,7 @@ pub fn start(config: CompileConfig) {
 
 fn compile(config: CompileConfig) -> Result<(), CompileError> {
     let started = Instant::now();
-    let preparation_progress = compilation_progress(1, "Preparing");
+    let preparation_progress = compilation_progress(1, "Preparing", true);
     let current_directory = std::env::current_dir()?;
     let walked = walk::walk(&current_directory, &config.inputs)?;
 
@@ -90,33 +104,41 @@ fn compile(config: CompileConfig) -> Result<(), CompileError> {
         return Err(io::Error::new(io::ErrorKind::NotFound, "no input files found").into());
     }
 
-    let color = match config.color {
-        ColorChoice::Auto => {
-            let no_color = std::env::var_os("NO_COLOR").is_some_and(|value| !value.is_empty());
-            io::stderr().is_terminal() && !no_color
-        }
-        ColorChoice::Always => true,
-        ColorChoice::Never => false,
+    let build_config = BuildConfig {
+        output: &config.output,
+        current_directory: &current_directory,
+        diagnostic_limit: config.diagnostic_limit,
+        color: use_color(config.color),
+        progress: true,
     };
-    let has_errors = report_diagnostics(
-        &compilation,
-        &source_ids,
-        &current_directory,
-        config.diagnostic_limit,
-        color,
-    )?;
-    if has_errors {
+    if build(&compilation, &build_config)? == BuildOutcome::Diagnostics {
         return Err(CompileError::Diagnostics);
     }
 
-    let modules = generate_modules(&compilation, &source_ids)?;
-    write_modules(&compilation, &modules, &config.output)?;
     report_completion(started.elapsed());
 
     Ok(())
 }
 
-fn load_source(compilation: &mut CompilationState, path: &Path) -> Result<(), CompileError> {
+pub(crate) fn build(
+    compilation: &CompilationState,
+    config: &BuildConfig<'_>,
+) -> Result<BuildOutcome, CompileError> {
+    let source_ids = compilation.input_source_ids();
+    let has_errors = report_diagnostics(compilation, &source_ids, config)?;
+    if has_errors {
+        return Ok(BuildOutcome::Diagnostics);
+    }
+
+    let modules = generate_modules(compilation, &source_ids, config.progress)?;
+    write_modules(compilation, &modules, config.output, config.progress)?;
+    Ok(BuildOutcome::Succeeded)
+}
+
+pub(crate) fn load_source(
+    compilation: &mut CompilationState,
+    path: &Path,
+) -> Result<(), CompileError> {
     let source_url =
         Url::from_file_path(path).map_err(|()| CompileError::InvalidPath(path.to_path_buf()))?;
     let foreign_path = path.with_extension("js");
@@ -138,6 +160,17 @@ fn load_source(compilation: &mut CompilationState, path: &Path) -> Result<(), Co
     Ok(())
 }
 
+pub(crate) fn use_color(choice: ColorChoice) -> bool {
+    match choice {
+        ColorChoice::Auto => {
+            let no_color = std::env::var_os("NO_COLOR").is_some_and(|value| !value.is_empty());
+            io::stderr().is_terminal() && !no_color
+        }
+        ColorChoice::Always => true,
+        ColorChoice::Never => false,
+    }
+}
+
 fn display_source_path(source_path: &str, current_directory: &Path) -> String {
     if let Some(file_path) = Url::parse(source_path).ok().and_then(|url| url.to_file_path().ok()) {
         file_path.strip_prefix(current_directory).unwrap_or(&file_path).display().to_string()
@@ -149,14 +182,14 @@ fn display_source_path(source_path: &str, current_directory: &Path) -> String {
 fn report_diagnostics(
     compilation: &CompilationState,
     source_ids: &[FileId],
-    current_directory: &Path,
-    diagnostic_limit: Option<usize>,
-    color: bool,
+    config: &BuildConfig<'_>,
 ) -> Result<bool, CompileError> {
     let progress = MultiProgress::new();
     progress.set_move_cursor(true);
-    let analysing_progress = phase_progress(&progress, source_ids.len(), "Analyse");
-    let checking_progress = phase_progress(&progress, source_ids.len(), "Elaborate");
+    let analysing_progress =
+        phase_progress(&progress, source_ids.len(), "Analyse", config.progress);
+    let checking_progress =
+        phase_progress(&progress, source_ids.len(), "Elaborate", config.progress);
 
     let diagnostics = source_ids.par_iter().map(|&file_id| {
         let engine = compilation.snapshot();
@@ -210,7 +243,7 @@ fn report_diagnostics(
         } else {
             let source_path =
                 compilation.source_path(file_id).expect("input source has no lifecycle path");
-            Some(display_source_path(&source_path, current_directory))
+            Some(display_source_path(&source_path, config.current_directory))
         };
         Ok::<_, CompileError>((has_errors, all, content, display_path))
     });
@@ -219,7 +252,7 @@ fn report_diagnostics(
     finish_progress(&checking_progress);
 
     let mut has_errors = false;
-    let mut remaining = diagnostic_limit.unwrap_or(usize::MAX);
+    let mut remaining = config.diagnostic_limit.unwrap_or(usize::MAX);
     let mut omitted = 0;
     let mut rendered_any = false;
     let separate_from_progress = io::stderr().is_terminal();
@@ -240,12 +273,12 @@ fn report_diagnostics(
                 &all[..rendered_count],
                 &content,
                 &display_path,
-                color,
+                config.color,
             );
             eprint!("{rendered}");
         }
     }
-    if omitted > 0 && diagnostic_limit != Some(0) {
+    if omitted > 0 && config.diagnostic_limit != Some(0) {
         eprintln!("note: {omitted} additional diagnostics omitted by --diagnostic-limit");
     }
 
@@ -255,12 +288,13 @@ fn report_diagnostics(
 fn generate_modules(
     compilation: &CompilationState,
     source_ids: &[FileId],
+    show_progress: bool,
 ) -> Result<Vec<Arc<javascript::Module>>, CompileError> {
     let mut pending = source_ids.to_vec();
     let mut visited = HashSet::new();
 
     let initial_total = source_ids.iter().copied().collect::<HashSet<_>>().len();
-    let progress = compilation_progress(initial_total, "Codegen");
+    let progress = compilation_progress(initial_total, "Codegen", show_progress);
     let mut first_frontier = true;
     let mut modules = vec![];
     while !pending.is_empty() {
@@ -305,6 +339,7 @@ fn write_modules(
     compilation: &CompilationState,
     modules: &[Arc<javascript::Module>],
     output: &Path,
+    show_progress: bool,
 ) -> Result<(), CompileError> {
     if modules.iter().any(|module| module.requires_runtime()) {
         let runtime = output.join(javascript::runtime_filename());
@@ -312,7 +347,7 @@ fn write_modules(
         fs::write(runtime, javascript::runtime_source())?;
     }
 
-    let progress = compilation_progress(modules.len(), "Output");
+    let progress = compilation_progress(modules.len(), "Output", show_progress);
     modules.par_iter().try_for_each(|module| -> Result<(), CompileError> {
         set_progress_module(&progress, module.name());
         let output_path = output.join(module.filename());
@@ -346,8 +381,8 @@ fn write_modules(
     Ok(())
 }
 
-fn compilation_progress(total: usize, phase: &'static str) -> ProgressBar {
-    let progress = ProgressBar::new(total as u64);
+fn compilation_progress(total: usize, phase: &'static str, show: bool) -> ProgressBar {
+    let progress = if show { ProgressBar::new(total as u64) } else { ProgressBar::hidden() };
     configure_progress(&progress, phase);
     progress
 }
@@ -397,8 +432,14 @@ fn configure_progress(progress: &ProgressBar, phase: &'static str) {
     progress.enable_steady_tick(SHIMMER_FRAME_INTERVAL);
 }
 
-fn phase_progress(progress: &MultiProgress, total: usize, phase: &'static str) -> ProgressBar {
-    let phase_progress = progress.add(ProgressBar::new(total as u64));
+fn phase_progress(
+    progress: &MultiProgress,
+    total: usize,
+    phase: &'static str,
+    show: bool,
+) -> ProgressBar {
+    let phase_progress = if show { ProgressBar::new(total as u64) } else { ProgressBar::hidden() };
+    let phase_progress = progress.add(phase_progress);
     configure_progress(&phase_progress, phase);
     phase_progress
 }

--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -5,20 +5,17 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{fmt, fs, io, process};
 
-use building::{
-    DiskObservation, FileLifecycle, ForeignEvent, LifecycleEvent, QueryEngine, QueryError,
-    SourceEvent, SourceUnitKey,
-};
+use building::{DiskObservation, QueryError, SourceUnitKey};
 use console::{Color, Style};
 use diagnostics::{DiagnosticsContext, Severity, ToDiagnostics};
 use files::FileId;
 use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
-use prim_constants::MODULE_MAP;
 use rayon::prelude::*;
 use thiserror::Error;
 use url::Url;
 
 use crate::cli::ColorChoice;
+use crate::compilation::CompilationState;
 use crate::walk;
 
 const CARGO_PROGRESS_REGION_WIDTH: usize = 50;
@@ -80,15 +77,12 @@ fn compile(config: CompileConfig) -> Result<(), CompileError> {
     let current_directory = std::env::current_dir()?;
     let walked = walk::walk(&current_directory, &config.inputs)?;
 
-    let engine = QueryEngine::default();
-    let mut files = FileLifecycle::<(), ()>::default();
-    configure_prim(&engine, &mut files);
+    let mut compilation = CompilationState::new();
 
-    let mut source_ids = vec![];
     for path in walked.files {
-        let source_id = load_source(&engine, &mut files, &path)?;
-        source_ids.push(source_id);
+        load_source(&mut compilation, &path)?;
     }
+    let source_ids = compilation.input_source_ids();
     preparation_progress.inc(1);
     finish_progress(&preparation_progress);
 
@@ -105,8 +99,7 @@ fn compile(config: CompileConfig) -> Result<(), CompileError> {
         ColorChoice::Never => false,
     };
     let has_errors = report_diagnostics(
-        &engine,
-        &files,
+        &compilation,
         &source_ids,
         &current_directory,
         config.diagnostic_limit,
@@ -116,41 +109,14 @@ fn compile(config: CompileConfig) -> Result<(), CompileError> {
         return Err(CompileError::Diagnostics);
     }
 
-    let modules = generate_modules(&engine, &files, &source_ids)?;
-    write_modules(&files, &modules, &config.output)?;
+    let modules = generate_modules(&compilation, &source_ids)?;
+    write_modules(&compilation, &modules, &config.output)?;
     report_completion(started.elapsed());
 
     Ok(())
 }
 
-fn configure_prim(engine: &QueryEngine, files: &mut FileLifecycle<(), ()>) {
-    for (name, content) in MODULE_MAP {
-        let source = format!("prim://localhost/{name}.purs");
-        let foreign = format!("prim://localhost/{name}.js");
-
-        let event = LifecycleEvent::Source {
-            unit: SourceUnitKey::new(source, foreign),
-            event: SourceEvent::DiskObserved {
-                disk: DiskObservation::Found(Arc::from(*content)),
-                metadata: (),
-            },
-        };
-
-        let change = files.apply(engine, event);
-        let id = change
-            .changed_sources()
-            .next()
-            .expect("invariant violated: Prim source lifecycle did not insert a source");
-
-        engine.set_module_file(name, id);
-    }
-}
-
-fn load_source(
-    engine: &QueryEngine,
-    files: &mut FileLifecycle<(), ()>,
-    path: &Path,
-) -> Result<FileId, CompileError> {
+fn load_source(compilation: &mut CompilationState, path: &Path) -> Result<(), CompileError> {
     let source_url =
         Url::from_file_path(path).map_err(|()| CompileError::InvalidPath(path.to_path_buf()))?;
     let foreign_path = path.with_extension("js");
@@ -160,19 +126,7 @@ fn load_source(
     let unit = SourceUnitKey::new(source_url.as_str(), foreign_url.as_str());
 
     let content = fs::read_to_string(path)?;
-    let event = LifecycleEvent::Source {
-        unit: SourceUnitKey::clone(&unit),
-        event: SourceEvent::DiskObserved {
-            disk: DiskObservation::Found(content.into()),
-            metadata: (),
-        },
-    };
-
-    let change = files.apply(engine, event);
-    let source_id = change
-        .changed_sources()
-        .next()
-        .expect("invariant violated: source lifecycle did not insert an input source");
+    compilation.observe_source(SourceUnitKey::clone(&unit), DiskObservation::Found(content.into()));
 
     let disk = match fs::read_to_string(&foreign_path) {
         Ok(content) => DiskObservation::Found(content.into()),
@@ -180,9 +134,8 @@ fn load_source(
         Err(error) => return Err(error.into()),
     };
 
-    let event = LifecycleEvent::Foreign { unit, event: ForeignEvent::DiskObserved { disk } };
-    files.apply(engine, event);
-    Ok(source_id)
+    compilation.observe_foreign(unit, disk);
+    Ok(())
 }
 
 fn display_source_path(source_path: &str, current_directory: &Path) -> String {
@@ -194,8 +147,7 @@ fn display_source_path(source_path: &str, current_directory: &Path) -> String {
 }
 
 fn report_diagnostics(
-    engine: &QueryEngine,
-    files: &FileLifecycle<(), ()>,
+    compilation: &CompilationState,
     source_ids: &[FileId],
     current_directory: &Path,
     diagnostic_limit: Option<usize>,
@@ -207,7 +159,7 @@ fn report_diagnostics(
     let checking_progress = phase_progress(&progress, source_ids.len(), "Elaborate");
 
     let diagnostics = source_ids.par_iter().map(|&file_id| {
-        let engine = engine.snapshot();
+        let engine = compilation.snapshot();
         let content = engine.content(file_id)?;
         let (parsed, _) = engine.parsed(file_id)?;
         let module_name = parsed.module_name(&content);
@@ -257,7 +209,7 @@ fn report_diagnostics(
             None
         } else {
             let source_path =
-                files.source_path(file_id).expect("input source has no lifecycle path");
+                compilation.source_path(file_id).expect("input source has no lifecycle path");
             Some(display_source_path(&source_path, current_directory))
         };
         Ok::<_, CompileError>((has_errors, all, content, display_path))
@@ -301,8 +253,7 @@ fn report_diagnostics(
 }
 
 fn generate_modules(
-    engine: &QueryEngine,
-    files: &FileLifecycle<(), ()>,
+    compilation: &CompilationState,
     source_ids: &[FileId],
 ) -> Result<Vec<Arc<javascript::Module>>, CompileError> {
     let mut pending = source_ids.to_vec();
@@ -323,14 +274,14 @@ fn generate_modules(
         }
 
         let generated = frontier.par_iter().map(|&file_id| {
-            let engine = engine.snapshot();
+            let engine = compilation.snapshot();
             let content = engine.content(file_id)?;
             let (parsed, _) = engine.parsed(file_id)?;
             if let Some(module_name) = parsed.module_name(&content) {
                 set_progress_module(&progress, &module_name);
             }
             let module = engine.javascript(file_id)?.map_err(|source| {
-                let path = files
+                let path = compilation
                     .source_path(file_id)
                     .expect("invariant violated: generated module has no lifecycle path");
                 CompileError::JavaScript { path, source }
@@ -351,7 +302,7 @@ fn generate_modules(
 }
 
 fn write_modules(
-    files: &FileLifecycle<(), ()>,
+    compilation: &CompilationState,
     modules: &[Arc<javascript::Module>],
     output: &Path,
 ) -> Result<(), CompileError> {
@@ -376,7 +327,7 @@ fn write_modules(
             return Ok(());
         }
 
-        let source_locator = files
+        let source_locator = compilation
             .source_path(module.file_id())
             .expect("invariant violated: generated module has no lifecycle path");
         let source_url = Url::parse(&source_locator)

--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -7,7 +7,7 @@ use std::{fmt, fs, io, process};
 
 use building::{DiskObservation, QueryError, SourceUnitKey};
 use console::{Color, Style};
-use diagnostics::{DiagnosticsContext, Severity, ToDiagnostics};
+use diagnostics::Severity;
 use files::FileId;
 use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
 use rayon::prelude::*;
@@ -26,14 +26,13 @@ pub struct CompileConfig {
     pub output: PathBuf,
     pub inputs: Vec<PathBuf>,
     pub json_errors: bool,
-    pub diagnostic_limit: Option<usize>,
+    pub quiet: bool,
     pub color: ColorChoice,
 }
 
 pub(crate) struct BuildConfig<'a> {
     pub output: &'a Path,
     pub current_directory: &'a Path,
-    pub diagnostic_limit: Option<usize>,
     pub color: bool,
     pub progress: bool,
 }
@@ -87,7 +86,7 @@ pub fn start(config: CompileConfig) {
 
 fn compile(config: CompileConfig) -> Result<(), CompileError> {
     let started = Instant::now();
-    let preparation_progress = compilation_progress(1, "Preparing", true);
+    let preparation_progress = compilation_progress(1, "Preparing", !config.quiet);
     let current_directory = std::env::current_dir()?;
     let walked = walk::walk(&current_directory, &config.inputs)?;
 
@@ -107,15 +106,16 @@ fn compile(config: CompileConfig) -> Result<(), CompileError> {
     let build_config = BuildConfig {
         output: &config.output,
         current_directory: &current_directory,
-        diagnostic_limit: config.diagnostic_limit,
         color: use_color(config.color),
-        progress: true,
+        progress: !config.quiet,
     };
     if matches!(build(&compilation, &build_config)?, BuildOutcome::Diagnostics) {
         return Err(CompileError::Diagnostics);
     }
 
-    report_completion(started.elapsed());
+    if !config.quiet {
+        report_completion(started.elapsed());
+    }
 
     Ok(())
 }
@@ -191,7 +191,7 @@ fn report_diagnostics(
     let checking_progress =
         phase_progress(&progress, source_ids.len(), "Elaborate", config.progress);
 
-    let diagnostics = source_ids.par_iter().map(|&file_id| {
+    let module_names = source_ids.par_iter().map(|&file_id| {
         let engine = compilation.snapshot();
         let content = engine.content(file_id)?;
         let (parsed, _) = engine.parsed(file_id)?;
@@ -199,88 +199,58 @@ fn report_diagnostics(
         if let Some(module_name) = &module_name {
             set_progress_module(&analysing_progress, module_name);
         }
-        let root = parsed.syntax_node();
-
-        let stabilized = engine.stabilized(file_id)?;
-        let indexed = engine.indexed(file_id)?;
-        let resolved = engine.resolved(file_id)?;
-        let lowered = engine.lowered(file_id)?;
+        engine.stabilized(file_id)?;
+        engine.indexed(file_id)?;
+        engine.resolved(file_id)?;
+        engine.lowered(file_id)?;
         analysing_progress.inc(1);
-        if let Some(module_name) = &module_name {
+        Ok::<_, CompileError>(module_name)
+    });
+    let module_names = module_names.collect::<Result<Vec<_>, _>>()?;
+    finish_progress(&analysing_progress);
+
+    let elaborated = source_ids.par_iter().zip(&module_names).map(|(&file_id, module_name)| {
+        let engine = compilation.snapshot();
+        if let Some(module_name) = module_name {
             set_progress_module(&checking_progress, module_name);
         }
-        let checked = engine.checked(file_id)?;
-        let foreign = engine.foreign_validation(file_id)?;
+        engine.checked(file_id)?;
+        engine.foreign_validation(file_id)?;
         checking_progress.inc(1);
-
-        let context = DiagnosticsContext::new(
-            &engine,
-            &content,
-            &root,
-            &stabilized,
-            &indexed,
-            &lowered,
-            &checked,
-        );
-
-        let mut all = vec![];
-        for error in &lowered.errors {
-            all.extend(error.to_diagnostics(&context));
-        }
-        for error in &resolved.errors {
-            all.extend(error.to_diagnostics(&context));
-        }
-        for error in &checked.errors {
-            all.extend(error.to_diagnostics(&context));
-        }
-        for error in foreign.errors.iter() {
-            all.extend(error.to_diagnostics(&context));
-        }
-
-        let has_errors = all.iter().any(|diagnostic| diagnostic.severity == Severity::Error);
-        let display_path = if all.is_empty() {
-            None
-        } else {
-            let source_path =
-                compilation.source_path(file_id).expect("input source has no lifecycle path");
-            Some(display_source_path(&source_path, config.current_directory))
-        };
-        Ok::<_, CompileError>((has_errors, all, content, display_path))
+        Ok::<_, CompileError>(())
     });
-    let diagnostics = diagnostics.collect::<Result<Vec<_>, _>>()?;
-    finish_progress(&analysing_progress);
+    elaborated.collect::<Result<Vec<_>, _>>()?;
     finish_progress(&checking_progress);
 
-    let mut has_errors = false;
-    let mut remaining = config.diagnostic_limit.unwrap_or(usize::MAX);
-    let mut omitted = 0;
-    let mut rendered_any = false;
-    for (file_has_errors, all, content, display_path) in diagnostics {
-        has_errors |= file_has_errors;
-        let rendered_count = remaining.min(all.len());
-        omitted += all.len() - rendered_count;
-        remaining -= rendered_count;
+    let engine = compilation.snapshot();
+    let diagnostics = diagnostics::collect_diagnostics(&engine, source_ids)?;
+    let has_errors = diagnostics
+        .iter()
+        .flat_map(diagnostics::DiagnosticCollection::diagnostics)
+        .any(|diagnostic| diagnostic.severity == Severity::Error);
+    let has_diagnostics = diagnostics.iter().any(|collected| !collected.diagnostics().is_empty());
 
-        if rendered_count > 0 {
-            if !rendered_any && config.progress && io::stderr().is_terminal() {
-                eprint!("\n\n");
-            } else if !rendered_any && !config.progress {
-                eprintln!();
-            }
-            rendered_any = true;
-            let display_path =
-                display_path.expect("non-empty diagnostics must have a display path");
-            let rendered = diagnostics::format_rich_with_path(
-                &all[..rendered_count],
-                &content,
-                &display_path,
-                config.color,
-            );
-            eprint!("{rendered}");
+    if has_diagnostics {
+        if config.progress && io::stderr().is_terminal() {
+            eprint!("\n\n");
+        } else if !config.progress {
+            eprintln!();
         }
     }
-    if omitted > 0 && config.diagnostic_limit != Some(0) {
-        eprintln!("note: {omitted} additional diagnostics omitted by --diagnostic-limit");
+    for collected in diagnostics {
+        if collected.diagnostics().is_empty() {
+            continue;
+        }
+        let source_path =
+            compilation.source_path(collected.file_id).expect("input source has no lifecycle path");
+        let display_path = display_source_path(&source_path, config.current_directory);
+        let rendered = diagnostics::format_rich_with_path(
+            collected.diagnostics(),
+            &collected.content,
+            &display_path,
+            config.color,
+        );
+        eprint!("{rendered}");
     }
     Ok(has_errors)
 }

--- a/compiler-bin/src/lib.rs
+++ b/compiler-bin/src/lib.rs
@@ -45,7 +45,7 @@ pub fn run() {
                 output: options.build.output,
                 inputs: options.build.inputs,
                 json_errors: options.json_errors,
-                diagnostic_limit: options.build.diagnostic_limit,
+                quiet: options.build.quiet,
                 color: options.build.color,
             });
         }
@@ -59,7 +59,7 @@ pub fn run() {
             watch::start(watch::WatchConfig {
                 output: options.build.output,
                 inputs: options.build.inputs,
-                diagnostic_limit: options.build.diagnostic_limit,
+                quiet: options.build.quiet,
                 color: options.build.color,
             });
         }

--- a/compiler-bin/src/lib.rs
+++ b/compiler-bin/src/lib.rs
@@ -8,6 +8,7 @@ pub mod docs;
 pub mod logging;
 pub mod lsp;
 pub mod walk;
+mod watch;
 
 pub fn run() {
     let cli = cli::Cli::parse();
@@ -35,17 +36,31 @@ pub fn run() {
         }
         cli::Command::Compile(options) => {
             logging::start(logging::LoggingFilters {
-                query_log: options.logging.query_log,
-                checking_log: options.logging.checking_log,
+                query_log: options.build.logging.query_log,
+                checking_log: options.build.logging.checking_log,
                 lsp_log: LevelFilter::OFF,
                 docs_log: LevelFilter::OFF,
             });
             compile::start(compile::CompileConfig {
-                output: options.output,
-                inputs: options.inputs,
+                output: options.build.output,
+                inputs: options.build.inputs,
                 json_errors: options.json_errors,
-                diagnostic_limit: options.diagnostic_limit,
-                color: options.color,
+                diagnostic_limit: options.build.diagnostic_limit,
+                color: options.build.color,
+            });
+        }
+        cli::Command::Watch(options) => {
+            logging::start(logging::LoggingFilters {
+                query_log: options.build.logging.query_log,
+                checking_log: options.build.logging.checking_log,
+                lsp_log: LevelFilter::OFF,
+                docs_log: LevelFilter::OFF,
+            });
+            watch::start(watch::WatchConfig {
+                output: options.build.output,
+                inputs: options.build.inputs,
+                diagnostic_limit: options.build.diagnostic_limit,
+                color: options.build.color,
             });
         }
         cli::Command::Docs(options) => {

--- a/compiler-bin/src/lib.rs
+++ b/compiler-bin/src/lib.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use tracing::level_filters::LevelFilter;
 
 pub mod cli;
+mod compilation;
 pub mod compile;
 pub mod docs;
 pub mod logging;

--- a/compiler-bin/src/watch.rs
+++ b/compiler-bin/src/watch.rs
@@ -23,7 +23,7 @@ const MODULE_DISPLAY_LIMIT: usize = 3;
 pub struct WatchConfig {
     pub output: PathBuf,
     pub inputs: Vec<PathBuf>,
-    pub diagnostic_limit: Option<usize>,
+    pub quiet: bool,
     pub color: ColorChoice,
 }
 
@@ -61,7 +61,9 @@ fn watch(config: WatchConfig) -> Result<(), WatchError> {
         watcher.watch(root, RecursiveMode::Recursive)?;
     }
     report_lifecycle_warnings(&initial_change.lifecycle);
-    report_changed_modules(&initial_change.modules, compile::use_color(config.color));
+    if !config.quiet {
+        report_changed_modules(&initial_change.modules, compile::use_color(config.color));
+    }
     rebuild(&mut workspace, &config)?;
 
     loop {
@@ -84,7 +86,9 @@ fn watch(config: WatchConfig) -> Result<(), WatchError> {
         let change = workspace.synchronize_events(events)?;
         report_lifecycle_warnings(&change.lifecycle);
         if !change.modules.is_empty() {
-            report_changed_modules(&change.modules, compile::use_color(config.color));
+            if !config.quiet {
+                report_changed_modules(&change.modules, compile::use_color(config.color));
+            }
             rebuild(&mut workspace, &config)?;
         }
     }
@@ -95,14 +99,15 @@ fn rebuild(workspace: &mut WatchWorkspace, config: &WatchConfig) -> Result<(), W
         if let Err(error) = workspace.reconcile_outputs(BTreeSet::new()) {
             eprintln!("Failed to remove stale output: {error}");
         }
-        println!("No input files found; waiting for changes.");
+        if !config.quiet {
+            println!("No input files found; waiting for changes.");
+        }
         return Ok(());
     }
 
     let build_config = BuildConfig {
         output: &config.output,
         current_directory: &workspace.current_directory,
-        diagnostic_limit: config.diagnostic_limit,
         color: compile::use_color(config.color),
         progress: false,
     };

--- a/compiler-bin/src/watch.rs
+++ b/compiler-bin/src/watch.rs
@@ -1,0 +1,398 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::time::Duration;
+use std::{fs, io, process};
+
+use building::{DiskObservation, LifecycleChange, ReloadFailure, SourceUnitKey};
+use notify::event::{CreateKind, ModifyKind, RemoveKind};
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use thiserror::Error;
+use url::Url;
+
+use crate::cli::ColorChoice;
+use crate::compilation::CompilationState;
+use crate::compile::{self, BuildConfig, BuildOutcome, CompileError};
+use crate::walk;
+
+const DEBOUNCE_DURATION: Duration = Duration::from_millis(100);
+
+pub struct WatchConfig {
+    pub output: PathBuf,
+    pub inputs: Vec<PathBuf>,
+    pub diagnostic_limit: Option<usize>,
+    pub color: ColorChoice,
+}
+
+#[derive(Debug, Error)]
+enum WatchError {
+    #[error(transparent)]
+    Compile(#[from] CompileError),
+    #[error("failed to convert path to a file URL: {0}")]
+    InvalidPath(PathBuf),
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Notify(#[from] notify::Error),
+    #[error(transparent)]
+    Walk(#[from] walk::Error),
+}
+
+pub fn start(config: WatchConfig) {
+    if let Err(error) = watch(config) {
+        eprintln!("Watch exited: {error}");
+        tracing::error!(?error, "Watch exited");
+        process::exit(1);
+    }
+}
+
+fn watch(config: WatchConfig) -> Result<(), WatchError> {
+    let current_directory = std::env::current_dir()?;
+    let (mut workspace, initial_change) =
+        WatchWorkspace::new(current_directory, config.inputs.clone(), config.output.clone())?;
+    let (sender, receiver) = mpsc::channel();
+    let mut watcher = RecommendedWatcher::new(sender, notify::Config::default())?;
+    for root in &workspace.watch_roots {
+        watcher.watch(root, RecursiveMode::Recursive)?;
+    }
+    report_lifecycle_warnings(&initial_change);
+    rebuild(&workspace, &config);
+
+    loop {
+        let first = receiver.recv().map_err(|error| {
+            io::Error::new(io::ErrorKind::BrokenPipe, format!("watch channel closed: {error}"))
+        })?;
+        let mut events = vec![first?];
+        loop {
+            match receiver.recv_timeout(DEBOUNCE_DURATION) {
+                Ok(event) => events.push(event?),
+                Err(RecvTimeoutError::Timeout) => break,
+                Err(RecvTimeoutError::Disconnected) => {
+                    return Err(
+                        io::Error::new(io::ErrorKind::BrokenPipe, "watch channel closed").into()
+                    );
+                }
+            }
+        }
+
+        let change = workspace.synchronize_events(events)?;
+        report_lifecycle_warnings(&change);
+        if lifecycle_changed(&change) {
+            rebuild(&workspace, &config);
+        }
+    }
+}
+
+fn rebuild(workspace: &WatchWorkspace, config: &WatchConfig) {
+    if workspace.compilation.input_source_ids().is_empty() {
+        eprintln!("No input files found; waiting for changes.");
+        return;
+    }
+
+    let build_config = BuildConfig {
+        output: &config.output,
+        current_directory: &workspace.current_directory,
+        diagnostic_limit: config.diagnostic_limit,
+        color: compile::use_color(config.color),
+        progress: false,
+    };
+    match compile::build(&workspace.compilation, &build_config) {
+        Ok(BuildOutcome::Succeeded) => eprintln!("Compilation succeeded; watching for changes."),
+        Ok(BuildOutcome::Diagnostics) => eprintln!("Compilation failed; watching for changes."),
+        Err(error) => eprintln!("Compilation failed: {error}; watching for changes."),
+    }
+}
+
+fn report_lifecycle_warnings(change: &LifecycleChange) {
+    for warning in change.warnings() {
+        tracing::warn!("{warning}");
+        eprintln!("Watch warning: {warning}");
+    }
+}
+
+fn lifecycle_changed(change: &LifecycleChange) -> bool {
+    change.changed_sources().next().is_some() || !change.removed_sources().is_empty()
+}
+
+struct WatchWorkspace {
+    current_directory: PathBuf,
+    inputs: Vec<PathBuf>,
+    output: PathBuf,
+    watch_roots: BTreeSet<PathBuf>,
+    source_globs: globset::GlobSet,
+    source_paths: BTreeSet<PathBuf>,
+    compilation: CompilationState,
+}
+
+impl WatchWorkspace {
+    fn new(
+        current_directory: PathBuf,
+        inputs: Vec<PathBuf>,
+        output: PathBuf,
+    ) -> Result<(WatchWorkspace, LifecycleChange), WatchError> {
+        let walked = walk::walk(&current_directory, &inputs)?;
+        let watch_roots = walked.roots.iter().map(|root| persistent_watch_root(root)).collect();
+        let source_paths = walked
+            .files
+            .into_iter()
+            .filter(|path| !path.starts_with(&output))
+            .collect::<BTreeSet<_>>();
+        let mut compilation = CompilationState::new();
+        let mut initial_change = LifecycleChange::default();
+        for path in &source_paths {
+            initial_change.combine(observe_source_unit(&mut compilation, path)?);
+        }
+
+        let workspace = WatchWorkspace {
+            current_directory,
+            inputs,
+            output,
+            watch_roots,
+            source_globs: walked.globs,
+            source_paths,
+            compilation,
+        };
+        Ok((workspace, initial_change))
+    }
+
+    fn synchronize_events(
+        &mut self,
+        events: impl IntoIterator<Item = Event>,
+    ) -> Result<LifecycleChange, WatchError> {
+        let mut rescan = false;
+        let mut paths = BTreeSet::new();
+        for event in events {
+            if !event.paths.is_empty()
+                && event.paths.iter().all(|path| path.starts_with(&self.output))
+            {
+                continue;
+            }
+            if event.need_rescan() {
+                rescan = true;
+            }
+            if matches!(event.kind, EventKind::Access(_)) {
+                continue;
+            }
+            if matches!(
+                event.kind,
+                EventKind::Create(CreateKind::Folder)
+                    | EventKind::Modify(ModifyKind::Name(_))
+                    | EventKind::Remove(RemoveKind::Folder)
+                    | EventKind::Any
+                    | EventKind::Other
+            ) {
+                rescan = true;
+            }
+            paths.extend(event.paths.into_iter().filter(|path| !path.starts_with(&self.output)));
+        }
+
+        if rescan { self.rescan() } else { self.synchronize_paths(paths) }
+    }
+
+    fn synchronize_paths(
+        &mut self,
+        paths: impl IntoIterator<Item = PathBuf>,
+    ) -> Result<LifecycleChange, WatchError> {
+        let mut source_paths = BTreeSet::new();
+        let mut foreign_paths = BTreeSet::new();
+        for path in paths {
+            if path.starts_with(&self.output) {
+                continue;
+            }
+            match path.extension().and_then(|extension| extension.to_str()) {
+                Some("purs") => {
+                    if self.source_paths.contains(&path)
+                        || !self.source_globs.matches(&path).is_empty()
+                    {
+                        source_paths.insert(path);
+                    }
+                }
+                Some("js") => {
+                    let source_path = path.with_extension("purs");
+                    if self.source_paths.contains(&source_path) {
+                        foreign_paths.insert(source_path);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let mut change = LifecycleChange::default();
+        for path in source_paths {
+            change.combine(observe_source_unit(&mut self.compilation, &path)?);
+            if path.exists() {
+                self.source_paths.insert(path);
+            } else {
+                self.source_paths.remove(&path);
+            }
+        }
+        for source_path in foreign_paths {
+            change.combine(observe_foreign(&mut self.compilation, &source_path)?);
+        }
+        Ok(change)
+    }
+
+    fn rescan(&mut self) -> Result<LifecycleChange, WatchError> {
+        let walked = walk::walk(&self.current_directory, &self.inputs)?;
+        let current_paths = walked
+            .files
+            .into_iter()
+            .filter(|path| !path.starts_with(&self.output))
+            .collect::<BTreeSet<_>>();
+        let affected_paths = self.source_paths.union(&current_paths).cloned();
+        let affected_paths = affected_paths.collect::<Vec<_>>();
+
+        let mut change = LifecycleChange::default();
+        for path in affected_paths {
+            change.combine(observe_source_unit(&mut self.compilation, &path)?);
+        }
+        self.source_globs = walked.globs;
+        self.source_paths = current_paths;
+        Ok(change)
+    }
+}
+
+fn observe_source_unit(
+    compilation: &mut CompilationState,
+    source_path: &Path,
+) -> Result<LifecycleChange, WatchError> {
+    let unit = source_unit(source_path)?;
+    let source = observe_disk(source_path);
+    let mut change = compilation.observe_source(SourceUnitKey::clone(&unit), source);
+    let foreign = observe_disk(&source_path.with_extension("js"));
+    change.combine(compilation.observe_foreign(unit, foreign));
+    Ok(change)
+}
+
+fn observe_foreign(
+    compilation: &mut CompilationState,
+    source_path: &Path,
+) -> Result<LifecycleChange, WatchError> {
+    let unit = source_unit(source_path)?;
+    let foreign = observe_disk(&source_path.with_extension("js"));
+    Ok(compilation.observe_foreign(unit, foreign))
+}
+
+fn source_unit(source_path: &Path) -> Result<SourceUnitKey, WatchError> {
+    let source_url = Url::from_file_path(source_path)
+        .map_err(|()| WatchError::InvalidPath(source_path.to_path_buf()))?;
+    let foreign_path = source_path.with_extension("js");
+    let foreign_url = Url::from_file_path(&foreign_path)
+        .map_err(|()| WatchError::InvalidPath(foreign_path.clone()))?;
+    Ok(SourceUnitKey::new(source_url.as_str(), foreign_url.as_str()))
+}
+
+fn observe_disk(path: &Path) -> DiskObservation {
+    match fs::read_to_string(path) {
+        Ok(content) => DiskObservation::Found(content.into()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => DiskObservation::NotFound,
+        Err(error) => DiskObservation::Failed(ReloadFailure::new(error.kind(), error.to_string())),
+    }
+}
+
+fn persistent_watch_root(root: &Path) -> PathBuf {
+    let mut candidate = root.parent().unwrap_or(root);
+    while !candidate.exists() {
+        let Some(parent) = candidate.parent() else {
+            break;
+        };
+        candidate = parent;
+    }
+    if candidate.is_file() {
+        candidate.parent().unwrap_or(candidate).to_path_buf()
+    } else {
+        candidate.to_path_buf()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn workspace() -> (TempDir, WatchWorkspace) {
+        let temporary = TempDir::new().unwrap();
+        let root = temporary.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/Main.purs"), "module Main where\n\nvalue = 1\n").unwrap();
+        let (workspace, _) = WatchWorkspace::new(
+            root.to_path_buf(),
+            vec![PathBuf::from("src/**/*.purs")],
+            root.join("output"),
+        )
+        .unwrap();
+        (temporary, workspace)
+    }
+
+    #[test]
+    fn synchronizes_source_additions_modifications_and_deletions() {
+        let (temporary, mut workspace) = workspace();
+        let main = temporary.path().join("src/Main.purs");
+        let original = workspace.compilation.input_source_ids()[0];
+
+        fs::write(&main, "module Main where\n\nvalue = 2\n").unwrap();
+        workspace.synchronize_paths([main.clone()]).unwrap();
+        assert_eq!(workspace.compilation.input_source_ids(), vec![original]);
+        assert_eq!(
+            workspace.compilation.snapshot().content(original).unwrap().as_ref(),
+            "module Main where\n\nvalue = 2\n"
+        );
+
+        let added = temporary.path().join("src/Added.purs");
+        fs::write(&added, "module Added where\n").unwrap();
+        workspace.synchronize_paths([added.clone()]).unwrap();
+        assert_eq!(workspace.compilation.input_source_ids().len(), 2);
+
+        fs::remove_file(&main).unwrap();
+        workspace.synchronize_paths([main]).unwrap();
+        assert_eq!(workspace.compilation.input_source_ids().len(), 1);
+    }
+
+    #[test]
+    fn synchronizes_foreign_changes_for_tracked_sources() {
+        let (temporary, mut workspace) = workspace();
+        let source_id = workspace.compilation.input_source_ids()[0];
+        let foreign = temporary.path().join("src/Main.js");
+        fs::write(&foreign, "export const value = 1;\n").unwrap();
+
+        let change = workspace.synchronize_paths([foreign]).unwrap();
+
+        assert_eq!(change.changed_sources().collect::<Vec<_>>(), vec![source_id]);
+        assert!(workspace.compilation.snapshot().foreign_file(source_id).is_some());
+    }
+
+    #[test]
+    fn full_rescan_reloads_existing_sources_and_removes_missing_sources() {
+        let (temporary, mut workspace) = workspace();
+        let main = temporary.path().join("src/Main.purs");
+        let original = workspace.compilation.input_source_ids()[0];
+        fs::write(&main, "module Main where\n\nvalue = 2\n").unwrap();
+
+        workspace.rescan().unwrap();
+        assert_eq!(
+            workspace.compilation.snapshot().content(original).unwrap().as_ref(),
+            "module Main where\n\nvalue = 2\n"
+        );
+
+        fs::remove_file(main).unwrap();
+        workspace.rescan().unwrap();
+        assert!(workspace.compilation.input_source_ids().is_empty());
+    }
+
+    #[test]
+    fn excludes_output_from_source_membership() {
+        let temporary = TempDir::new().unwrap();
+        let root = temporary.path();
+        fs::create_dir_all(root.join("output")).unwrap();
+        fs::write(root.join("output/Generated.purs"), "module Generated where\n").unwrap();
+
+        let (workspace, _) = WatchWorkspace::new(
+            root.to_path_buf(),
+            vec![PathBuf::from("**/*.purs")],
+            root.join("output"),
+        )
+        .unwrap();
+
+        assert!(workspace.compilation.input_source_ids().is_empty());
+    }
+}

--- a/compiler-bin/src/watch.rs
+++ b/compiler-bin/src/watch.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 use std::{fs, io, process};
 
 use building::{DiskObservation, LifecycleChange, ReloadFailure, SourceUnitKey};
+use console::Style;
+use itertools::Itertools;
 use notify::event::{CreateKind, ModifyKind, RemoveKind};
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use thiserror::Error;
@@ -16,6 +18,7 @@ use crate::compile::{self, BuildConfig, BuildOutcome, CompileError};
 use crate::walk;
 
 const DEBOUNCE_DURATION: Duration = Duration::from_millis(100);
+const MODULE_DISPLAY_LIMIT: usize = 3;
 
 pub struct WatchConfig {
     pub output: PathBuf,
@@ -55,7 +58,8 @@ fn watch(config: WatchConfig) -> Result<(), WatchError> {
     for root in &workspace.watch_roots {
         watcher.watch(root, RecursiveMode::Recursive)?;
     }
-    report_lifecycle_warnings(&initial_change);
+    report_lifecycle_warnings(&initial_change.lifecycle);
+    report_changed_modules(&initial_change.modules, compile::use_color(config.color));
     rebuild(&mut workspace, &config);
 
     loop {
@@ -76,8 +80,9 @@ fn watch(config: WatchConfig) -> Result<(), WatchError> {
         }
 
         let change = workspace.synchronize_events(events)?;
-        report_lifecycle_warnings(&change);
-        if lifecycle_changed(&change) {
+        report_lifecycle_warnings(&change.lifecycle);
+        if !change.modules.is_empty() {
+            report_changed_modules(&change.modules, compile::use_color(config.color));
             rebuild(&mut workspace, &config);
         }
     }
@@ -103,12 +108,10 @@ fn rebuild(workspace: &mut WatchWorkspace, config: &WatchConfig) {
         Ok(BuildOutcome::Succeeded(outputs)) => {
             if let Err(error) = workspace.reconcile_outputs(outputs) {
                 eprintln!("Compilation succeeded, but stale output could not be removed: {error}");
-            } else {
-                eprintln!("Compilation succeeded; watching for changes.");
             }
         }
-        Ok(BuildOutcome::Diagnostics) => eprintln!("Compilation failed; watching for changes."),
-        Err(error) => eprintln!("Compilation failed: {error}; watching for changes."),
+        Ok(BuildOutcome::Diagnostics) => {}
+        Err(error) => eprintln!("\n\nCompilation failed: {error}\n"),
     }
 }
 
@@ -119,8 +122,38 @@ fn report_lifecycle_warnings(change: &LifecycleChange) {
     }
 }
 
-fn lifecycle_changed(change: &LifecycleChange) -> bool {
-    change.changed_sources().next().is_some() || !change.removed_sources().is_empty()
+fn report_changed_modules(module_names: &BTreeSet<String>, color: bool) {
+    if module_names.is_empty() {
+        return;
+    }
+
+    let timestamp = jiff::Zoned::now().strftime("%H:%M:%S");
+    let timestamp =
+        Style::new().cyan().dim().force_styling(color).apply_to(format!("[{timestamp}]"));
+    let count = module_names.len();
+    let noun = if count == 1 { "file" } else { "files" };
+    let mut displayed = module_names.iter().take(MODULE_DISPLAY_LIMIT).map(String::as_str);
+    let displayed = displayed.join(", ");
+    let omitted = count.saturating_sub(MODULE_DISPLAY_LIMIT);
+
+    if omitted == 0 {
+        eprintln!("{timestamp} {count} {noun} changed: {displayed}");
+    } else {
+        eprintln!("{timestamp} {count} {noun} changed: {displayed}, … +{omitted} more");
+    }
+}
+
+#[derive(Default)]
+struct WorkspaceChange {
+    lifecycle: LifecycleChange,
+    modules: BTreeSet<String>,
+}
+
+impl WorkspaceChange {
+    fn combine(&mut self, other: WorkspaceChange) {
+        self.lifecycle.combine(other.lifecycle);
+        self.modules.extend(other.modules);
+    }
 }
 
 struct WatchWorkspace {
@@ -139,7 +172,7 @@ impl WatchWorkspace {
         current_directory: PathBuf,
         inputs: Vec<PathBuf>,
         output: PathBuf,
-    ) -> Result<(WatchWorkspace, LifecycleChange), WatchError> {
+    ) -> Result<(WatchWorkspace, WorkspaceChange), WatchError> {
         let walked = walk::walk(&current_directory, &inputs)?;
         let watch_roots = walked.roots.iter().map(|root| persistent_watch_root(root)).collect();
         let source_paths = walked
@@ -148,7 +181,7 @@ impl WatchWorkspace {
             .filter(|path| !path.starts_with(&output))
             .collect::<BTreeSet<_>>();
         let mut compilation = CompilationState::new();
-        let mut initial_change = LifecycleChange::default();
+        let mut initial_change = WorkspaceChange::default();
         for path in &source_paths {
             initial_change.combine(observe_source_unit(&mut compilation, path)?);
         }
@@ -169,7 +202,7 @@ impl WatchWorkspace {
     fn synchronize_events(
         &mut self,
         events: impl IntoIterator<Item = Event>,
-    ) -> Result<LifecycleChange, WatchError> {
+    ) -> Result<WorkspaceChange, WatchError> {
         let mut rescan = false;
         let mut paths = BTreeSet::new();
         for event in events {
@@ -203,7 +236,7 @@ impl WatchWorkspace {
     fn synchronize_paths(
         &mut self,
         paths: impl IntoIterator<Item = PathBuf>,
-    ) -> Result<LifecycleChange, WatchError> {
+    ) -> Result<WorkspaceChange, WatchError> {
         let mut source_paths = BTreeSet::new();
         let mut foreign_paths = BTreeSet::new();
         for path in paths {
@@ -228,7 +261,7 @@ impl WatchWorkspace {
             }
         }
 
-        let mut change = LifecycleChange::default();
+        let mut change = WorkspaceChange::default();
         for path in source_paths {
             change.combine(observe_source_unit(&mut self.compilation, &path)?);
             if path.exists() {
@@ -243,7 +276,7 @@ impl WatchWorkspace {
         Ok(change)
     }
 
-    fn rescan(&mut self) -> Result<LifecycleChange, WatchError> {
+    fn rescan(&mut self) -> Result<WorkspaceChange, WatchError> {
         let walked = walk::walk(&self.current_directory, &self.inputs)?;
         let current_paths = walked
             .files
@@ -253,7 +286,7 @@ impl WatchWorkspace {
         let affected_paths = self.source_paths.union(&current_paths).cloned();
         let affected_paths = affected_paths.collect::<Vec<_>>();
 
-        let mut change = LifecycleChange::default();
+        let mut change = WorkspaceChange::default();
         for path in affected_paths {
             change.combine(observe_source_unit(&mut self.compilation, &path)?);
         }
@@ -278,22 +311,42 @@ impl WatchWorkspace {
 fn observe_source_unit(
     compilation: &mut CompilationState,
     source_path: &Path,
-) -> Result<LifecycleChange, WatchError> {
+) -> Result<WorkspaceChange, WatchError> {
     let unit = source_unit(source_path)?;
+    let previous_source = compilation.source_content(unit.source());
+    let previous_foreign = compilation.foreign_content(unit.foreign());
+    let previous_name = compilation.module_name(unit.source());
+
     let source = observe_disk(source_path);
-    let mut change = compilation.observe_source(SourceUnitKey::clone(&unit), source);
+    let mut lifecycle = compilation.observe_source(SourceUnitKey::clone(&unit), source);
     let foreign = observe_disk(&source_path.with_extension("js"));
-    change.combine(compilation.observe_foreign(unit, foreign));
-    Ok(change)
+    lifecycle.combine(compilation.observe_foreign(SourceUnitKey::clone(&unit), foreign));
+
+    let current_source = compilation.source_content(unit.source());
+    let current_foreign = compilation.foreign_content(unit.foreign());
+    let mut modules = BTreeSet::new();
+    if previous_source != current_source || previous_foreign != current_foreign {
+        let name = compilation.module_name(unit.source()).or(previous_name);
+        modules.insert(name.unwrap_or_else(|| fallback_module_name(source_path)));
+    }
+    Ok(WorkspaceChange { lifecycle, modules })
 }
 
 fn observe_foreign(
     compilation: &mut CompilationState,
     source_path: &Path,
-) -> Result<LifecycleChange, WatchError> {
+) -> Result<WorkspaceChange, WatchError> {
     let unit = source_unit(source_path)?;
+    let previous_foreign = compilation.foreign_content(unit.foreign());
     let foreign = observe_disk(&source_path.with_extension("js"));
-    Ok(compilation.observe_foreign(unit, foreign))
+    let lifecycle = compilation.observe_foreign(SourceUnitKey::clone(&unit), foreign);
+    let current_foreign = compilation.foreign_content(unit.foreign());
+    let mut modules = BTreeSet::new();
+    if previous_foreign != current_foreign {
+        let name = compilation.module_name(unit.source());
+        modules.insert(name.unwrap_or_else(|| fallback_module_name(source_path)));
+    }
+    Ok(WorkspaceChange { lifecycle, modules })
 }
 
 fn source_unit(source_path: &Path) -> Result<SourceUnitKey, WatchError> {
@@ -311,6 +364,13 @@ fn observe_disk(path: &Path) -> DiskObservation {
         Err(error) if error.kind() == io::ErrorKind::NotFound => DiskObservation::NotFound,
         Err(error) => DiskObservation::Failed(ReloadFailure::new(error.kind(), error.to_string())),
     }
+}
+
+fn fallback_module_name(source_path: &Path) -> String {
+    source_path
+        .file_stem()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| source_path.display().to_string())
 }
 
 fn persistent_watch_root(root: &Path) -> PathBuf {
@@ -354,7 +414,8 @@ mod tests {
         let original = workspace.compilation.input_source_ids()[0];
 
         fs::write(&main, "module Main where\n\nvalue = 2\n").unwrap();
-        workspace.synchronize_paths([main.clone()]).unwrap();
+        let change = workspace.synchronize_paths([main.clone()]).unwrap();
+        assert_eq!(change.modules, BTreeSet::from([String::from("Main")]));
         assert_eq!(workspace.compilation.input_source_ids(), vec![original]);
         assert_eq!(
             workspace.compilation.snapshot().content(original).unwrap().as_ref(),
@@ -363,11 +424,13 @@ mod tests {
 
         let added = temporary.path().join("src/Added.purs");
         fs::write(&added, "module Added where\n").unwrap();
-        workspace.synchronize_paths([added.clone()]).unwrap();
+        let change = workspace.synchronize_paths([added.clone()]).unwrap();
+        assert_eq!(change.modules, BTreeSet::from([String::from("Added")]));
         assert_eq!(workspace.compilation.input_source_ids().len(), 2);
 
         fs::remove_file(&main).unwrap();
-        workspace.synchronize_paths([main]).unwrap();
+        let change = workspace.synchronize_paths([main]).unwrap();
+        assert_eq!(change.modules, BTreeSet::from([String::from("Main")]));
         assert_eq!(workspace.compilation.input_source_ids().len(), 1);
     }
 
@@ -380,8 +443,19 @@ mod tests {
 
         let change = workspace.synchronize_paths([foreign]).unwrap();
 
-        assert_eq!(change.changed_sources().collect::<Vec<_>>(), vec![source_id]);
+        assert_eq!(change.lifecycle.changed_sources().collect::<Vec<_>>(), vec![source_id]);
+        assert_eq!(change.modules, BTreeSet::from([String::from("Main")]));
         assert!(workspace.compilation.snapshot().foreign_file(source_id).is_some());
+    }
+
+    #[test]
+    fn ignores_events_when_disk_content_is_unchanged() {
+        let (temporary, mut workspace) = workspace();
+        let main = temporary.path().join("src/Main.purs");
+
+        let change = workspace.synchronize_paths([main]).unwrap();
+
+        assert!(change.modules.is_empty());
     }
 
     #[test]

--- a/compiler-bin/src/watch.rs
+++ b/compiler-bin/src/watch.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc::{self, RecvTimeoutError};
 use std::time::Duration;
 use std::{fs, io, process};
 
-use building::{DiskObservation, LifecycleChange, ReloadFailure, SourceUnitKey};
+use building::{DiskObservation, LifecycleChange, QueryError, ReloadFailure, SourceUnitKey};
 use console::Style;
 use itertools::Itertools;
 use notify::event::{CreateKind, ModifyKind, RemoveKind};
@@ -38,6 +38,8 @@ enum WatchError {
     #[error(transparent)]
     Notify(#[from] notify::Error),
     #[error(transparent)]
+    Query(#[from] QueryError),
+    #[error(transparent)]
     Walk(#[from] walk::Error),
 }
 
@@ -60,7 +62,7 @@ fn watch(config: WatchConfig) -> Result<(), WatchError> {
     }
     report_lifecycle_warnings(&initial_change.lifecycle);
     report_changed_modules(&initial_change.modules, compile::use_color(config.color));
-    rebuild(&mut workspace, &config);
+    rebuild(&mut workspace, &config)?;
 
     loop {
         let first = receiver.recv().map_err(|error| {
@@ -83,18 +85,18 @@ fn watch(config: WatchConfig) -> Result<(), WatchError> {
         report_lifecycle_warnings(&change.lifecycle);
         if !change.modules.is_empty() {
             report_changed_modules(&change.modules, compile::use_color(config.color));
-            rebuild(&mut workspace, &config);
+            rebuild(&mut workspace, &config)?;
         }
     }
 }
 
-fn rebuild(workspace: &mut WatchWorkspace, config: &WatchConfig) {
+fn rebuild(workspace: &mut WatchWorkspace, config: &WatchConfig) -> Result<(), WatchError> {
     if workspace.compilation.input_source_ids().is_empty() {
         if let Err(error) = workspace.reconcile_outputs(BTreeSet::new()) {
             eprintln!("Failed to remove stale output: {error}");
         }
         println!("No input files found; waiting for changes.");
-        return;
+        return Ok(());
     }
 
     let build_config = BuildConfig {
@@ -104,15 +106,15 @@ fn rebuild(workspace: &mut WatchWorkspace, config: &WatchConfig) {
         color: compile::use_color(config.color),
         progress: false,
     };
-    match compile::build(&workspace.compilation, &build_config) {
-        Ok(BuildOutcome::Succeeded(outputs)) => {
+    match compile::build(&workspace.compilation, &build_config)? {
+        BuildOutcome::Succeeded(outputs) => {
             if let Err(error) = workspace.reconcile_outputs(outputs) {
                 eprintln!("Compilation succeeded, but stale output could not be removed: {error}");
             }
         }
-        Ok(BuildOutcome::Diagnostics) => {}
-        Err(error) => eprintln!("\n\nCompilation failed: {error}\n"),
+        BuildOutcome::Diagnostics => {}
     }
+    Ok(())
 }
 
 fn report_lifecycle_warnings(change: &LifecycleChange) {
@@ -313,20 +315,20 @@ fn observe_source_unit(
     source_path: &Path,
 ) -> Result<WorkspaceChange, WatchError> {
     let unit = source_unit(source_path)?;
-    let previous_source = compilation.source_content(unit.source());
+    let previous_source = compilation.source_content(unit.source())?;
     let previous_foreign = compilation.foreign_content(unit.foreign());
-    let previous_name = compilation.module_name(unit.source());
+    let previous_name = compilation.module_name(unit.source())?;
 
     let source = observe_disk(source_path);
     let mut lifecycle = compilation.observe_source(SourceUnitKey::clone(&unit), source);
     let foreign = observe_disk(&source_path.with_extension("js"));
     lifecycle.combine(compilation.observe_foreign(SourceUnitKey::clone(&unit), foreign));
 
-    let current_source = compilation.source_content(unit.source());
+    let current_source = compilation.source_content(unit.source())?;
     let current_foreign = compilation.foreign_content(unit.foreign());
     let mut modules = BTreeSet::new();
     if previous_source != current_source || previous_foreign != current_foreign {
-        let name = compilation.module_name(unit.source()).or(previous_name);
+        let name = compilation.module_name(unit.source())?.or(previous_name);
         modules.insert(name.unwrap_or_else(|| fallback_module_name(source_path)));
     }
     Ok(WorkspaceChange { lifecycle, modules })
@@ -343,7 +345,7 @@ fn observe_foreign(
     let current_foreign = compilation.foreign_content(unit.foreign());
     let mut modules = BTreeSet::new();
     if previous_foreign != current_foreign {
-        let name = compilation.module_name(unit.source());
+        let name = compilation.module_name(unit.source())?;
         modules.insert(name.unwrap_or_else(|| fallback_module_name(source_path)));
     }
     Ok(WorkspaceChange { lifecycle, modules })

--- a/compiler-bin/src/watch.rs
+++ b/compiler-bin/src/watch.rs
@@ -29,8 +29,6 @@ pub struct WatchConfig {
 
 #[derive(Debug, Error)]
 enum WatchError {
-    #[error(transparent)]
-    Compile(#[from] CompileError),
     #[error("failed to convert path to a file URL: {0}")]
     InvalidPath(PathBuf),
     #[error(transparent)]
@@ -64,7 +62,7 @@ fn watch(config: WatchConfig) -> Result<(), WatchError> {
     if !config.quiet {
         report_changed_modules(&initial_change.modules, compile::use_color(config.color));
     }
-    rebuild(&mut workspace, &config)?;
+    rebuild_or_report(&mut workspace, &config);
 
     loop {
         let first = receiver.recv().map_err(|error| {
@@ -89,12 +87,19 @@ fn watch(config: WatchConfig) -> Result<(), WatchError> {
             if !config.quiet {
                 report_changed_modules(&change.modules, compile::use_color(config.color));
             }
-            rebuild(&mut workspace, &config)?;
+            rebuild_or_report(&mut workspace, &config);
         }
     }
 }
 
-fn rebuild(workspace: &mut WatchWorkspace, config: &WatchConfig) -> Result<(), WatchError> {
+fn rebuild_or_report(workspace: &mut WatchWorkspace, config: &WatchConfig) {
+    if let Err(error) = rebuild(workspace, config) {
+        eprintln!("Compilation failed: {error}");
+        tracing::error!(?error, "Watch compilation failed");
+    }
+}
+
+fn rebuild(workspace: &mut WatchWorkspace, config: &WatchConfig) -> Result<(), CompileError> {
     if workspace.compilation.input_source_ids().is_empty() {
         if let Err(error) = workspace.reconcile_outputs(BTreeSet::new()) {
             eprintln!("Failed to remove stale output: {error}");
@@ -381,6 +386,7 @@ fn fallback_module_name(source_path: &Path) -> String {
 }
 
 fn persistent_watch_root(root: &Path) -> PathBuf {
+    // The parent remains watched so deleting the input root does not prevent observing its recreation.
     let mut candidate = root.parent().unwrap_or(root);
     while !candidate.exists() {
         let Some(parent) = candidate.parent() else {
@@ -516,5 +522,33 @@ mod tests {
         assert!(!stale.exists());
         assert!(retained.exists());
         assert_eq!(workspace.generated_outputs, BTreeSet::from([retained]));
+    }
+
+    #[test]
+    fn rebuilds_after_a_recoverable_output_error() {
+        let (temporary, mut workspace) = workspace();
+        let output = temporary.path().join("output");
+        let config = WatchConfig {
+            output: output.clone(),
+            inputs: vec![PathBuf::from("src/**/*.purs")],
+            quiet: true,
+            color: ColorChoice::Never,
+        };
+        fs::write(&output, "not a directory").unwrap();
+
+        rebuild_or_report(&mut workspace, &config);
+
+        fs::remove_file(&output).unwrap();
+        rebuild_or_report(&mut workspace, &config);
+        assert!(output.join("Main/index.js").is_file());
+    }
+
+    #[test]
+    fn watches_the_parent_of_an_existing_input_root() {
+        let temporary = TempDir::new().unwrap();
+        let input_root = temporary.path().join("src");
+        fs::create_dir(&input_root).unwrap();
+
+        assert_eq!(persistent_watch_root(&input_root), temporary.path());
     }
 }

--- a/compiler-bin/src/watch.rs
+++ b/compiler-bin/src/watch.rs
@@ -93,7 +93,7 @@ fn rebuild(workspace: &mut WatchWorkspace, config: &WatchConfig) {
         if let Err(error) = workspace.reconcile_outputs(BTreeSet::new()) {
             eprintln!("Failed to remove stale output: {error}");
         }
-        eprintln!("No input files found; waiting for changes.");
+        println!("No input files found; waiting for changes.");
         return;
     }
 
@@ -137,9 +137,9 @@ fn report_changed_modules(module_names: &BTreeSet<String>, color: bool) {
     let omitted = count.saturating_sub(MODULE_DISPLAY_LIMIT);
 
     if omitted == 0 {
-        eprintln!("{timestamp} {count} {noun} changed: {displayed}");
+        println!("{timestamp} {count} {noun} changed: {displayed}");
     } else {
-        eprintln!("{timestamp} {count} {noun} changed: {displayed}, … +{omitted} more");
+        println!("{timestamp} {count} {noun} changed: {displayed}, … +{omitted} more");
     }
 }
 

--- a/compiler-bin/src/watch.rs
+++ b/compiler-bin/src/watch.rs
@@ -56,7 +56,7 @@ fn watch(config: WatchConfig) -> Result<(), WatchError> {
         watcher.watch(root, RecursiveMode::Recursive)?;
     }
     report_lifecycle_warnings(&initial_change);
-    rebuild(&workspace, &config);
+    rebuild(&mut workspace, &config);
 
     loop {
         let first = receiver.recv().map_err(|error| {
@@ -78,13 +78,16 @@ fn watch(config: WatchConfig) -> Result<(), WatchError> {
         let change = workspace.synchronize_events(events)?;
         report_lifecycle_warnings(&change);
         if lifecycle_changed(&change) {
-            rebuild(&workspace, &config);
+            rebuild(&mut workspace, &config);
         }
     }
 }
 
-fn rebuild(workspace: &WatchWorkspace, config: &WatchConfig) {
+fn rebuild(workspace: &mut WatchWorkspace, config: &WatchConfig) {
     if workspace.compilation.input_source_ids().is_empty() {
+        if let Err(error) = workspace.reconcile_outputs(BTreeSet::new()) {
+            eprintln!("Failed to remove stale output: {error}");
+        }
         eprintln!("No input files found; waiting for changes.");
         return;
     }
@@ -97,7 +100,13 @@ fn rebuild(workspace: &WatchWorkspace, config: &WatchConfig) {
         progress: false,
     };
     match compile::build(&workspace.compilation, &build_config) {
-        Ok(BuildOutcome::Succeeded) => eprintln!("Compilation succeeded; watching for changes."),
+        Ok(BuildOutcome::Succeeded(outputs)) => {
+            if let Err(error) = workspace.reconcile_outputs(outputs) {
+                eprintln!("Compilation succeeded, but stale output could not be removed: {error}");
+            } else {
+                eprintln!("Compilation succeeded; watching for changes.");
+            }
+        }
         Ok(BuildOutcome::Diagnostics) => eprintln!("Compilation failed; watching for changes."),
         Err(error) => eprintln!("Compilation failed: {error}; watching for changes."),
     }
@@ -121,6 +130,7 @@ struct WatchWorkspace {
     watch_roots: BTreeSet<PathBuf>,
     source_globs: globset::GlobSet,
     source_paths: BTreeSet<PathBuf>,
+    generated_outputs: BTreeSet<PathBuf>,
     compilation: CompilationState,
 }
 
@@ -150,6 +160,7 @@ impl WatchWorkspace {
             watch_roots,
             source_globs: walked.globs,
             source_paths,
+            generated_outputs: BTreeSet::new(),
             compilation,
         };
         Ok((workspace, initial_change))
@@ -249,6 +260,18 @@ impl WatchWorkspace {
         self.source_globs = walked.globs;
         self.source_paths = current_paths;
         Ok(change)
+    }
+
+    fn reconcile_outputs(&mut self, current: BTreeSet<PathBuf>) -> io::Result<()> {
+        for stale in self.generated_outputs.difference(&current) {
+            match fs::remove_file(stale) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+        }
+        self.generated_outputs = current;
+        Ok(())
     }
 }
 
@@ -394,5 +417,23 @@ mod tests {
         .unwrap();
 
         assert!(workspace.compilation.input_source_ids().is_empty());
+    }
+
+    #[test]
+    fn removes_outputs_missing_from_the_latest_successful_build() {
+        let (temporary, mut workspace) = workspace();
+        let stale = temporary.path().join("output/Stale/index.js");
+        let retained = temporary.path().join("output/Main/index.js");
+        fs::create_dir_all(stale.parent().unwrap()).unwrap();
+        fs::create_dir_all(retained.parent().unwrap()).unwrap();
+        fs::write(&stale, "stale").unwrap();
+        fs::write(&retained, "retained").unwrap();
+        workspace.generated_outputs = BTreeSet::from([stale.clone(), retained.clone()]);
+
+        workspace.reconcile_outputs(BTreeSet::from([retained.clone()])).unwrap();
+
+        assert!(!stale.exists());
+        assert!(retained.exists());
+        assert_eq!(workspace.generated_outputs, BTreeSet::from([retained]));
     }
 }

--- a/compiler-frontend/diagnostics/Cargo.toml
+++ b/compiler-frontend/diagnostics/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+building-types = { version = "0.1.0", path = "../../compiler-core/building-types" }
 files = { version = "0.1.0", path = "../../compiler-core/files" }
 foreign-javascript = { version = "0.1.0", path = "../../compiler-backend/foreign-javascript" }
 indexing = { version = "0.1.0", path = "../indexing" }

--- a/compiler-frontend/diagnostics/src/collection.rs
+++ b/compiler-frontend/diagnostics/src/collection.rs
@@ -1,0 +1,89 @@
+use std::sync::Arc;
+
+use building_types::QueryResult;
+use files::FileId;
+use foreign_javascript::ForeignQueries;
+
+use crate::{Diagnostic, DiagnosticsContext, ExternalQueries, ToDiagnostics};
+
+pub struct DiagnosticCollection {
+    pub file_id: FileId,
+    pub content: Arc<str>,
+    diagnostics: Vec<Diagnostic>,
+    source_start: usize,
+    foreign_start: usize,
+}
+
+impl DiagnosticCollection {
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics[self.source_start..]
+    }
+
+    pub fn checking_diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics[..self.foreign_start]
+    }
+
+    pub fn foreign_diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics[self.foreign_start..]
+    }
+}
+
+pub fn collect_diagnostics<Q>(
+    queries: &Q,
+    source_files: &[FileId],
+) -> QueryResult<Vec<DiagnosticCollection>>
+where
+    Q: ExternalQueries + ForeignQueries,
+{
+    let collections =
+        source_files.iter().map(|&file_id| collect_file_diagnostics(queries, file_id));
+    collections.collect()
+}
+
+fn collect_file_diagnostics<Q>(queries: &Q, file_id: FileId) -> QueryResult<DiagnosticCollection>
+where
+    Q: ExternalQueries + ForeignQueries,
+{
+    let content = queries.content(file_id)?;
+    let (parsed, _) = queries.parsed(file_id)?;
+    let root = parsed.syntax_node();
+    let stabilized = queries.stabilized(file_id)?;
+    let indexed = queries.indexed(file_id)?;
+    let resolved = queries.resolved(file_id)?;
+    let lowered = queries.lowered(file_id)?;
+    let checked = queries.checked(file_id)?;
+    let foreign_validation = queries.foreign_validation(file_id)?;
+
+    let context = DiagnosticsContext::new(
+        queries,
+        &content,
+        &root,
+        &stabilized,
+        &indexed,
+        &lowered,
+        &checked,
+    );
+
+    let mut diagnostics = vec![];
+    for error in &indexed.errors {
+        diagnostics.extend(error.to_diagnostics(&context));
+    }
+
+    let source_start = diagnostics.len();
+    for error in &lowered.errors {
+        diagnostics.extend(error.to_diagnostics(&context));
+    }
+    for error in &resolved.errors {
+        diagnostics.extend(error.to_diagnostics(&context));
+    }
+    for error in &checked.errors {
+        diagnostics.extend(error.to_diagnostics(&context));
+    }
+
+    let foreign_start = diagnostics.len();
+    for error in foreign_validation.errors.iter() {
+        diagnostics.extend(error.to_diagnostics(&context));
+    }
+
+    Ok(DiagnosticCollection { file_id, content, diagnostics, source_start, foreign_start })
+}

--- a/compiler-frontend/diagnostics/src/lib.rs
+++ b/compiler-frontend/diagnostics/src/lib.rs
@@ -1,8 +1,10 @@
+mod collection;
 mod context;
 mod convert;
 mod model;
 mod render;
 
+pub use collection::{DiagnosticCollection, collect_diagnostics};
 pub use context::{DiagnosticsContext, ExternalQueries};
 pub use convert::ToDiagnostics;
 pub use model::{Diagnostic, DiagnosticCode, RelatedSpan, Severity, Span};

--- a/compiler-lsp/analyzer/src/diagnostics.rs
+++ b/compiler-lsp/analyzer/src/diagnostics.rs
@@ -1,7 +1,4 @@
-use building_types::QueryProxy;
-use diagnostics::{DiagnosticsContext, ToDiagnostics};
 use files::FileId;
-use foreign_javascript::ForeignQueries;
 use line_index::LineIndex;
 use lsp_types::{Diagnostic, Url};
 
@@ -18,53 +15,15 @@ pub fn implementation<Host>(
 ) -> Result<CollectedDiagnostics, AnalyzerError>
 where
     Host: AnalyzerHost,
-    Host::Queries: diagnostics::ExternalQueries + ForeignQueries,
+    Host::Queries: diagnostics::ExternalQueries + foreign_javascript::ForeignQueries,
 {
     let queries = context.queries();
-    let content = queries.content(file_id)?;
-
-    let (parsed, _) = queries.parsed(file_id)?;
-    let root = parsed.syntax_node();
-
-    let stabilized = queries.stabilized(file_id)?;
-    let indexed = queries.indexed(file_id)?;
-    let resolved = queries.resolved(file_id)?;
-    let lowered = queries.lowered(file_id)?;
-    let checked = queries.checked(file_id)?;
-    let foreign = queries.foreign_validation(file_id)?;
-
+    let mut collected = diagnostics::collect_diagnostics(queries, &[file_id])?;
+    let collected = collected.pop().expect("one source file should produce one collection");
     let uri = common::file_uri(context, file_id)?;
-    let diagnostics_context = DiagnosticsContext::new(
-        queries,
-        &content,
-        &root,
-        &stabilized,
-        &indexed,
-        &lowered,
-        &checked,
-    );
-
-    let mut all_diagnostics = vec![];
-
-    for error in &lowered.errors {
-        all_diagnostics.extend(error.to_diagnostics(&diagnostics_context));
-    }
-
-    for error in &resolved.errors {
-        all_diagnostics.extend(error.to_diagnostics(&diagnostics_context));
-    }
-
-    for error in &checked.errors {
-        all_diagnostics.extend(error.to_diagnostics(&diagnostics_context));
-    }
-
-    for error in foreign.errors.iter() {
-        all_diagnostics.extend(error.to_diagnostics(&diagnostics_context));
-    }
-
     let position_encoding = context.position_encoding().into();
-    let line_index = LineIndex::new(&content);
-    let diagnostics = all_diagnostics.iter().filter_map(|diagnostic| {
+    let line_index = LineIndex::new(&collected.content);
+    let diagnostics = collected.diagnostics().iter().filter_map(|diagnostic| {
         diagnostics::to_lsp_diagnostic_with_line_index(
             diagnostic,
             &line_index,

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -4,7 +4,7 @@ use analyzer::position;
 use building::QueryEngine;
 use checking::core::pretty;
 use checking::{PrettyQueries, core};
-use diagnostics::{DiagnosticsContext, ToDiagnostics, format_rich_with_path};
+use diagnostics::{collect_diagnostics, format_rich_with_path};
 use files::FileId;
 use indexing::{ImportKind, IndexedTermItem, IndexedTypeItem, IndexedTypeItemKind, TypeItemId};
 use itertools::Itertools;
@@ -356,35 +356,26 @@ pub fn report_checked(engine: &QueryEngine, id: FileId, path: &str) -> String {
         writeln!(out, "{name} = [{}]", roles_str.join(", ")).unwrap();
     }
 
-    write_checked_diagnostics(&mut out, engine, id, path, &indexed, &checked);
+    write_checked_diagnostics(&mut out, engine, id, path);
 
     out
 }
 
 pub fn report_foreign(engine: &QueryEngine, id: FileId, path: &str) -> String {
-    let validation = engine.foreign_validation(id).unwrap();
-    if validation.errors.is_empty() {
+    let mut collected = collect_diagnostics(engine, &[id]).unwrap();
+    let collected = collected.pop().unwrap();
+    if collected.foreign_diagnostics().is_empty() {
         return String::new();
-    }
-
-    let content = engine.content(id).unwrap();
-    let (parsed, _) = engine.parsed(id).unwrap();
-    let root = parsed.syntax_node();
-    let stabilized = engine.stabilized(id).unwrap();
-    let indexed = engine.indexed(id).unwrap();
-    let lowered = engine.lowered(id).unwrap();
-    let checked = engine.checked(id).unwrap();
-    let context =
-        DiagnosticsContext::new(engine, &content, &root, &stabilized, &indexed, &lowered, &checked);
-
-    let mut diagnostics = Vec::new();
-    for error in validation.errors.iter() {
-        diagnostics.extend(error.to_diagnostics(&context));
     }
 
     let mut out = String::new();
     heading(&mut out, "Diagnostics");
-    out.push_str(&format_rich_with_path(&diagnostics, &content, path, false));
+    out.push_str(&format_rich_with_path(
+        collected.foreign_diagnostics(),
+        &collected.content,
+        path,
+        false,
+    ));
     out
 }
 
@@ -490,45 +481,17 @@ fn write_term_resolution(
     }
 }
 
-fn write_checked_diagnostics(
-    out: &mut String,
-    engine: &QueryEngine,
-    id: FileId,
-    path: &str,
-    indexed: &indexing::IndexedModule,
-    checked: &checking::CheckedModule,
-) {
-    let content = engine.content(id).unwrap();
-    let (parsed, _) = engine.parsed(id).unwrap();
-    let root = parsed.syntax_node();
-    let stabilized = engine.stabilized(id).unwrap();
-    let lowered = engine.lowered(id).unwrap();
-    let resolved = engine.resolved(id).unwrap();
-
-    let context =
-        DiagnosticsContext::new(engine, &content, &root, &stabilized, indexed, &lowered, checked);
-
-    let mut all_diagnostics = vec![];
-
-    for error in &indexed.errors {
-        all_diagnostics.extend(error.to_diagnostics(&context));
-    }
-
-    for error in &lowered.errors {
-        all_diagnostics.extend(error.to_diagnostics(&context));
-    }
-
-    for error in &resolved.errors {
-        all_diagnostics.extend(error.to_diagnostics(&context));
-    }
-
-    for error in &checked.errors {
-        all_diagnostics.extend(error.to_diagnostics(&context));
-    }
-
-    if !all_diagnostics.is_empty() {
+fn write_checked_diagnostics(out: &mut String, engine: &QueryEngine, id: FileId, path: &str) {
+    let mut collected = collect_diagnostics(engine, &[id]).unwrap();
+    let collected = collected.pop().unwrap();
+    if !collected.checking_diagnostics().is_empty() {
         writeln!(out, "\nDiagnostics").unwrap();
-        out.push_str(&format_rich_with_path(&all_diagnostics, &content, path, false));
+        out.push_str(&format_rich_with_path(
+            collected.checking_diagnostics(),
+            &collected.content,
+            path,
+            false,
+        ));
     }
 }
 


### PR DESCRIPTION
## Summary

Add a persistent `watch` subcommand for PureScript development builds. The command keeps compiler query state alive across refreshes, reconciles source and sibling JavaScript additions, modifications, and deletions, and updates generated output without rewriting unchanged files.

Watch refreshes deliberately omit compile progress bars. Lifecycle progress is written to stdout, while diagnostics and failures remain on stderr, making the process suitable for a long-lived development server alongside the language server.

## Design

- Extract the query engine and file lifecycle into reusable compilation state shared by `compile` and `watch`.
- Separate reusable build cycles from one-shot compile process handling.
- Rescan watched inputs after filesystem events so glob membership, missed events, directory recreation, and stale output removal converge on disk state.
- Preserve query failures instead of demoting them to absent values, and emit the exact observed foreign content used during validation.
- Centralize diagnostic collection for the CLI, analyzer, and integration fixtures while keeping rendering at each application boundary.
- Replace diagnostic truncation with `--quiet`, which suppresses build progress without hiding diagnostics.

The future HTTP-driven `watch --server` mode is intentionally outside this change. This establishes the persistent compilation and lifecycle boundaries it can reuse without coupling filesystem watching to a future client-driven event source.

## Verification

- `cargo check -p diagnostics -p analyzer -p purescript-alexandrite -p tests-integration --tests`
- `cargo nextest run -p diagnostics -p analyzer -p purescript-alexandrite` (93 passed)
- `just t checking` (all passed, no pending snapshots)
- `just t backend` (all passed, no pending snapshots)
- Manual terminal verification of separate `Analyse` and `Elaborate` progress for `compile`
- Manual quiet-mode verification: no progress/completion output; diagnostics remain on stderr
- Manual watch refresh verification for source/foreign create, modify, delete, stale output cleanup, and diagnostic recovery