### PR TITLE
[backend] Fold negation of known numeric literals

### DIFF
--- a/compiler-backend/functional/src/convert/application.rs
+++ b/compiler-backend/functional/src/convert/application.rs
@@ -216,6 +216,19 @@ where
                 value: *value,
             }));
         }
+        if let Some([value]) = self.known_instance_member_arguments(
+            function,
+            arguments,
+            "Data.Ring",
+            "negate",
+            "Data.Ring",
+            "ringNumber",
+        )? {
+            return Ok(Some(ExpressionKind::Unary {
+                operator: UnaryOperator::NumberNegate,
+                value: *value,
+            }));
+        }
         if let Some([left, right]) = self.known_instance_member_arguments(
             function,
             arguments,

--- a/compiler-backend/functional/src/optimize.rs
+++ b/compiler-backend/functional/src/optimize.rs
@@ -2,10 +2,11 @@
 
 use itertools::Itertools;
 use rustc_hash::FxHashSet;
+use smol_str::{SmolStr, format_smolstr};
 
 use crate::tree::{
-    Binding, EffectExpression, ExpressionId, ExpressionKind, GlobalId, Guard, LocalId,
-    RecordUpdate, Storage,
+    Binding, EffectExpression, ExpressionId, ExpressionKind, GlobalId, Guard, Literal, LocalId,
+    RecordUpdate, Storage, UnaryOperator,
 };
 
 pub fn inline_simple_bindings(
@@ -61,6 +62,10 @@ fn optimize_expression(
         optimize_expression(storage, child, recursive_globals, visited);
     }
 
+    if fold_literal_negation(storage, expression) {
+        return;
+    }
+
     let ExpressionKind::Let { recursive: false, bindings, body } = kind else {
         return;
     };
@@ -90,6 +95,47 @@ fn optimize_expression(
         ExpressionKind::Let { recursive: false, bindings: bindings.into(), body }
     };
     storage.replace_expression_kind(expression, replacement);
+    fold_literal_negation(storage, expression);
+}
+
+fn fold_literal_negation(storage: &mut Storage, expression: ExpressionId) -> bool {
+    let (operator, value) = match &storage[expression].kind {
+        ExpressionKind::Unary { operator, value } => (*operator, *value),
+        _ => return false,
+    };
+    let Some(literal) = folded_negation(storage, operator, value) else {
+        return false;
+    };
+    storage.replace_expression_kind(expression, ExpressionKind::Literal { literal });
+    true
+}
+
+fn folded_negation(
+    storage: &Storage,
+    operator: UnaryOperator,
+    value: ExpressionId,
+) -> Option<Literal> {
+    match (operator, &storage[value].kind) {
+        (
+            UnaryOperator::IntegerNegate,
+            ExpressionKind::Literal { literal: Literal::Integer(value) },
+        ) => Some(Literal::Integer(value.wrapping_neg())),
+        (
+            UnaryOperator::NumberNegate,
+            ExpressionKind::Literal { literal: Literal::Number(value) },
+        ) => Some(Literal::Number(negated_number(value))),
+        (
+            UnaryOperator::BooleanNot | UnaryOperator::IntegerNegate | UnaryOperator::NumberNegate,
+            _,
+        ) => None,
+    }
+}
+
+fn negated_number(value: &str) -> SmolStr {
+    match value.strip_prefix('-') {
+        Some(value) => SmolStr::new(value),
+        None => format_smolstr!("-{value}"),
+    }
 }
 
 fn binding_uses(

--- a/compiler-backend/functional/src/pretty.rs
+++ b/compiler-backend/functional/src/pretty.rs
@@ -150,6 +150,7 @@ impl<'a> Printer<'a, '_> {
                 let operator = match operator {
                     UnaryOperator::BooleanNot => "boolean.not",
                     UnaryOperator::IntegerNegate => "integer.negate",
+                    UnaryOperator::NumberNegate => "number.negate",
                 };
                 let value = self.expression_at(*value, ExpressionPrecedence::Atom);
                 self.arena.text(operator).append(" ").append(value)

--- a/compiler-backend/functional/src/tree.rs
+++ b/compiler-backend/functional/src/tree.rs
@@ -220,6 +220,7 @@ impl StyleXIntrinsic {
 pub enum UnaryOperator {
     BooleanNot,
     IntegerNegate,
+    NumberNegate,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/compiler-backend/javascript/src/convert/generator/functional/render/syntax.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render/syntax.rs
@@ -58,6 +58,7 @@ pub(super) fn unary_expression(
             let value = tree.unary(UnaryOperator::Negate, value);
             integer_coercion_expression(tree, value)
         }
+        FunctionalUnaryOperator::NumberNegate => tree.unary(UnaryOperator::Negate, value),
     }
 }
 

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Data.Ring.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Data.Ring.js
@@ -1,2 +1,4 @@
 export const intSubtract = left => right => (left - right) | 0;
 export const intNegate = value => -value | 0;
+export const numberSubtract = left => right => left - right;
+export const numberNegate = value => -value;

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.functional.snap
@@ -19,18 +19,16 @@ expression: report
 
 @export integerNegate = \value%10 -> integer.negate value%10
 
-@export integerNegateLiteral = integer.negate 20
+@export integerNegateLiteral = -20
 
-@export inlineIntegerNegateLiteral = integer.negate 20
+@export inlineIntegerNegateLiteral = -20
 
-@export numberNegate = \value%12 -> ringNumberDictNegate value%12
+@export numberNegate = \value%12 -> number.negate value%12
 
-@export numberNegateLiteral = ringNumberDictNegate 20.5
+@export numberNegateLiteral = -20.5
 
 @export integerAddOrder = \$boolean%13@(_) -> integer.add (observe "left" 20) (observe "right" 22)
 
 @export partiallyAppliedAdd = add semiringInt 1
 
 @export lookalikeAdd = \left%14 right%15 -> add semiringInt left%14 right%15
-
-ringNumberDictNegate = negate ringNumber

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.functional.snap
@@ -19,8 +19,18 @@ expression: report
 
 @export integerNegate = \value%10 -> integer.negate value%10
 
-@export integerAddOrder = \$boolean%11@(_) -> integer.add (observe "left" 20) (observe "right" 22)
+@export integerNegateLiteral = integer.negate 20
+
+@export inlineIntegerNegateLiteral = integer.negate 20
+
+@export numberNegate = \value%12 -> ringNumberDictNegate value%12
+
+@export numberNegateLiteral = ringNumberDictNegate 20.5
+
+@export integerAddOrder = \$boolean%13@(_) -> integer.add (observe "left" 20) (observe "right" 22)
 
 @export partiallyAppliedAdd = add semiringInt 1
 
-@export lookalikeAdd = \left%12 right%13 -> add semiringInt left%12 right%13
+@export lookalikeAdd = \left%14 right%15 -> add semiringInt left%14 right%15
+
+ringNumberDictNegate = negate ringNumber

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.purs
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.purs
@@ -28,6 +28,20 @@ integerMultiply left right = Semiring.mul left right
 integerNegate :: Int -> Int
 integerNegate value = Ring.negate value
 
+integerNegateLiteral :: Int
+integerNegateLiteral = Ring.negate 20
+
+inlineIntegerNegateLiteral :: Int
+inlineIntegerNegateLiteral =
+  let value = 20
+  in Ring.negate value
+
+numberNegate :: Number -> Number
+numberNegate value = Ring.negate value
+
+numberNegateLiteral :: Number
+numberNegateLiteral = Ring.negate 20.5
+
 integerAddOrder :: Boolean -> Int
 integerAddOrder _ =
   Semiring.add

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.snap
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 262
+assertion_line: 278
 expression: diagnostics_report
 ---
 Terms
@@ -12,6 +12,10 @@ inlineIntegerAdd :: Prim.Int -> Prim.Int -> Prim.Int
 integerSubtract :: Prim.Int -> Prim.Int -> Prim.Int
 integerMultiply :: Prim.Int -> Prim.Int -> Prim.Int
 integerNegate :: Prim.Int -> Prim.Int
+integerNegateLiteral :: Prim.Int
+inlineIntegerNegateLiteral :: Prim.Int
+numberNegate :: Prim.Number -> Prim.Number
+numberNegateLiteral :: Prim.Number
 integerAddOrder :: Prim.Boolean -> Prim.Int
 partiallyAppliedAdd :: Prim.Int -> Prim.Int
 lookalikeAdd :: Prim.Int -> Prim.Int -> Prim.Int

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.Ring/foreign.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.Ring/foreign.js
@@ -1,2 +1,4 @@
 export const intSubtract = left => right => (left - right) | 0;
 export const intNegate = value => -value | 0;
+export const numberSubtract = left => right => left - right;
+export const numberNegate = value => -value;

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.Ring/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Data.Ring/index.js
@@ -7,7 +7,13 @@ export function negate(dictionary) {
 }
 export const intSubtract = $foreign["intSubtract"];
 export const intNegate = $foreign["intNegate"];
+export const numberSubtract = $foreign["numberSubtract"];
+export const numberNegate = $foreign["numberNegate"];
 export const ringInt = {
   sub: intSubtract,
   negate: intNegate
+};
+export const ringNumber = {
+  sub: numberSubtract,
+  negate: numberNegate
 };

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Main/index.js
@@ -1,3 +1,4 @@
+import * as Data_Ring from "../Data.Ring/index.js";
 import * as Data_Semiring from "../Data.Semiring/index.js";
 import * as Lookalike from "../Lookalike/index.js";
 import * as $foreign from "./foreign.js";
@@ -27,6 +28,9 @@ export function integerMultiply(left) {
 export function integerNegate(value) {
   return -value | 0;
 }
+export function numberNegate(value) {
+  return /* @__PURE__ */ ringNumberDictNegate(value);
+}
 export function integerAddOrder($boolean) {
   return observe("left")(20 | 0) + observe("right")(22 | 0) | 0;
 }
@@ -37,4 +41,8 @@ export function lookalikeAdd(left) {
 }
 export const observe = $foreign["observe"];
 export const readTrace = $foreign["readTrace"];
+const ringNumberDictNegate = /* @__PURE__ */ Data_Ring.negate(Data_Ring.ringNumber);
+export const integerNegateLiteral = -(20 | 0) | 0;
+export const inlineIntegerNegateLiteral = -(20 | 0) | 0;
+export const numberNegateLiteral = /* @__PURE__ */ ringNumberDictNegate(20.5);
 export const partiallyAppliedAdd = /* @__PURE__ */ Data_Semiring.add(Data_Semiring.semiringInt)(1 | 0);

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/output/Main/index.js
@@ -1,4 +1,3 @@
-import * as Data_Ring from "../Data.Ring/index.js";
 import * as Data_Semiring from "../Data.Semiring/index.js";
 import * as Lookalike from "../Lookalike/index.js";
 import * as $foreign from "./foreign.js";
@@ -29,7 +28,7 @@ export function integerNegate(value) {
   return -value | 0;
 }
 export function numberNegate(value) {
-  return /* @__PURE__ */ ringNumberDictNegate(value);
+  return -value;
 }
 export function integerAddOrder($boolean) {
   return observe("left")(20 | 0) + observe("right")(22 | 0) | 0;
@@ -41,8 +40,7 @@ export function lookalikeAdd(left) {
 }
 export const observe = $foreign["observe"];
 export const readTrace = $foreign["readTrace"];
-const ringNumberDictNegate = /* @__PURE__ */ Data_Ring.negate(Data_Ring.ringNumber);
-export const integerNegateLiteral = -(20 | 0) | 0;
-export const inlineIntegerNegateLiteral = -(20 | 0) | 0;
-export const numberNegateLiteral = /* @__PURE__ */ ringNumberDictNegate(20.5);
+export const integerNegateLiteral = -20 | 0;
+export const inlineIntegerNegateLiteral = -20 | 0;
+export const numberNegateLiteral = -20.5;
 export const partiallyAppliedAdd = /* @__PURE__ */ Data_Semiring.add(Data_Semiring.semiringInt)(1 | 0);

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/verify.mjs
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/verify.mjs
@@ -9,6 +9,7 @@ const expectedPrimitives = [
   "left - right | 0",
   "left * right | 0",
   "-value | 0",
+  "return -value;",
 ];
 for (const expected of expectedPrimitives) {
   if (!source.includes(expected)) {

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/verify.mjs
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/verify.mjs
@@ -24,6 +24,10 @@ strictEqual(Main.integerAdd(2147483647)(1), -2147483648);
 strictEqual(Main.integerSubtract(-2147483647)(2), 2147483647);
 strictEqual(Main.integerMultiply(65536)(65536), 0);
 strictEqual(Main.integerNegate(-2147483648), -2147483648);
+strictEqual(Main.integerNegateLiteral, -20);
+strictEqual(Main.inlineIntegerNegateLiteral, -20);
+strictEqual(Main.numberNegate(20.5), -20.5);
+strictEqual(Main.numberNegateLiteral, -20.5);
 strictEqual(Main.partiallyAppliedAdd(41), 42);
 strictEqual(Main.lookalikeAdd(20)(22), 42);
 

--- a/tests-integration/fixtures/backend/1787547540_known_primitive_operations/verify.mjs
+++ b/tests-integration/fixtures/backend/1787547540_known_primitive_operations/verify.mjs
@@ -1,24 +1,5 @@
 import { deepStrictEqual, strictEqual } from "node:assert/strict";
-import { readFile } from "node:fs/promises";
 import * as Main from "./output/Main/index.js";
-
-const source = await readFile(new URL("./output/Main/index.js", import.meta.url), "utf8");
-const expectedPrimitives = [
-  "!value",
-  "left + right | 0",
-  "left - right | 0",
-  "left * right | 0",
-  "-value | 0",
-  "return -value;",
-];
-for (const expected of expectedPrimitives) {
-  if (!source.includes(expected)) {
-    throw new Error(`missing known primitive output: ${expected}`);
-  }
-}
-if (!source.includes("Lookalike.add(Lookalike.semiringInt)")) {
-  throw new Error("same-named non-canonical member was reduced");
-}
 
 strictEqual(Main.booleanNot(true), false);
 strictEqual(Main.integerAdd(2147483647)(1), -2147483648);

--- a/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Data.Ring.js
+++ b/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Data.Ring.js
@@ -1,0 +1,2 @@
+export const intNegate = value => -value | 0;
+export const numberNegate = value => -value;

--- a/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Data.Ring.purs
+++ b/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Data.Ring.purs
@@ -1,18 +1,13 @@
 module Data.Ring where
 
 class Ring value where
-  sub :: value -> value -> value
   negate :: value -> value
 
-foreign import intSubtract :: Int -> Int -> Int
 foreign import intNegate :: Int -> Int
-foreign import numberSubtract :: Number -> Number -> Number
 foreign import numberNegate :: Number -> Number
 
 instance ringInt :: Ring Int where
-  sub = intSubtract
   negate = intNegate
 
 instance ringNumber :: Ring Number where
-  sub = numberSubtract
   negate = numberNegate

--- a/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Main.functional.snap
@@ -10,8 +10,8 @@ expression: report
     {
       color: "red",
       padding: 8,
-      marginInline: integer.negate 20,
-      opacity: negate ringNumber 0.5,
+      marginInline: -20,
+      opacity: -0.5,
       animationName: animation,
       ":hover": { color: "blue" }
     },

--- a/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Main.functional.snap
@@ -6,7 +6,15 @@ expression: report
 @export animation = stylex.keyframes { from: { opacity: 0.0 }, to: { opacity: 1.0 } }
 
 @export styles = stylex.create {
-  button: { color: "red", padding: 8, animationName: animation, ":hover": { color: "blue" } },
+  button:
+    {
+      color: "red",
+      padding: 8,
+      marginInline: integer.negate 20,
+      opacity: negate ringNumber 0.5,
+      animationName: animation,
+      ":hover": { color: "blue" }
+    },
   label: { fontWeight: 600 }
 }
 

--- a/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Main.purs
+++ b/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/Main.purs
@@ -1,6 +1,7 @@
 module Main where
 
 import Alexandrite.StyleX as StyleX
+import Data.Ring as Ring
 
 animation :: StyleX.Keyframes
 animation = StyleX.keyframes
@@ -12,6 +13,8 @@ styles = StyleX.create
   { button:
       { color: "red"
       , padding: 8
+      , marginInline: Ring.negate 20
+      , opacity: Ring.negate 0.5
       , animationName: animation
       , ":hover": { color: "blue" }
       }

--- a/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/output/Data.Ring/foreign.js
+++ b/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/output/Data.Ring/foreign.js
@@ -1,0 +1,2 @@
+export const intNegate = value => -value | 0;
+export const numberNegate = value => -value;

--- a/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/output/Data.Ring/index.js
+++ b/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/output/Data.Ring/index.js
@@ -1,0 +1,8 @@
+import * as $foreign from "./foreign.js";
+export function negate(dictionary) {
+  return dictionary.negate;
+}
+export const intNegate = $foreign["intNegate"];
+export const numberNegate = $foreign["numberNegate"];
+export const ringInt = { negate: intNegate };
+export const ringNumber = { negate: numberNegate };

--- a/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/output/Main/index.js
@@ -1,3 +1,4 @@
+import * as Data_Ring from "../Data.Ring/index.js";
 import * as $stylex from "@stylexjs/stylex";
 export function buttonPropsArray(highlighted) {
   return $stylex.props([styles.button, highlighted && secondary.root]);
@@ -10,6 +11,8 @@ export const styles = $stylex.create({
   button: {
     color: "red",
     padding: 8 | 0,
+    marginInline: -(20 | 0) | 0,
+    opacity: /* @__PURE__ */ Data_Ring.negate(Data_Ring.ringNumber)(.5),
     animationName: animation,
     ":hover": { color: "blue" }
   },

--- a/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1787994720_stylex_intrinsics/output/Main/index.js
@@ -1,4 +1,3 @@
-import * as Data_Ring from "../Data.Ring/index.js";
 import * as $stylex from "@stylexjs/stylex";
 export function buttonPropsArray(highlighted) {
   return $stylex.props([styles.button, highlighted && secondary.root]);
@@ -11,8 +10,8 @@ export const styles = $stylex.create({
   button: {
     color: "red",
     padding: 8 | 0,
-    marginInline: -(20 | 0) | 0,
-    opacity: /* @__PURE__ */ Data_Ring.negate(Data_Ring.ringNumber)(.5),
+    marginInline: -20 | 0,
+    opacity: -.5,
     animationName: animation,
     ":hover": { color: "blue" }
   },


### PR DESCRIPTION
## Intent

StyleX requires style values to remain statically analyzable. Numeric negation currently leaves known `Number` values behind `Data.Ring.negate` calls, while known `Int` values retain a redundant runtime-shaped unary/coercion expression.

## Changes

- recognize canonical `ringNumber` negation as a backend primitive
- fold known `Int` and `Number` negations in the functional optimizer, including literals exposed by simple-binding inlining
- preserve wrapping `Int` semantics and dynamic negation behavior
- cover primitive and StyleX-generated JavaScript in backend regression fixtures

## Verification

- `cargo check -p functional --tests`
- `cargo check -p javascript --tests`
- `just t backend 1787547540_known_primitive_operations`
- `just t backend 1787994720_stylex_intrinsics`
- `just t backend`
