### PR TITLE
[compiler-bin] Adapt progress text to terminal theme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,6 +2547,7 @@ dependencies = [
  "spago",
  "stabilizing",
  "tempfile",
+ "terminal-colorsaurus",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -3368,6 +3369,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal-colorsaurus"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a46bb5364467da040298c573c8a95dbf9a512efc039630409a03126e3703e90"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "memchr",
+ "mio",
+ "terminal-trx",
+ "windows-sys 0.61.2",
+ "xterm-color",
+]
+
+[[package]]
+name = "terminal-trx"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3f27d9a8a177e57545481faec87acb45c6e854ed1e5a3658ad186c106f38ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4203,6 +4230,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xterm-color"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7008a9d8ba97a7e47d9b2df63fcdb8dade303010c5a7cd5bf2469d4da6eba673"
 
 [[package]]
 name = "yoke"

--- a/compiler-bin/Cargo.toml
+++ b/compiler-bin/Cargo.toml
@@ -55,6 +55,7 @@ smol_str = "0.3.6"
 spago = { version = "0.1.0", path = "../compiler-lsp/spago" }
 stabilizing = { version = "0.1.0", path = "../compiler-frontend/stabilizing" }
 tempfile = "3.27.0"
+terminal-colorsaurus = "1.0.3"
 thiserror = "2.0.20"
 tokio = { version = "1.53.1", features = ["full"] }
 tower = "0.5.3"

--- a/compiler-bin/src/progress.rs
+++ b/compiler-bin/src/progress.rs
@@ -104,10 +104,11 @@ fn configure(progress: &ProgressBar, phase: &'static str) {
 }
 
 fn phase_style(theme_mode: Option<ThemeMode>, intensity: u8) -> Style {
+    let style = Style::new().for_stderr();
     let intensity = match theme_mode {
         Some(ThemeMode::Dark) => intensity,
         Some(ThemeMode::Light) => 255 - intensity,
-        None => return Style::new(),
+        None => return style,
     };
-    Style::new().fg(Color::TrueColor(intensity, intensity, intensity))
+    style.fg(Color::TrueColor(intensity, intensity, intensity))
 }

--- a/compiler-bin/src/progress.rs
+++ b/compiler-bin/src/progress.rs
@@ -1,16 +1,22 @@
 use std::fmt;
 use std::io::{self, IsTerminal};
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use console::{Color, Style};
 use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
+use terminal_colorsaurus::{QueryOptions, ThemeMode};
 
 const CARGO_PROGRESS_REGION_WIDTH: usize = 50;
 const CARGO_PROGRESS_FIXED_OVERHEAD: usize = 17;
 const SHIMMER_FRAME_INTERVAL: Duration = Duration::from_millis(80);
+static TERMINAL_THEME_MODE: OnceLock<Option<ThemeMode>> = OnceLock::new();
 
 pub(crate) fn bar(total: usize, phase: &'static str, show: bool) -> ProgressBar {
-    let progress = if show { ProgressBar::new(total as u64) } else { ProgressBar::hidden() };
+    if !show {
+        return ProgressBar::hidden();
+    }
+    let progress = ProgressBar::new(total as u64);
     configure(&progress, phase);
     progress
 }
@@ -53,6 +59,8 @@ pub(crate) fn report_completion(elapsed: Duration) {
 fn configure(progress: &ProgressBar, phase: &'static str) {
     let started = Instant::now();
     let characters = phase.chars().collect::<Vec<_>>();
+    let theme_mode = *TERMINAL_THEME_MODE
+        .get_or_init(|| terminal_colorsaurus::theme_mode(QueryOptions::default()).ok());
     let cycle = characters.len() + 4;
     let total = progress.length().unwrap_or_default();
     let count_width = total.to_string().len().max(4);
@@ -62,7 +70,7 @@ fn configure(progress: &ProgressBar, phase: &'static str) {
         .max(1);
     let phase_text = move |state: &ProgressState, writer: &mut dyn fmt::Write| {
         if state.is_finished() {
-            let style = Style::new().fg(Color::TrueColor(255, 255, 255));
+            let style = phase_style(theme_mode, 255);
             write!(writer, "{}", style.apply_to(phase))
                 .expect("writing to a formatter cannot fail");
             return;
@@ -80,7 +88,7 @@ fn configure(progress: &ProgressBar, phase: &'static str) {
                 3 => 115,
                 _ => 90,
             };
-            let style = Style::new().fg(Color::TrueColor(intensity, intensity, intensity));
+            let style = phase_style(theme_mode, intensity);
             write!(writer, "{}", style.apply_to(character))
                 .expect("writing to a formatter cannot fail");
         }
@@ -93,4 +101,13 @@ fn configure(progress: &ProgressBar, phase: &'static str) {
         .progress_chars("=> ");
     progress.set_style(style);
     progress.enable_steady_tick(SHIMMER_FRAME_INTERVAL);
+}
+
+fn phase_style(theme_mode: Option<ThemeMode>, intensity: u8) -> Style {
+    let intensity = match theme_mode {
+        Some(ThemeMode::Dark) => intensity,
+        Some(ThemeMode::Light) => 255 - intensity,
+        None => return Style::new(),
+    };
+    Style::new().fg(Color::TrueColor(intensity, intensity, intensity))
 }


### PR DESCRIPTION
The progress phase shimmer currently uses a fixed light grayscale ramp, which becomes difficult to read against light terminal backgrounds.

Detect the terminal theme once with terminal-colorsaurus and invert the grayscale ramp for light backgrounds while preserving the existing appearance on dark backgrounds. If detection is unavailable, use the terminal's default foreground color so the phase text remains readable. Hidden progress bars avoid running theme detection.

## Verification

- `just format`
- `cargo check -p purescript-alexandrite --tests`
- `cargo nextest run -p purescript-alexandrite` (61 tests passed)