### PR TITLE
[compiler-bin] Report documentation generation progress

### DIFF
--- a/compiler-bin/src/cli.rs
+++ b/compiler-bin/src/cli.rs
@@ -153,6 +153,9 @@ pub struct DocsOptions {
     /// Output directory for the generated documentation.
     #[arg(long, value_name("DIR"), default_value("docs"), value_parser = absolute_path_parser())]
     pub output: PathBuf,
+    /// Suppress documentation progress output.
+    #[arg(short, long)]
+    pub quiet: bool,
     /// Spago project directory containing spago.lock.
     #[arg(long, value_name("DIR"), conflicts_with("package"), value_parser = absolute_path_parser())]
     pub spago_project: Option<PathBuf>,
@@ -315,9 +318,10 @@ mod tests {
 
     #[test]
     fn single_package_folder() {
-        let options = docs(&["--package", "packages/effect"]);
+        let options = docs(&["--package", "packages/effect", "--quiet"]);
 
         assert_eq!(options.packages, vec![current_directory_path("packages/effect")]);
+        assert!(options.quiet);
     }
 
     #[test]

--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -2,25 +2,20 @@ use std::collections::{BTreeSet, HashSet};
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
-use std::{fmt, fs, io, process};
+use std::time::Instant;
+use std::{fs, io, process};
 
 use building::{DiskObservation, QueryError, SourceUnitKey};
-use console::{Color, Style};
 use diagnostics::Severity;
 use files::FileId;
-use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
+use indicatif::MultiProgress;
 use rayon::prelude::*;
 use thiserror::Error;
 use url::Url;
 
 use crate::cli::ColorChoice;
 use crate::compilation::CompilationState;
-use crate::walk;
-
-const CARGO_PROGRESS_REGION_WIDTH: usize = 50;
-const CARGO_PROGRESS_FIXED_OVERHEAD: usize = 17;
-const SHIMMER_FRAME_INTERVAL: Duration = Duration::from_millis(80);
+use crate::{progress, walk};
 
 pub struct CompileConfig {
     pub output: PathBuf,
@@ -86,7 +81,7 @@ pub fn start(config: CompileConfig) {
 
 fn compile(config: CompileConfig) -> Result<(), CompileError> {
     let started = Instant::now();
-    let preparation_progress = compilation_progress(1, "Preparing", !config.quiet);
+    let preparation_progress = progress::bar(1, "Preparing", !config.quiet);
     let current_directory = std::env::current_dir()?;
     let walked = walk::walk(&current_directory, &config.inputs)?;
 
@@ -97,7 +92,7 @@ fn compile(config: CompileConfig) -> Result<(), CompileError> {
     }
     let source_ids = compilation.input_source_ids();
     preparation_progress.inc(1);
-    finish_progress(&preparation_progress);
+    progress::finish(&preparation_progress);
 
     if source_ids.is_empty() {
         return Err(io::Error::new(io::ErrorKind::NotFound, "no input files found").into());
@@ -114,7 +109,7 @@ fn compile(config: CompileConfig) -> Result<(), CompileError> {
     }
 
     if !config.quiet {
-        report_completion(started.elapsed());
+        progress::report_completion(started.elapsed());
     }
 
     Ok(())
@@ -187,9 +182,9 @@ fn report_diagnostics(
     let progress = MultiProgress::new();
     progress.set_move_cursor(true);
     let analysing_progress =
-        phase_progress(&progress, source_ids.len(), "Analyse", config.progress);
+        progress::phase(&progress, source_ids.len(), "Analyse", config.progress);
     let checking_progress =
-        phase_progress(&progress, source_ids.len(), "Elaborate", config.progress);
+        progress::phase(&progress, source_ids.len(), "Elaborate", config.progress);
 
     let module_names = source_ids.par_iter().map(|&file_id| {
         let engine = compilation.snapshot();
@@ -197,7 +192,7 @@ fn report_diagnostics(
         let (parsed, _) = engine.parsed(file_id)?;
         let module_name = parsed.module_name(&content);
         if let Some(module_name) = &module_name {
-            set_progress_module(&analysing_progress, module_name);
+            progress::set_message(&analysing_progress, module_name);
         }
         engine.stabilized(file_id)?;
         engine.indexed(file_id)?;
@@ -207,12 +202,12 @@ fn report_diagnostics(
         Ok::<_, CompileError>(module_name)
     });
     let module_names = module_names.collect::<Result<Vec<_>, _>>()?;
-    finish_progress(&analysing_progress);
+    progress::finish(&analysing_progress);
 
     let elaborated = source_ids.par_iter().zip(&module_names).map(|(&file_id, module_name)| {
         let engine = compilation.snapshot();
         if let Some(module_name) = module_name {
-            set_progress_module(&checking_progress, module_name);
+            progress::set_message(&checking_progress, module_name);
         }
         engine.checked(file_id)?;
         engine.foreign_validation(file_id)?;
@@ -220,7 +215,7 @@ fn report_diagnostics(
         Ok::<_, CompileError>(())
     });
     elaborated.collect::<Result<Vec<_>, _>>()?;
-    finish_progress(&checking_progress);
+    progress::finish(&checking_progress);
 
     let engine = compilation.snapshot();
     let diagnostics = diagnostics::collect_diagnostics(&engine, source_ids)?;
@@ -264,7 +259,7 @@ fn generate_modules(
     let mut visited = HashSet::new();
 
     let initial_total = source_ids.iter().copied().collect::<HashSet<_>>().len();
-    let progress = compilation_progress(initial_total, "Codegen", show_progress);
+    let progress = progress::bar(initial_total, "Codegen", show_progress);
     let mut first_frontier = true;
     let mut modules = vec![];
     while !pending.is_empty() {
@@ -282,7 +277,7 @@ fn generate_modules(
             let content = engine.content(file_id)?;
             let (parsed, _) = engine.parsed(file_id)?;
             if let Some(module_name) = parsed.module_name(&content) {
-                set_progress_module(&progress, &module_name);
+                progress::set_message(&progress, &module_name);
             }
             let module = engine.javascript(file_id)?.map_err(|source| {
                 let path = compilation
@@ -300,7 +295,7 @@ fn generate_modules(
             modules.push(module);
         }
     }
-    finish_progress(&progress);
+    progress::finish(&progress);
 
     Ok(modules)
 }
@@ -319,9 +314,9 @@ fn write_modules(
         outputs.insert(runtime);
     }
 
-    let progress = compilation_progress(modules.len(), "Output", show_progress);
+    let progress = progress::bar(modules.len(), "Output", show_progress);
     let module_outputs = modules.par_iter().map(|module| -> Result<Vec<PathBuf>, CompileError> {
-        set_progress_module(&progress, module.name());
+        progress::set_message(&progress, module.name());
         let output_path = output.join(module.filename());
         let output_parent =
             output_path.parent().expect("invariant violated: module filename has no parent");
@@ -346,7 +341,7 @@ fn write_modules(
     });
     let module_outputs = module_outputs.collect::<Result<Vec<_>, _>>()?;
     outputs.extend(module_outputs.into_iter().flatten());
-    finish_progress(&progress);
+    progress::finish(&progress);
     Ok(outputs)
 }
 
@@ -357,90 +352,4 @@ fn write_if_changed(path: &Path, content: &[u8]) -> io::Result<()> {
         Err(error) if error.kind() == io::ErrorKind::NotFound => fs::write(path, content),
         Err(error) => Err(error),
     }
-}
-
-fn compilation_progress(total: usize, phase: &'static str, show: bool) -> ProgressBar {
-    let progress = if show { ProgressBar::new(total as u64) } else { ProgressBar::hidden() };
-    configure_progress(&progress, phase);
-    progress
-}
-
-fn configure_progress(progress: &ProgressBar, phase: &'static str) {
-    let started = Instant::now();
-    let characters = phase.chars().collect::<Vec<_>>();
-    let cycle = characters.len() + 4;
-    let total = progress.length().unwrap_or_default();
-    let count_width = total.to_string().len().max(4);
-    let statistics_width = count_width * 2 + 2;
-    let bar_width = CARGO_PROGRESS_REGION_WIDTH
-        .saturating_sub(CARGO_PROGRESS_FIXED_OVERHEAD + statistics_width)
-        .max(1);
-    let phase_text = move |state: &ProgressState, writer: &mut dyn fmt::Write| {
-        if state.is_finished() {
-            let style = Style::new().fg(Color::TrueColor(255, 255, 255));
-            write!(writer, "{}", style.apply_to(phase))
-                .expect("writing to a formatter cannot fail");
-            return;
-        }
-
-        let frame =
-            (started.elapsed().as_millis() / SHIMMER_FRAME_INTERVAL.as_millis()) as usize % cycle;
-        let highlight = frame as isize - 2;
-        for (index, character) in characters.iter().enumerate() {
-            let distance = (index as isize - highlight).unsigned_abs();
-            let intensity = match distance {
-                0 => 255,
-                1 => 210,
-                2 => 155,
-                3 => 115,
-                _ => 90,
-            };
-            let style = Style::new().fg(Color::TrueColor(intensity, intensity, intensity));
-            write!(writer, "{}", style.apply_to(character))
-                .expect("writing to a formatter cannot fail");
-        }
-    };
-    let template =
-        format!("{{phase:>12}} [{{bar:{bar_width}.cyan/blue}}] {{pos:>4}}/{{len:4}} {{msg}}");
-    let style = ProgressStyle::with_template(&template)
-        .expect("progress bar template is valid")
-        .with_key("phase", phase_text)
-        .progress_chars("=> ");
-    progress.set_style(style);
-    progress.enable_steady_tick(SHIMMER_FRAME_INTERVAL);
-}
-
-fn phase_progress(
-    progress: &MultiProgress,
-    total: usize,
-    phase: &'static str,
-    show: bool,
-) -> ProgressBar {
-    if !show {
-        return ProgressBar::hidden();
-    }
-    let phase_progress = progress.add(ProgressBar::new(total as u64));
-    configure_progress(&phase_progress, phase);
-    phase_progress
-}
-
-fn set_progress_module(progress: &ProgressBar, module_name: &str) {
-    progress.set_message(module_name.to_string());
-}
-
-fn finish_progress(progress: &ProgressBar) {
-    progress.set_message("");
-    progress.finish();
-}
-
-fn report_completion(elapsed: Duration) {
-    if !io::stderr().is_terminal() {
-        return;
-    }
-
-    let label = format!("{:>12}", "Finished");
-    let style = Style::new().green().bold();
-    let jobs = rayon::current_num_threads();
-    let job_label = if jobs == 1 { "job" } else { "jobs" };
-    eprintln!("{} in {elapsed:.2?} via {jobs} {job_label}", style.apply_to(label));
 }

--- a/compiler-bin/src/docs.rs
+++ b/compiler-bin/src/docs.rs
@@ -157,9 +157,9 @@ fn prepare_documentation_queries(
     let elaborating_progress =
         progress::phase(&progress, modules.len(), "Elaborate", show_progress);
 
-    let analysed = modules.par_iter().map(|&id| {
+    let analysed = modules.par_iter().map(|&file_id| {
         let engine = engine.snapshot();
-        let module_name = analyse_module(&engine, id)?;
+        let module_name = analyse_module(&engine, file_id)?;
         if let Some(module_name) = &module_name {
             progress::set_message(&analysing_progress, module_name);
         }
@@ -169,12 +169,12 @@ fn prepare_documentation_queries(
     let module_names = analysed.collect::<Result<Vec<_>, _>>()?;
     progress::finish(&analysing_progress);
 
-    let elaborated = modules.par_iter().zip(&module_names).map(|(&id, module_name)| {
+    let elaborated = modules.par_iter().zip(&module_names).map(|(&file_id, module_name)| {
         let engine = engine.snapshot();
         if let Some(module_name) = module_name {
             progress::set_message(&elaborating_progress, module_name);
         }
-        engine.checked(id)?;
+        engine.checked(file_id)?;
         elaborating_progress.inc(1);
         Ok::<_, DocsError>(())
     });
@@ -184,17 +184,17 @@ fn prepare_documentation_queries(
     Ok(())
 }
 
-fn analyse_module(engine: &QueryEngine, id: FileId) -> Result<Option<String>, DocsError> {
-    let content = engine.content(id)?;
-    let (parsed, _) = engine.parsed(id)?;
+fn analyse_module(engine: &QueryEngine, file_id: FileId) -> Result<Option<String>, DocsError> {
+    let content = engine.content(file_id)?;
+    let (parsed, _) = engine.parsed(file_id)?;
     let module_name = parsed.module_name(&content).map(|name| name.to_string());
 
-    engine.indexed(id)?;
-    engine.resolved(id)?;
-    engine.lowered(id)?;
-    engine.grouped(id)?;
-    engine.bracketed(id)?;
-    engine.sectioned(id)?;
+    engine.indexed(file_id)?;
+    engine.resolved(file_id)?;
+    engine.lowered(file_id)?;
+    engine.grouped(file_id)?;
+    engine.bracketed(file_id)?;
+    engine.sectioned(file_id)?;
 
     Ok(module_name)
 }
@@ -413,11 +413,12 @@ fn render_documentation(
     packages: &[Package],
     show_progress: bool,
 ) -> Result<Vec<RenderedPackage>, DocsError> {
-    let package_by_file = packages
-        .iter()
-        .flat_map(|package| package.modules.iter().map(|&id| (id, package.name.as_str())))
-        .collect_vec();
-    let module_count = packages.iter().map(|package| package.modules.len()).sum();
+    let package_by_file = packages.iter().flat_map(|package| {
+        package.modules.iter().map(|&file_id| (file_id, package.name.as_str()))
+    });
+    let package_by_file = package_by_file.collect_vec();
+    let module_counts = packages.iter().map(|package| package.modules.len());
+    let module_count = module_counts.sum();
     let progress = progress::bar(module_count, "Document", show_progress);
 
     let mut rendered = vec![];
@@ -434,9 +435,9 @@ fn render_documentation(
         let manifest = documentation::render_package_manifest(engine, &package_input)?;
 
         progress::set_message(&progress, &package.name);
-        let modules = package.modules.par_iter().map(|&id| {
+        let modules = package.modules.par_iter().map(|&file_id| {
             let engine = engine.snapshot();
-            let module = documentation::render_module(&engine, id, &package_by_file)?;
+            let module = documentation::render_module(&engine, file_id, &package_by_file)?;
             if let Some(module) = &module {
                 progress::set_message(&progress, &module.name);
             }
@@ -462,7 +463,8 @@ fn write_documentation(
         fs::remove_dir_all(output)?;
     }
 
-    let file_count = packages.iter().map(|package| package.modules.len() + 1).sum();
+    let file_counts = packages.iter().map(|package| package.modules.len() + 1);
+    let file_count = file_counts.sum();
     let progress = progress::bar(file_count, "Output", show_progress);
 
     for package in packages {
@@ -827,12 +829,13 @@ mod tests {
     #[test]
     fn analysis_propagates_query_failures() {
         let mut compiler = Compiler::default();
-        let id = compiler.files.insert("file:///Main.purs", "module Main where\n");
+        let file_id = compiler.files.insert("file:///Main.purs", "module Main where\n");
 
         assert!(matches!(
-            analyse_module(&compiler.engine, id),
-            Err(DocsError::QueryError(building::QueryError::MissingContent { file_id }))
-                if file_id == id
+            analyse_module(&compiler.engine, file_id),
+            Err(DocsError::QueryError(building::QueryError::MissingContent {
+                file_id: missing_file_id
+            })) if missing_file_id == file_id
         ));
     }
 }

--- a/compiler-bin/src/docs.rs
+++ b/compiler-bin/src/docs.rs
@@ -3,33 +3,26 @@ mod location;
 
 use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
+use std::time::Instant;
 use std::{env, fs, process};
 
 use building::{QueryEngine, prim};
 use documentation::schema::Location;
 use files::{FileId, Files};
+use indicatif::MultiProgress;
 use itertools::Itertools;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use serde::Deserialize;
 
 use crate::docs::error::DocsError;
 use crate::docs::location::{manifest_location, package_reference_location};
-use crate::walk;
-
-macro_rules! warm_modules {
-    ($engine:expr, $modules:expr, $query:ident) => {
-        $modules.par_iter().try_for_each(|&id| {
-            let engine = $engine.snapshot();
-            let _ = engine.$query(id)?;
-            Ok::<(), DocsError>(())
-        })
-    };
-}
+use crate::{progress, walk};
 
 pub struct DocsConfig {
     pub output: PathBuf,
     pub spago_project: Option<PathBuf>,
     pub packages: Vec<PathBuf>,
+    pub quiet: bool,
 }
 
 pub struct TypeScriptConfig {
@@ -71,6 +64,11 @@ struct Package {
     dependencies: BTreeMap<String, String>,
     location: Option<Location>,
     modules: Vec<FileId>,
+}
+
+struct RenderedPackage {
+    manifest: documentation::schema::Package,
+    modules: Vec<documentation::schema::Module>,
 }
 
 #[derive(Debug, Default)]
@@ -122,27 +120,23 @@ enum PursLocation {
 }
 
 fn generate_documentation(config: DocsConfig) -> Result<(), DocsError> {
+    let started = Instant::now();
+    let show_progress = !config.quiet;
+    let preparation_progress = progress::bar(1, "Preparing", show_progress);
     let mut compiler = Compiler::default();
     prim::configure(&mut compiler.engine, &mut compiler.files);
 
     let packages = load_packages(&config, &mut compiler)?;
     let modules = package_modules(&packages);
+    preparation_progress.inc(1);
+    progress::finish(&preparation_progress);
 
-    warm_documentation_queries(&compiler.engine, &modules)?;
+    prepare_documentation_queries(&compiler.engine, &modules, show_progress)?;
+    let rendered = render_documentation(&compiler.engine, &packages, show_progress)?;
+    write_documentation(&config.output, &rendered, show_progress)?;
 
-    if config.output.exists() {
-        fs::remove_dir_all(&config.output)?;
-    }
-
-    write_packages_manifest(&compiler.engine, &config, &packages)?;
-
-    let package_by_file = packages
-        .iter()
-        .flat_map(|package| package.modules.iter().map(|&id| (id, package.name.as_str())))
-        .collect_vec();
-
-    for package in &packages {
-        generate_package_documentation(&config, &mut compiler, package, &package_by_file)?;
+    if show_progress {
+        progress::report_completion(started.elapsed());
     }
 
     Ok(())
@@ -152,17 +146,57 @@ fn package_modules(packages: &[Package]) -> Vec<FileId> {
     packages.iter().flat_map(|package| package.modules.iter().copied()).collect_vec()
 }
 
-fn warm_documentation_queries(engine: &QueryEngine, modules: &[FileId]) -> Result<(), DocsError> {
-    warm_modules!(engine, modules, indexed)?;
-    warm_modules!(engine, modules, resolved)?;
-    warm_modules!(engine, modules, lowered)?;
-    warm_modules!(engine, modules, grouped)?;
-    warm_modules!(engine, modules, bracketed)?;
-    warm_modules!(engine, modules, sectioned)?;
-    warm_modules!(engine, modules, checked)?;
-    warm_modules!(engine, modules, documented)?;
+fn prepare_documentation_queries(
+    engine: &QueryEngine,
+    modules: &[FileId],
+    show_progress: bool,
+) -> Result<(), DocsError> {
+    let progress = MultiProgress::new();
+    progress.set_move_cursor(true);
+    let analysing_progress = progress::phase(&progress, modules.len(), "Analyse", show_progress);
+    let elaborating_progress =
+        progress::phase(&progress, modules.len(), "Elaborate", show_progress);
+
+    let analysed = modules.par_iter().map(|&id| {
+        let engine = engine.snapshot();
+        let module_name = analyse_module(&engine, id)?;
+        if let Some(module_name) = &module_name {
+            progress::set_message(&analysing_progress, module_name);
+        }
+        analysing_progress.inc(1);
+        Ok::<_, DocsError>(module_name)
+    });
+    let module_names = analysed.collect::<Result<Vec<_>, _>>()?;
+    progress::finish(&analysing_progress);
+
+    let elaborated = modules.par_iter().zip(&module_names).map(|(&id, module_name)| {
+        let engine = engine.snapshot();
+        if let Some(module_name) = module_name {
+            progress::set_message(&elaborating_progress, module_name);
+        }
+        engine.checked(id)?;
+        elaborating_progress.inc(1);
+        Ok::<_, DocsError>(())
+    });
+    elaborated.collect::<Result<Vec<_>, _>>()?;
+    progress::finish(&elaborating_progress);
 
     Ok(())
+}
+
+fn analyse_module(engine: &QueryEngine, id: FileId) -> Result<Option<String>, DocsError> {
+    let content = engine.content(id)?;
+    let (parsed, _) = engine.parsed(id)?;
+    let module_name = parsed.module_name(&content).map(|name| name.to_string());
+
+    engine.indexed(id)?;
+    engine.resolved(id)?;
+    engine.lowered(id)?;
+    engine.grouped(id)?;
+    engine.bracketed(id)?;
+    engine.sectioned(id)?;
+
+    Ok(module_name)
 }
 
 fn load_packages(config: &DocsConfig, compiler: &mut Compiler) -> Result<Vec<Package>, DocsError> {
@@ -374,11 +408,19 @@ fn package_version(reference: &spago::PackageReference) -> String {
     }
 }
 
-fn write_packages_manifest(
+fn render_documentation(
     engine: &QueryEngine,
-    config: &DocsConfig,
     packages: &[Package],
-) -> Result<(), DocsError> {
+    show_progress: bool,
+) -> Result<Vec<RenderedPackage>, DocsError> {
+    let package_by_file = packages
+        .iter()
+        .flat_map(|package| package.modules.iter().map(|&id| (id, package.name.as_str())))
+        .collect_vec();
+    let module_count = packages.iter().map(|package| package.modules.len()).sum();
+    let progress = progress::bar(module_count, "Document", show_progress);
+
+    let mut rendered = vec![];
     for package in packages {
         let package_input = documentation::PackageInput {
             name: &package.name,
@@ -389,39 +431,61 @@ fn write_packages_manifest(
             location: package.location.as_ref(),
             modules: &package.modules,
         };
-        let package = documentation::render_package_manifest(engine, &package_input)?;
+        let manifest = documentation::render_package_manifest(engine, &package_input)?;
 
-        let package_folder = config.output.join(&package.name);
-        fs::create_dir_all(&package_folder)?;
+        progress::set_message(&progress, &package.name);
+        let modules = package.modules.par_iter().map(|&id| {
+            let engine = engine.snapshot();
+            let module = documentation::render_module(&engine, id, &package_by_file)?;
+            if let Some(module) = &module {
+                progress::set_message(&progress, &module.name);
+            }
+            progress.inc(1);
+            Ok::<_, DocsError>(module)
+        });
+        let modules = modules.collect::<Result<Vec<_>, _>>()?;
+        let modules = modules.into_iter().flatten().collect_vec();
 
-        let manifest = package_folder.join("manifest.json");
-        let package = serde_json::to_string(&package)?;
-        fs::write(manifest, package)?;
+        rendered.push(RenderedPackage { manifest, modules });
     }
+    progress::finish(&progress);
 
-    Ok(())
+    Ok(rendered)
 }
 
-fn generate_package_documentation(
-    config: &DocsConfig,
-    compiler: &mut Compiler,
-    package: &Package,
-    package_by_file: &[(FileId, &str)],
+fn write_documentation(
+    output: &Path,
+    packages: &[RenderedPackage],
+    show_progress: bool,
 ) -> Result<(), DocsError> {
-    let modules_folder = config.output.join(&package.name).join("modules");
-    fs::create_dir_all(&modules_folder)?;
-
-    for &id in &package.modules {
-        let Some(module) = documentation::render_module(&compiler.engine, id, package_by_file)?
-        else {
-            continue;
-        };
-
-        let module_file = modules_folder.join(format!("{}.json", module.name));
-        let module = serde_json::to_string_pretty(&module)?;
-
-        fs::write(module_file, module)?;
+    if output.exists() {
+        fs::remove_dir_all(output)?;
     }
+
+    let file_count = packages.iter().map(|package| package.modules.len() + 1).sum();
+    let progress = progress::bar(file_count, "Output", show_progress);
+
+    for package in packages {
+        let package_folder = output.join(&package.manifest.name);
+        let modules_folder = package_folder.join("modules");
+        fs::create_dir_all(&modules_folder)?;
+
+        progress::set_message(&progress, &package.manifest.name);
+        let manifest_file = package_folder.join("manifest.json");
+        let manifest = serde_json::to_string(&package.manifest)?;
+        fs::write(manifest_file, manifest)?;
+        progress.inc(1);
+
+        for module in &package.modules {
+            progress::set_message(&progress, &module.name);
+            let module_file = modules_folder.join(format!("{}.json", module.name));
+            let module = serde_json::to_string_pretty(module)?;
+
+            fs::write(module_file, module)?;
+            progress.inc(1);
+        }
+    }
+    progress::finish(&progress);
 
     Ok(())
 }
@@ -730,6 +794,7 @@ mod tests {
             output: output.clone(),
             spago_project: None,
             packages: vec![package],
+            quiet: true,
         })
         .unwrap();
 
@@ -757,5 +822,17 @@ mod tests {
         ));
 
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn analysis_propagates_query_failures() {
+        let mut compiler = Compiler::default();
+        let id = compiler.files.insert("file:///Main.purs", "module Main where\n");
+
+        assert!(matches!(
+            analyse_module(&compiler.engine, id),
+            Err(DocsError::QueryError(building::QueryError::MissingContent { file_id }))
+                if file_id == id
+        ));
     }
 }

--- a/compiler-bin/src/lib.rs
+++ b/compiler-bin/src/lib.rs
@@ -80,6 +80,7 @@ pub fn run() {
                         output: options.output,
                         spago_project: options.spago_project,
                         packages: options.packages,
+                        quiet: options.quiet,
                     });
                 }
             }

--- a/compiler-bin/src/lib.rs
+++ b/compiler-bin/src/lib.rs
@@ -7,6 +7,7 @@ pub mod compile;
 pub mod docs;
 pub mod logging;
 pub mod lsp;
+mod progress;
 pub mod walk;
 mod watch;
 

--- a/compiler-bin/src/progress.rs
+++ b/compiler-bin/src/progress.rs
@@ -1,0 +1,96 @@
+use std::fmt;
+use std::io::{self, IsTerminal};
+use std::time::{Duration, Instant};
+
+use console::{Color, Style};
+use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
+
+const CARGO_PROGRESS_REGION_WIDTH: usize = 50;
+const CARGO_PROGRESS_FIXED_OVERHEAD: usize = 17;
+const SHIMMER_FRAME_INTERVAL: Duration = Duration::from_millis(80);
+
+pub(crate) fn bar(total: usize, phase: &'static str, show: bool) -> ProgressBar {
+    let progress = if show { ProgressBar::new(total as u64) } else { ProgressBar::hidden() };
+    configure(&progress, phase);
+    progress
+}
+
+pub(crate) fn phase(
+    progress: &MultiProgress,
+    total: usize,
+    phase: &'static str,
+    show: bool,
+) -> ProgressBar {
+    if !show {
+        return ProgressBar::hidden();
+    }
+    let phase_progress = progress.add(ProgressBar::new(total as u64));
+    configure(&phase_progress, phase);
+    phase_progress
+}
+
+pub(crate) fn set_message(progress: &ProgressBar, message: &str) {
+    progress.set_message(message.to_string());
+}
+
+pub(crate) fn finish(progress: &ProgressBar) {
+    progress.set_message("");
+    progress.finish();
+}
+
+pub(crate) fn report_completion(elapsed: Duration) {
+    if !io::stderr().is_terminal() {
+        return;
+    }
+
+    let label = format!("{:>12}", "Finished");
+    let style = Style::new().green().bold();
+    let jobs = rayon::current_num_threads();
+    let job_label = if jobs == 1 { "job" } else { "jobs" };
+    eprintln!("{} in {elapsed:.2?} via {jobs} {job_label}", style.apply_to(label));
+}
+
+fn configure(progress: &ProgressBar, phase: &'static str) {
+    let started = Instant::now();
+    let characters = phase.chars().collect::<Vec<_>>();
+    let cycle = characters.len() + 4;
+    let total = progress.length().unwrap_or_default();
+    let count_width = total.to_string().len().max(4);
+    let statistics_width = count_width * 2 + 2;
+    let bar_width = CARGO_PROGRESS_REGION_WIDTH
+        .saturating_sub(CARGO_PROGRESS_FIXED_OVERHEAD + statistics_width)
+        .max(1);
+    let phase_text = move |state: &ProgressState, writer: &mut dyn fmt::Write| {
+        if state.is_finished() {
+            let style = Style::new().fg(Color::TrueColor(255, 255, 255));
+            write!(writer, "{}", style.apply_to(phase))
+                .expect("writing to a formatter cannot fail");
+            return;
+        }
+
+        let frame =
+            (started.elapsed().as_millis() / SHIMMER_FRAME_INTERVAL.as_millis()) as usize % cycle;
+        let highlight = frame as isize - 2;
+        for (index, character) in characters.iter().enumerate() {
+            let distance = (index as isize - highlight).unsigned_abs();
+            let intensity = match distance {
+                0 => 255,
+                1 => 210,
+                2 => 155,
+                3 => 115,
+                _ => 90,
+            };
+            let style = Style::new().fg(Color::TrueColor(intensity, intensity, intensity));
+            write!(writer, "{}", style.apply_to(character))
+                .expect("writing to a formatter cannot fail");
+        }
+    };
+    let template =
+        format!("{{phase:>12}} [{{bar:{bar_width}.cyan/blue}}] {{pos:>4}}/{{len:4}} {{msg}}");
+    let style = ProgressStyle::with_template(&template)
+        .expect("progress bar template is valid")
+        .with_key("phase", phase_text)
+        .progress_chars("=> ");
+    progress.set_style(style);
+    progress.enable_steady_tick(SHIMMER_FRAME_INTERVAL);
+}


### PR DESCRIPTION
## Summary

- extract compile's Cargo-like progress rendering into a shared terminal module without changing compile behavior
- report docs preparation, analysis, elaboration, rendering, output, and completion progress
- add `-q`/`--quiet` to docs while preserving errors, and separate documentation rendering from filesystem output
- keep query errors explicit and covered by a focused regression test

## Validation

- `just format`
- `cargo check -p purescript-alexandrite --tests`
- `cargo nextest run -p purescript-alexandrite` (57 passed)
- `just t docs` (all passed, no pending snapshots)
- manually verified normal PTY output includes Preparing, Analyse, Elaborate, Render, Output, and Finished
- manually verified quiet success has empty stdout/stderr, generated output is identical, and quiet failures still print errors

Stacked on #428; base branch: `compiler-bin/watch-mode`.
