### PR TITLE
[building] Derive foreign source kinds from file identities

### DIFF
--- a/compiler-core/building/src/engine.rs
+++ b/compiler-core/building/src/engine.rs
@@ -890,7 +890,7 @@ impl QueryEngine {
 
     pub fn set_foreign_file(&self, source_id: FileId, foreign_id: ForeignFileId) {
         let mut candidates = self.foreign_files(source_id);
-        candidates.set(foreign_id.kind(), Some(foreign_id));
+        candidates.insert(foreign_id);
         self.set_input(source_id, |input| &input.foreign, candidates);
     }
 
@@ -902,8 +902,7 @@ impl QueryEngine {
         for shard in &self.input.foreign.inner {
             let mut associations = shard.write();
             for state in associations.values_mut() {
-                if state.value.get(foreign_id.kind()) == Some(foreign_id) {
-                    state.value.set(foreign_id.kind(), None);
+                if state.value.remove(foreign_id) {
                     state.changed = changed;
                 }
             }

--- a/compiler-core/building/src/lifecycle.rs
+++ b/compiler-core/building/src/lifecycle.rs
@@ -325,7 +325,7 @@ impl<Version, Metadata> SourceUnit<Version, Metadata> {
             let Member::Present(foreign) = self.foreign.get(kind) else {
                 continue;
             };
-            candidates.set(kind, Some(foreign.id));
+            candidates.insert(foreign.id);
         }
         candidates
     }

--- a/compiler-core/building/src/lifecycle/foreign.rs
+++ b/compiler-core/building/src/lifecycle/foreign.rs
@@ -109,15 +109,7 @@ where
                     });
                     Member::Present(document)
                 } else {
-                    self.reconcile_foreign(
-                        engine,
-                        unit,
-                        kind,
-                        source_unit,
-                        document,
-                        disk,
-                        &mut change,
-                    )
+                    self.reconcile_foreign(engine, unit, source_unit, document, disk, &mut change)
                 }
             }
             (Member::Present(document), ForeignEvent::DiskObserved { disk }) => {
@@ -128,15 +120,7 @@ where
                     });
                     Member::Present(document)
                 } else {
-                    self.reconcile_foreign(
-                        engine,
-                        unit,
-                        kind,
-                        source_unit,
-                        document,
-                        disk,
-                        &mut change,
-                    )
+                    self.reconcile_foreign(engine, unit, source_unit, document, disk, &mut change)
                 }
             }
         };
@@ -148,12 +132,12 @@ where
         &mut self,
         engine: &QueryEngine,
         unit: &SourceUnitKey,
-        kind: ForeignSourceKind,
         source_unit: &SourceUnit<Version, Metadata>,
         mut document: ForeignDocument<Version>,
         disk: DiskObservation,
         change: &mut LifecycleChange,
     ) -> Member<ForeignDocument<Version>> {
+        let kind = document.id.kind();
         match disk {
             DiskObservation::Found(text) => {
                 self.set_foreign_content(engine, document.id, &text);
@@ -162,7 +146,7 @@ where
                 Member::Present(document)
             }
             DiskObservation::NotFound => {
-                self.remove_foreign(engine, unit, kind, document.id);
+                self.remove_foreign(engine, unit, document.id);
                 change.foreign_changed(source_unit.source_id());
                 Member::Missing
             }
@@ -203,21 +187,13 @@ where
         if previous_content == *text {
             return;
         }
-        let path = self.foreign_files.path(id);
-        let inserted_id = self.foreign_files.insert(id.kind(), path, Arc::clone(text));
-        debug_assert_eq!(inserted_id, id);
+        self.foreign_files.set_content(id, Arc::clone(text));
         engine.set_foreign_content(id, Arc::clone(text));
     }
 
-    fn remove_foreign(
-        &mut self,
-        engine: &QueryEngine,
-        unit: &SourceUnitKey,
-        kind: ForeignSourceKind,
-        id: ForeignFileId,
-    ) {
+    fn remove_foreign(&mut self, engine: &QueryEngine, unit: &SourceUnitKey, id: ForeignFileId) {
         engine.remove_foreign_file(id);
-        let removed_id = self.foreign_files.remove(unit.foreign_for(kind));
+        let removed_id = self.foreign_files.remove(unit.foreign_for(id.kind()));
         debug_assert_eq!(removed_id, Some(id));
     }
 }

--- a/compiler-core/files/src/lib.rs
+++ b/compiler-core/files/src/lib.rs
@@ -48,11 +48,23 @@ impl ForeignFileCandidates {
         }
     }
 
-    pub fn set(&mut self, kind: ForeignSourceKind, id: Option<ForeignFileId>) {
-        match kind {
-            ForeignSourceKind::JavaScript => self.javascript = id,
-            ForeignSourceKind::Jsx => self.jsx = id,
+    pub fn insert(&mut self, id: ForeignFileId) {
+        match id.kind() {
+            ForeignSourceKind::JavaScript => self.javascript = Some(id),
+            ForeignSourceKind::Jsx => self.jsx = Some(id),
         }
+    }
+
+    pub fn remove(&mut self, id: ForeignFileId) -> bool {
+        let candidate = match id.kind() {
+            ForeignSourceKind::JavaScript => &mut self.javascript,
+            ForeignSourceKind::Jsx => &mut self.jsx,
+        };
+        if *candidate != Some(id) {
+            return false;
+        }
+        *candidate = None;
+        true
     }
 
     pub fn unique(self) -> Option<ForeignFileId> {
@@ -212,6 +224,11 @@ impl ForeignFiles {
     pub fn content(&self, foreign_file_id: ForeignFileId) -> Arc<str> {
         let file = self.file(foreign_file_id);
         Arc::clone(&file.content)
+    }
+
+    pub fn set_content(&mut self, foreign_file_id: ForeignFileId, content: impl Into<Arc<str>>) {
+        let file = self.file_mut(foreign_file_id);
+        file.content = content.into();
     }
 
     pub fn remove(&mut self, path: &str) -> Option<ForeignFileId> {


### PR DESCRIPTION
## Summary

- derive foreign source kinds from existing `ForeignFileId` values during lifecycle reconciliation
- make foreign candidate insertion and removal identity-driven
- update foreign file content directly by identity instead of re-entering the creation API

This removes the redundant argument that triggered `clippy::too_many_arguments` on `reconcile_foreign` and prevents callers from supplying a source kind inconsistent with an existing foreign file identity.

## Verification

- `cargo check -p files --tests`
- `cargo check -p building --tests`
- `cargo nextest run -p files -p building` (59 passed)
- `cargo clippy --workspace`
