### PR TITLE
[backend] Support JSX foreign modules

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -48,36 +48,6 @@ jobs:
       - name: Run integration tests
         run: cargo nextest run -p tests-integration
 
-  compatibility_build_cache:
-    name: Package compatibility build cache
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          path: base
-
-      - name: Install Rust toolchain
-        run: rustup update stable && rustup default stable
-
-      - name: Cache compatibility build artifacts
-        uses: Swatinem/rust-cache@v2.9.1
-        with:
-          add-job-id-key: "false"
-          cache-bin: "false"
-          cache-workspace-crates: "true"
-          key: ${{ github.sha }}
-          prefix-key: "v2-compatibility-build"
-          workspaces: |
-            base -> ../compatibility-target
-
-      - name: Build compatibility verifier
-        run: >-
-          cargo build --release --manifest-path base/Cargo.toml
-          --target-dir compatibility-target -p tests-compatibility
-
   compatibility:
     name: Package compatibility
     if: github.event_name == 'pull_request'
@@ -100,18 +70,6 @@ jobs:
       - name: Install Rust toolchain
         run: rustup update stable && rustup default stable
 
-      - name: Cache compatibility build artifacts
-        uses: Swatinem/rust-cache@v2.9.1
-        with:
-          add-job-id-key: "false"
-          cache-bin: "false"
-          cache-workspace-crates: "true"
-          cache-on-failure: "true"
-          key: ${{ github.event.pull_request.base.sha }}
-          prefix-key: "v2-compatibility-build"
-          workspaces: |
-            base -> ../compatibility-target
-
       - name: Restore compatibility packages
         id: compatibility-package-cache
         uses: actions/cache/restore@v5
@@ -128,11 +86,11 @@ jobs:
         run: |
           mkdir -p compatibility-binaries
           cargo build --release --manifest-path base/Cargo.toml \
-            --target-dir compatibility-target -p tests-compatibility
-          cp compatibility-target/release/tests-compatibility compatibility-binaries/base
+            --target-dir compatibility-target/base -p tests-compatibility
+          cp compatibility-target/base/release/tests-compatibility compatibility-binaries/base
           cargo build --release --manifest-path candidate/Cargo.toml \
-            --target-dir compatibility-target -p tests-compatibility
-          cp compatibility-target/release/tests-compatibility compatibility-binaries/candidate
+            --target-dir compatibility-target/candidate -p tests-compatibility
+          cp compatibility-target/candidate/release/tests-compatibility compatibility-binaries/candidate
 
       - name: Prepare core and Acme corpus
         working-directory: candidate

--- a/compiler-backend/foreign-javascript/src/lib.rs
+++ b/compiler-backend/foreign-javascript/src/lib.rs
@@ -3,7 +3,7 @@ use std::iter;
 use std::sync::Arc;
 
 use building_types::QueryResult;
-use files::{FileId, ForeignFileId};
+use files::{FileId, ForeignFileCandidates, ForeignFileId, ForeignSourceKind};
 use indexing::{IndexedModule, IndexedTermItemKind, TermItemId};
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
@@ -25,6 +25,7 @@ pub struct ForeignValidation {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ForeignError {
     MissingModule { declaration: TermItemId, name: SmolStr },
+    AmbiguousModule { declaration: TermItemId },
     MissingImplementation { declaration: TermItemId, name: SmolStr },
     Parse { declaration: TermItemId, message: Arc<str> },
 }
@@ -35,9 +36,13 @@ pub trait ForeignQueries {
     fn foreign_validation(&self, id: FileId) -> QueryResult<Arc<ForeignValidation>>;
 }
 
-pub fn parse_module(content: &str) -> ForeignModule {
+pub fn parse_module(kind: ForeignSourceKind, content: &str) -> ForeignModule {
     let allocator = Allocator::default();
-    let parsed = Parser::new(&allocator, content, SourceType::mjs()).parse();
+    let source_type = match kind {
+        ForeignSourceKind::JavaScript => SourceType::mjs(),
+        ForeignSourceKind::Jsx => SourceType::jsx(),
+    };
+    let parsed = Parser::new(&allocator, content, source_type).parse();
 
     let errors = parsed.diagnostics.into_iter().map(|diagnostic| diagnostic.to_string().into());
     let errors: Arc<[_]> = errors.collect();
@@ -63,6 +68,7 @@ fn export_name(entry: &ExportEntry<'_>) -> Option<SmolStr> {
 
 pub fn validate_module(
     indexed: &IndexedModule,
+    candidates: ForeignFileCandidates,
     foreign: Option<&ForeignModule>,
 ) -> ForeignValidation {
     let declarations = indexed.items.iter_terms().filter_map(|(declaration, item)| {
@@ -75,6 +81,12 @@ pub fn validate_module(
     let declarations = declarations.collect::<Vec<_>>();
 
     let mut errors = Vec::new();
+    if candidates.count() > 1 {
+        if let Some((declaration, _)) = declarations.first() {
+            errors.push(ForeignError::AmbiguousModule { declaration: *declaration });
+        }
+        return ForeignValidation { errors: errors.into() };
+    }
     let Some(foreign) = foreign else {
         let missing_modules = declarations
             .into_iter()
@@ -106,4 +118,22 @@ pub fn validate_module(
     errors.extend(missing_implementations);
 
     ForeignValidation { errors: errors.into() }
+}
+
+#[cfg(test)]
+mod tests {
+    use files::ForeignSourceKind;
+
+    use super::parse_module;
+
+    #[test]
+    fn jsx_modules_are_parsed_with_jsx_syntax_enabled() {
+        let module = parse_module(
+            ForeignSourceKind::Jsx,
+            "export const component = <section>Hello</section>;",
+        );
+
+        assert!(module.errors.is_empty(), "{:#?}", module.errors);
+        assert!(module.exports.contains("component"));
+    }
 }

--- a/compiler-backend/javascript/src/convert.rs
+++ b/compiler-backend/javascript/src/convert.rs
@@ -11,12 +11,13 @@ use crate::error::ModuleResult;
 use crate::module::Module;
 
 pub fn convert_module(
-    queries: &impl functional::ExternalQueries,
+    queries: &impl crate::ExternalQueries,
     file_id: FileId,
 ) -> QueryResult<ModuleResult<Module>> {
     let functional = match queries.functional(file_id)? {
         Ok(functional) => functional,
         Err(error) => return Ok(Err(error.into())),
     };
-    Ok(generator::Generator::new(&functional).generate())
+    let foreign_file = queries.foreign_file(file_id)?;
+    Ok(generator::Generator::new(&functional, foreign_file.map(|file| file.kind())).generate())
 }

--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -8,7 +8,7 @@ mod tail_call;
 
 use std::sync::Arc;
 
-use files::FileId;
+use files::{FileId, ForeignSourceKind};
 use functional::tree::{
     Binding, CaseAlternative, Declaration, DeclarationKind, EffectExpression,
     ExpressionId as FunctionalExpressionId, ExpressionKind, Global, GlobalId, Guard,
@@ -45,12 +45,17 @@ pub(crate) struct Generator<'m> {
     global_names: FxHashMap<GlobalId, SmolStr>,
     external_module_namespaces: FxHashMap<FileId, SmolStr>,
     external_references: Vec<Global>,
-    foreign_namespace: Option<SmolStr>,
+    foreign_import: Option<ForeignImport>,
     runtime_namespace: Option<SmolStr>,
     lazy_global_names: FxHashMap<GlobalId, SmolStr>,
     global_tail_call_groups: Vec<TailCallGroup>,
     global_tail_call_group_positions: FxHashMap<GlobalId, usize>,
     reserved_module_names: Arc<FxHashSet<SmolStr>>,
+}
+
+struct ForeignImport {
+    namespace: SmolStr,
+    kind: ForeignSourceKind,
 }
 
 #[derive(Debug)]
@@ -241,7 +246,10 @@ impl<'a> Destination<'a> {
 }
 
 impl<'m> Generator<'m> {
-    pub(crate) fn new(module: &'m FunctionalModule) -> Generator<'m> {
+    pub(crate) fn new(
+        module: &'m FunctionalModule,
+        foreign_kind: Option<ForeignSourceKind>,
+    ) -> Generator<'m> {
         let mut allocator = NameAllocator::default();
         let mut global_names = FxHashMap::default();
         for declaration in module.declarations.iter() {
@@ -267,7 +275,10 @@ impl<'m> Generator<'m> {
             .declarations
             .iter()
             .any(|declaration| matches!(declaration.kind, DeclarationKind::Foreign));
-        let foreign_namespace = has_foreign.then(|| allocator.allocate("$foreign"));
+        let foreign_import = has_foreign.then(|| ForeignImport {
+            namespace: allocator.allocate("$foreign"),
+            kind: foreign_kind.unwrap_or(ForeignSourceKind::JavaScript),
+        });
         let lazy_globals = cyclic_instance_initializers(module);
         let requires_runtime = !lazy_globals.is_empty() || has_local_lazy_initializers(module);
         let runtime_namespace = requires_runtime.then(|| allocator.allocate("$runtime"));
@@ -314,7 +325,7 @@ impl<'m> Generator<'m> {
             global_names,
             external_module_namespaces,
             external_references,
-            foreign_namespace,
+            foreign_import,
             runtime_namespace,
             lazy_global_names,
             global_tail_call_groups,
@@ -341,7 +352,6 @@ impl<'m> Generator<'m> {
 
         let dependencies = self.module.dependencies.iter().map(|dependency| dependency.file_id);
         let dependencies = dependencies.collect_vec();
-        let requires_foreign = self.foreign_namespace.is_some();
         let requires_runtime = self.runtime_namespace.is_some();
         let source = writer.finish();
         Ok(Module::new(
@@ -349,7 +359,7 @@ impl<'m> Generator<'m> {
             self.module.name.to_string(),
             source,
             dependencies,
-            requires_foreign,
+            self.foreign_import.as_ref().map(|foreign_import| foreign_import.kind),
             requires_runtime,
         ))
     }
@@ -380,15 +390,16 @@ fn render_imports(renderer: &mut ModuleRenderer<'_, '_, '_, '_>) {
         let path = format!("../{}", module_filename(module_name));
         writer.import_namespace(namespace, &path);
     }
-    if let Some(namespace) = &generator.foreign_namespace {
-        writer.import_namespace(namespace, "./foreign.js");
+    if let Some(foreign_import) = &generator.foreign_import {
+        let path = format!("./foreign.{}", foreign_import.kind.extension());
+        writer.import_namespace(&foreign_import.namespace, &path);
     }
     if let Some(namespace) = &generator.runtime_namespace {
         let path = format!("../{}", runtime_filename());
         writer.import_namespace(namespace, &path);
     }
     if !generator.external_references.is_empty()
-        || generator.foreign_namespace.is_some()
+        || generator.foreign_import.is_some()
         || generator.runtime_namespace.is_some()
     {
         writer.blank();
@@ -938,7 +949,7 @@ impl Generator<'_> {
 
 fn render_foreign_declarations(renderer: &mut ModuleRenderer<'_, '_, '_, '_>) {
     let ModuleRenderer { generator, tree, writer } = renderer;
-    let Some(namespace) = &generator.foreign_namespace else {
+    let Some(foreign_import) = &generator.foreign_import else {
         return;
     };
     let mut rendered = false;
@@ -947,7 +958,7 @@ fn render_foreign_declarations(renderer: &mut ModuleRenderer<'_, '_, '_, '_>) {
             continue;
         }
         let name = generator.global_name(declaration.global.id);
-        let object = tree.identifier(namespace);
+        let object = tree.identifier(&foreign_import.namespace);
         let index = tree.string(declaration.global.item_name.as_str());
         let access = tree.index(object, index);
         let exported = generator.declaration_is_inline_exported(declaration);

--- a/compiler-backend/javascript/src/lib.rs
+++ b/compiler-backend/javascript/src/lib.rs
@@ -14,3 +14,10 @@ pub use error::{ModuleError, ModuleResult, UnsupportedState};
 pub use module::{
     Module, foreign_module_filename, module_filename, runtime_filename, runtime_source,
 };
+
+use building_types::QueryResult;
+use files::{FileId, ForeignFileId};
+
+pub trait ExternalQueries: functional::ExternalQueries {
+    fn foreign_file(&self, file_id: FileId) -> QueryResult<Option<ForeignFileId>>;
+}

--- a/compiler-backend/javascript/src/module.rs
+++ b/compiler-backend/javascript/src/module.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use files::FileId;
+use files::{FileId, ForeignSourceKind};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Module {
@@ -8,7 +8,7 @@ pub struct Module {
     name: Arc<str>,
     source: Arc<str>,
     dependencies: Arc<[FileId]>,
-    requires_foreign: bool,
+    foreign_kind: Option<ForeignSourceKind>,
     requires_runtime: bool,
 }
 
@@ -18,7 +18,7 @@ impl Module {
         name: String,
         source: String,
         dependencies: Vec<FileId>,
-        requires_foreign: bool,
+        foreign_kind: Option<ForeignSourceKind>,
         requires_runtime: bool,
     ) -> Module {
         Module {
@@ -26,7 +26,7 @@ impl Module {
             name: name.into(),
             source: source.into(),
             dependencies: dependencies.into(),
-            requires_foreign,
+            foreign_kind,
             requires_runtime,
         }
     }
@@ -44,7 +44,10 @@ impl Module {
     }
 
     pub fn foreign_filename(&self) -> String {
-        foreign_module_filename(&self.name)
+        let kind = self
+            .foreign_kind
+            .expect("invariant violated: module without foreign source has no foreign filename");
+        foreign_module_filename(&self.name, kind)
     }
 
     pub fn source(&self) -> &str {
@@ -56,7 +59,11 @@ impl Module {
     }
 
     pub fn requires_foreign(&self) -> bool {
-        self.requires_foreign
+        self.foreign_kind.is_some()
+    }
+
+    pub fn foreign_kind(&self) -> Option<ForeignSourceKind> {
+        self.foreign_kind
     }
 
     pub fn requires_runtime(&self) -> bool {
@@ -76,6 +83,6 @@ pub fn module_filename(module_name: &str) -> String {
     format!("{module_name}/index.js")
 }
 
-pub fn foreign_module_filename(module_name: &str) -> String {
-    format!("{module_name}/foreign.js")
+pub fn foreign_module_filename(module_name: &str, kind: ForeignSourceKind) -> String {
+    format!("{module_name}/foreign.{}", kind.extension())
 }

--- a/compiler-bin/src/compilation.rs
+++ b/compiler-bin/src/compilation.rs
@@ -4,7 +4,7 @@ use building::{
     DiskObservation, FileLifecycle, ForeignEvent, LifecycleChange, LifecycleEvent, QueryEngine,
     QueryError, SourceEvent, SourceUnitKey,
 };
-use files::FileId;
+use files::{FileId, ForeignSourceKind};
 use prim_constants::MODULE_MAP;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -60,9 +60,11 @@ impl CompilationState {
     pub fn observe_foreign(
         &mut self,
         unit: SourceUnitKey,
+        kind: ForeignSourceKind,
         disk: DiskObservation,
     ) -> LifecycleChange {
-        let event = LifecycleEvent::Foreign { unit, event: ForeignEvent::DiskObserved { disk } };
+        let event =
+            LifecycleEvent::Foreign { unit, kind, event: ForeignEvent::DiskObserved { disk } };
         self.files.apply(&self.engine, event)
     }
 
@@ -162,7 +164,7 @@ mod tests {
         let source_id = compilation.input_source_ids()[0];
 
         let content = DiskObservation::Found(Arc::from("export const value = 1;\n"));
-        let change = compilation.observe_foreign(unit, content);
+        let change = compilation.observe_foreign(unit, ForeignSourceKind::JavaScript, content);
 
         assert_eq!(change.changed_sources().collect::<Vec<_>>(), vec![source_id]);
         assert!(compilation.snapshot().foreign_file(source_id).is_some());

--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -153,13 +153,15 @@ pub(crate) fn load_source(
     let content = fs::read_to_string(path)?;
     compilation.observe_source(SourceUnitKey::clone(&unit), DiskObservation::Found(content.into()));
 
-    let disk = match fs::read_to_string(&foreign_path) {
-        Ok(content) => DiskObservation::Found(content.into()),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => DiskObservation::NotFound,
-        Err(error) => return Err(error.into()),
-    };
-
-    compilation.observe_foreign(unit, ForeignSourceKind::JavaScript, disk);
+    for kind in ForeignSourceKind::ALL {
+        let foreign_path = path.with_extension(kind.extension());
+        let disk = match fs::read_to_string(&foreign_path) {
+            Ok(content) => DiskObservation::Found(content.into()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => DiskObservation::NotFound,
+            Err(error) => return Err(error.into()),
+        };
+        compilation.observe_foreign(SourceUnitKey::clone(&unit), kind, disk);
+    }
     Ok(())
 }
 

--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -7,7 +7,7 @@ use std::{fs, io, process};
 
 use building::{DiskObservation, QueryError, SourceUnitKey};
 use diagnostics::Severity;
-use files::FileId;
+use files::{FileId, ForeignSourceKind};
 use indicatif::MultiProgress;
 use rayon::prelude::*;
 use thiserror::Error;
@@ -159,7 +159,7 @@ pub(crate) fn load_source(
         Err(error) => return Err(error.into()),
     };
 
-    compilation.observe_foreign(unit, disk);
+    compilation.observe_foreign(unit, ForeignSourceKind::JavaScript, disk);
     Ok(())
 }
 

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -27,7 +27,7 @@ use building::lifecycle::{
     AnalysisInvalidation, DiskObservation, DocumentKey, DocumentKind, FileLifecycle, ForeignEvent,
     LifecycleChange, LifecycleEvent, ReloadFailure, SourceEvent, SourceUnitKey,
 };
-use files::FileId;
+use files::{FileId, ForeignSourceKind};
 use itertools::Itertools;
 use lsp_types::notification::Notification;
 use lsp_types::request::Request;
@@ -349,6 +349,10 @@ fn file_watcher_registration() -> RegistrationParams {
                 glob_pattern: GlobPattern::String("**/*.js".to_string()),
                 kind: None,
             },
+            FileSystemWatcher {
+                glob_pattern: GlobPattern::String("**/*.jsx".to_string()),
+                kind: None,
+            },
         ],
     };
     let register_options = serde_json::to_value(options)
@@ -611,8 +615,9 @@ fn did_change(state: &mut State, p: DidChangeTextDocumentParams) -> Result<(), L
     };
     let (document, unit) = source_unit_from_document_uri(uri)?;
     let event = match document {
-        DocumentKind::Foreign => LifecycleEvent::Foreign {
+        DocumentKind::Foreign(kind) => LifecycleEvent::Foreign {
             unit,
+            kind,
             event: ForeignEvent::Changed {
                 text: Arc::from(content_change.text.as_str()),
                 version: p.text_document.version,
@@ -641,9 +646,10 @@ fn did_open(state: &mut State, p: DidOpenTextDocumentParams) -> Result<(), LspEr
     let (document, unit) = source_unit_from_document_uri(uri)?;
 
     let change = match document {
-        DocumentKind::Foreign => {
+        DocumentKind::Foreign(kind) => {
             let event = LifecycleEvent::Foreign {
                 unit,
+                kind,
                 event: ForeignEvent::Opened {
                     text: Arc::from(p.text_document.text.as_str()),
                     version: p.text_document.version,
@@ -680,8 +686,9 @@ fn did_close(state: &mut State, p: DidCloseTextDocumentParams) -> Result<(), Lsp
     let (document, unit) = source_unit_from_document_uri(&uri)?;
     let disk = observe_disk(&uri);
     let change = match document {
-        DocumentKind::Foreign => {
-            let event = LifecycleEvent::Foreign { unit, event: ForeignEvent::Closed { disk } };
+        DocumentKind::Foreign(kind) => {
+            let event =
+                LifecycleEvent::Foreign { unit, kind, event: ForeignEvent::Closed { disk } };
             apply_lifecycle_event(state, event)
         }
         DocumentKind::Source => {
@@ -720,8 +727,9 @@ fn did_change_watched_files(
     let mut foreign_units = FxHashSet::default();
     for change in p.changes {
         match document_kind(&change.uri) {
-            Some(DocumentKind::Foreign) => {
-                foreign_units.insert(source_unit_from_foreign_uri(&change.uri)?);
+            Some(DocumentKind::Foreign(kind)) => {
+                let unit = source_unit_from_foreign_uri(&change.uri)?;
+                foreign_units.insert((unit, kind));
             }
             Some(DocumentKind::Source) => {
                 source_units.insert(source_unit_from_source_uri(&change.uri)?);
@@ -752,24 +760,26 @@ fn did_change_watched_files(
         }
     }
 
-    for unit in foreign_units {
+    for (unit, kind) in foreign_units {
         if observed_foreign.contains(&unit) {
             continue;
         }
-        let document = DocumentKey::Foreign(SourceUnitKey::clone(&unit));
+        let document = DocumentKey::Foreign(SourceUnitKey::clone(&unit), kind);
         if state.files.read().is_open(&document) {
             continue;
         }
         let tracked = {
             let files = state.files.read();
-            files.source_id(unit.source()).is_some() || files.foreign_id(unit.foreign()).is_some()
+            files.source_id(unit.source()).is_some()
+                || files.foreign_id(unit.foreign_for(kind)).is_some()
         };
         if !tracked {
             continue;
         }
-        let uri = Url::parse(unit.foreign())?;
+        let uri = Url::parse(unit.foreign_for(kind))?;
         let event = LifecycleEvent::Foreign {
             unit,
+            kind,
             event: ForeignEvent::DiskObserved { disk: observe_disk(&uri) },
         };
         lifecycle_change.combine(apply_lifecycle_event(state, event));
@@ -782,7 +792,9 @@ fn did_change_watched_files(
 
 fn document_kind(uri: &Url) -> Option<DocumentKind> {
     if uri.path().ends_with(".js") {
-        Some(DocumentKind::Foreign)
+        Some(DocumentKind::Foreign(ForeignSourceKind::JavaScript))
+    } else if uri.path().ends_with(".jsx") {
+        Some(DocumentKind::Foreign(ForeignSourceKind::Jsx))
     } else if uri.path().ends_with(".purs") {
         Some(DocumentKind::Source)
     } else {
@@ -795,7 +807,7 @@ fn source_unit_from_document_uri(uri: &Url) -> Result<(DocumentKind, SourceUnitK
         document_kind(uri).ok_or_else(|| LspError::UnsupportedDocumentUri(Url::clone(uri)))?;
     let unit = match document {
         DocumentKind::Source => source_unit_from_source_uri(uri)?,
-        DocumentKind::Foreign => source_unit_from_foreign_uri(uri)?,
+        DocumentKind::Foreign(_) => source_unit_from_foreign_uri(uri)?,
     };
     Ok((document, unit))
 }
@@ -820,13 +832,18 @@ fn file_uri_with_extension(uri: &Url, extension: &str) -> Result<Url, LspError> 
 }
 
 fn source_unit_from_source_uri(source_uri: &Url) -> Result<SourceUnitKey, LspError> {
-    let foreign_uri = file_uri_with_extension(source_uri, "js")?;
-    Ok(SourceUnitKey::new(source_uri.as_str(), foreign_uri.as_str()))
+    let javascript_uri = file_uri_with_extension(source_uri, "js")?;
+    let jsx_uri = file_uri_with_extension(source_uri, "jsx")?;
+    Ok(SourceUnitKey::with_foreign_sources(
+        source_uri.as_str(),
+        javascript_uri.as_str(),
+        jsx_uri.as_str(),
+    ))
 }
 
 fn source_unit_from_foreign_uri(foreign_uri: &Url) -> Result<SourceUnitKey, LspError> {
     let source_uri = file_uri_with_extension(foreign_uri, "purs")?;
-    Ok(SourceUnitKey::new(source_uri.as_str(), foreign_uri.as_str()))
+    source_unit_from_source_uri(&source_uri)
 }
 
 fn emit_associated_diagnostics(state: &mut State, uri: Url) -> Result<(), LspError> {
@@ -864,16 +881,21 @@ fn observe_sibling_foreign(
     state: &mut State,
     unit: &SourceUnitKey,
 ) -> Result<LifecycleChange, LspError> {
-    let document = DocumentKey::Foreign(SourceUnitKey::clone(unit));
-    if state.files.read().is_open(&document) {
-        return Ok(LifecycleChange::default());
+    let mut change = LifecycleChange::default();
+    for kind in ForeignSourceKind::ALL {
+        let document = DocumentKey::Foreign(SourceUnitKey::clone(unit), kind);
+        if state.files.read().is_open(&document) {
+            continue;
+        }
+        let uri = Url::parse(unit.foreign_for(kind))?;
+        let event = LifecycleEvent::Foreign {
+            unit: SourceUnitKey::clone(unit),
+            kind,
+            event: ForeignEvent::DiskObserved { disk: observe_disk(&uri) },
+        };
+        change.combine(apply_lifecycle_event(state, event));
     }
-    let uri = Url::parse(unit.foreign())?;
-    let event = LifecycleEvent::Foreign {
-        unit: SourceUnitKey::clone(unit),
-        event: ForeignEvent::DiskObserved { disk: observe_disk(&uri) },
-    };
-    Ok(apply_lifecycle_event(state, event))
+    Ok(change)
 }
 
 fn observe_disk(uri: &Url) -> DiskObservation {

--- a/compiler-bin/src/lsp/tests.rs
+++ b/compiler-bin/src/lsp/tests.rs
@@ -7,6 +7,7 @@ use building::lifecycle::{
     ContentAuthority, DiskObservation, DocumentKind, ForeignEvent, LifecycleEvent, SourceEvent,
     SourceUnitKey,
 };
+use files::ForeignSourceKind;
 use lsp_types::{DidCloseTextDocumentParams, TextDocumentIdentifier, Url};
 use tempfile::tempdir;
 
@@ -45,6 +46,7 @@ fn assert_source_close_result(
         apply_lifecycle_event(&mut state, event);
         let event = LifecycleEvent::Foreign {
             unit: SourceUnitKey::clone(&unit),
+            kind: ForeignSourceKind::JavaScript,
             event: ForeignEvent::DiskObserved {
                 disk: DiskObservation::Found(Arc::from("export const life = 42;\n")),
             },
@@ -70,15 +72,20 @@ fn source_and_foreign_uris_produce_the_same_unit_key() {
     let directory = tempdir().unwrap();
     let source_path = directory.path().join("Source Files").join("Main.purs");
     let foreign_path = source_path.with_extension("js");
+    let jsx_path = source_path.with_extension("jsx");
     let source_uri = Url::from_file_path(source_path).unwrap();
     let foreign_uri = Url::from_file_path(foreign_path).unwrap();
+    let jsx_uri = Url::from_file_path(jsx_path).unwrap();
 
     let from_source = source_unit_from_source_uri(&source_uri).unwrap();
     let from_foreign = source_unit_from_foreign_uri(&foreign_uri).unwrap();
+    let from_jsx = source_unit_from_foreign_uri(&jsx_uri).unwrap();
 
     assert_eq!(from_source, from_foreign);
+    assert_eq!(from_source, from_jsx);
     assert_eq!(from_source.source(), source_uri.as_str());
     assert_eq!(from_source.foreign(), foreign_uri.as_str());
+    assert_eq!(from_source.foreign_for(ForeignSourceKind::Jsx), jsx_uri.as_str());
 }
 
 #[test]
@@ -106,10 +113,15 @@ fn non_file_document_uris_are_rejected() {
 fn document_kind_is_bounded_to_source_and_foreign_extensions() {
     let source_uri = Url::parse("file:///workspace/Main.purs").unwrap();
     let foreign_uri = Url::parse("file:///workspace/Main.js").unwrap();
+    let jsx_uri = Url::parse("file:///workspace/Main.jsx").unwrap();
     let unsupported_uri = Url::parse("file:///workspace/Main.json").unwrap();
 
     assert_eq!(document_kind(&source_uri), Some(DocumentKind::Source));
-    assert_eq!(document_kind(&foreign_uri), Some(DocumentKind::Foreign));
+    assert_eq!(
+        document_kind(&foreign_uri),
+        Some(DocumentKind::Foreign(ForeignSourceKind::JavaScript))
+    );
+    assert_eq!(document_kind(&jsx_uri), Some(DocumentKind::Foreign(ForeignSourceKind::Jsx)));
     assert_eq!(document_kind(&unsupported_uri), None);
     assert!(source_unit_from_document_uri(&unsupported_uri).is_err());
 }
@@ -160,6 +172,7 @@ fn duplicate_source_close_does_not_reconcile_foreign() {
         apply_lifecycle_event(&mut state, event);
         let event = LifecycleEvent::Foreign {
             unit: SourceUnitKey::clone(&unit),
+            kind: ForeignSourceKind::JavaScript,
             event: ForeignEvent::DiskObserved {
                 disk: DiskObservation::Found(Arc::from("export const life = 42;\n")),
             },

--- a/compiler-bin/src/watch.rs
+++ b/compiler-bin/src/watch.rs
@@ -6,6 +6,7 @@ use std::{fs, io, process};
 
 use building::{DiskObservation, LifecycleChange, QueryError, ReloadFailure, SourceUnitKey};
 use console::Style;
+use files::ForeignSourceKind;
 use itertools::Itertools;
 use notify::event::{CreateKind, ModifyKind, RemoveKind};
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
@@ -332,7 +333,11 @@ fn observe_source_unit(
     let source = observe_disk(source_path);
     let mut lifecycle = compilation.observe_source(SourceUnitKey::clone(&unit), source);
     let foreign = observe_disk(&source_path.with_extension("js"));
-    lifecycle.combine(compilation.observe_foreign(SourceUnitKey::clone(&unit), foreign));
+    lifecycle.combine(compilation.observe_foreign(
+        SourceUnitKey::clone(&unit),
+        ForeignSourceKind::JavaScript,
+        foreign,
+    ));
 
     let current_source = compilation.source_content(unit.source())?;
     let current_foreign = compilation.foreign_content(unit.foreign());
@@ -351,7 +356,11 @@ fn observe_foreign(
     let unit = source_unit(source_path)?;
     let previous_foreign = compilation.foreign_content(unit.foreign());
     let foreign = observe_disk(&source_path.with_extension("js"));
-    let lifecycle = compilation.observe_foreign(SourceUnitKey::clone(&unit), foreign);
+    let lifecycle = compilation.observe_foreign(
+        SourceUnitKey::clone(&unit),
+        ForeignSourceKind::JavaScript,
+        foreign,
+    );
     let current_foreign = compilation.foreign_content(unit.foreign());
     let mut modules = BTreeSet::new();
     if previous_foreign != current_foreign {

--- a/compiler-bin/src/watch.rs
+++ b/compiler-bin/src/watch.rs
@@ -264,7 +264,7 @@ impl WatchWorkspace {
                         source_paths.insert(path);
                     }
                 }
-                Some("js") => {
+                Some("js" | "jsx") => {
                     let source_path = path.with_extension("purs");
                     if self.source_paths.contains(&source_path) {
                         foreign_paths.insert(source_path);
@@ -327,20 +327,20 @@ fn observe_source_unit(
 ) -> Result<WorkspaceChange, WatchError> {
     let unit = source_unit(source_path)?;
     let previous_source = compilation.source_content(unit.source())?;
-    let previous_foreign = compilation.foreign_content(unit.foreign());
+    let previous_foreign =
+        ForeignSourceKind::ALL.map(|kind| compilation.foreign_content(unit.foreign_for(kind)));
     let previous_name = compilation.module_name(unit.source())?;
 
     let source = observe_disk(source_path);
     let mut lifecycle = compilation.observe_source(SourceUnitKey::clone(&unit), source);
-    let foreign = observe_disk(&source_path.with_extension("js"));
-    lifecycle.combine(compilation.observe_foreign(
-        SourceUnitKey::clone(&unit),
-        ForeignSourceKind::JavaScript,
-        foreign,
-    ));
+    for kind in ForeignSourceKind::ALL {
+        let foreign = observe_disk(&source_path.with_extension(kind.extension()));
+        lifecycle.combine(compilation.observe_foreign(SourceUnitKey::clone(&unit), kind, foreign));
+    }
 
     let current_source = compilation.source_content(unit.source())?;
-    let current_foreign = compilation.foreign_content(unit.foreign());
+    let current_foreign =
+        ForeignSourceKind::ALL.map(|kind| compilation.foreign_content(unit.foreign_for(kind)));
     let mut modules = BTreeSet::new();
     if previous_source != current_source || previous_foreign != current_foreign {
         let name = compilation.module_name(unit.source())?.or(previous_name);
@@ -354,14 +354,15 @@ fn observe_foreign(
     source_path: &Path,
 ) -> Result<WorkspaceChange, WatchError> {
     let unit = source_unit(source_path)?;
-    let previous_foreign = compilation.foreign_content(unit.foreign());
-    let foreign = observe_disk(&source_path.with_extension("js"));
-    let lifecycle = compilation.observe_foreign(
-        SourceUnitKey::clone(&unit),
-        ForeignSourceKind::JavaScript,
-        foreign,
-    );
-    let current_foreign = compilation.foreign_content(unit.foreign());
+    let previous_foreign =
+        ForeignSourceKind::ALL.map(|kind| compilation.foreign_content(unit.foreign_for(kind)));
+    let mut lifecycle = LifecycleChange::default();
+    for kind in ForeignSourceKind::ALL {
+        let foreign = observe_disk(&source_path.with_extension(kind.extension()));
+        lifecycle.combine(compilation.observe_foreign(SourceUnitKey::clone(&unit), kind, foreign));
+    }
+    let current_foreign =
+        ForeignSourceKind::ALL.map(|kind| compilation.foreign_content(unit.foreign_for(kind)));
     let mut modules = BTreeSet::new();
     if previous_foreign != current_foreign {
         let name = compilation.module_name(unit.source())?;
@@ -460,14 +461,22 @@ mod tests {
     fn synchronizes_foreign_changes_for_tracked_sources() {
         let (temporary, mut workspace) = workspace();
         let source_id = workspace.compilation.input_source_ids()[0];
-        let foreign = temporary.path().join("src/Main.js");
+        let foreign = temporary.path().join("src/Main.jsx");
         fs::write(&foreign, "export const value = 1;\n").unwrap();
 
         let change = workspace.synchronize_paths([foreign]).unwrap();
 
         assert_eq!(change.lifecycle.changed_sources().collect::<Vec<_>>(), vec![source_id]);
         assert_eq!(change.modules, BTreeSet::from([String::from("Main")]));
-        assert!(workspace.compilation.snapshot().foreign_file(source_id).is_some());
+        assert_eq!(
+            workspace.compilation.snapshot().foreign_file(source_id).map(|file| file.kind()),
+            Some(ForeignSourceKind::Jsx)
+        );
+
+        let javascript = temporary.path().join("src/Main.js");
+        fs::write(&javascript, "export const value = 2;\n").unwrap();
+        workspace.synchronize_paths([javascript]).unwrap();
+        assert_eq!(workspace.compilation.snapshot().foreign_files(source_id).count(), 2);
     }
 
     #[test]

--- a/compiler-core/building/src/engine.rs
+++ b/compiler-core/building/src/engine.rs
@@ -36,7 +36,7 @@ use building_types::{
 };
 use checking::CheckedModule;
 use documenting::DocumentedModule;
-use files::{FileId, ForeignFileId};
+use files::{FileId, ForeignFileCandidates, ForeignFileId};
 use foreign_javascript::{ForeignModule, ForeignValidation};
 use graph::SnapshotGraph;
 use indexing::IndexedModule;
@@ -125,7 +125,7 @@ where
 #[derive(Default)]
 struct InputStorage {
     content: Shards<FileId, InputState<Arc<str>>>,
-    foreign: Shards<FileId, InputState<Option<ForeignFileId>>>,
+    foreign: Shards<FileId, InputState<ForeignFileCandidates>>,
     foreign_content: Shards<ForeignFileId, InputState<Arc<str>>>,
     module: Shards<ModuleNameId, InputState<Option<FileId>>>,
 }
@@ -889,7 +889,9 @@ impl QueryEngine {
     }
 
     pub fn set_foreign_file(&self, source_id: FileId, foreign_id: ForeignFileId) {
-        self.set_input(source_id, |input| &input.foreign, Some(foreign_id));
+        let mut candidates = self.foreign_files(source_id);
+        candidates.set(foreign_id.kind(), Some(foreign_id));
+        self.set_input(source_id, |input| &input.foreign, candidates);
     }
 
     pub fn remove_foreign_file(&self, foreign_id: ForeignFileId) {
@@ -900,8 +902,8 @@ impl QueryEngine {
         for shard in &self.input.foreign.inner {
             let mut associations = shard.write();
             for state in associations.values_mut() {
-                if state.value == Some(foreign_id) {
-                    state.value = None;
+                if state.value.get(foreign_id.kind()) == Some(foreign_id) {
+                    state.value.set(foreign_id.kind(), None);
                     state.changed = changed;
                 }
             }
@@ -924,7 +926,12 @@ impl QueryEngine {
     }
 
     pub fn foreign_file(&self, source_id: FileId) -> Option<ForeignFileId> {
-        self.get_input(QueryKey::Foreign(source_id), source_id, |input| &input.foreign).flatten()
+        self.foreign_files(source_id).unique()
+    }
+
+    pub fn foreign_files(&self, source_id: FileId) -> ForeignFileCandidates {
+        self.get_input(QueryKey::Foreign(source_id), source_id, |input| &input.foreign)
+            .unwrap_or_default()
     }
 
     pub fn foreign_module(&self, id: ForeignFileId) -> QueryResult<Option<Arc<ForeignModule>>> {
@@ -935,7 +942,7 @@ impl QueryEngine {
             |this| {
                 let module = this
                     .foreign_content(id)
-                    .map(|content| Arc::new(foreign_javascript::parse_module(&content)));
+                    .map(|content| Arc::new(foreign_javascript::parse_module(id.kind(), &content)));
                 Ok(module)
             },
         )
@@ -948,12 +955,14 @@ impl QueryEngine {
             |derived| &derived.foreign_validation,
             |this| {
                 let indexed = this.indexed(id)?;
-                let foreign = if let Some(foreign_id) = this.foreign_file(id) {
+                let candidates = this.foreign_files(id);
+                let foreign = if let Some(foreign_id) = candidates.unique() {
                     this.foreign_module(foreign_id)?
                 } else {
                     None
                 };
-                let validation = foreign_javascript::validate_module(&indexed, foreign.as_deref());
+                let validation =
+                    foreign_javascript::validate_module(&indexed, candidates, foreign.as_deref());
                 Ok(Arc::new(validation))
             },
         )
@@ -1294,6 +1303,12 @@ impl functional::ExternalQueries for QueryEngine {
     }
 }
 
+impl javascript::ExternalQueries for QueryEngine {
+    fn foreign_file(&self, file_id: FileId) -> QueryResult<Option<ForeignFileId>> {
+        Ok(QueryEngine::foreign_file(self, file_id))
+    }
+}
+
 impl checking::PrettyQueries for QueryEngine {
     fn lookup_type(&self, id: checking::TypeId) -> checking::Type {
         self.interned.checking.lookup_type(id)
@@ -1361,7 +1376,7 @@ mod tests {
     use std::sync::{Arc, Barrier};
 
     use building_types::{QueryError, QueryResult};
-    use files::{FileId, Files, ForeignFiles};
+    use files::{FileId, Files, ForeignFiles, ForeignSourceKind};
     use foreign_javascript::ForeignError;
     use parking_lot::Mutex;
     use resolving::ResolvedModule;
@@ -1729,8 +1744,16 @@ mod tests {
 
         let source = "module Main where\n\nforeign import life :: Int";
         let source_id = files.insert("src/Main.purs", source);
-        let first_id = foreign_files.insert("src/Main.js", "export const life = 1;");
-        let second_id = foreign_files.insert("src/Other.js", "export const life = 2;");
+        let first_id = foreign_files.insert(
+            ForeignSourceKind::JavaScript,
+            "src/Main.js",
+            "export const life = 1;",
+        );
+        let second_id = foreign_files.insert(
+            ForeignSourceKind::JavaScript,
+            "src/Other.js",
+            "export const life = 2;",
+        );
         engine.set_content(source_id, source);
 
         assert_eq!(engine.foreign_file(source_id), None);
@@ -1774,7 +1797,11 @@ mod tests {
             [ForeignError::MissingModule { name, .. }] if name == "life"
         ));
 
-        let foreign_id = foreign_files.insert("src/Main.js", "export const other = 42;");
+        let foreign_id = foreign_files.insert(
+            ForeignSourceKind::JavaScript,
+            "src/Main.js",
+            "export const other = 42;",
+        );
         engine.set_foreign_content(foreign_id, foreign_files.content(foreign_id));
         engine.set_foreign_file(source_id, foreign_id);
 
@@ -1800,7 +1827,11 @@ mod tests {
 
         for number in 0..32 {
             let path = format!("src/Main-{number}.js");
-            let foreign_id = foreign_files.insert(path.as_str(), "export const life = 42;");
+            let foreign_id = foreign_files.insert(
+                ForeignSourceKind::JavaScript,
+                path.as_str(),
+                "export const life = 42;",
+            );
             engine.set_foreign_content(foreign_id, foreign_files.content(foreign_id));
             engine.set_foreign_file(source_id, foreign_id);
 
@@ -1833,6 +1864,27 @@ mod tests {
     }
 
     #[test]
+    fn test_foreign_validation_rejects_javascript_and_jsx_candidates() {
+        let engine = QueryEngine::default();
+        let mut files = Files::default();
+        let mut foreign_files = ForeignFiles::default();
+
+        let source_id =
+            files.insert("src/Main.purs", "module Main where\n\nforeign import life :: Int");
+        engine.set_content(source_id, files.content(source_id));
+        for kind in ForeignSourceKind::ALL {
+            let path = format!("src/Main.{}", kind.extension());
+            let foreign_id = foreign_files.insert(kind, path, "export const life = 42;");
+            engine.set_foreign_content(foreign_id, foreign_files.content(foreign_id));
+            engine.set_foreign_file(source_id, foreign_id);
+        }
+
+        assert_eq!(engine.foreign_file(source_id), None);
+        let validation = engine.foreign_validation(source_id).unwrap();
+        assert!(matches!(validation.errors.as_ref(), [ForeignError::AmbiguousModule { .. }]));
+    }
+
+    #[test]
     fn test_unparseable_foreign_modules_skip_export_validation() {
         let engine = QueryEngine::default();
         let mut files = Files::default();
@@ -1846,7 +1898,7 @@ mod tests {
             ["export _null = null;", "export const registerVersionProvider u => u;"];
         for (index, content) in malformed_modules.into_iter().enumerate() {
             let path = format!("src/Main-{index}.js");
-            let foreign_id = foreign_files.insert(path, content);
+            let foreign_id = foreign_files.insert(ForeignSourceKind::JavaScript, path, content);
             engine.set_foreign_content(foreign_id, foreign_files.content(foreign_id));
             engine.set_foreign_file(source_id, foreign_id);
 
@@ -1891,7 +1943,10 @@ mod tests {
             let DerivedState::Computed { dependencies, .. } = shard.get(&main).unwrap() else {
                 unreachable!("invariant violated: expected computed query");
             };
-            assert_eq!(dependencies.as_ref(), &[QueryKey::Functional(main)]);
+            assert_eq!(
+                dependencies.as_ref(),
+                &[QueryKey::Functional(main), QueryKey::Foreign(main)]
+            );
         }
 
         let unrelated = files.insert("Unrelated.purs", "module Unrelated where\n\nvalue = 1");

--- a/compiler-core/building/src/lifecycle.rs
+++ b/compiler-core/building/src/lifecycle.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use files::{FileId, Files, ForeignFileId, ForeignFiles};
+use files::{FileId, Files, ForeignFileCandidates, ForeignFileId, ForeignFiles, ForeignSourceKind};
 use rustc_hash::FxHashMap;
 
 use crate::QueryEngine;
@@ -42,12 +42,40 @@ impl<Version, Metadata> Default for FileLifecycle<Version, Metadata> {
 #[derive(Debug)]
 struct SourceUnit<Version, Metadata> {
     source: Member<SourceDocument<Version, Metadata>>,
-    foreign: Member<ForeignDocument<Version>>,
+    foreign: ForeignMembers<Version>,
 }
 
 impl<Version, Metadata> Default for SourceUnit<Version, Metadata> {
     fn default() -> SourceUnit<Version, Metadata> {
-        SourceUnit { source: Member::Missing, foreign: Member::Missing }
+        SourceUnit { source: Member::Missing, foreign: ForeignMembers::default() }
+    }
+}
+
+#[derive(Debug)]
+struct ForeignMembers<Version> {
+    javascript: Member<ForeignDocument<Version>>,
+    jsx: Member<ForeignDocument<Version>>,
+}
+
+impl<Version> Default for ForeignMembers<Version> {
+    fn default() -> ForeignMembers<Version> {
+        ForeignMembers { javascript: Member::Missing, jsx: Member::Missing }
+    }
+}
+
+impl<Version> ForeignMembers<Version> {
+    fn get(&self, kind: ForeignSourceKind) -> &Member<ForeignDocument<Version>> {
+        match kind {
+            ForeignSourceKind::JavaScript => &self.javascript,
+            ForeignSourceKind::Jsx => &self.jsx,
+        }
+    }
+
+    fn get_mut(&mut self, kind: ForeignSourceKind) -> &mut Member<ForeignDocument<Version>> {
+        match kind {
+            ForeignSourceKind::JavaScript => &mut self.javascript,
+            ForeignSourceKind::Jsx => &mut self.jsx,
+        }
     }
 }
 
@@ -122,14 +150,16 @@ where
         }
         match event {
             LifecycleEvent::Source { unit, event } => self.apply_source(engine, unit, event),
-            LifecycleEvent::Foreign { unit, event } => self.apply_foreign(engine, unit, event),
+            LifecycleEvent::Foreign { unit, kind, event } => {
+                self.apply_foreign(engine, unit, kind, event)
+            }
         }
     }
 
     pub fn is_open(&self, document: &DocumentKey) -> bool {
         let (unit, kind) = match document {
             DocumentKey::Source(unit) => (unit, DocumentKind::Source),
-            DocumentKey::Foreign(unit) => (unit, DocumentKind::Foreign),
+            DocumentKey::Foreign(unit, kind) => (unit, DocumentKind::Foreign(*kind)),
         };
         let Some(source_unit) = self.units.get(unit) else {
             return false;
@@ -139,9 +169,14 @@ where
                 Member::Missing => false,
                 Member::Present(document) => document.content.authority() == ContentAuthority::Open,
             },
-            DocumentKind::Foreign => match &source_unit.foreign {
-                Member::Missing => false,
-                Member::Present(document) => document.content.authority() == ContentAuthority::Open,
+            DocumentKind::Foreign(_) => match document {
+                DocumentKey::Foreign(_, kind) => match source_unit.foreign.get(*kind) {
+                    Member::Missing => false,
+                    Member::Present(document) => {
+                        document.content.authority() == ContentAuthority::Open
+                    }
+                },
+                DocumentKey::Source(_) => unreachable!(),
             },
         }
     }
@@ -201,7 +236,8 @@ where
 
     pub fn foreign_authority(&self, unit: &SourceUnitKey) -> Option<ContentAuthority> {
         let source_unit = self.units.get(unit)?;
-        let Member::Present(foreign) = &source_unit.foreign else {
+        let Member::Present(foreign) = source_unit.foreign.get(ForeignSourceKind::JavaScript)
+        else {
             return None;
         };
         Some(foreign.content.authority())
@@ -209,7 +245,8 @@ where
 
     pub fn foreign_reload_failure(&self, unit: &SourceUnitKey) -> Option<&ReloadFailure> {
         let source_unit = self.units.get(unit)?;
-        let Member::Present(foreign) = &source_unit.foreign else {
+        let Member::Present(foreign) = source_unit.foreign.get(ForeignSourceKind::JavaScript)
+        else {
             return None;
         };
         foreign.content.reload_failure()
@@ -229,14 +266,17 @@ where
                 requested: SourceUnitKey::clone(unit),
             });
         }
-        if let Some(owner) = self.foreign_owners.get(unit.foreign())
-            && owner != unit
-        {
-            return Some(LifecycleWarning::LocatorAlreadyOwned {
-                locator: Arc::clone(&unit.foreign),
-                owner: SourceUnitKey::clone(owner),
-                requested: SourceUnitKey::clone(unit),
-            });
+        for kind in ForeignSourceKind::ALL {
+            let locator = unit.foreign_for(kind);
+            if let Some(owner) = self.foreign_owners.get(locator)
+                && owner != unit
+            {
+                return Some(LifecycleWarning::LocatorAlreadyOwned {
+                    locator: Arc::from(locator),
+                    owner: SourceUnitKey::clone(owner),
+                    requested: SourceUnitKey::clone(unit),
+                });
+            }
         }
         None
     }
@@ -244,25 +284,32 @@ where
     fn store_unit(&mut self, unit: SourceUnitKey, source_unit: SourceUnit<Version, Metadata>) {
         if source_unit.is_missing() {
             let source_owner = self.source_owners.remove(unit.source());
-            let foreign_owner = self.foreign_owners.remove(unit.foreign());
             debug_assert!(source_owner.is_none_or(|owner| owner == unit));
-            debug_assert!(foreign_owner.is_none_or(|owner| owner == unit));
+            for kind in ForeignSourceKind::ALL {
+                let foreign_owner = self.foreign_owners.remove(unit.foreign_for(kind));
+                debug_assert!(foreign_owner.is_none_or(|owner| owner == unit));
+            }
             return;
         }
 
         let previous_source_owner =
             self.source_owners.insert(Arc::clone(&unit.source), SourceUnitKey::clone(&unit));
-        let previous_foreign_owner =
-            self.foreign_owners.insert(Arc::clone(&unit.foreign), SourceUnitKey::clone(&unit));
         debug_assert!(previous_source_owner.is_none_or(|owner| owner == unit));
-        debug_assert!(previous_foreign_owner.is_none_or(|owner| owner == unit));
+        for kind in ForeignSourceKind::ALL {
+            let locator = Arc::from(unit.foreign_for(kind));
+            let previous_foreign_owner =
+                self.foreign_owners.insert(locator, SourceUnitKey::clone(&unit));
+            debug_assert!(previous_foreign_owner.is_none_or(|owner| owner == unit));
+        }
         self.units.insert(unit, source_unit);
     }
 }
 
 impl<Version, Metadata> SourceUnit<Version, Metadata> {
     fn is_missing(&self) -> bool {
-        matches!(self.source, Member::Missing) && matches!(self.foreign, Member::Missing)
+        matches!(self.source, Member::Missing)
+            && matches!(self.foreign.javascript, Member::Missing)
+            && matches!(self.foreign.jsx, Member::Missing)
     }
 
     fn source_id(&self) -> Option<FileId> {
@@ -272,10 +319,14 @@ impl<Version, Metadata> SourceUnit<Version, Metadata> {
         Some(source.id)
     }
 
-    fn foreign_id(&self) -> Option<ForeignFileId> {
-        let Member::Present(foreign) = &self.foreign else {
-            return None;
-        };
-        Some(foreign.id)
+    fn foreign_files(&self) -> ForeignFileCandidates {
+        let mut candidates = ForeignFileCandidates::default();
+        for kind in ForeignSourceKind::ALL {
+            let Member::Present(foreign) = self.foreign.get(kind) else {
+                continue;
+            };
+            candidates.set(kind, Some(foreign.id));
+        }
+        candidates
     }
 }

--- a/compiler-core/building/src/lifecycle/event.rs
+++ b/compiler-core/building/src/lifecycle/event.rs
@@ -2,15 +2,32 @@ use core::fmt;
 use std::io;
 use std::sync::Arc;
 
+use files::ForeignSourceKind;
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SourceUnitKey {
     pub(super) source: Arc<str>,
-    pub(super) foreign: Arc<str>,
+    pub(super) javascript: Arc<str>,
+    pub(super) jsx: Arc<str>,
 }
 
 impl SourceUnitKey {
-    pub fn new(source: impl Into<Arc<str>>, foreign: impl Into<Arc<str>>) -> SourceUnitKey {
-        SourceUnitKey { source: source.into(), foreign: foreign.into() }
+    pub fn new(source: impl Into<Arc<str>>, javascript: impl Into<Arc<str>>) -> SourceUnitKey {
+        let javascript = javascript.into();
+        let jsx = if let Some(stem) = javascript.strip_suffix(".js") {
+            format!("{stem}.jsx").into()
+        } else {
+            panic!("invariant violated: JavaScript foreign locator must end in .js")
+        };
+        SourceUnitKey { source: source.into(), javascript, jsx }
+    }
+
+    pub fn with_foreign_sources(
+        source: impl Into<Arc<str>>,
+        javascript: impl Into<Arc<str>>,
+        jsx: impl Into<Arc<str>>,
+    ) -> SourceUnitKey {
+        SourceUnitKey { source: source.into(), javascript: javascript.into(), jsx: jsx.into() }
     }
 
     pub fn source(&self) -> &str {
@@ -18,7 +35,14 @@ impl SourceUnitKey {
     }
 
     pub fn foreign(&self) -> &str {
-        &self.foreign
+        &self.javascript
+    }
+
+    pub fn foreign_for(&self, kind: ForeignSourceKind) -> &str {
+        match kind {
+            ForeignSourceKind::JavaScript => &self.javascript,
+            ForeignSourceKind::Jsx => &self.jsx,
+        }
     }
 }
 
@@ -58,7 +82,7 @@ pub enum DiskObservation {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LifecycleEvent<Version, Metadata> {
     Source { unit: SourceUnitKey, event: SourceEvent<Version, Metadata> },
-    Foreign { unit: SourceUnitKey, event: ForeignEvent<Version> },
+    Foreign { unit: SourceUnitKey, kind: ForeignSourceKind, event: ForeignEvent<Version> },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -80,13 +104,13 @@ pub enum ForeignEvent<Version> {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DocumentKey {
     Source(SourceUnitKey),
-    Foreign(SourceUnitKey),
+    Foreign(SourceUnitKey, ForeignSourceKind),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DocumentKind {
     Source,
-    Foreign,
+    Foreign(ForeignSourceKind),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/compiler-core/building/src/lifecycle/foreign.rs
+++ b/compiler-core/building/src/lifecycle/foreign.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use files::ForeignFileId;
+use files::{ForeignFileId, ForeignSourceKind};
 
 use super::*;
 use crate::QueryEngine;
@@ -169,7 +169,11 @@ where
         source_unit: &SourceUnit<Version, Metadata>,
         text: &Arc<str>,
     ) -> ForeignDocument<Version> {
-        let id = self.foreign_files.insert(Arc::clone(&unit.foreign), Arc::clone(text));
+        let id = self.foreign_files.insert(
+            ForeignSourceKind::JavaScript,
+            Arc::clone(&unit.foreign),
+            Arc::clone(text),
+        );
         engine.set_foreign_content(id, Arc::clone(text));
         if let Some(source_id) = source_unit.source_id() {
             engine.set_foreign_file(source_id, id);
@@ -183,7 +187,7 @@ where
             return;
         }
         let path = self.foreign_files.path(id);
-        let inserted_id = self.foreign_files.insert(path, Arc::clone(text));
+        let inserted_id = self.foreign_files.insert(id.kind(), path, Arc::clone(text));
         debug_assert_eq!(inserted_id, id);
         engine.set_foreign_content(id, Arc::clone(text));
     }

--- a/compiler-core/building/src/lifecycle/foreign.rs
+++ b/compiler-core/building/src/lifecycle/foreign.rs
@@ -13,10 +13,11 @@ where
         &mut self,
         engine: &QueryEngine,
         unit: SourceUnitKey,
+        kind: ForeignSourceKind,
         event: ForeignEvent<Version>,
     ) -> LifecycleChange {
         let mut source_unit = self.units.remove(&unit).unwrap_or_default();
-        let result = self.apply_foreign_event(engine, &unit, &mut source_unit, event);
+        let result = self.apply_foreign_event(engine, &unit, kind, &mut source_unit, event);
         self.store_unit(unit, source_unit);
         result
     }
@@ -25,14 +26,15 @@ where
         &mut self,
         engine: &QueryEngine,
         unit: &SourceUnitKey,
+        kind: ForeignSourceKind,
         source_unit: &mut SourceUnit<Version, Metadata>,
         event: ForeignEvent<Version>,
     ) -> LifecycleChange {
         let mut change = LifecycleChange::default();
-        let current = std::mem::take(&mut source_unit.foreign);
+        let current = std::mem::take(source_unit.foreign.get_mut(kind));
         let next = match (current, event) {
             (Member::Missing, ForeignEvent::Opened { text, version }) => {
-                let document = self.insert_foreign(engine, unit, source_unit, &text);
+                let document = self.insert_foreign(engine, unit, kind, source_unit, &text);
                 change.foreign_changed(source_unit.source_id());
                 Member::Present(ForeignDocument {
                     id: document.id,
@@ -41,7 +43,7 @@ where
             }
             (Member::Missing, ForeignEvent::DiskObserved { disk }) => match disk {
                 DiskObservation::Found(text) => {
-                    let document = self.insert_foreign(engine, unit, source_unit, &text);
+                    let document = self.insert_foreign(engine, unit, kind, source_unit, &text);
                     change.foreign_changed(source_unit.source_id());
                     Member::Present(document)
                 }
@@ -49,7 +51,7 @@ where
                 DiskObservation::Failed(failure) => {
                     change.warnings.push(LifecycleWarning::ReloadFailed {
                         unit: SourceUnitKey::clone(unit),
-                        document: DocumentKind::Foreign,
+                        document: DocumentKind::Foreign(kind),
                         failure,
                     });
                     Member::Missing
@@ -58,14 +60,14 @@ where
             (Member::Missing, ForeignEvent::Changed { .. }) => {
                 change.warnings.push(LifecycleWarning::ChangedNonOpen {
                     unit: SourceUnitKey::clone(unit),
-                    document: DocumentKind::Foreign,
+                    document: DocumentKind::Foreign(kind),
                 });
                 Member::Missing
             }
             (Member::Missing, ForeignEvent::Closed { .. }) => {
                 change.warnings.push(LifecycleWarning::ClosedNonOpen {
                     unit: SourceUnitKey::clone(unit),
-                    document: DocumentKind::Foreign,
+                    document: DocumentKind::Foreign(kind),
                 });
                 Member::Missing
             }
@@ -87,13 +89,13 @@ where
                     EffectiveContent::Open { .. } => {
                         change.warnings.push(LifecycleWarning::StaleChange {
                             unit: SourceUnitKey::clone(unit),
-                            document: DocumentKind::Foreign,
+                            document: DocumentKind::Foreign(kind),
                         });
                     }
                     EffectiveContent::Disk { .. } | EffectiveContent::Retained { .. } => {
                         change.warnings.push(LifecycleWarning::ChangedNonOpen {
                             unit: SourceUnitKey::clone(unit),
-                            document: DocumentKind::Foreign,
+                            document: DocumentKind::Foreign(kind),
                         });
                     }
                 }
@@ -103,26 +105,42 @@ where
                 if !matches!(document.content, EffectiveContent::Open { .. }) {
                     change.warnings.push(LifecycleWarning::ClosedNonOpen {
                         unit: SourceUnitKey::clone(unit),
-                        document: DocumentKind::Foreign,
+                        document: DocumentKind::Foreign(kind),
                     });
                     Member::Present(document)
                 } else {
-                    self.reconcile_foreign(engine, unit, source_unit, document, disk, &mut change)
+                    self.reconcile_foreign(
+                        engine,
+                        unit,
+                        kind,
+                        source_unit,
+                        document,
+                        disk,
+                        &mut change,
+                    )
                 }
             }
             (Member::Present(document), ForeignEvent::DiskObserved { disk }) => {
                 if matches!(document.content, EffectiveContent::Open { .. }) {
                     change.warnings.push(LifecycleWarning::DiskObservedWhileOpen {
                         unit: SourceUnitKey::clone(unit),
-                        document: DocumentKind::Foreign,
+                        document: DocumentKind::Foreign(kind),
                     });
                     Member::Present(document)
                 } else {
-                    self.reconcile_foreign(engine, unit, source_unit, document, disk, &mut change)
+                    self.reconcile_foreign(
+                        engine,
+                        unit,
+                        kind,
+                        source_unit,
+                        document,
+                        disk,
+                        &mut change,
+                    )
                 }
             }
         };
-        source_unit.foreign = next;
+        *source_unit.foreign.get_mut(kind) = next;
         change
     }
 
@@ -130,6 +148,7 @@ where
         &mut self,
         engine: &QueryEngine,
         unit: &SourceUnitKey,
+        kind: ForeignSourceKind,
         source_unit: &SourceUnit<Version, Metadata>,
         mut document: ForeignDocument<Version>,
         disk: DiskObservation,
@@ -143,7 +162,7 @@ where
                 Member::Present(document)
             }
             DiskObservation::NotFound => {
-                self.remove_foreign(engine, unit, document.id);
+                self.remove_foreign(engine, unit, kind, document.id);
                 change.foreign_changed(source_unit.source_id());
                 Member::Missing
             }
@@ -154,7 +173,7 @@ where
                 change.foreign_changed(source_unit.source_id());
                 change.warnings.push(LifecycleWarning::ReloadFailed {
                     unit: SourceUnitKey::clone(unit),
-                    document: DocumentKind::Foreign,
+                    document: DocumentKind::Foreign(kind),
                     failure,
                 });
                 Member::Present(document)
@@ -166,14 +185,12 @@ where
         &mut self,
         engine: &QueryEngine,
         unit: &SourceUnitKey,
+        kind: ForeignSourceKind,
         source_unit: &SourceUnit<Version, Metadata>,
         text: &Arc<str>,
     ) -> ForeignDocument<Version> {
-        let id = self.foreign_files.insert(
-            ForeignSourceKind::JavaScript,
-            Arc::clone(&unit.foreign),
-            Arc::clone(text),
-        );
+        let id =
+            self.foreign_files.insert(kind, Arc::from(unit.foreign_for(kind)), Arc::clone(text));
         engine.set_foreign_content(id, Arc::clone(text));
         if let Some(source_id) = source_unit.source_id() {
             engine.set_foreign_file(source_id, id);
@@ -192,9 +209,15 @@ where
         engine.set_foreign_content(id, Arc::clone(text));
     }
 
-    fn remove_foreign(&mut self, engine: &QueryEngine, unit: &SourceUnitKey, id: ForeignFileId) {
+    fn remove_foreign(
+        &mut self,
+        engine: &QueryEngine,
+        unit: &SourceUnitKey,
+        kind: ForeignSourceKind,
+        id: ForeignFileId,
+    ) {
         engine.remove_foreign_file(id);
-        let removed_id = self.foreign_files.remove(unit.foreign());
+        let removed_id = self.foreign_files.remove(unit.foreign_for(kind));
         debug_assert_eq!(removed_id, Some(id));
     }
 }

--- a/compiler-core/building/src/lifecycle/source.rs
+++ b/compiler-core/building/src/lifecycle/source.rs
@@ -190,8 +190,11 @@ where
         if let Some(name) = parsed.module_name(&text) {
             engine.set_module_file(&name, id);
         }
-        if let Some(foreign_id) = source_unit.foreign_id() {
-            engine.set_foreign_file(id, foreign_id);
+        let foreign_files = source_unit.foreign_files();
+        for kind in files::ForeignSourceKind::ALL {
+            if let Some(foreign_id) = foreign_files.get(kind) {
+                engine.set_foreign_file(id, foreign_id);
+            }
         }
         SourceDocument { id, metadata, content: EffectiveContent::Disk { text } }
     }

--- a/compiler-core/building/src/lifecycle/tests.rs
+++ b/compiler-core/building/src/lifecycle/tests.rs
@@ -6,6 +6,7 @@ use super::{
     SourceUnitKey,
 };
 use crate::QueryEngine;
+use files::ForeignSourceKind;
 
 fn unit() -> SourceUnitKey {
     SourceUnitKey::new("file:///src/Main.purs", "file:///src/Main.js")
@@ -35,13 +36,19 @@ fn source_disk(content: &str) -> LifecycleEvent<i32, bool> {
 fn foreign_opened(version: i32, content: &str) -> LifecycleEvent<i32, bool> {
     LifecycleEvent::Foreign {
         unit: unit(),
+        kind: ForeignSourceKind::JavaScript,
         event: ForeignEvent::Opened { text: text(content), version },
     }
 }
 
 fn foreign_disk(content: &str) -> LifecycleEvent<i32, bool> {
+    foreign_disk_for(ForeignSourceKind::JavaScript, content)
+}
+
+fn foreign_disk_for(kind: ForeignSourceKind, content: &str) -> LifecycleEvent<i32, bool> {
     LifecycleEvent::Foreign {
         unit: unit(),
+        kind,
         event: ForeignEvent::DiskObserved { disk: DiskObservation::Found(text(content)) },
     }
 }
@@ -132,6 +139,37 @@ fn foreign_only_unit_associates_when_source_appears() {
 }
 
 #[test]
+fn source_associates_both_javascript_and_jsx_candidates() {
+    let engine = QueryEngine::default();
+    let mut files = FileLifecycle::default();
+    files.apply(
+        &engine,
+        foreign_disk_for(ForeignSourceKind::JavaScript, "export const life = 41;\n"),
+    );
+    files.apply(
+        &engine,
+        foreign_disk_for(ForeignSourceKind::Jsx, "export const life = <Life />;\n"),
+    );
+    files.apply(&engine, source_disk("module Main where\n"));
+
+    let source_id = files.source_id(unit().source()).unwrap();
+    let candidates = engine.foreign_files(source_id);
+    assert!(candidates.get(ForeignSourceKind::JavaScript).is_some());
+    assert!(candidates.get(ForeignSourceKind::Jsx).is_some());
+
+    let event = LifecycleEvent::Foreign {
+        unit: unit(),
+        kind: ForeignSourceKind::JavaScript,
+        event: ForeignEvent::DiskObserved { disk: DiskObservation::NotFound },
+    };
+    files.apply(&engine, event);
+    assert_eq!(
+        engine.foreign_file(source_id).map(|foreign| foreign.kind()),
+        Some(ForeignSourceKind::Jsx)
+    );
+}
+
+#[test]
 fn open_foreign_ignores_disk_deletion_until_close() {
     let engine = QueryEngine::default();
     let mut files = FileLifecycle::default();
@@ -141,14 +179,16 @@ fn open_foreign_ignores_disk_deletion_until_close() {
 
     let event = LifecycleEvent::Foreign {
         unit: unit(),
+        kind: ForeignSourceKind::JavaScript,
         event: ForeignEvent::DiskObserved { disk: DiskObservation::NotFound },
     };
     files.apply(&engine, event);
     assert_eq!(files.foreign_id(unit().foreign()), Some(foreign_id));
-    assert!(files.is_open(&DocumentKey::Foreign(unit())));
+    assert!(files.is_open(&DocumentKey::Foreign(unit(), ForeignSourceKind::JavaScript)));
 
     let event = LifecycleEvent::Foreign {
         unit: unit(),
+        kind: ForeignSourceKind::JavaScript,
         event: ForeignEvent::Closed { disk: DiskObservation::NotFound },
     };
     files.apply(&engine, event);
@@ -172,12 +212,13 @@ fn invalid_events_are_ignored_with_typed_warnings() {
 
     let event = LifecycleEvent::Foreign {
         unit: unit(),
+        kind: ForeignSourceKind::JavaScript,
         event: ForeignEvent::Closed { disk: DiskObservation::NotFound },
     };
     let change = files.apply(&engine, event);
     assert!(matches!(
         change.warnings(),
-        [LifecycleWarning::ClosedNonOpen { document: DocumentKind::Foreign, .. }]
+        [LifecycleWarning::ClosedNonOpen { document: DocumentKind::Foreign(_), .. }]
     ));
 
     let failure = ReloadFailure::new(std::io::ErrorKind::PermissionDenied, "permission denied");
@@ -295,6 +336,7 @@ fn sibling_identity_and_association_follow_delete_and_recreate() {
     files.apply(&engine, source_disk("module Main where\n"));
     let event = LifecycleEvent::Foreign {
         unit: unit(),
+        kind: ForeignSourceKind::JavaScript,
         event: ForeignEvent::DiskObserved {
             disk: DiskObservation::Found(text("export const life = 42;\n")),
         },
@@ -318,6 +360,7 @@ fn sibling_identity_and_association_follow_delete_and_recreate() {
 
     let event = LifecycleEvent::Foreign {
         unit: unit(),
+        kind: ForeignSourceKind::JavaScript,
         event: ForeignEvent::DiskObserved { disk: DiskObservation::NotFound },
     };
     files.apply(&engine, event);
@@ -326,6 +369,7 @@ fn sibling_identity_and_association_follow_delete_and_recreate() {
 
     let event = LifecycleEvent::Foreign {
         unit: unit(),
+        kind: ForeignSourceKind::JavaScript,
         event: ForeignEvent::DiskObserved {
             disk: DiskObservation::Found(text("export const life = 43;\n")),
         },
@@ -346,6 +390,7 @@ fn foreign_changes_reject_stale_versions_and_recover_retained_content() {
 
     let event = LifecycleEvent::Foreign {
         unit: unit(),
+        kind: ForeignSourceKind::JavaScript,
         event: ForeignEvent::Changed { text: text("export const life = 1;\n"), version: 1 },
     };
     let change = files.apply(&engine, event);
@@ -354,6 +399,7 @@ fn foreign_changes_reject_stale_versions_and_recover_retained_content() {
 
     let event = LifecycleEvent::Foreign {
         unit: unit(),
+        kind: ForeignSourceKind::JavaScript,
         event: ForeignEvent::Changed { text: text("export const life = 43;\n"), version: 3 },
     };
     files.apply(&engine, event);
@@ -362,6 +408,7 @@ fn foreign_changes_reject_stale_versions_and_recover_retained_content() {
     let failure = ReloadFailure::new(std::io::ErrorKind::Interrupted, "interrupted");
     let event = LifecycleEvent::Foreign {
         unit: unit(),
+        kind: ForeignSourceKind::JavaScript,
         event: ForeignEvent::Closed {
             disk: DiskObservation::Failed(ReloadFailure::clone(&failure)),
         },
@@ -372,6 +419,7 @@ fn foreign_changes_reject_stale_versions_and_recover_retained_content() {
 
     let event = LifecycleEvent::Foreign {
         unit: unit(),
+        kind: ForeignSourceKind::JavaScript,
         event: ForeignEvent::DiskObserved {
             disk: DiskObservation::Found(text("export const life = 44;\n")),
         },
@@ -429,6 +477,7 @@ fn one_source_locator_cannot_belong_to_two_sibling_pairs() {
 
     let event = LifecycleEvent::Foreign {
         unit: SourceUnitKey::clone(&original),
+        kind: ForeignSourceKind::JavaScript,
         event: ForeignEvent::DiskObserved { disk: DiskObservation::NotFound },
     };
     files.apply(&engine, event);
@@ -457,6 +506,7 @@ fn one_foreign_locator_cannot_belong_to_two_sibling_pairs() {
 
     let event = LifecycleEvent::Foreign {
         unit: SourceUnitKey::clone(&conflicting),
+        kind: ForeignSourceKind::JavaScript,
         event: ForeignEvent::DiskObserved {
             disk: DiskObservation::Found(text("export const conflict = 1;\n")),
         },
@@ -479,12 +529,14 @@ fn one_foreign_locator_cannot_belong_to_two_sibling_pairs() {
     files.apply(&engine, event);
     let event = LifecycleEvent::Foreign {
         unit: SourceUnitKey::clone(&original),
+        kind: ForeignSourceKind::JavaScript,
         event: ForeignEvent::DiskObserved { disk: DiskObservation::NotFound },
     };
     files.apply(&engine, event);
 
     let event = LifecycleEvent::Foreign {
         unit: SourceUnitKey::clone(&conflicting),
+        kind: ForeignSourceKind::JavaScript,
         event: ForeignEvent::DiskObserved {
             disk: DiskObservation::Found(text("export const conflict = 1;\n")),
         },

--- a/compiler-core/files/src/lib.rs
+++ b/compiler-core/files/src/lib.rs
@@ -17,6 +17,56 @@ pub struct FileId {
     index: u32,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ForeignSourceKind {
+    JavaScript,
+    Jsx,
+}
+
+impl ForeignSourceKind {
+    pub const ALL: [ForeignSourceKind; 2] = [ForeignSourceKind::JavaScript, ForeignSourceKind::Jsx];
+
+    pub const fn extension(self) -> &'static str {
+        match self {
+            ForeignSourceKind::JavaScript => "js",
+            ForeignSourceKind::Jsx => "jsx",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ForeignFileCandidates {
+    javascript: Option<ForeignFileId>,
+    jsx: Option<ForeignFileId>,
+}
+
+impl ForeignFileCandidates {
+    pub fn get(self, kind: ForeignSourceKind) -> Option<ForeignFileId> {
+        match kind {
+            ForeignSourceKind::JavaScript => self.javascript,
+            ForeignSourceKind::Jsx => self.jsx,
+        }
+    }
+
+    pub fn set(&mut self, kind: ForeignSourceKind, id: Option<ForeignFileId>) {
+        match kind {
+            ForeignSourceKind::JavaScript => self.javascript = id,
+            ForeignSourceKind::Jsx => self.jsx = id,
+        }
+    }
+
+    pub fn unique(self) -> Option<ForeignFileId> {
+        match (self.javascript, self.jsx) {
+            (Some(id), None) | (None, Some(id)) => Some(id),
+            (None, None) | (Some(_), Some(_)) => None,
+        }
+    }
+
+    pub fn count(self) -> usize {
+        usize::from(self.javascript.is_some()) + usize::from(self.jsx.is_some())
+    }
+}
+
 impl fmt::Debug for FileId {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(formatter, "Idx::<File>({})", self.index)
@@ -49,6 +99,13 @@ pub struct ForeignFiles {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ForeignFileId {
     index: u32,
+    kind: ForeignSourceKind,
+}
+
+impl ForeignFileId {
+    pub const fn kind(self) -> ForeignSourceKind {
+        self.kind
+    }
 }
 
 #[derive(Debug)]
@@ -121,18 +178,20 @@ impl Files {
 impl ForeignFiles {
     pub fn insert(
         &mut self,
+        kind: ForeignSourceKind,
         path: impl Into<Arc<str>>,
         content: impl Into<Arc<str>>,
     ) -> ForeignFileId {
         let path = path.into();
         let content = content.into();
         if let Some(foreign_file_id) = self.paths.get(path.as_ref()).copied() {
+            assert_eq!(foreign_file_id.kind(), kind, "foreign source kind changed for locator");
             let file = self.file_mut(foreign_file_id);
             file.content = content;
             return foreign_file_id;
         }
 
-        let foreign_file_id = ForeignFileId { index: self.next_id };
+        let foreign_file_id = ForeignFileId { index: self.next_id, kind };
         self.next_id =
             self.next_id.checked_add(1).expect("invariant violated: too many foreign files");
         let file = ForeignFileData { path: Arc::clone(&path), content };
@@ -176,7 +235,7 @@ impl ForeignFiles {
 
 #[cfg(test)]
 mod tests {
-    use super::{Files, ForeignFiles};
+    use super::{Files, ForeignFiles, ForeignSourceKind};
 
     #[test]
     fn test_basic() {
@@ -224,21 +283,26 @@ mod tests {
 
         let path = "src/Main.js";
         let content = "export const life = 42;\n";
-        let id = files.insert(path, content);
+        let id = files.insert(ForeignSourceKind::JavaScript, path, content);
 
         assert_eq!(files.id(path), Some(id));
+        assert_eq!(id.kind(), ForeignSourceKind::JavaScript);
         assert_eq!(files.path(id).as_ref(), path);
         assert_eq!(files.content(id).as_ref(), content);
 
         let retained_path = "src/Retained.js";
-        let retained_id = files.insert(retained_path, "export const retained = 1;");
+        let retained_id = files.insert(
+            ForeignSourceKind::JavaScript,
+            retained_path,
+            "export const retained = 1;",
+        );
 
         assert_eq!(files.remove(path), Some(id));
         assert_eq!(files.id(path), None);
         assert!(!files.files.contains_key(&id));
         assert_eq!(files.path(retained_id).as_ref(), retained_path);
 
-        let replacement_id = files.insert(path, content);
+        let replacement_id = files.insert(ForeignSourceKind::JavaScript, path, content);
         assert_ne!(replacement_id, id);
         assert_eq!(files.remove(path), Some(replacement_id));
 
@@ -246,7 +310,7 @@ mod tests {
         let mut previous_id = replacement_id;
         for number in 0..32 {
             let path = format!("src/Temporary-{number}.js");
-            let temporary_id = files.insert(path.as_str(), content);
+            let temporary_id = files.insert(ForeignSourceKind::JavaScript, path.as_str(), content);
             assert!(temporary_id > previous_id);
             assert_eq!(files.remove(&path), Some(temporary_id));
             previous_id = temporary_id;

--- a/compiler-frontend/diagnostics/src/convert.rs
+++ b/compiler-frontend/diagnostics/src/convert.rs
@@ -23,6 +23,7 @@ impl ToDiagnostics for ForeignError {
     {
         let declaration = match self {
             ForeignError::MissingModule { declaration, .. }
+            | ForeignError::AmbiguousModule { declaration }
             | ForeignError::MissingImplementation { declaration, .. }
             | ForeignError::Parse { declaration, .. } => declaration,
         };
@@ -39,6 +40,12 @@ impl ToDiagnostics for ForeignError {
             ForeignError::MissingModule { name, .. } => Diagnostic::error(
                 "MissingFFIModule",
                 format!("No JavaScript FFI module was found for foreign import '{name}'"),
+                span,
+                "foreign-javascript",
+            ),
+            ForeignError::AmbiguousModule { .. } => Diagnostic::error(
+                "AmbiguousFFIModule",
+                "Both JavaScript and JSX FFI modules were found. Remove one of the foreign files",
                 span,
                 "foreign-javascript",
             ),

--- a/tests-compatibility/src/verifier/compile.rs
+++ b/tests-compatibility/src/verifier/compile.rs
@@ -5,7 +5,7 @@ use building::{QueryEngine, QueryError, prim};
 use diagnostics::{
     Diagnostic, DiagnosticsContext, Severity, Span, ToDiagnostics, format_rich_with_path,
 };
-use files::{FileId, Files, ForeignFiles};
+use files::{FileId, Files, ForeignFiles, ForeignSourceKind};
 use rayon::prelude::*;
 use url::Url;
 
@@ -100,7 +100,7 @@ fn register_foreign_module(
     let uri = Url::from_file_path(&absolute_path)
         .map_err(|_| VerifierError::FileUrl(absolute_path.clone()))?
         .to_string();
-    let foreign_id = foreign_files.insert(uri, content.clone());
+    let foreign_id = foreign_files.insert(ForeignSourceKind::JavaScript, uri, content.clone());
     engine.set_foreign_content(foreign_id, content);
     engine.set_foreign_file(file_id, foreign_id);
     Ok(())

--- a/tests-compatibility/src/verifier/compile.rs
+++ b/tests-compatibility/src/verifier/compile.rs
@@ -48,7 +48,7 @@ pub fn compile_sources(source_files: &[SourceFile]) -> Result<CompileReport, Ver
             .to_string();
         let file_id = files.insert(uri, content.clone());
         engine.set_content(file_id, content.clone());
-        register_foreign_module(&engine, &mut foreign_files, source, file_id)?;
+        register_foreign_modules(&engine, &mut foreign_files, source, file_id)?;
         file_ids.push(file_id);
         file_metadata.insert(
             file_id,
@@ -84,25 +84,27 @@ pub fn compile_sources(source_files: &[SourceFile]) -> Result<CompileReport, Ver
     Ok(report)
 }
 
-fn register_foreign_module(
+fn register_foreign_modules(
     engine: &QueryEngine,
     foreign_files: &mut ForeignFiles,
     source: &SourceFile,
     file_id: FileId,
 ) -> Result<(), VerifierError> {
-    let foreign_path = source.path.with_extension("js");
-    if !foreign_path.is_file() {
-        return Ok(());
-    }
+    for kind in ForeignSourceKind::ALL {
+        let foreign_path = source.path.with_extension(kind.extension());
+        if !foreign_path.is_file() {
+            continue;
+        }
 
-    let content = fs::read_to_string(&foreign_path)?;
-    let absolute_path = fs::canonicalize(&foreign_path)?;
-    let uri = Url::from_file_path(&absolute_path)
-        .map_err(|_| VerifierError::FileUrl(absolute_path.clone()))?
-        .to_string();
-    let foreign_id = foreign_files.insert(ForeignSourceKind::JavaScript, uri, content.clone());
-    engine.set_foreign_content(foreign_id, content);
-    engine.set_foreign_file(file_id, foreign_id);
+        let content = fs::read_to_string(&foreign_path)?;
+        let absolute_path = fs::canonicalize(&foreign_path)?;
+        let uri = Url::from_file_path(&absolute_path)
+            .map_err(|_| VerifierError::FileUrl(absolute_path.clone()))?
+            .to_string();
+        let foreign_id = foreign_files.insert(kind, uri, content.clone());
+        engine.set_foreign_content(foreign_id, content);
+        engine.set_foreign_file(file_id, foreign_id);
+    }
     Ok(())
 }
 
@@ -465,7 +467,7 @@ mod tests {
     }
 
     #[test]
-    fn loads_foreign_modules_for_checking_and_javascript_generation() {
+    fn loads_jsx_foreign_modules_for_checking_and_javascript_generation() {
         let dir = tempdir().unwrap();
         fs::create_dir_all(dir.path().join("src")).unwrap();
         let main = dir.path().join("src/Main.purs");
@@ -474,7 +476,8 @@ mod tests {
             "module Main where\n\nforeign import answer :: Int\n\nresult :: Int\nresult = answer\n",
         )
         .unwrap();
-        fs::write(dir.path().join("src/Main.js"), "export const answer = 42;\n").unwrap();
+        fs::write(dir.path().join("src/Main.jsx"), "export const answer = <span>42</span>;\n")
+            .unwrap();
 
         let report = compile_sources(&[source("fixture", "1.0.0", &main)]).unwrap();
 

--- a/tests-integration/fixtures/backend/1787926560_ambiguous_foreign_modules/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787926560_ambiguous_foreign_modules/Main.functional.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign component

--- a/tests-integration/fixtures/backend/1787926560_ambiguous_foreign_modules/Main.js
+++ b/tests-integration/fixtures/backend/1787926560_ambiguous_foreign_modules/Main.js
@@ -1,0 +1,1 @@
+export const component = 42;

--- a/tests-integration/fixtures/backend/1787926560_ambiguous_foreign_modules/Main.jsx
+++ b/tests-integration/fixtures/backend/1787926560_ambiguous_foreign_modules/Main.jsx
@@ -1,0 +1,1 @@
+export const component = <section>Hello</section>;

--- a/tests-integration/fixtures/backend/1787926560_ambiguous_foreign_modules/Main.purs
+++ b/tests-integration/fixtures/backend/1787926560_ambiguous_foreign_modules/Main.purs
@@ -1,0 +1,3 @@
+module Main where
+
+foreign import component :: Int

--- a/tests-integration/fixtures/backend/1787926560_ambiguous_foreign_modules/Main.snap
+++ b/tests-integration/fixtures/backend/1787926560_ambiguous_foreign_modules/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+component :: Prim.Int
+
+Types
+
+Diagnostics
+Error! · [AmbiguousFFIModule] · Main.purs:3:1
+  •
+  │
+  • Both JavaScript and JSX FFI modules were found. Remove one of the foreign files
+  │
+  │   foreign import component :: Int
+  │   ╰──────────────────────────────
+  •

--- a/tests-integration/fixtures/backend/1787926560_ambiguous_foreign_modules/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1787926560_ambiguous_foreign_modules/output/Main/foreign.js
@@ -1,0 +1,1 @@
+export const component = 42;

--- a/tests-integration/fixtures/backend/1787926560_ambiguous_foreign_modules/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787926560_ambiguous_foreign_modules/output/Main/index.js
@@ -1,0 +1,2 @@
+import * as $foreign from "./foreign.js";
+export const component = $foreign["component"];

--- a/tests-integration/fixtures/backend/1787926560_jsx_foreign_module/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787926560_jsx_foreign_module/Main.functional.snap
@@ -1,0 +1,8 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign component
+
+@export result = component

--- a/tests-integration/fixtures/backend/1787926560_jsx_foreign_module/Main.jsx
+++ b/tests-integration/fixtures/backend/1787926560_jsx_foreign_module/Main.jsx
@@ -1,0 +1,1 @@
+export const component = <section>Hello</section>;

--- a/tests-integration/fixtures/backend/1787926560_jsx_foreign_module/Main.purs
+++ b/tests-integration/fixtures/backend/1787926560_jsx_foreign_module/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+foreign import component :: Int
+
+result :: Int
+result = component

--- a/tests-integration/fixtures/backend/1787926560_jsx_foreign_module/Main.snap
+++ b/tests-integration/fixtures/backend/1787926560_jsx_foreign_module/Main.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+component :: Prim.Int
+result :: Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1787926560_jsx_foreign_module/output/Main/foreign.jsx
+++ b/tests-integration/fixtures/backend/1787926560_jsx_foreign_module/output/Main/foreign.jsx
@@ -1,0 +1,1 @@
+export const component = <section>Hello</section>;

--- a/tests-integration/fixtures/backend/1787926560_jsx_foreign_module/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787926560_jsx_foreign_module/output/Main/index.js
@@ -1,0 +1,3 @@
+import * as $foreign from "./foreign.jsx";
+export const component = $foreign["component"];
+export const result = component;

--- a/tests-integration/src/fixtures.rs
+++ b/tests-integration/src/fixtures.rs
@@ -70,7 +70,10 @@ impl JavaScriptModules {
                         "invariant violated: source URL is not a file: {source_url}"
                     ))
                 })?;
-                let foreign_path = source_path.with_extension("js");
+                let kind = module
+                    .foreign_kind()
+                    .expect("invariant violated: required foreign module has no source kind");
+                let foreign_path = source_path.with_extension(kind.extension());
                 if !foreign_path.exists() {
                     continue;
                 }

--- a/tests-integration/src/lib.rs
+++ b/tests-integration/src/lib.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use building::QueryEngine;
-use files::{Files, ForeignFiles};
+use files::{Files, ForeignFiles, ForeignSourceKind};
 use glob::glob;
 use prim_constants::MODULE_MAP;
 use tempfile::TempDir;
@@ -57,7 +57,11 @@ fn load_file(
         let foreign_url = Url::from_file_path(&foreign_path).unwrap();
         let foreign_content = fs::read_to_string(foreign_path).unwrap();
         let foreign_content = foreign_content.replace("\r\n", "\n");
-        let foreign_id = foreign_files.insert(foreign_url.as_str(), foreign_content);
+        let foreign_id = foreign_files.insert(
+            ForeignSourceKind::JavaScript,
+            foreign_url.as_str(),
+            foreign_content,
+        );
         engine.set_foreign_content(foreign_id, foreign_files.content(foreign_id));
         engine.set_foreign_file(id, foreign_id);
     }

--- a/tests-integration/src/lib.rs
+++ b/tests-integration/src/lib.rs
@@ -52,16 +52,15 @@ fn load_file(
         engine.set_module_file(&name, id);
     }
 
-    let foreign_path = path.with_extension("js");
-    if foreign_path.is_file() {
+    for kind in ForeignSourceKind::ALL {
+        let foreign_path = path.with_extension(kind.extension());
+        if !foreign_path.is_file() {
+            continue;
+        }
         let foreign_url = Url::from_file_path(&foreign_path).unwrap();
         let foreign_content = fs::read_to_string(foreign_path).unwrap();
         let foreign_content = foreign_content.replace("\r\n", "\n");
-        let foreign_id = foreign_files.insert(
-            ForeignSourceKind::JavaScript,
-            foreign_url.as_str(),
-            foreign_content,
-        );
+        let foreign_id = foreign_files.insert(kind, foreign_url.as_str(), foreign_content);
         engine.set_foreign_content(foreign_id, foreign_files.content(foreign_id));
         engine.set_foreign_file(id, foreign_id);
     }


### PR DESCRIPTION
## Summary

PureScript projects can now implement foreign imports in a sibling `.jsx` module. Alexandrite parses JSX for export validation, preserves the authored source, emits it as `foreign.jsx`, and generates an import with the matching extension.

Foreign source identity now carries its JavaScript source kind through lifecycle tracking, incremental queries, code generation, watch mode, and LSP document handling. If both `.js` and `.jsx` siblings exist, compilation reports `AmbiguousFFIModule` instead of choosing one implicitly.

JSX transformation remains the responsibility of the downstream runtime or bundler.

## Verification

- `cargo check -p files -p foreign-javascript -p building -p javascript -p diagnostics -p purescript-alexandrite -p tests-integration -p tests-compatibility --tests`
- `cargo nextest run -p building -p purescript-alexandrite`
- `cargo nextest run -p purescript-alexandrite -p tests-compatibility`
- `just t backend`
- Manual CLI compilation of a JSX foreign module and the ambiguous `.js`/`.jsx` case