### PR TITLE
[javascript] Initialize straight-line let results directly

### DIFF
--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -1541,6 +1541,15 @@ impl Generator<'_> {
                 let value = effect_expression(&mut renderer, effect)?;
                 Ok(RenderedExpression { value, pending_evaluation: false })
             }
+            ExpressionKind::Let { recursive: false, bindings, body } => {
+                let name = context.allocate("$result");
+                let mut renderer = self.renderer(tree, writer, context);
+                render_let(&mut renderer, false, bindings)?;
+                let value = self.expression_value(tree, writer, *body, context)?;
+                writer.constant(tree, &name, value, false);
+                let value = tree.identifier(name);
+                Ok(RenderedExpression { value, pending_evaluation: false })
+            }
             ExpressionKind::IfThenElse { .. }
             | ExpressionKind::Case { .. }
             | ExpressionKind::Guarded { .. }

--- a/tests-integration/fixtures/backend/1787791560_function_composition_reductions/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787791560_function_composition_reductions/output/Main/index.js
@@ -1,32 +1,28 @@
 import * as Lookalike from "../Lookalike/index.js";
 import * as $foreign from "./foreign.js";
 export function composeOrder($boolean) {
-  let $result;
   const composeOuter = observe("outer")((value) => value);
   const composeInner = observe("inner")((value$1) => value$1);
-  $result = (composeArgument) => /* @__PURE__ */ composeOuter(/* @__PURE__ */ composeInner(composeArgument));
+  const $result = (composeArgument) => /* @__PURE__ */ composeOuter(/* @__PURE__ */ composeInner(composeArgument));
   return $result(observe("argument")(42 | 0));
 }
 export function partiallyComposedOrder($boolean) {
-  let $result;
   const composeOuter = observe("outer")((value) => value);
   const composeInner = observe("inner")((value$1) => value$1);
-  $result = (composeArgument) => /* @__PURE__ */ composeOuter(/* @__PURE__ */ composeInner(composeArgument));
+  const $result = (composeArgument) => /* @__PURE__ */ composeOuter(/* @__PURE__ */ composeInner(composeArgument));
   const composedFunction = $result;
   return composedFunction(observe("argument")(42 | 0));
 }
 export function flippedComposeOrder($boolean) {
-  let $result;
   const composeInner = observe("inner")((value) => value);
   const composeOuter = observe("outer")((value$1) => value$1);
-  $result = (composeArgument) => /* @__PURE__ */ composeOuter(/* @__PURE__ */ composeInner(composeArgument));
+  const $result = (composeArgument) => /* @__PURE__ */ composeOuter(/* @__PURE__ */ composeInner(composeArgument));
   return $result(observe("argument")(42 | 0));
 }
 export function partiallyFlippedComposedOrder($boolean) {
-  let $result;
   const composeInner = observe("inner")((value) => value);
   const composeOuter = observe("outer")((value$1) => value$1);
-  $result = (composeArgument) => /* @__PURE__ */ composeOuter(/* @__PURE__ */ composeInner(composeArgument));
+  const $result = (composeArgument) => /* @__PURE__ */ composeOuter(/* @__PURE__ */ composeInner(composeArgument));
   const composedFunction = $result;
   return composedFunction(observe("argument")(42 | 0));
 }


### PR DESCRIPTION
## Summary

Render non-recursive functional let expressions in JavaScript expression position by emitting their bindings first and directly initializing the generated result constant. Expressions whose result depends on branching control flow continue to use the mutable assignment destination.

This removes the unnecessary mutable temporary produced for reduced function composition while preserving evaluation order.

Closes #426.

## Verification

- `cargo check -p javascript --tests`
- `cargo nextest run -p javascript --no-tests pass`
- `just t backend`
- `git diff --check`