### PR TITLE
[compiler-bin] Add Spago project workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -48,6 +48,63 @@ jobs:
       - name: Run integration tests
         run: cargo nextest run -p tests-integration
 
+  end_to_end:
+    name: End-to-end tests (${{ matrix.os }})
+    permissions:
+      contents: read
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            spago_cache: ~/.cache/spago-nodejs
+          - os: macos-latest
+            spago_cache: ~/Library/Caches/spago-nodejs
+          - os: windows-latest
+            spago_cache: ~/AppData/Local/spago-nodejs/Cache
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm and Node.js
+        uses: pnpm/setup@v2
+        with:
+          version: 12
+          runtime: node@22
+          cache: true
+          cache-dependency-path: tests-e2e/tools/pnpm-lock.yaml
+          install: false
+
+      - name: Install Rust toolchain
+        run: rustup update stable && rustup default stable
+
+      - name: Cache build artifacts
+        uses: Swatinem/rust-cache@v2.9.1
+        with:
+          cache-bin: "false"
+          prefix-key: "v1-e2e-${{ matrix.os }}"
+
+      - name: Install tools
+        uses: taiki-e/install-action@v2.85.4
+        with:
+          tool: cargo-nextest,just
+
+      - name: Cache Spago registry
+        uses: actions/cache@v5
+        with:
+          path: ${{ matrix.spago_cache }}
+          key: v1-spago-${{ runner.os }}-${{ hashFiles('tests-e2e/tools/pnpm-lock.yaml') }}
+
+      - name: Prepare end-to-end tools
+        run: just e2e-prepare
+
+      - name: Run end-to-end tests
+        run: just e2e
+
   compatibility:
     name: Package compatibility
     if: github.event_name == 'pull_request'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexing"
 version = "0.1.0"
 dependencies = [
@@ -1724,6 +1740,16 @@ dependencies = [
  "anstyle",
  "clap",
  "escape8259",
+]
+
+[[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
 ]
 
 [[package]]
@@ -2525,6 +2551,7 @@ dependencies = [
  "documentation",
  "files",
  "globset",
+ "ignore",
  "indexing",
  "indicatif",
  "insta",
@@ -2543,6 +2570,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "serde_yml",
  "smol_str",
  "spago",
  "stabilizing",
@@ -2917,6 +2945,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3190,6 +3224,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
+ "tempfile",
  "thiserror",
  "url",
  "walkdir",
@@ -3450,6 +3485,15 @@ dependencies = [
  "thiserror",
  "url",
  "walkdir",
+]
+
+[[package]]
+name = "tests-e2e"
+version = "0.1.0"
+dependencies = [
+ "insta",
+ "purescript-alexandrite",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2549,6 +2549,7 @@ dependencies = [
  "console",
  "diagnostics",
  "documentation",
+ "dunce",
  "files",
  "globset",
  "ignore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,6 +3095,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3883,6 +3898,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "waitpid-any"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "compiler-scripts",
   "docs/src/wasm",
   "tests-compatibility",
+  "tests-e2e",
   "tests-integration",
 ]
 default-members = [

--- a/compiler-bin/Cargo.toml
+++ b/compiler-bin/Cargo.toml
@@ -34,6 +34,7 @@ documentation = { version = "0.1.0", path = "../compiler-lsp/documentation" }
 diagnostics = { version = "0.1.0", path = "../compiler-frontend/diagnostics" }
 files = { version = "0.1.0", path = "../compiler-core/files" }
 globset = "0.4.20"
+ignore = "0.4.25"
 indicatif = "0.18.6"
 indexing = { version = "0.1.0", path = "../compiler-frontend/indexing" }
 itertools = "0.15.0"
@@ -51,6 +52,7 @@ resolving = { version = "0.1.0", path = "../compiler-frontend/resolving" }
 rustc-hash = "2.1.3"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
+serde_yml = "0.0.12"
 smol_str = "0.3.6"
 spago = { version = "0.1.0", path = "../compiler-lsp/spago" }
 stabilizing = { version = "0.1.0", path = "../compiler-frontend/stabilizing" }

--- a/compiler-bin/Cargo.toml
+++ b/compiler-bin/Cargo.toml
@@ -32,6 +32,7 @@ clap = { version = "4.6.6", features = ["derive"] }
 console = "0.16.4"
 documentation = { version = "0.1.0", path = "../compiler-lsp/documentation" }
 diagnostics = { version = "0.1.0", path = "../compiler-frontend/diagnostics" }
+dunce = "1.0.5"
 files = { version = "0.1.0", path = "../compiler-core/files" }
 globset = "0.4.20"
 ignore = "0.4.25"

--- a/compiler-bin/bundled/project/Main.purs
+++ b/compiler-bin/bundled/project/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Console (log)
+
+main :: Effect Unit
+main = do
+  log "🍝"

--- a/compiler-bin/bundled/project/Test.Main.purs
+++ b/compiler-bin/bundled/project/Test.Main.purs
@@ -1,0 +1,11 @@
+module Test.Main where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Class.Console (log)
+
+main :: Effect Unit
+main = do
+  log "🍕"
+  log "You should add some tests."

--- a/compiler-bin/bundled/project/gitignore
+++ b/compiler-bin/bundled/project/gitignore
@@ -1,0 +1,2 @@
+.spago/
+output/

--- a/compiler-bin/bundled/project/runner.mjs
+++ b/compiler-bin/bundled/project/runner.mjs
@@ -1,0 +1,8 @@
+if (process.argv[2] === "--") {
+  process.argv.splice(2, 1);
+}
+const target = await import(process.argv[1]);
+if (typeof target.main !== "function") {
+  throw new Error(`Module does not export a main function: ${process.argv[1]}`);
+}
+await target.main();

--- a/compiler-bin/src/cli.rs
+++ b/compiler-bin/src/cli.rs
@@ -39,6 +39,16 @@ impl Cli {
 pub enum Command {
     /// Run the language server.
     Lsp(LspOptions),
+    /// Create a Spago project in the current directory.
+    New(NewOptions),
+    /// Build a Spago workspace or package.
+    Build(ProjectBuildOptions),
+    /// Add dependencies to a Spago package.
+    Add(AddOptions),
+    /// Build and run a Spago package with Node.js.
+    Run(RunOptions),
+    /// Build and test one or more Spago packages with Node.js.
+    Test(TestOptions),
     /// Compile PureScript modules to JavaScript (experimental).
     Compile(CompileOptions),
     /// Compile PureScript modules and rebuild when inputs change (experimental).
@@ -144,6 +154,78 @@ pub struct BuildOptions {
     /// When to use colors in human-readable diagnostics.
     #[arg(long, value_enum, default_value_t = ColorChoice::Auto)]
     pub color: ColorChoice,
+}
+
+#[derive(Debug, Args)]
+pub struct NewOptions {
+    /// Package name. Defaults to the current directory name.
+    #[arg(long, value_name("NAME"))]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct ProjectBuildOptions {
+    #[command(flatten)]
+    pub logging: LoggingOptions,
+
+    /// Workspace package to build.
+    #[arg(short, long, value_name("NAME"))]
+    pub package: Option<String>,
+
+    /// Output directory for compiled modules. Defaults to output in the workspace root.
+    #[arg(short, long, value_name("DIR"), value_parser = absolute_path_parser())]
+    pub output: Option<PathBuf>,
+
+    /// Suppress build progress output.
+    #[arg(short, long)]
+    pub quiet: bool,
+
+    /// When to use colors in human-readable diagnostics.
+    #[arg(long, value_enum, default_value_t = ColorChoice::Auto)]
+    pub color: ColorChoice,
+}
+
+#[derive(Debug, Args)]
+pub struct AddOptions {
+    /// Workspace package whose dependencies should change.
+    #[arg(short, long, value_name("NAME"))]
+    pub package: Option<String>,
+
+    /// Add packages as test dependencies.
+    #[arg(long)]
+    pub test: bool,
+
+    /// Packages to add.
+    #[arg(value_name("DEPENDENCY"), required = true)]
+    pub dependencies: Vec<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct RunOptions {
+    #[command(flatten)]
+    pub build: ProjectBuildOptions,
+
+    /// Module containing the program entry point.
+    #[arg(long, value_name("MODULE"))]
+    pub main: Option<String>,
+
+    /// Arguments passed to the program.
+    #[arg(last = true)]
+    pub arguments: Vec<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct TestOptions {
+    #[command(flatten)]
+    pub build: ProjectBuildOptions,
+
+    /// Module containing the test entry point.
+    #[arg(long, value_name("MODULE"))]
+    pub main: Option<String>,
+
+    /// Arguments passed to each test program.
+    #[arg(last = true)]
+    pub arguments: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]

--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -93,6 +93,40 @@ fn compile(config: CompileConfig) -> Result<(), CompileError> {
         source_paths.extend(package::source_files(&current_directory, package)?);
     }
 
+    compile_source_paths(
+        &current_directory,
+        &config.output,
+        source_paths,
+        config.quiet,
+        config.color,
+        started,
+        preparation_progress,
+    )
+}
+
+pub(crate) fn compile_inputs(
+    root: &Path,
+    output: &Path,
+    inputs: &[PathBuf],
+    quiet: bool,
+    color: ColorChoice,
+) -> Result<(), CompileError> {
+    let started = Instant::now();
+    let preparation_progress = progress::bar(1, "Preparing", !quiet);
+    let walked = walk::walk(root, inputs)?;
+    let source_paths = walked.files.into_iter().collect::<BTreeSet<_>>();
+    compile_source_paths(root, output, source_paths, quiet, color, started, preparation_progress)
+}
+
+fn compile_source_paths(
+    current_directory: &Path,
+    output: &Path,
+    source_paths: BTreeSet<PathBuf>,
+    quiet: bool,
+    color: ColorChoice,
+    started: Instant,
+    preparation_progress: indicatif::ProgressBar,
+) -> Result<(), CompileError> {
     let mut compilation = CompilationState::new();
 
     for path in source_paths {
@@ -106,17 +140,13 @@ fn compile(config: CompileConfig) -> Result<(), CompileError> {
         return Err(io::Error::new(io::ErrorKind::NotFound, "no input files found").into());
     }
 
-    let build_config = BuildConfig {
-        output: &config.output,
-        current_directory: &current_directory,
-        color: use_color(config.color),
-        progress: !config.quiet,
-    };
+    let build_config =
+        BuildConfig { output, current_directory, color: use_color(color), progress: !quiet };
     if matches!(build(&compilation, &build_config)?, BuildOutcome::Diagnostics) {
         return Err(CompileError::Diagnostics);
     }
 
-    if !config.quiet {
+    if !quiet {
         progress::report_completion(started.elapsed());
     }
 

--- a/compiler-bin/src/lib.rs
+++ b/compiler-bin/src/lib.rs
@@ -9,8 +9,10 @@ pub mod logging;
 pub mod lsp;
 mod package;
 mod progress;
+mod project;
 pub mod walk;
 mod watch;
+mod workspace;
 
 pub fn run() {
     let cli = cli::Cli::parse();
@@ -35,6 +37,34 @@ pub fn run() {
                 diagnostics_on_save: options.diagnostics_on_save,
                 diagnostics_on_change: options.diagnostics_on_change,
             });
+        }
+        cli::Command::New(options) => project::start(project::new(options.name)),
+        cli::Command::Build(options) => {
+            start_project_logging(&options.logging);
+            project::start(project::build(project_build_config(options)));
+        }
+        cli::Command::Add(options) => {
+            project::start(project::add(project::AddProjectConfig {
+                package: options.package,
+                dependencies: options.dependencies,
+                test_dependencies: options.test,
+            }));
+        }
+        cli::Command::Run(options) => {
+            start_project_logging(&options.build.logging);
+            project::start(project::run(project::RunProjectConfig {
+                build: project_build_config(options.build),
+                main: options.main,
+                arguments: options.arguments,
+            }));
+        }
+        cli::Command::Test(options) => {
+            start_project_logging(&options.build.logging);
+            project::start(project::test(project::TestProjectConfig {
+                build: project_build_config(options.build),
+                main: options.main,
+                arguments: options.arguments,
+            }));
         }
         cli::Command::Compile(options) => {
             logging::start(logging::LoggingFilters {
@@ -87,5 +117,23 @@ pub fn run() {
                 }
             }
         }
+    }
+}
+
+fn start_project_logging(options: &cli::LoggingOptions) {
+    logging::start(logging::LoggingFilters {
+        query_log: options.query_log,
+        checking_log: options.checking_log,
+        lsp_log: LevelFilter::OFF,
+        docs_log: LevelFilter::OFF,
+    });
+}
+
+fn project_build_config(options: cli::ProjectBuildOptions) -> project::BuildProjectConfig {
+    project::BuildProjectConfig {
+        package: options.package,
+        output: options.output,
+        quiet: options.quiet,
+        color: options.color,
     }
 }

--- a/compiler-bin/src/project.rs
+++ b/compiler-bin/src/project.rs
@@ -1,0 +1,298 @@
+use std::path::{Path, PathBuf};
+use std::process::{self, Command, ExitStatus};
+use std::{env, fs, io};
+
+use thiserror::Error;
+use url::Url;
+
+use crate::cli::ColorChoice;
+use crate::compile::{self, CompileError};
+use crate::workspace::{Workspace, WorkspaceError};
+use spago::{SpagoCommand, SpagoError};
+
+const MAIN_SOURCE: &str = include_str!("../bundled/project/Main.purs");
+const TEST_SOURCE: &str = include_str!("../bundled/project/Test.Main.purs");
+const NODE_RUNNER: &str = include_str!("../bundled/project/runner.mjs");
+const GITIGNORE: &str = include_str!("../bundled/project/gitignore");
+
+#[derive(Debug, Error)]
+pub enum ProjectError {
+    #[error(transparent)]
+    Compile(#[from] CompileError),
+    #[error(transparent)]
+    Spago(#[from] SpagoError),
+    #[error(transparent)]
+    Workspace(#[from] WorkspaceError),
+    #[error("invalid package name '{0}'; use lowercase letters, digits, and hyphens")]
+    InvalidPackageName(String),
+    #[error("cannot create a project because these paths already exist: {0}")]
+    ExistingPaths(String),
+    #[error("cannot create a project inside the existing Spago workspace at {0}")]
+    ExistingWorkspace(PathBuf),
+    #[error("failed to determine the current directory: {0}")]
+    CurrentDirectory(io::Error),
+    #[error("failed to write {path}: {source}")]
+    Write {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to execute Node.js: {0}")]
+    Node(io::Error),
+    #[error("Node.js exited without a status code")]
+    MissingStatus,
+    #[error("Node.js exited with status {0}")]
+    NodeFailed(ExitStatus),
+    #[error("module output does not exist: {0}")]
+    MissingModule(PathBuf),
+    #[error("failed to canonicalize module output {path}: {source}")]
+    CanonicalizeModule {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to convert module output to a file URL: {0}")]
+    ModuleUrl(PathBuf),
+    #[error("no selected packages contain tests")]
+    NoTests,
+}
+
+pub struct BuildProjectConfig {
+    pub package: Option<String>,
+    pub output: Option<PathBuf>,
+    pub quiet: bool,
+    pub color: ColorChoice,
+}
+
+pub struct AddProjectConfig {
+    pub package: Option<String>,
+    pub dependencies: Vec<String>,
+    pub test_dependencies: bool,
+}
+
+pub struct RunProjectConfig {
+    pub build: BuildProjectConfig,
+    pub main: Option<String>,
+    pub arguments: Vec<String>,
+}
+
+pub struct TestProjectConfig {
+    pub build: BuildProjectConfig,
+    pub main: Option<String>,
+    pub arguments: Vec<String>,
+}
+
+pub fn start(result: Result<(), ProjectError>) {
+    if let Err(error) = result {
+        eprintln!("{error}");
+        let exit_code = match error {
+            ProjectError::NodeFailed(status) => status.code().unwrap_or(1),
+            _ => 1,
+        };
+        process::exit(exit_code);
+    }
+}
+
+pub fn new(name: Option<String>) -> Result<(), ProjectError> {
+    let current_directory = env::current_dir().map_err(ProjectError::CurrentDirectory)?;
+    if let Some(root) = Workspace::find_ancestor(&current_directory)? {
+        return Err(ProjectError::ExistingWorkspace(root));
+    }
+    let name = match name {
+        Some(name) => name,
+        None => current_directory
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("main")
+            .to_owned(),
+    };
+    validate_package_name(&name)?;
+
+    let targets = [
+        current_directory.join("spago.yaml"),
+        current_directory.join("src/Main.purs"),
+        current_directory.join("test/Test/Main.purs"),
+        current_directory.join(".gitignore"),
+    ];
+    let required_directories = [
+        current_directory.join("src"),
+        current_directory.join("test"),
+        current_directory.join("test/Test"),
+    ];
+    let existing_targets = targets.iter().filter(|path| path.exists());
+    let invalid_directories =
+        required_directories.iter().filter(|path| path.exists() && !path.is_dir());
+    let existing = existing_targets.chain(invalid_directories);
+    let existing = existing.map(|path| path.display().to_string());
+    let existing = existing.collect::<Vec<_>>();
+    if !existing.is_empty() {
+        return Err(ProjectError::ExistingPaths(existing.join(", ")));
+    }
+
+    let manifest = format!(
+        r#"package:
+  name: {name}
+  dependencies:
+    - console
+    - effect
+    - prelude
+  test:
+    main: Test.Main
+    dependencies:
+      - assert
+workspace: {{}}
+"#
+    );
+    write_file(&targets[0], &manifest)?;
+    write_file(&targets[1], MAIN_SOURCE)?;
+    write_file(&targets[2], TEST_SOURCE)?;
+    write_file(&targets[3], GITIGNORE)?;
+    Ok(())
+}
+
+pub fn build(config: BuildProjectConfig) -> Result<(), ProjectError> {
+    let current_directory = env::current_dir().map_err(ProjectError::CurrentDirectory)?;
+    let workspace = Workspace::discover(&current_directory, config.package.as_deref())?;
+    compile_workspace(&workspace, &current_directory, &config)
+}
+
+pub fn add(config: AddProjectConfig) -> Result<(), ProjectError> {
+    let current_directory = env::current_dir().map_err(ProjectError::CurrentDirectory)?;
+    let workspace = Workspace::discover(&current_directory, config.package.as_deref())?;
+    let selected = workspace.require_selected()?.manifest.name.as_str();
+    let spago = SpagoCommand::new(&current_directory)?;
+    spago.add(selected, &config.dependencies, config.test_dependencies).map_err(ProjectError::from)
+}
+
+pub fn run(config: RunProjectConfig) -> Result<(), ProjectError> {
+    let current_directory = env::current_dir().map_err(ProjectError::CurrentDirectory)?;
+    let workspace = Workspace::discover(&current_directory, config.build.package.as_deref())?;
+    let package = workspace.require_selected()?;
+    compile_workspace(&workspace, &current_directory, &config.build)?;
+
+    let execution = package.manifest.run.as_ref().cloned().unwrap_or_default();
+    let main = config.main.or(execution.main).unwrap_or_else(|| "Main".to_owned());
+    let arguments =
+        if config.arguments.is_empty() { execution.exec_args } else { config.arguments };
+    execute_module(&workspace.root, output(&workspace, &config.build), &main, &arguments)
+}
+
+pub fn test(config: TestProjectConfig) -> Result<(), ProjectError> {
+    let current_directory = env::current_dir().map_err(ProjectError::CurrentDirectory)?;
+    let workspace = Workspace::discover(&current_directory, config.build.package.as_deref())?;
+    if workspace.selected.is_some() {
+        let package = workspace.require_selected()?;
+        if !package.has_tests {
+            return Err(ProjectError::NoTests);
+        }
+    } else if !workspace.packages.values().any(|package| package.has_tests) {
+        return Err(ProjectError::NoTests);
+    }
+    compile_workspace(&workspace, &current_directory, &config.build)?;
+    let output = output(&workspace, &config.build);
+
+    let packages = workspace.packages.values().filter(|package| {
+        workspace.selected.as_ref().is_some_and(|selected| selected == &package.manifest.name)
+            || (workspace.selected.is_none() && package.has_tests)
+    });
+    for package in packages {
+        let execution = package.manifest.test.as_ref().cloned().unwrap_or_default();
+        let main = config.main.clone().or(execution.main).unwrap_or_else(|| "Test.Main".to_owned());
+        let arguments = if config.arguments.is_empty() {
+            execution.exec_args
+        } else {
+            config.arguments.clone()
+        };
+        execute_module(&workspace.root, output.clone(), &main, &arguments)?;
+    }
+    Ok(())
+}
+
+fn compile_workspace(
+    workspace: &Workspace,
+    current_directory: &Path,
+    config: &BuildProjectConfig,
+) -> Result<(), ProjectError> {
+    let spago = SpagoCommand::new(current_directory)?;
+    spago.fetch(workspace.selected.as_deref())?;
+    let sources = spago.source_globs(workspace.selected.as_deref())?;
+    let output = output(workspace, config);
+    compile::compile_inputs(&workspace.root, &output, &sources, config.quiet, config.color)?;
+    Ok(())
+}
+
+fn output(workspace: &Workspace, config: &BuildProjectConfig) -> PathBuf {
+    config.output.clone().unwrap_or_else(|| workspace.root.join("output"))
+}
+
+fn execute_module(
+    workspace_root: &Path,
+    output: PathBuf,
+    module: &str,
+    arguments: &[String],
+) -> Result<(), ProjectError> {
+    let module = output.join(module).join("index.js");
+    if !module.is_file() {
+        return Err(ProjectError::MissingModule(module));
+    }
+    let module = module
+        .canonicalize()
+        .map_err(|source| ProjectError::CanonicalizeModule { path: module.clone(), source })?;
+    let module_url = Url::from_file_path(&module)
+        .map_err(|()| ProjectError::ModuleUrl(module.clone()))?
+        .to_string();
+    let status = Command::new("node")
+        .arg("--input-type=module")
+        .arg("--eval")
+        .arg(NODE_RUNNER)
+        .arg(module_url)
+        .arg("--")
+        .args(arguments)
+        .current_dir(workspace_root)
+        .status()
+        .map_err(ProjectError::Node)?;
+    ensure_node_success(status)
+}
+
+fn ensure_node_success(status: ExitStatus) -> Result<(), ProjectError> {
+    if status.success() {
+        return Ok(());
+    }
+    if status.code().is_none() {
+        return Err(ProjectError::MissingStatus);
+    }
+    Err(ProjectError::NodeFailed(status))
+}
+
+fn validate_package_name(name: &str) -> Result<(), ProjectError> {
+    let mut characters = name.chars();
+    let starts_lowercase =
+        characters.next().is_some_and(|character| character.is_ascii_lowercase());
+    let remaining_valid = characters.all(|character| {
+        character.is_ascii_lowercase() || character.is_ascii_digit() || character == '-'
+    });
+    if !starts_lowercase || !remaining_valid {
+        return Err(ProjectError::InvalidPackageName(name.to_owned()));
+    }
+    Ok(())
+}
+
+fn write_file(path: &Path, content: &str) -> Result<(), ProjectError> {
+    let parent = path.parent().expect("project file path has no parent");
+    fs::create_dir_all(parent)
+        .map_err(|source| ProjectError::Write { path: parent.to_path_buf(), source })?;
+    fs::write(path, content)
+        .map_err(|source| ProjectError::Write { path: path.to_path_buf(), source })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_package_names() {
+        assert!(validate_package_name("my-project2").is_ok());
+        assert!(validate_package_name("MyProject").is_err());
+        assert!(validate_package_name("2project").is_err());
+    }
+}

--- a/compiler-bin/src/walk.rs
+++ b/compiler-bin/src/walk.rs
@@ -35,7 +35,7 @@ pub fn walk_filtered(
     let mut globs = GlobSetBuilder::new();
 
     for path in includes {
-        let path = root.join(path);
+        let path = dunce::simplified(root).join(path);
         if let Ok(path) = path.absolutize()
             && let Some(path) = path.to_str()
             && let Ok(glob) = Glob::new(path)
@@ -77,7 +77,7 @@ fn build_excludes(
     let mut globs = GlobSetBuilder::new();
 
     for path in excludes {
-        let path = root.join(path);
+        let path = dunce::simplified(root).join(path);
         if let Ok(path) = path.absolutize()
             && let Some(path) = path.to_str()
         {
@@ -199,5 +199,18 @@ mod tests {
 
         assert!(Glob::new(pattern).is_ok());
         assert_eq!(glob_literal_base(pattern), PathBuf::from("/workspace/src"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn walks_windows_style_globs() {
+        let root = temporary_directory();
+        touch(&root.join("src/Main.purs"));
+        let canonical_root = dunce::canonicalize(&root).unwrap();
+
+        let walk = walk(&canonical_root, [r"src\**\*.purs"]).unwrap();
+
+        assert_eq!(relative_files(&canonical_root, walk.files), vec!["src/Main.purs"]);
+        fs::remove_dir_all(root).unwrap();
     }
 }

--- a/compiler-bin/src/workspace.rs
+++ b/compiler-bin/src/workspace.rs
@@ -1,0 +1,372 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::{fs, io};
+
+use ignore::WalkBuilder;
+use serde::Deserialize;
+use thiserror::Error;
+
+const MANIFEST: &str = "spago.yaml";
+
+#[derive(Debug, Error)]
+pub enum WorkspaceError {
+    #[error("no Spago workspace found from {0}")]
+    MissingWorkspace(PathBuf),
+    #[error("workspace package '{requested}' was not found; available packages: {available}")]
+    UnknownPackage { requested: String, available: String },
+    #[error("workspace contains no packages")]
+    NoPackages,
+    #[error("workspace package selection is ambiguous; use --package <NAME>")]
+    AmbiguousPackage,
+    #[error("duplicate workspace package name '{name}' in {first} and {second}")]
+    DuplicatePackage { name: String, first: PathBuf, second: PathBuf },
+    #[error("failed to read {path}: {source}")]
+    ReadManifest {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to canonicalize working directory {path}: {source}")]
+    CanonicalizeDirectory {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to parse {path}: {source}")]
+    ParseManifest {
+        path: PathBuf,
+        #[source]
+        source: serde_yml::Error,
+    },
+    #[error(transparent)]
+    Walk(#[from] ignore::Error),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Manifest {
+    pub workspace: Option<serde_yml::Value>,
+    pub package: Option<PackageManifest>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PackageManifest {
+    pub name: String,
+    pub run: Option<ExecutionConfig>,
+    pub test: Option<ExecutionConfig>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutionConfig {
+    pub main: Option<String>,
+    #[serde(default)]
+    pub exec_args: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkspacePackage {
+    pub root: PathBuf,
+    pub manifest: PackageManifest,
+    pub has_tests: bool,
+}
+
+#[derive(Debug)]
+pub struct Workspace {
+    pub root: PathBuf,
+    pub packages: BTreeMap<String, WorkspacePackage>,
+    pub selected: Option<String>,
+}
+
+impl Workspace {
+    pub fn find_ancestor(current_directory: &Path) -> Result<Option<PathBuf>, WorkspaceError> {
+        for directory in current_directory.ancestors().skip(1) {
+            let path = directory.join(MANIFEST);
+            if path.is_file() && read_manifest(&path)?.workspace.is_some() {
+                return Ok(Some(directory.to_path_buf()));
+            }
+        }
+        Ok(None)
+    }
+
+    pub fn discover(
+        current_directory: &Path,
+        requested_package: Option<&str>,
+    ) -> Result<Workspace, WorkspaceError> {
+        let current_directory = current_directory.canonicalize().map_err(|source| {
+            WorkspaceError::CanonicalizeDirectory { path: current_directory.to_path_buf(), source }
+        })?;
+        let (root, inferred_package) = find_root(&current_directory)?;
+        let packages = discover_packages(&root)?;
+        if packages.is_empty() {
+            return Err(WorkspaceError::NoPackages);
+        }
+
+        let selected = if let Some(requested) = requested_package {
+            if !packages.contains_key(requested) {
+                let available = packages.keys().cloned().collect::<Vec<_>>().join(", ");
+                return Err(WorkspaceError::UnknownPackage {
+                    requested: requested.to_owned(),
+                    available,
+                });
+            }
+            Some(requested.to_owned())
+        } else if let Some(inferred) = inferred_package.filter(|name| packages.contains_key(name)) {
+            Some(inferred)
+        } else if packages.len() == 1 {
+            packages.keys().next().cloned()
+        } else {
+            None
+        };
+
+        Ok(Workspace { root, packages, selected })
+    }
+
+    pub fn require_selected(&self) -> Result<&WorkspacePackage, WorkspaceError> {
+        let Some(name) = &self.selected else {
+            return Err(WorkspaceError::AmbiguousPackage);
+        };
+        Ok(&self.packages[name])
+    }
+}
+
+fn find_root(current_directory: &Path) -> Result<(PathBuf, Option<String>), WorkspaceError> {
+    let mut inferred_package = None;
+    for directory in current_directory.ancestors() {
+        let path = directory.join(MANIFEST);
+        if !path.is_file() {
+            continue;
+        }
+        let manifest = read_manifest(&path)?;
+        if manifest.workspace.is_some() {
+            return Ok((directory.to_path_buf(), inferred_package));
+        }
+        if inferred_package.is_none()
+            && let Some(package) = manifest.package
+        {
+            inferred_package = Some(package.name);
+        }
+    }
+    Err(WorkspaceError::MissingWorkspace(current_directory.to_path_buf()))
+}
+
+fn discover_packages(root: &Path) -> Result<BTreeMap<String, WorkspacePackage>, WorkspaceError> {
+    let mut builder = WalkBuilder::new(root);
+    builder.hidden(false);
+    builder.ignore(false);
+    builder.require_git(false);
+    builder.git_global(false);
+    builder.git_exclude(false);
+    builder.parents(false);
+    let filter_root = root.to_path_buf();
+    builder.filter_entry(move |entry| !excluded_directory(entry.path(), &filter_root));
+    let manifests = builder.build().filter_map(|entry| {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => return Some(Err(error)),
+        };
+        if !entry.file_type().is_some_and(|file_type| file_type.is_file()) {
+            return None;
+        }
+        if entry.file_name() != MANIFEST {
+            return None;
+        }
+        Some(Ok(entry.into_path()))
+    });
+    let mut manifests = manifests.collect::<Result<Vec<_>, _>>()?;
+    manifests.sort_by_key(|path| path.components().count());
+
+    let mut nested_workspaces = Vec::new();
+    let mut packages = BTreeMap::new();
+    for path in manifests {
+        let package_root = path.parent().expect("spago.yaml path has no parent");
+        if package_root != root
+            && nested_workspaces.iter().any(|nested: &PathBuf| package_root.starts_with(nested))
+        {
+            continue;
+        }
+
+        let manifest = read_manifest(&path)?;
+        if package_root != root && manifest.workspace.is_some() {
+            nested_workspaces.push(package_root.to_path_buf());
+            continue;
+        }
+        let Some(package) = manifest.package else {
+            continue;
+        };
+        let name = package.name.clone();
+        let workspace_package = WorkspacePackage {
+            root: package_root.to_path_buf(),
+            has_tests: package_root.join("test").is_dir(),
+            manifest: package,
+        };
+        if let Some(previous) = packages.insert(name.clone(), workspace_package) {
+            return Err(WorkspaceError::DuplicatePackage {
+                name,
+                first: previous.root,
+                second: package_root.to_path_buf(),
+            });
+        }
+    }
+    Ok(packages)
+}
+
+fn excluded_directory(path: &Path, root: &Path) -> bool {
+    if path == root {
+        return false;
+    }
+    matches!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some(".git" | ".spago" | "node_modules")
+    )
+}
+
+fn read_manifest(path: &Path) -> Result<Manifest, WorkspaceError> {
+    let source = fs::read_to_string(path)
+        .map_err(|source| WorkspaceError::ReadManifest { path: path.to_path_buf(), source })?;
+    serde_yml::from_str(&source)
+        .map_err(|source| WorkspaceError::ParseManifest { path: path.to_path_buf(), source })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn write(path: &Path, content: &str) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn discovers_current_package_in_workspace() {
+        let temporary = tempdir().unwrap();
+        write(&temporary.path().join("spago.yaml"), "workspace: {}\n");
+        write(
+            &temporary.path().join("packages/app/spago.yaml"),
+            r#"package:
+  name: app
+"#,
+        );
+        write(
+            &temporary.path().join("packages/library/spago.yaml"),
+            r#"package:
+  name: library
+"#,
+        );
+        let current = temporary.path().join("packages/app/src");
+        fs::create_dir_all(&current).unwrap();
+
+        let workspace = Workspace::discover(&current, None).unwrap();
+        assert_eq!(workspace.selected.as_deref(), Some("app"));
+        assert_eq!(workspace.packages.keys().collect::<Vec<_>>(), vec!["app", "library"]);
+    }
+
+    #[test]
+    fn workspace_root_does_not_select_its_package() {
+        let temporary = tempdir().unwrap();
+        write(
+            &temporary.path().join("spago.yaml"),
+            r#"workspace: {}
+package:
+  name: root
+"#,
+        );
+        write(
+            &temporary.path().join("packages/library/spago.yaml"),
+            r#"package:
+  name: library
+"#,
+        );
+
+        let workspace = Workspace::discover(temporary.path(), None).unwrap();
+        assert_eq!(workspace.selected, None);
+    }
+
+    #[test]
+    fn root_package_subdirectory_does_not_select_it() {
+        let temporary = tempdir().unwrap();
+        write(
+            &temporary.path().join("spago.yaml"),
+            r#"workspace: {}
+package:
+  name: root
+"#,
+        );
+        write(
+            &temporary.path().join("packages/library/spago.yaml"),
+            r#"package:
+  name: library
+"#,
+        );
+        let current = temporary.path().join("src");
+        fs::create_dir_all(&current).unwrap();
+
+        let workspace = Workspace::discover(&current, None).unwrap();
+        assert_eq!(workspace.selected, None);
+    }
+
+    #[test]
+    fn gitignored_packages_are_not_discovered() {
+        let temporary = tempdir().unwrap();
+        write(
+            &temporary.path().join("spago.yaml"),
+            r#"workspace: {}
+package:
+  name: root
+"#,
+        );
+        write(&temporary.path().join(".gitignore"), "ignored/\n");
+        write(
+            &temporary.path().join("ignored/spago.yaml"),
+            r#"package:
+  name: ignored
+"#,
+        );
+
+        let workspace = Workspace::discover(temporary.path(), None).unwrap();
+        assert_eq!(workspace.packages.keys().collect::<Vec<_>>(), vec!["root"]);
+    }
+
+    #[test]
+    fn nested_workspace_is_not_part_of_parent() {
+        let temporary = tempdir().unwrap();
+        write(
+            &temporary.path().join("spago.yaml"),
+            r#"workspace: {}
+package:
+  name: root
+"#,
+        );
+        write(
+            &temporary.path().join("nested/spago.yaml"),
+            r#"workspace: {}
+package:
+  name: nested
+"#,
+        );
+        write(
+            &temporary.path().join("nested/packages/child/spago.yaml"),
+            r#"package:
+  name: child
+"#,
+        );
+
+        let workspace = Workspace::discover(temporary.path(), None).unwrap();
+        assert_eq!(workspace.packages.keys().collect::<Vec<_>>(), vec!["root"]);
+    }
+
+    #[test]
+    fn finds_ancestor_workspace() {
+        let temporary = tempdir().unwrap();
+        write(&temporary.path().join("spago.yaml"), "workspace: {}\n");
+        let nested = temporary.path().join("packages/application");
+        fs::create_dir_all(&nested).unwrap();
+
+        assert_eq!(
+            Workspace::find_ancestor(&nested).unwrap(),
+            Some(temporary.path().to_path_buf())
+        );
+        assert_eq!(Workspace::find_ancestor(temporary.path()).unwrap(), None);
+    }
+}

--- a/compiler-lsp/spago/Cargo.toml
+++ b/compiler-lsp/spago/Cargo.toml
@@ -10,6 +10,7 @@ rustc-hash = "2.1.3"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 smol_str = { version = "0.3.4", features = ["serde"] }
+tempfile = "3.27.0"
 thiserror = "2.0.20"
 walkdir = "2.5.0"
 

--- a/compiler-lsp/spago/bundled/purs/purs.cmd
+++ b/compiler-lsp/spago/bundled/purs/purs.cmd
@@ -1,0 +1,7 @@
+@echo off
+if "%~1"=="--version" if "%~2"=="" (
+  echo 0.15.15
+  exit /b 0
+)
+echo Alexandrite compatibility shim only supports purs --version 1>&2
+exit /b 64

--- a/compiler-lsp/spago/bundled/purs/purs.sh
+++ b/compiler-lsp/spago/bundled/purs/purs.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ "$#" -eq 1 ] && [ "$1" = "--version" ]; then
+  printf '%s\n' '0.15.15'
+  exit 0
+fi
+printf '%s\n' 'Alexandrite compatibility shim only supports purs --version' >&2
+exit 64

--- a/compiler-lsp/spago/src/command.rs
+++ b/compiler-lsp/spago/src/command.rs
@@ -1,0 +1,225 @@
+use std::ffi::OsString;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::{env, fs};
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SpagoError {
+    #[error("failed to prepare the Spago compiler compatibility shim: {0}")]
+    Shim(io::Error),
+    #[error("failed to execute Spago: {0}")]
+    Execute(io::Error),
+    #[error("Spago {command} failed with status {status}")]
+    Failed { command: String, status: String },
+    #[error("Spago returned an invalid JSON source list: {0}")]
+    InvalidSources(serde_json::Error),
+    #[error("Spago returned no source paths")]
+    EmptySources,
+}
+
+pub struct SpagoCommand {
+    current_directory: PathBuf,
+    executable: OsString,
+    path: OsString,
+    _shim: tempfile::TempDir,
+}
+
+impl SpagoCommand {
+    pub fn new(current_directory: &Path) -> Result<SpagoCommand, SpagoError> {
+        let shim = tempfile::tempdir().map_err(SpagoError::Shim)?;
+        write_purs_shim(shim.path()).map_err(SpagoError::Shim)?;
+        let path = prepend_path(shim.path()).map_err(SpagoError::Shim)?;
+        let executable = env::var_os("ALEXANDRITE_SPAGO").unwrap_or_else(|| "spago".into());
+        Ok(SpagoCommand {
+            current_directory: current_directory.to_path_buf(),
+            executable,
+            path,
+            _shim: shim,
+        })
+    }
+
+    pub fn fetch(&self, selected: Option<&str>) -> Result<(), SpagoError> {
+        let mut arguments = vec!["fetch".to_owned()];
+        add_selection(&mut arguments, selected);
+        let output = self.execute(&arguments)?;
+        forward_output(&output)?;
+        ensure_success("fetch", &output)
+    }
+
+    pub fn add(
+        &self,
+        selected: &str,
+        packages: &[String],
+        test_dependencies: bool,
+    ) -> Result<(), SpagoError> {
+        let mut arguments = vec!["fetch".to_owned(), "-p".to_owned(), selected.to_owned()];
+        if test_dependencies {
+            arguments.push("--test-deps".to_owned());
+        }
+        arguments.extend(packages.iter().cloned());
+        let output = self.execute(&arguments)?;
+        forward_output(&output)?;
+        ensure_success("fetch", &output)
+    }
+
+    pub fn source_globs(&self, selected: Option<&str>) -> Result<Vec<PathBuf>, SpagoError> {
+        let mut arguments = vec!["sources".to_owned(), "--json".to_owned()];
+        add_selection(&mut arguments, selected);
+        let output = self.execute(&arguments)?;
+        io::stderr().write_all(&output.stderr).map_err(SpagoError::Execute)?;
+        ensure_success("sources --json", &output)?;
+        let sources: Vec<PathBuf> =
+            serde_json::from_slice(&output.stdout).map_err(SpagoError::InvalidSources)?;
+        if sources.is_empty() {
+            return Err(SpagoError::EmptySources);
+        }
+        Ok(sources)
+    }
+
+    fn execute(&self, arguments: &[String]) -> Result<Output, SpagoError> {
+        Command::new(&self.executable)
+            .args(arguments)
+            .current_dir(&self.current_directory)
+            .env("PATH", &self.path)
+            .output()
+            .map_err(SpagoError::Execute)
+    }
+}
+
+fn add_selection(arguments: &mut Vec<String>, selected: Option<&str>) {
+    if let Some(selected) = selected {
+        arguments.push("-p".to_owned());
+        arguments.push(selected.to_owned());
+    }
+}
+
+fn ensure_success(command: &str, output: &Output) -> Result<(), SpagoError> {
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(SpagoError::Failed { command: command.to_owned(), status: output.status.to_string() })
+}
+
+fn forward_output(output: &Output) -> Result<(), SpagoError> {
+    io::stdout().write_all(&output.stdout).map_err(SpagoError::Execute)?;
+    io::stderr().write_all(&output.stderr).map_err(SpagoError::Execute)
+}
+
+fn prepend_path(directory: &Path) -> io::Result<OsString> {
+    let mut paths = vec![directory.to_path_buf()];
+    if let Some(current) = env::var_os("PATH") {
+        paths.extend(env::split_paths(&current));
+    }
+    env::join_paths(paths).map_err(io::Error::other)
+}
+
+#[cfg(unix)]
+fn write_purs_shim(directory: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = directory.join("purs");
+    fs::write(&path, include_str!("../bundled/purs/purs.sh"))?;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755))
+}
+
+#[cfg(windows)]
+fn write_purs_shim(directory: &Path) -> io::Result<()> {
+    fs::write(directory.join("purs.cmd"), include_str!("../bundled/purs/purs.cmd"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prepares_spago_command_for_a_project() {
+        let temporary = tempfile::tempdir().unwrap();
+        let command = SpagoCommand::new(temporary.path()).unwrap();
+
+        assert_eq!(command.current_directory, temporary.path());
+        assert_eq!(env::split_paths(&command.path).next().as_deref(), Some(command._shim.path()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executes_spago_package_commands() {
+        let temporary = tempfile::tempdir().unwrap();
+        let executable = write_executable(
+            &temporary,
+            r#"#!/bin/sh
+case "$*" in
+  "fetch -p application") exit 0 ;;
+  "fetch -p application --test-deps console effect") exit 0 ;;
+  "sources --json -p application")
+    printf '%s\n' '["src/**/*.purs", ".spago/p/prelude/1.0.0/src/**/*.purs"]'
+    exit 0
+    ;;
+esac
+exit 9
+"#,
+        );
+        let command = test_command(&temporary, &executable);
+
+        command.fetch(Some("application")).unwrap();
+        command.add("application", &["console".to_owned(), "effect".to_owned()], true).unwrap();
+        let sources = command.source_globs(Some("application")).unwrap();
+
+        assert_eq!(
+            sources,
+            vec![
+                PathBuf::from("src/**/*.purs"),
+                PathBuf::from(".spago/p/prelude/1.0.0/src/**/*.purs"),
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reports_spago_failures_and_invalid_source_lists() {
+        let temporary = tempfile::tempdir().unwrap();
+        let executable = write_executable(
+            &temporary,
+            r#"#!/bin/sh
+case "$*" in
+  "sources --json -p invalid") printf '%s\n' 'invalid' ;;
+  "sources --json -p empty") printf '%s\n' '[]' ;;
+  *) exit 7 ;;
+esac
+"#,
+        );
+        let command = test_command(&temporary, &executable);
+
+        assert!(matches!(command.fetch(None), Err(SpagoError::Failed { .. })));
+        assert!(matches!(
+            command.source_globs(Some("invalid")),
+            Err(SpagoError::InvalidSources(_))
+        ));
+        assert!(matches!(command.source_globs(Some("empty")), Err(SpagoError::EmptySources)));
+    }
+
+    #[cfg(unix)]
+    fn write_executable(temporary: &tempfile::TempDir, source: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        let executable = temporary.path().join("spago");
+        fs::write(&executable, source).unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+        executable
+    }
+
+    #[cfg(unix)]
+    fn test_command(temporary: &tempfile::TempDir, executable: &Path) -> SpagoCommand {
+        let shim = tempfile::tempdir().unwrap();
+        write_purs_shim(shim.path()).unwrap();
+        let path = prepend_path(shim.path()).unwrap();
+        SpagoCommand {
+            current_directory: temporary.path().to_path_buf(),
+            executable: executable.as_os_str().to_owned(),
+            path,
+            _shim: shim,
+        }
+    }
+}

--- a/compiler-lsp/spago/src/lib.rs
+++ b/compiler-lsp/spago/src/lib.rs
@@ -1,8 +1,10 @@
+mod command;
 pub mod lockfile;
 
 use std::path::Path;
 use std::{fs, io};
 
+pub use command::{SpagoCommand, SpagoError};
 pub use lockfile::{PackageReference, PackageSources, PackagesBySource};
 use thiserror::Error;
 

--- a/justfile
+++ b/justfile
@@ -24,6 +24,14 @@ coverage-html:
 @integration *args="":
   cargo nextest run -p tests-integration "$@" --status-level=fail --final-status-level=fail --failure-output=final
 
+[doc("Install end-to-end test tools")]
+@e2e-prepare:
+  pnpm --dir tests-e2e/tools install --frozen-lockfile
+
+[doc("Run end-to-end tests")]
+@e2e *args="":
+  cargo nextest run -p tests-e2e "$@"
+
 [doc("Run integration tests with snapshot diffing: backend|checking|semantic|lowering|resolving|lsp")]
 @t *args="":
   cargo run -q -p compiler-scripts --release -- "$@"

--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ coverage-html:
 
 [doc("Run end-to-end tests")]
 @e2e *args="":
-  cargo nextest run -p tests-e2e "$@"
+  cargo nextest run -p tests-e2e -j 1 "$@"
 
 [doc("Run integration tests with snapshot diffing: backend|checking|semantic|lowering|resolving|lsp")]
 @t *args="":

--- a/tests-e2e/Cargo.toml
+++ b/tests-e2e/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tests-e2e"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+purescript-alexandrite = { path = "../compiler-bin" }
+
+[dev-dependencies]
+insta = "1.48.0"
+tempfile = "3.27.0"
+
+[[bin]]
+name = "alexandrite-e2e"
+path = "src/bin/alexandrite-e2e.rs"
+
+[[bin]]
+name = "spago-e2e"
+path = "src/bin/spago-e2e.rs"

--- a/tests-e2e/src/bin/alexandrite-e2e.rs
+++ b/tests-e2e/src/bin/alexandrite-e2e.rs
@@ -1,0 +1,3 @@
+fn main() {
+    purescript_alexandrite::run();
+}

--- a/tests-e2e/src/bin/spago-e2e.rs
+++ b/tests-e2e/src/bin/spago-e2e.rs
@@ -1,0 +1,22 @@
+use std::env;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::process::{self, Command};
+
+fn main() {
+    let arguments = env::args_os().skip(1).collect::<Vec<_>>();
+    let log_path = env::var_os("ALEXANDRITE_E2E_SPAGO_LOG").expect("missing Spago log path");
+    let current_directory = env::current_dir().expect("failed to read Spago working directory");
+    let mut log = OpenOptions::new().create(true).append(true).open(log_path).unwrap();
+    let mut record = current_directory.display().to_string();
+    for argument in &arguments {
+        record.push('\t');
+        record.push_str(&argument.to_string_lossy());
+    }
+    record.push('\n');
+    log.write_all(record.as_bytes()).unwrap();
+
+    let executable = env::var_os("ALEXANDRITE_E2E_SPAGO").expect("missing real Spago executable");
+    let status = Command::new(executable).args(arguments).status().unwrap();
+    process::exit(status.code().unwrap_or(1));
+}

--- a/tests-e2e/tests/package_manager.rs
+++ b/tests-e2e/tests/package_manager.rs
@@ -1,0 +1,12 @@
+#[path = "package_manager/add.rs"]
+mod add;
+#[path = "package_manager/build.rs"]
+mod build;
+#[path = "package_manager/new.rs"]
+mod new;
+#[path = "package_manager/run.rs"]
+mod run;
+#[path = "package_manager/support.rs"]
+mod support;
+#[path = "package_manager/test.rs"]
+mod test;

--- a/tests-e2e/tests/package_manager/add.rs
+++ b/tests-e2e/tests/package_manager/add.rs
@@ -1,0 +1,37 @@
+use super::support::{TestWorkspace, assert_success};
+
+#[test]
+fn adds_a_workspace_dependency_with_real_spago() {
+    let workspace = TestWorkspace::empty();
+    workspace.write(
+        "spago.yaml",
+        r#"workspace: {}
+"#,
+    );
+    workspace.write(
+        "packages/application/spago.yaml",
+        r#"package:
+  name: application
+  dependencies: []
+"#,
+    );
+    workspace.write(
+        "packages/library/spago.yaml",
+        r#"package:
+  name: library
+  dependencies: []
+"#,
+    );
+
+    let output = workspace.command(&["add", "--package", "application", "library"]);
+    assert_success(&output);
+
+    insta::assert_snapshot!(workspace.read("packages/application/spago.yaml"), @r#"
+    package:
+      name: application
+      dependencies:
+        - library: "*"
+    "#);
+    assert!(workspace.path().join("spago.lock").is_file());
+    workspace.assert_spago_calls("", &[&["fetch", "-p", "application", "library"]]);
+}

--- a/tests-e2e/tests/package_manager/build.rs
+++ b/tests-e2e/tests/package_manager/build.rs
@@ -1,0 +1,58 @@
+use super::support::{TestWorkspace, assert_success};
+
+#[test]
+fn builds_a_single_package_with_real_spago() {
+    let workspace = TestWorkspace::empty();
+    workspace.write(
+        "spago.yaml",
+        r#"workspace: {}
+package:
+  name: application
+  dependencies: []
+"#,
+    );
+    workspace.write(
+        "src/Main.purs",
+        r#"module Main where
+
+value = 42
+"#,
+    );
+
+    let output = workspace.command(&["build", "--quiet"]);
+    assert_success(&output);
+    assert!(workspace.path().join("spago.lock").is_file());
+    assert!(workspace.path().join("output/Main/index.js").is_file());
+    workspace.assert_spago_calls(
+        "",
+        &[&["fetch", "-p", "application"], &["sources", "--json", "-p", "application"]],
+    );
+}
+
+#[test]
+fn builds_the_whole_workspace_from_a_root_package_subdirectory() {
+    let workspace = TestWorkspace::empty();
+    workspace.write(
+        "spago.yaml",
+        r#"workspace: {}
+package:
+  name: application
+  dependencies: []
+"#,
+    );
+    workspace.write("src/Application.purs", "module Application where\n");
+    workspace.write(
+        "packages/library/spago.yaml",
+        r#"package:
+  name: library
+  dependencies: []
+"#,
+    );
+    workspace.write("packages/library/src/Library.purs", "module Library where\n");
+
+    let output = workspace.command_in("src", &["build", "--quiet"]);
+    assert_success(&output);
+    assert!(workspace.path().join("output/Application/index.js").is_file());
+    assert!(workspace.path().join("output/Library/index.js").is_file());
+    workspace.assert_spago_calls("src", &[&["fetch"], &["sources", "--json"]]);
+}

--- a/tests-e2e/tests/package_manager/new.rs
+++ b/tests-e2e/tests/package_manager/new.rs
@@ -1,0 +1,88 @@
+use super::support::{TestWorkspace, assert_success};
+
+#[test]
+fn creates_a_spago_project_without_running_spago() {
+    let workspace = TestWorkspace::empty();
+    let output = workspace.command(&["new", "--name", "example"]);
+    assert_success(&output);
+    workspace.assert_spago_calls("", &[]);
+
+    insta::assert_snapshot!(workspace.summary(), @r#"
+    --- .gitignore
+    .spago/
+    output/
+    --- spago.yaml
+    package:
+      name: example
+      dependencies:
+        - console
+        - effect
+        - prelude
+      test:
+        main: Test.Main
+        dependencies:
+          - assert
+    workspace: {}
+    --- src/Main.purs
+    module Main where
+
+    import Prelude
+
+    import Effect (Effect)
+    import Effect.Console (log)
+
+    main :: Effect Unit
+    main = do
+      log "🍝"
+    --- test/Test/Main.purs
+    module Test.Main where
+
+    import Prelude
+
+    import Effect (Effect)
+    import Effect.Class.Console (log)
+
+    main :: Effect Unit
+    main = do
+      log "🍕"
+      log "You should add some tests."
+    "#);
+}
+
+#[test]
+fn does_not_overwrite_existing_project_files() {
+    let workspace = TestWorkspace::empty();
+    workspace.write("src/Main.purs", "original");
+
+    let output = workspace.command(&["new", "--name", "example"]);
+    assert!(!output.status.success());
+    assert_eq!(workspace.read("src/Main.purs"), "original");
+    assert!(!workspace.path().join("spago.yaml").exists());
+}
+
+#[test]
+fn does_not_create_a_partial_project_when_a_source_directory_is_a_file() {
+    let workspace = TestWorkspace::empty();
+    workspace.write("src", "original");
+
+    let output = workspace.command(&["new", "--name", "example"]);
+    assert!(!output.status.success());
+    assert_eq!(workspace.read("src"), "original");
+    assert!(!workspace.path().join("spago.yaml").exists());
+}
+
+#[test]
+fn does_not_create_a_nested_workspace() {
+    let workspace = TestWorkspace::empty();
+    workspace.write(
+        "spago.yaml",
+        r#"workspace: {}
+package:
+  name: root
+"#,
+    );
+
+    let output = workspace.command_in("packages/application", &["new", "--name", "application"]);
+    assert!(!output.status.success());
+    assert!(!workspace.path().join("packages/application/spago.yaml").exists());
+}

--- a/tests-e2e/tests/package_manager/run.rs
+++ b/tests-e2e/tests/package_manager/run.rs
@@ -1,0 +1,39 @@
+use super::support::{TestWorkspace, assert_success};
+
+#[test]
+fn runs_the_configured_module_with_node() {
+    let workspace = TestWorkspace::empty();
+    workspace.write(
+        "spago.yaml",
+        r#"workspace: {}
+package:
+  name: application
+  dependencies: []
+  run:
+    main: Configured
+"#,
+    );
+    workspace.write(
+        "src/Configured.purs",
+        r#"module Configured where
+
+data Unit = Unit
+foreign import data Effect :: Type -> Type
+foreign import main :: Effect Unit
+"#,
+    );
+    workspace.write(
+        "src/Configured.js",
+        "export const main = () => console.log(process.argv.slice(2).join(\",\"));\n",
+    );
+
+    let output =
+        workspace.command(&["run", "--output", "generated", "--quiet", "--", "first", "second"]);
+    assert_success(&output);
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "first,second\n");
+    assert!(workspace.path().join("generated/Configured/index.js").is_file());
+    workspace.assert_spago_calls(
+        "",
+        &[&["fetch", "-p", "application"], &["sources", "--json", "-p", "application"]],
+    );
+}

--- a/tests-e2e/tests/package_manager/support.rs
+++ b/tests-e2e/tests/package_manager/support.rs
@@ -33,8 +33,9 @@ impl TestWorkspace {
         let mut summary = String::new();
         for path in files {
             let relative = path.strip_prefix(self.path()).unwrap();
+            let relative = relative.to_string_lossy().replace('\\', "/");
             let content = fs::read_to_string(&path).unwrap();
-            summary.push_str(&format!("--- {}\n{content}", relative.display()));
+            summary.push_str(&format!("--- {relative}\n{content}"));
             if !content.ends_with('\n') {
                 summary.push('\n');
             }
@@ -68,12 +69,13 @@ impl TestWorkspace {
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
             Err(error) => panic!("failed to read Spago call log: {error}"),
         };
-        let expected_directory = self.path().join(directory);
+        let expected_directory = fs::canonicalize(self.path().join(directory)).unwrap();
         let mut actual_arguments = Vec::new();
         for line in source.lines() {
             let mut fields = line.split('\t');
             let actual_directory = fields.next().unwrap();
-            assert_eq!(Path::new(actual_directory), expected_directory);
+            let actual_directory = fs::canonicalize(actual_directory).unwrap();
+            assert_eq!(actual_directory, expected_directory);
             actual_arguments.push(fields.collect::<Vec<_>>());
         }
         assert_eq!(actual_arguments, expected);

--- a/tests-e2e/tests/package_manager/support.rs
+++ b/tests-e2e/tests/package_manager/support.rs
@@ -1,0 +1,111 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+pub struct TestWorkspace {
+    temporary: tempfile::TempDir,
+}
+
+impl TestWorkspace {
+    pub fn empty() -> TestWorkspace {
+        TestWorkspace { temporary: tempfile::tempdir().unwrap() }
+    }
+
+    pub fn path(&self) -> &Path {
+        self.temporary.path()
+    }
+
+    pub fn write(&self, path: &str, content: &str) {
+        let path = self.path().join(path);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, content).unwrap();
+    }
+
+    pub fn read(&self, path: &str) -> String {
+        fs::read_to_string(self.path().join(path)).unwrap()
+    }
+
+    pub fn summary(&self) -> String {
+        let mut files = Vec::new();
+        collect_files(self.path(), &mut files);
+        files.sort();
+
+        let mut summary = String::new();
+        for path in files {
+            let relative = path.strip_prefix(self.path()).unwrap();
+            let content = fs::read_to_string(&path).unwrap();
+            summary.push_str(&format!("--- {}\n{content}", relative.display()));
+            if !content.ends_with('\n') {
+                summary.push('\n');
+            }
+        }
+        summary
+    }
+
+    pub fn command(&self, arguments: &[&str]) -> Output {
+        self.command_in("", arguments)
+    }
+
+    pub fn command_in(&self, directory: &str, arguments: &[&str]) -> Output {
+        let spago = spago_executable();
+        let current_directory = self.path().join(directory);
+        fs::create_dir_all(&current_directory).unwrap();
+        Command::new(env!("CARGO_BIN_EXE_alexandrite-e2e"))
+            .args(arguments)
+            .current_dir(current_directory)
+            .env("ALEXANDRITE_SPAGO", env!("CARGO_BIN_EXE_spago-e2e"))
+            .env("ALEXANDRITE_E2E_SPAGO", spago)
+            .env("ALEXANDRITE_E2E_SPAGO_LOG", self.path().join("spago-calls"))
+            .env("NO_COLOR", "1")
+            .output()
+            .unwrap()
+    }
+
+    pub fn assert_spago_calls(&self, directory: &str, expected: &[&[&str]]) {
+        let path = self.path().join("spago-calls");
+        let source = match fs::read_to_string(path) {
+            Ok(source) => source,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(error) => panic!("failed to read Spago call log: {error}"),
+        };
+        let expected_directory = self.path().join(directory);
+        let mut actual_arguments = Vec::new();
+        for line in source.lines() {
+            let mut fields = line.split('\t');
+            let actual_directory = fields.next().unwrap();
+            assert_eq!(Path::new(actual_directory), expected_directory);
+            actual_arguments.push(fields.collect::<Vec<_>>());
+        }
+        assert_eq!(actual_arguments, expected);
+    }
+}
+
+fn collect_files(directory: &Path, files: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(directory).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_dir() {
+            collect_files(&path, files);
+        } else if path.is_file() {
+            files.push(path);
+        }
+    }
+}
+
+pub fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn spago_executable() -> PathBuf {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let executable = if cfg!(windows) { "spago.cmd" } else { "spago" };
+    let path = manifest.join("tools/node_modules/.bin").join(executable);
+    if !path.is_file() {
+        panic!("missing pinned Spago executable {}; run `just e2e-prepare`", path.display());
+    }
+    path
+}

--- a/tests-e2e/tests/package_manager/test.rs
+++ b/tests-e2e/tests/package_manager/test.rs
@@ -1,0 +1,56 @@
+use super::support::{TestWorkspace, assert_success};
+
+#[test]
+fn tests_the_configured_module_with_node() {
+    let workspace = TestWorkspace::empty();
+    workspace.write(
+        "spago.yaml",
+        r#"workspace: {}
+package:
+  name: application
+  dependencies: []
+  test:
+    main: Application.Test
+    dependencies: []
+"#,
+    );
+    workspace.write(
+        "test/Application/Test.purs",
+        r#"module Application.Test where
+
+data Unit = Unit
+foreign import data Effect :: Type -> Type
+foreign import main :: Effect Unit
+"#,
+    );
+    workspace.write(
+        "test/Application/Test.js",
+        "export const main = () => console.log(\"tests ran\");\n",
+    );
+
+    let output = workspace.command(&["test", "--quiet"]);
+    assert_success(&output);
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "tests ran\n");
+    workspace.assert_spago_calls(
+        "",
+        &[&["fetch", "-p", "application"], &["sources", "--json", "-p", "application"]],
+    );
+}
+
+#[test]
+fn rejects_a_selected_package_without_tests_before_fetching() {
+    let workspace = TestWorkspace::empty();
+    workspace.write(
+        "spago.yaml",
+        r#"workspace: {}
+package:
+  name: application
+  dependencies: []
+"#,
+    );
+    workspace.write("src/Main.purs", "module Main where\n");
+
+    let output = workspace.command(&["test", "--quiet"]);
+    assert!(!output.status.success());
+    workspace.assert_spago_calls("", &[]);
+}

--- a/tests-e2e/tools/.gitignore
+++ b/tests-e2e/tools/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tests-e2e/tools/package.json
+++ b/tests-e2e/tools/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "devDependencies": {
+    "spago": "1.0.3"
+  }
+}

--- a/tests-e2e/tools/pnpm-lock.yaml
+++ b/tests-e2e/tools/pnpm-lock.yaml
@@ -1,0 +1,608 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      spago:
+        specifier: 1.0.3
+        version: 1.0.3
+
+packages:
+
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@nodelib/fs.scandir@4.0.1':
+    resolution: {integrity: sha512-vAkI715yhnmiPupY+dq+xenu5Tdf2TBQ66jLvBIcCddtz+5Q8LbMKaf9CIJJreez8fQ8fgaY+RaywQx8RJIWpw==}
+    engines: {node: '>=18.18.0'}
+
+  '@nodelib/fs.stat@4.0.0':
+    resolution: {integrity: sha512-ctr6bByzksKRCV0bavi8WoQevU6plSp2IkllIsEqaiKe2mwNNnaluhnRhcsgGZHrrHk57B3lf95MkLMO3STYcg==}
+    engines: {node: '>=18.18.0'}
+
+  '@nodelib/fs.walk@3.0.1':
+    resolution: {integrity: sha512-nIh/M6Kh3ZtOmlY00DaUYB4xeeV6F3/ts1l29iwl3/cfyY/OuCfUx+v08zgx8TKPTifXRcjjqVQ4KB2zOYSbyw==}
+    engines: {node: '>=18.18.0'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.1:
+    resolution: {integrity: sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  fastq@1.20.3:
+    resolution: {integrity: sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  fs-extra@11.4.0:
+    resolution: {integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==}
+    engines: {node: '>=14.14'}
+
+  fuse.js@7.5.0:
+    resolution: {integrity: sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==}
+    engines: {node: '>=10'}
+
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
+  markdown-it@14.3.1:
+    resolution: {integrity: sha512-4Ej49aYTDFIQ+uBkfX8GBvJGccoARxxPep+7aWTs55ozbjQJpW9M26Fe53vnGgvLeVzva/amzjQQaQu9w0vMhA==}
+    hasBin: true
+
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
+  nan@2.28.0:
+    resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  readline-sync@1.4.10:
+    resolution: {integrity: sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==}
+    engines: {node: '>= 0.8.0'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  spago@1.0.3:
+    resolution: {integrity: sha512-3JR6ExwLwaKIMYdc77e6fKqiBKXNentyVkcfhaQx4tGDnWjfHS2Td+zxJZ/28QaBx8s6RXfgFD1VjbALGtM89g==}
+    engines: {node: '>=22.5.0'}
+    hasBin: true
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@4.0.0:
+    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
+    engines: {node: '>=18'}
+
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+    engines: {node: '>=14.14'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
+  xhr2@0.2.1:
+    resolution: {integrity: sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw==}
+    engines: {node: '>= 6'}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+snapshots:
+
+  '@isaacs/cliui@9.0.0': {}
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
+  '@nodelib/fs.scandir@4.0.1':
+    dependencies:
+      '@nodelib/fs.stat': 4.0.0
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@4.0.0': {}
+
+  '@nodelib/fs.walk@3.0.1':
+    dependencies:
+      '@nodelib/fs.scandir': 4.0.1
+      fastq: 1.20.3
+
+  argparse@2.0.1: {}
+
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  balanced-match@4.0.4: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  buildcheck@0.0.7:
+    optional: true
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
+  chownr@3.0.0: {}
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.28.0
+    optional: true
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.1:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
+  entities@4.5.0: {}
+
+  env-paths@3.0.0: {}
+
+  fastq@1.20.3:
+    dependencies:
+      reusify: 1.1.0
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  fs-extra@11.4.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  fuse.js@7.5.0: {}
+
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.6
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
+
+  graceful-fs@4.2.11: {}
+
+  is-docker@3.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-number@7.0.0: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
+  isexe@2.0.0: {}
+
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
+  lru-cache@11.5.2: {}
+
+  markdown-it@14.3.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  mdurl@2.1.0: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
+  nan@2.28.0:
+    optional: true
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.1
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
+  package-json-from-dist@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.7: {}
+
+  punycode.js@2.3.1: {}
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  readline-sync@1.4.10: {}
+
+  reusify@1.1.0: {}
+
+  run-applescript@7.1.0: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  safer-buffer@2.1.2: {}
+
+  semver@7.8.5: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  spago@1.0.3:
+    dependencies:
+      '@nodelib/fs.walk': 3.0.1
+      env-paths: 3.0.0
+      fs-extra: 11.4.0
+      fuse.js: 7.5.0
+      glob: 11.1.0
+      markdown-it: 14.3.1
+      micromatch: 4.0.8
+      open: 10.2.0
+      picomatch: 4.0.7
+      punycode: 2.3.1
+      readline-sync: 1.4.10
+      semver: 7.8.5
+      spdx-expression-parse: 4.0.0
+      ssh2: 1.17.0
+      supports-color: 10.2.2
+      tar: 7.5.22
+      tmp: 0.2.7
+      xhr2: 0.2.1
+      yaml: 2.9.0
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@4.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.28.0
+
+  supports-color@10.2.2: {}
+
+  tar@7.5.22:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  tmp@0.2.7: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  tweetnacl@0.14.5: {}
+
+  uc.micro@2.1.0: {}
+
+  universalify@2.0.1: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
+
+  xhr2@0.2.1: {}
+
+  yallist@5.0.0: {}
+
+  yaml@2.9.0: {}

--- a/tests-e2e/tools/pnpm-workspace.yaml
+++ b/tests-e2e/tools/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  cpu-features: false
+  ssh2: false


### PR DESCRIPTION
## Motivation

Alexandrite can compile package directories, but project orchestration still requires users to drive Spago or reproduce its dependency setup themselves. This adds a project-oriented workflow that keeps Spago authoritative for package resolution and fetching while ensuring Alexandrite—not `purs`—performs compilation.

## Changes

- add `new`, `build`, `add`, `run`, and `test` commands around Spago workspaces and package selection
- discover single- and multi-package workspaces with Spago-compatible current-directory, nested-workspace, and root-package semantics
- invoke only `spago fetch` and `spago sources --json` during builds, using a private `purs --version` compatibility shim
- execute compiled `run` and `test` entry points directly with Node.js
- generate a Spago-compatible initial project without invoking Spago
- add an opt-in `tests-e2e` crate with a pnpm-pinned Spago 1.0.3 installation
- record real Spago subprocess arguments and working directories so tests reject accidental `spago build`, `run`, or `test` delegation
- add independent `just e2e-prepare` and `just e2e` recipes
- run the complete end-to-end crate in a dedicated CI job

Spago BuildInfo module generation is intentionally deferred; this integration currently consumes the flat source plan returned by `spago sources --json`.

## Verification

- `cargo check -p purescript-alexandrite --tests`
- `cargo check -p tests-e2e --tests`
- `cargo nextest run -p purescript-alexandrite` — 69 passed
- `just e2e-prepare`
- `just e2e` — 9 passed

