### PR TITLE
[lsp] Use incremental document synchronization

### DIFF
--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -287,7 +287,7 @@ fn initialize(
                 text_document_sync: Some(TextDocumentSyncCapability::Options(
                     TextDocumentSyncOptions {
                         open_close: Some(true),
-                        change: Some(TextDocumentSyncKind::FULL),
+                        change: Some(TextDocumentSyncKind::INCREMENTAL),
                         save: Some(TextDocumentSyncSaveOptions::Supported(true)),
                         ..TextDocumentSyncOptions::default()
                     },
@@ -608,27 +608,88 @@ fn semantic_tokens(
     result.on_non_fatal(None)
 }
 
+fn document_content(
+    state: &State,
+    document: DocumentKind,
+    uri: &Url,
+) -> Result<Arc<str>, LspError> {
+    let files = state.files.read();
+    match document {
+        DocumentKind::Source => {
+            let file_id = files
+                .source_id(uri.as_str())
+                .ok_or_else(|| LspError::InvalidContentChange(Url::clone(uri)))?;
+            state.engine.content(file_id).map_err(LspError::from)
+        }
+        DocumentKind::Foreign(_) => {
+            let file_id = files
+                .foreign_id(uri.as_str())
+                .ok_or_else(|| LspError::InvalidContentChange(Url::clone(uri)))?;
+            state
+                .engine
+                .foreign_content(file_id)
+                .ok_or_else(|| LspError::InvalidContentChange(Url::clone(uri)))
+        }
+    }
+}
+
+fn apply_content_changes(
+    uri: &Url,
+    content: &str,
+    content_changes: &[TextDocumentContentChangeEvent],
+    position_encoding: PositionEncoding,
+) -> Result<Arc<str>, LspError> {
+    let mut content = content.to_string();
+    for content_change in content_changes {
+        let Some(range) = content_change.range else {
+            content = content_change.text.clone();
+            continue;
+        };
+
+        let start =
+            analyzer::position::protocol_position_to_utf8(&content, range.start, position_encoding);
+        let start = start
+            .and_then(|position| analyzer::position::utf8_position_to_offset(&content, position));
+
+        let end =
+            analyzer::position::protocol_position_to_utf8(&content, range.end, position_encoding);
+        let end = end
+            .and_then(|position| analyzer::position::utf8_position_to_offset(&content, position));
+
+        let (Some(start), Some(end)) = (start, end) else {
+            return Err(LspError::InvalidContentChange(Url::clone(uri)));
+        };
+
+        let start = usize::from(start);
+        let end = usize::from(end);
+
+        if start > end {
+            return Err(LspError::InvalidContentChange(Url::clone(uri)));
+        }
+
+        content.replace_range(start..end, &content_change.text);
+    }
+    Ok(Arc::from(content))
+}
+
 fn did_change(state: &mut State, p: DidChangeTextDocumentParams) -> Result<(), LspError> {
     let uri = &p.text_document.uri;
-    let Some(content_change) = p.content_changes.last() else {
+    if p.content_changes.is_empty() {
         return Ok(());
-    };
+    }
     let (document, unit) = source_unit_from_document_uri(uri)?;
+    let content = document_content(state, document, uri)?;
+    let content =
+        apply_content_changes(uri, &content, &p.content_changes, state.position_encoding)?;
     let event = match document {
         DocumentKind::Foreign(kind) => LifecycleEvent::Foreign {
             unit,
             kind,
-            event: ForeignEvent::Changed {
-                text: Arc::from(content_change.text.as_str()),
-                version: p.text_document.version,
-            },
+            event: ForeignEvent::Changed { text: content, version: p.text_document.version },
         },
         DocumentKind::Source => LifecycleEvent::Source {
             unit,
-            event: SourceEvent::Changed {
-                text: Arc::from(content_change.text.as_str()),
-                version: p.text_document.version,
-            },
+            event: SourceEvent::Changed { text: content, version: p.text_document.version },
         },
     };
     let change = apply_lifecycle_event(state, event);

--- a/compiler-bin/src/lsp/error.rs
+++ b/compiler-bin/src/lsp/error.rs
@@ -23,6 +23,8 @@ pub enum LspError {
     InvalidFileUri(Url),
     #[error("Expected a PureScript or JavaScript document URI, received {0}")]
     UnsupportedDocumentUri(Url),
+    #[error("Invalid content change for document {0}")]
+    InvalidContentChange(Url),
     #[error("UrlParseError: {0}")]
     UrlParseError(#[from] url::ParseError),
     #[error("Invalid or missing workspace root")]

--- a/compiler-bin/src/lsp/tests.rs
+++ b/compiler-bin/src/lsp/tests.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::sync::Arc;
 
+use analyzer::position::PositionEncoding;
 use async_lsp::ResponseError;
 use async_lsp::router::Router;
 use building::lifecycle::{
@@ -8,12 +9,16 @@ use building::lifecycle::{
     SourceUnitKey,
 };
 use files::ForeignSourceKind;
-use lsp_types::{DidCloseTextDocumentParams, TextDocumentIdentifier, Url};
+use lsp_types::{
+    DidCloseTextDocumentParams, Position, Range, TextDocumentContentChangeEvent,
+    TextDocumentIdentifier, Url,
+};
 use tempfile::tempdir;
 
 use super::{
-    LspConfig, State, apply_lifecycle_event, did_close, document_kind, observe_disk,
-    source_unit_from_document_uri, source_unit_from_foreign_uri, source_unit_from_source_uri,
+    LspConfig, State, apply_content_changes, apply_lifecycle_event, did_close, document_kind,
+    observe_disk, source_unit_from_document_uri, source_unit_from_foreign_uri,
+    source_unit_from_source_uri,
 };
 
 fn test_config() -> Arc<LspConfig> {
@@ -220,4 +225,67 @@ fn disk_observation_distinguishes_content_and_absence() {
 
     fs::remove_file(source_path).unwrap();
     assert_eq!(observe_disk(&source_uri), DiskObservation::NotFound);
+}
+
+#[test]
+fn incremental_content_changes_apply_sequentially() {
+    let uri = Url::parse("file:///workspace/Main.purs").unwrap();
+    let changes = [
+        TextDocumentContentChangeEvent {
+            range: Some(Range::new(Position::new(1, 0), Position::new(1, 4))),
+            range_length: Some(4),
+            text: "answer".to_string(),
+        },
+        TextDocumentContentChangeEvent {
+            range: Some(Range::new(Position::new(1, 9), Position::new(1, 10))),
+            range_length: Some(1),
+            text: "42".to_string(),
+        },
+    ];
+
+    let content = apply_content_changes(
+        &uri,
+        "module Main where\nlife = 0\n",
+        &changes,
+        PositionEncoding::Utf16,
+    )
+    .unwrap();
+
+    assert_eq!(content.as_ref(), "module Main where\nanswer = 42\n");
+}
+
+#[test]
+fn incremental_content_changes_use_negotiated_position_encoding() {
+    let uri = Url::parse("file:///workspace/Main.purs").unwrap();
+    let changes = [TextDocumentContentChangeEvent {
+        range: Some(Range::new(Position::new(0, 3), Position::new(0, 4))),
+        range_length: Some(1),
+        text: "c".to_string(),
+    }];
+
+    let content = apply_content_changes(&uri, "a😀b", &changes, PositionEncoding::Utf16).unwrap();
+
+    assert_eq!(content.as_ref(), "a😀c");
+}
+
+#[test]
+fn full_content_change_resets_incremental_change_base() {
+    let uri = Url::parse("file:///workspace/Main.purs").unwrap();
+    let changes = [
+        TextDocumentContentChangeEvent {
+            range: None,
+            range_length: None,
+            text: "life = 1".to_string(),
+        },
+        TextDocumentContentChangeEvent {
+            range: Some(Range::new(Position::new(0, 7), Position::new(0, 8))),
+            range_length: Some(1),
+            text: "2".to_string(),
+        },
+    ];
+
+    let content =
+        apply_content_changes(&uri, "discarded", &changes, PositionEncoding::Utf16).unwrap();
+
+    assert_eq!(content.as_ref(), "life = 2");
 }


### PR DESCRIPTION
## Summary

Advertise incremental text document synchronization and reconstruct each changed document by applying the complete change batch in order. Ranged edits use the negotiated position encoding, while full-document replacements remain supported.

The reconstructed text continues through the existing lifecycle path so version checks, query invalidation, caches, and diagnostics retain their current behavior. Invalid changes are rejected before lifecycle state is mutated.

## Verification

- `cargo check -p purescript-alexandrite --tests`
- `cargo nextest run -p purescript-alexandrite`
- `just t lsp`
- `just format`
