### PR TITLE
[backend] Support conditional StyleX props

### DIFF
--- a/compiler-backend/functional/src/convert.rs
+++ b/compiler-backend/functional/src/convert.rs
@@ -617,6 +617,7 @@ where
         let intrinsic = match indexed.items[term_id].name.as_deref() {
             Some("create") => Some(StyleXIntrinsic::Create),
             Some("props") => Some(StyleXIntrinsic::Props),
+            Some("conditional") => Some(StyleXIntrinsic::Conditional),
             Some("keyframes") => Some(StyleXIntrinsic::Keyframes),
             _ => None,
         };

--- a/compiler-backend/functional/src/convert/application.rs
+++ b/compiler-backend/functional/src/convert/application.rs
@@ -107,10 +107,8 @@ where
         {
             return Ok(composition);
         }
-        if let Some((intrinsic, argument)) =
-            self.stylex_intrinsic(known_function, &known_arguments)?
-        {
-            return Ok(self.expression(ExpressionKind::StyleX { intrinsic, argument }));
+        if let Some(kind) = self.stylex_intrinsic(known_function, &known_arguments)? {
+            return Ok(self.expression(kind));
         }
         if let Some(effect) = self.known_effect_application(known_function, &known_arguments)? {
             return Ok(self.expression(ExpressionKind::Effect { effect }));
@@ -496,7 +494,7 @@ where
         &self,
         expression: ExpressionId,
         arguments: &[ExpressionId],
-    ) -> QueryResult<Option<(StyleXIntrinsic, ExpressionId)>> {
+    ) -> QueryResult<Option<ExpressionKind>> {
         let ExpressionKind::Global { global } = &self.storage[expression].kind else {
             return Ok(None);
         };
@@ -504,14 +502,20 @@ where
         let Some(intrinsic) = self.stylex_intrinsic_identity(file_id, term_id)? else {
             return Ok(None);
         };
-        let application = match (intrinsic, arguments) {
-            (StyleXIntrinsic::Create, [_, argument]) => Some((intrinsic, *argument)),
-            (StyleXIntrinsic::Props, [argument]) | (StyleXIntrinsic::Keyframes, [argument]) => {
-                Some((intrinsic, *argument))
+        let kind = match (intrinsic, arguments) {
+            (StyleXIntrinsic::Create, [_, argument])
+            | (StyleXIntrinsic::Props, [_, argument])
+            | (StyleXIntrinsic::Keyframes, [argument]) => {
+                Some(ExpressionKind::StyleX { intrinsic, argument: *argument })
             }
+            (StyleXIntrinsic::Conditional, [condition, style]) => Some(ExpressionKind::Binary {
+                operator: BinaryOperator::StyleXConditional,
+                left: *condition,
+                right: *style,
+            }),
             _ => None,
         };
-        Ok(application)
+        Ok(kind)
     }
 
     fn known_numbered_term_arity(

--- a/compiler-backend/functional/src/pretty.rs
+++ b/compiler-backend/functional/src/pretty.rs
@@ -159,6 +159,7 @@ impl<'a> Printer<'a, '_> {
                     BinaryOperator::IntegerAdd => "integer.add",
                     BinaryOperator::IntegerSubtract => "integer.subtract",
                     BinaryOperator::IntegerMultiply => "integer.multiply",
+                    BinaryOperator::StyleXConditional => "stylex.conditional",
                 };
                 let left = self.expression_at(*left, ExpressionPrecedence::Atom);
                 let right = self.expression_at(*right, ExpressionPrecedence::Atom);

--- a/compiler-backend/functional/src/tree.rs
+++ b/compiler-backend/functional/src/tree.rs
@@ -201,6 +201,7 @@ pub enum ExpressionKind {
 pub enum StyleXIntrinsic {
     Create,
     Props,
+    Conditional,
     Keyframes,
 }
 
@@ -209,6 +210,7 @@ impl StyleXIntrinsic {
         match self {
             StyleXIntrinsic::Create => "create",
             StyleXIntrinsic::Props => "props",
+            StyleXIntrinsic::Conditional => "conditional",
             StyleXIntrinsic::Keyframes => "keyframes",
         }
     }
@@ -225,6 +227,7 @@ pub enum BinaryOperator {
     IntegerAdd,
     IntegerSubtract,
     IntegerMultiply,
+    StyleXConditional,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler-backend/javascript/src/convert/generator/functional/render/syntax.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render/syntax.rs
@@ -67,11 +67,28 @@ pub(super) fn binary_expression(
     left: ExpressionId,
     right: ExpressionId,
 ) -> ExpressionId {
-    let operator = match operator {
-        FunctionalBinaryOperator::IntegerAdd => BinaryOperator::Add,
-        FunctionalBinaryOperator::IntegerSubtract => BinaryOperator::Subtract,
-        FunctionalBinaryOperator::IntegerMultiply => BinaryOperator::Multiply,
-    };
+    match operator {
+        FunctionalBinaryOperator::IntegerAdd => {
+            integer_binary_expression(tree, BinaryOperator::Add, left, right)
+        }
+        FunctionalBinaryOperator::IntegerSubtract => {
+            integer_binary_expression(tree, BinaryOperator::Subtract, left, right)
+        }
+        FunctionalBinaryOperator::IntegerMultiply => {
+            integer_binary_expression(tree, BinaryOperator::Multiply, left, right)
+        }
+        FunctionalBinaryOperator::StyleXConditional => {
+            tree.binary(BinaryOperator::LogicalAnd, left, right)
+        }
+    }
+}
+
+fn integer_binary_expression(
+    tree: &mut Tree,
+    operator: BinaryOperator,
+    left: ExpressionId,
+    right: ExpressionId,
+) -> ExpressionId {
     let value = tree.binary(operator, left, right);
     integer_coercion_expression(tree, value)
 }

--- a/compiler-core/prim-constants/src/prim/Alexandrite.StyleX.purs
+++ b/compiler-core/prim-constants/src/prim/Alexandrite.StyleX.purs
@@ -4,6 +4,7 @@ module Alexandrite.StyleX
   , Keyframes
   , create
   , props
+  , conditional
   , keyframes
   ) where
 
@@ -24,6 +25,8 @@ class CompileStyles input output | input -> output
 class CompileStyleList :: RowList.RowList Type -> Row Type -> Constraint
 class CompileStyleList input output | input -> output
 
+class PropsInput :: Type -> Constraint
+
 instance
   ( RowList.RowToList input inputList
   , CompileStyleList inputList output
@@ -38,12 +41,22 @@ instance
   ) =>
   CompileStyleList (RowList.Cons label (Record declarations) tail) output
 
+instance PropsInput Style
+
+instance PropsInput (Array Style)
+
 foreign import create
   :: forall input output
    . CompileStyles input output
   => Record input
   -> Record output
 
-foreign import props :: Style -> Props
+foreign import props
+  :: forall input
+   . PropsInput input
+  => input
+  -> Props
+
+foreign import conditional :: Boolean -> Style -> Style
 
 foreign import keyframes :: forall frames. Record frames -> Keyframes

--- a/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Main.functional.snap
@@ -14,4 +14,7 @@ expression: report
 
 @export buttonProps = stylex.props styles.button
 
+@export buttonPropsArray = \highlighted%0 ->
+  stylex.props [styles.button, stylex.conditional highlighted%0 secondary.root]
+
 @export buttonClassName = buttonProps.className

--- a/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Main.purs
+++ b/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Main.purs
@@ -25,5 +25,11 @@ secondary = StyleX.create
 buttonProps :: StyleX.Props
 buttonProps = StyleX.props styles.button
 
+buttonPropsArray :: Boolean -> StyleX.Props
+buttonPropsArray highlighted = StyleX.props
+  [ styles.button
+  , StyleX.conditional highlighted secondary.root
+  ]
+
 buttonClassName :: String
 buttonClassName = buttonProps.className

--- a/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Main.snap
+++ b/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Main.snap
@@ -8,6 +8,7 @@ animation :: Alexandrite.StyleX.Keyframes
 styles :: { button :: Alexandrite.StyleX.Style, label :: Alexandrite.StyleX.Style }
 secondary :: { root :: Alexandrite.StyleX.Style }
 buttonProps :: Alexandrite.StyleX.Props
+buttonPropsArray :: Prim.Boolean -> Alexandrite.StyleX.Props
 buttonClassName :: Prim.String
 
 Types

--- a/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/output/Main/index.js
@@ -1,4 +1,7 @@
 import * as $stylex from "@stylexjs/stylex";
+export function buttonPropsArray(highlighted) {
+  return $stylex.props([styles.button, highlighted && secondary.root]);
+}
 export const animation = $stylex.keyframes({
   from: { opacity: 0 },
   to: { opacity: 1 }

--- a/tests-integration/fixtures/backend/1788013200_stylex_conditional_unsupported_use/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788013200_stylex_conditional_unsupported_use/Main.functional.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+cannot convert checked module Idx::<File>(43): Alexandrite.StyleX.conditional must be used as a direct, saturated intrinsic call

--- a/tests-integration/fixtures/backend/1788013200_stylex_conditional_unsupported_use/Main.purs
+++ b/tests-integration/fixtures/backend/1788013200_stylex_conditional_unsupported_use/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Alexandrite.StyleX (Style, conditional)
+
+partialConditional :: Style -> Style
+partialConditional = conditional true

--- a/tests-integration/fixtures/backend/1788013200_stylex_conditional_unsupported_use/Main.snap
+++ b/tests-integration/fixtures/backend/1788013200_stylex_conditional_unsupported_use/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+partialConditional :: Alexandrite.StyleX.Style -> Alexandrite.StyleX.Style
+
+Types

--- a/tests-integration/fixtures/backend/1788013200_stylex_conditional_unsupported_use/output/error.txt
+++ b/tests-integration/fixtures/backend/1788013200_stylex_conditional_unsupported_use/output/error.txt
@@ -1,0 +1,1 @@
+cannot convert checked module Idx::<File>(43): Alexandrite.StyleX.conditional must be used as a direct, saturated intrinsic call


### PR DESCRIPTION
StyleX accepts either individual styles or arrays, while PureScript does not support variadic function arguments. Generalize `StyleX.props` through a `PropsInput` constraint so callers can pass one `Style` or an `Array Style` without introducing variadic lowering.

Add a strongly typed `StyleX.conditional :: Boolean -> Style -> Style` intrinsic for conditional array entries. Functional lowering recognizes direct saturated calls and JavaScript generation emits the StyleX-compatible `condition && style` expression without applying integer coercion. Partial applications remain unsupported and receive the existing direct, saturated intrinsic diagnostic.

Tests cover single and array props calls, generated conditional JavaScript, inferred types, and rejected partial application.

Verification:
- `cargo check -p functional --tests`
- `cargo check -p javascript --tests`
- `cargo check -p prim-constants --tests`
- `just t backend`