### PR TITLE
[compiler-bin] Add package support to compile

### DIFF
--- a/compiler-bin/src/cli.rs
+++ b/compiler-bin/src/cli.rs
@@ -94,6 +94,19 @@ pub struct CompileOptions {
     #[command(flatten)]
     pub build: BuildOptions,
 
+    /// Package folder to compile.
+    #[arg(
+        id = "package",
+        long = "package",
+        value_name("DIR"),
+        value_parser = absolute_path_parser()
+    )]
+    pub packages: Vec<PathBuf>,
+
+    /// PureScript source paths or glob patterns.
+    #[arg(value_name("INPUT"), required_unless_present("package"))]
+    pub inputs: Vec<PathBuf>,
+
     /// Code generation targets requested by build tools.
     #[arg(long, value_name("TARGETS"))]
     pub codegen: Option<String>,
@@ -109,6 +122,10 @@ pub struct CompileOptions {
 pub struct WatchOptions {
     #[command(flatten)]
     pub build: BuildOptions,
+
+    /// PureScript source paths or glob patterns.
+    #[arg(value_name("INPUT"), required = true)]
+    pub inputs: Vec<PathBuf>,
 }
 
 #[derive(Debug, Args)]
@@ -127,10 +144,6 @@ pub struct BuildOptions {
     /// When to use colors in human-readable diagnostics.
     #[arg(long, value_enum, default_value_t = ColorChoice::Auto)]
     pub color: ColorChoice,
-
-    /// PureScript source paths or glob patterns.
-    #[arg(value_name("INPUT"), required = true)]
-    pub inputs: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -240,6 +253,12 @@ mod tests {
         }
     }
 
+    fn compile_error_kind(args: &[&str]) -> ErrorKind {
+        let mut argv = vec!["alexandrite", "compile"];
+        argv.extend(args);
+        Cli::try_parse_from(argv).unwrap_err().kind()
+    }
+
     fn watch(args: &[&str]) -> WatchOptions {
         let mut argv = vec!["alexandrite", "watch"];
         argv.extend(args);
@@ -298,7 +317,7 @@ mod tests {
         assert!(options.build.quiet);
         assert_eq!(options.build.color, ColorChoice::Always);
         assert_eq!(
-            options.build.inputs,
+            options.inputs,
             vec![
                 PathBuf::from("src/**/*.purs"),
                 PathBuf::from(".spago/p/prelude-6.0.2/src/**/*.purs"),
@@ -313,7 +332,28 @@ mod tests {
         assert_eq!(options.build.output, current_directory_path("dist"));
         assert!(options.build.quiet);
         assert_eq!(options.build.color, ColorChoice::Never);
-        assert_eq!(options.build.inputs, vec![PathBuf::from("src/**/*.purs")]);
+        assert_eq!(options.inputs, vec![PathBuf::from("src/**/*.purs")]);
+    }
+
+    #[test]
+    fn compile_accepts_package_folders_without_inputs() {
+        let options =
+            compile(&["--package", "packages/effect", "--package", "packages/prelude", "--quiet"]);
+
+        assert_eq!(
+            options.packages,
+            vec![
+                current_directory_path("packages/effect"),
+                current_directory_path("packages/prelude"),
+            ]
+        );
+        assert!(options.inputs.is_empty());
+        assert!(options.build.quiet);
+    }
+
+    #[test]
+    fn compile_requires_inputs_or_a_package() {
+        insta::assert_debug_snapshot!(compile_error_kind(&[]), @"MissingRequiredArgument");
     }
 
     #[test]

--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -15,11 +15,12 @@ use url::Url;
 
 use crate::cli::ColorChoice;
 use crate::compilation::CompilationState;
-use crate::{progress, walk};
+use crate::{package, progress, walk};
 
 pub struct CompileConfig {
     pub output: PathBuf,
     pub inputs: Vec<PathBuf>,
+    pub packages: Vec<PathBuf>,
     pub json_errors: bool,
     pub quiet: bool,
     pub color: ColorChoice,
@@ -46,6 +47,8 @@ pub(crate) enum CompileError {
     InvalidPath(PathBuf),
     #[error(transparent)]
     Io(#[from] io::Error),
+    #[error(transparent)]
+    Package(#[from] package::PackageError),
     #[error(transparent)]
     Query(#[from] QueryError),
     #[error(transparent)]
@@ -85,9 +88,14 @@ fn compile(config: CompileConfig) -> Result<(), CompileError> {
     let current_directory = std::env::current_dir()?;
     let walked = walk::walk(&current_directory, &config.inputs)?;
 
+    let mut source_paths = walked.files.into_iter().collect::<BTreeSet<_>>();
+    for package in &config.packages {
+        source_paths.extend(package::source_files(&current_directory, package)?);
+    }
+
     let mut compilation = CompilationState::new();
 
-    for path in walked.files {
+    for path in source_paths {
         load_source(&mut compilation, &path)?;
     }
     let source_ids = compilation.input_source_ids();

--- a/compiler-bin/src/docs.rs
+++ b/compiler-bin/src/docs.rs
@@ -16,7 +16,7 @@ use serde::Deserialize;
 
 use crate::docs::error::DocsError;
 use crate::docs::location::{manifest_location, package_reference_location};
-use crate::{progress, walk};
+use crate::{package, progress};
 
 pub struct DocsConfig {
     pub output: PathBuf,
@@ -274,15 +274,13 @@ fn load_package_from_folder(
     location: Option<Location>,
 ) -> Result<Package, DocsError> {
     let package_root = root.join(path);
-    if !package_root.is_dir() {
-        return Err(DocsError::MissingPackageFolder(package_root));
-    }
-
     let metadata = load_package_metadata(&package_root)?;
-    let includes = package_include_globs(path, &metadata)?;
-    let excludes = package_exclude_globs(path, &metadata)?;
-
-    let walk::Walk { files, .. } = walk::walk_filtered(root, includes, excludes)?;
+    let files = package::source_files_with_globs(
+        root,
+        path,
+        &metadata.include_files,
+        &metadata.exclude_files,
+    )?;
 
     let name = metadata.name.or(name).unwrap_or_else(|| fallback_package_name(path));
     validate_package_name(&name)?;
@@ -324,35 +322,6 @@ fn load_package_metadata(package_root: &Path) -> Result<PackageMetadata, DocsErr
     })
 }
 
-fn package_include_globs(
-    package_root: &Path,
-    metadata: &PackageMetadata,
-) -> Result<Vec<PathBuf>, DocsError> {
-    let mut includes =
-        vec![package_root.join("src/**/*.purs"), package_root.join("test/**/*.purs")];
-
-    for path in &metadata.include_files {
-        validate_package_glob(path)?;
-        includes.push(package_root.join(path));
-    }
-
-    Ok(includes)
-}
-
-fn package_exclude_globs(
-    package_root: &Path,
-    metadata: &PackageMetadata,
-) -> Result<Vec<PathBuf>, DocsError> {
-    let mut excludes = vec![];
-
-    for path in &metadata.exclude_files {
-        validate_package_glob(path)?;
-        excludes.push(package_root.join(path));
-    }
-
-    Ok(excludes)
-}
-
 fn fallback_package_name(path: &Path) -> String {
     path.file_name()
         .and_then(|name| name.to_str())
@@ -369,14 +338,6 @@ fn validate_package_name(name: &str) -> Result<(), DocsError> {
     Ok(())
 }
 
-fn validate_package_glob(path: &str) -> Result<(), DocsError> {
-    if !is_package_relative_path(path) {
-        return Err(DocsError::InvalidPackageGlob(path.to_owned()));
-    }
-
-    Ok(())
-}
-
 fn is_single_path_segment(path: &str) -> bool {
     if path.contains('/') || path.contains('\\') {
         return false;
@@ -387,17 +348,6 @@ fn is_single_path_segment(path: &str) -> bool {
     let extra_component = components.next();
 
     matches!(first_component, Some(Component::Normal(_))) && extra_component.is_none()
-}
-
-fn is_package_relative_path(path: &str) -> bool {
-    !path.is_empty() && Path::new(path).components().all(is_package_relative_component)
-}
-
-fn is_package_relative_component(component: Component<'_>) -> bool {
-    match component {
-        Component::Normal(_) | Component::CurDir => true,
-        Component::Prefix(_) | Component::RootDir | Component::ParentDir => false,
-    }
 }
 
 fn package_version(reference: &spago::PackageReference) -> String {
@@ -701,57 +651,6 @@ mod tests {
     }
 
     #[test]
-    fn package_globs_are_relative_to_the_package_root() {
-        let metadata = PackageMetadata {
-            include_files: vec!["examples/**/*.purs".to_owned()],
-            exclude_files: vec!["test/Excluded.purs".to_owned()],
-            ..PackageMetadata::default()
-        };
-
-        let includes = package_include_globs(Path::new("packages/effect"), &metadata).unwrap();
-        let excludes = package_exclude_globs(Path::new("packages/effect"), &metadata).unwrap();
-
-        insta::assert_debug_snapshot!(
-            (includes, excludes),
-            @r#"
-        (
-            [
-                "packages/effect/src/**/*.purs",
-                "packages/effect/test/**/*.purs",
-                "packages/effect/examples/**/*.purs",
-            ],
-            [
-                "packages/effect/test/Excluded.purs",
-            ],
-        )
-        "#
-        );
-    }
-
-    #[test]
-    fn package_globs_reject_paths_outside_the_package_root() {
-        let metadata = PackageMetadata {
-            include_files: vec!["../Outside.purs".to_owned()],
-            ..PackageMetadata::default()
-        };
-
-        assert!(matches!(
-            package_include_globs(Path::new("packages/effect"), &metadata),
-            Err(DocsError::InvalidPackageGlob(_))
-        ));
-
-        let metadata = PackageMetadata {
-            exclude_files: vec!["/Outside.purs".to_owned()],
-            ..PackageMetadata::default()
-        };
-
-        assert!(matches!(
-            package_exclude_globs(Path::new("packages/effect"), &metadata),
-            Err(DocsError::InvalidPackageGlob(_))
-        ));
-    }
-
-    #[test]
     fn package_names_must_be_single_path_segments() {
         assert!(validate_package_name("effect").is_ok());
         assert!(matches!(
@@ -772,7 +671,7 @@ mod tests {
 
         assert!(matches!(
             load_package_from_folder(&mut compiler, &root, Path::new("missing"), None, None, None),
-            Err(DocsError::MissingPackageFolder(_))
+            Err(DocsError::PackageError(package::PackageError::MissingFolder(_)))
         ));
 
         fs::remove_dir_all(root).unwrap();

--- a/compiler-bin/src/docs/error.rs
+++ b/compiler-bin/src/docs/error.rs
@@ -5,7 +5,7 @@ use building::QueryError;
 use documentation::Error as DocumentationError;
 use thiserror::Error;
 
-use crate::walk;
+use crate::package;
 
 #[derive(Error, Debug)]
 pub enum DocsError {
@@ -15,20 +15,16 @@ pub enum DocsError {
     DocumentationError(#[from] DocumentationError),
     #[error("Duplicate module name: {0}")]
     DuplicateModuleName(String),
-    #[error("Invalid package glob: {0}")]
-    InvalidPackageGlob(String),
     #[error("Invalid package name: {0}")]
     InvalidPackageName(String),
-    #[error("Missing package folder: {0}")]
-    MissingPackageFolder(PathBuf),
     #[error("Failed to parse file {0}")]
     PathParseFail(PathBuf),
     #[error("IoError: {0}")]
     IoError(#[from] io::Error),
     #[error("GlobSetError: {0}")]
     GlobSetError(#[from] globset::Error),
-    #[error("WalkError: {0}")]
-    WalkError(#[from] walk::Error),
+    #[error(transparent)]
+    PackageError(#[from] package::PackageError),
     #[error("JsonError: {0}")]
     JsonError(#[from] serde_json::Error),
     #[error("SpagoLockError: {0}")]

--- a/compiler-bin/src/lib.rs
+++ b/compiler-bin/src/lib.rs
@@ -7,6 +7,7 @@ pub mod compile;
 pub mod docs;
 pub mod logging;
 pub mod lsp;
+mod package;
 mod progress;
 pub mod walk;
 mod watch;
@@ -44,7 +45,8 @@ pub fn run() {
             });
             compile::start(compile::CompileConfig {
                 output: options.build.output,
-                inputs: options.build.inputs,
+                inputs: options.inputs,
+                packages: options.packages,
                 json_errors: options.json_errors,
                 quiet: options.build.quiet,
                 color: options.build.color,
@@ -59,7 +61,7 @@ pub fn run() {
             });
             watch::start(watch::WatchConfig {
                 output: options.build.output,
-                inputs: options.build.inputs,
+                inputs: options.inputs,
                 quiet: options.build.quiet,
                 color: options.build.color,
             });

--- a/compiler-bin/src/package.rs
+++ b/compiler-bin/src/package.rs
@@ -1,0 +1,155 @@
+use std::path::{Component, Path, PathBuf};
+use std::{fs, io};
+
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::walk;
+
+#[derive(Debug, Error)]
+pub enum PackageError {
+    #[error("invalid package glob: {0}")]
+    InvalidGlob(String),
+    #[error("missing package folder: {0}")]
+    MissingFolder(PathBuf),
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Walk(#[from] walk::Error),
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PackageSources {
+    #[serde(default)]
+    include_files: Vec<String>,
+    #[serde(default)]
+    exclude_files: Vec<String>,
+}
+
+pub fn source_files(root: &Path, package: &Path) -> Result<Vec<PathBuf>, PackageError> {
+    let package_root = root.join(package);
+    if !package_root.is_dir() {
+        return Err(PackageError::MissingFolder(package_root));
+    }
+
+    let manifest = package_root.join("purs.json");
+    let sources = if manifest.exists() {
+        let manifest = fs::read_to_string(manifest)?;
+        serde_json::from_str(&manifest)?
+    } else {
+        PackageSources::default()
+    };
+
+    source_files_with_globs(root, package, &sources.include_files, &sources.exclude_files)
+}
+
+pub fn source_files_with_globs(
+    root: &Path,
+    package: &Path,
+    include_files: &[String],
+    exclude_files: &[String],
+) -> Result<Vec<PathBuf>, PackageError> {
+    let package_root = root.join(package);
+    if !package_root.is_dir() {
+        return Err(PackageError::MissingFolder(package_root));
+    }
+
+    let mut includes = vec![package.join("src/**/*.purs"), package.join("test/**/*.purs")];
+    for path in include_files {
+        validate_package_glob(path)?;
+        includes.push(package.join(path));
+    }
+
+    let mut excludes = vec![];
+    for path in exclude_files {
+        validate_package_glob(path)?;
+        excludes.push(package.join(path));
+    }
+
+    let walked = walk::walk_filtered(root, includes, excludes)?;
+    Ok(walked.files)
+}
+
+fn validate_package_glob(path: &str) -> Result<(), PackageError> {
+    let valid = !path.is_empty() && Path::new(path).components().all(is_package_relative_component);
+    if !valid {
+        return Err(PackageError::InvalidGlob(path.to_owned()));
+    }
+
+    Ok(())
+}
+
+fn is_package_relative_component(component: Component<'_>) -> bool {
+    match component {
+        Component::Normal(_) | Component::CurDir => true,
+        Component::Prefix(_) | Component::RootDir | Component::ParentDir => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temporary_directory() -> PathBuf {
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let directory = std::env::temp_dir().join(format!("alexandrite-package-{nanos}"));
+        fs::create_dir_all(&directory).unwrap();
+        directory
+    }
+
+    fn touch(path: &Path) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, "").unwrap();
+    }
+
+    #[test]
+    fn manifest_globs_extend_and_filter_package_sources() {
+        let root = temporary_directory();
+        let package = root.join("effect");
+        touch(&package.join("src/Main.purs"));
+        touch(&package.join("test/Test.Main.purs"));
+        touch(&package.join("test/Excluded.purs"));
+        touch(&package.join("examples/Example.purs"));
+        fs::write(
+            package.join("purs.json"),
+            r#"{
+              "includeFiles": ["examples/**/*.purs"],
+              "excludeFiles": ["test/Excluded.purs"]
+            }"#,
+        )
+        .unwrap();
+
+        let files = source_files(&root, Path::new("effect")).unwrap();
+        let files = files
+            .iter()
+            .map(|path| path.strip_prefix(&root).unwrap().to_string_lossy().to_string());
+        let files = files.collect::<Vec<_>>();
+
+        assert_eq!(
+            files,
+            ["effect/examples/Example.purs", "effect/src/Main.purs", "effect/test/Test.Main.purs"]
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn package_globs_reject_paths_outside_the_package_root() {
+        let root = temporary_directory();
+        fs::create_dir(root.join("effect")).unwrap();
+
+        let result = source_files_with_globs(
+            &root,
+            Path::new("effect"),
+            &["../Outside.purs".to_owned()],
+            &[],
+        );
+
+        assert!(matches!(result, Err(PackageError::InvalidGlob(_))));
+        fs::remove_dir_all(root).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

Add repeatable `--package DIR` arguments to `compile` so callers can compile package folders without constructing source globs themselves. Explicit source paths remain supported for Spago and can be combined with package folders.

Package compilation follows the same source-selection contract as documentation generation: `src/**/*.purs`, `test/**/*.purs`, and `purs.json` `includeFiles` entries are included, while `excludeFiles` entries are omitted. The shared package source discovery keeps the two commands in parity.

## Verification

- `cargo check -p purescript-alexandrite --tests`
- `cargo nextest run -p purescript-alexandrite`
- Compiled a temporary package through `compile --package` and confirmed it emitted `Main/index.js`