### PR TITLE
[resolving] Render integration diagnostics

### DIFF
--- a/tests-integration/fixtures/resolving/1747028580_local_resolution/Explicit.snap
+++ b/tests-integration/fixtures/resolving/1747028580_local_resolution/Explicit.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module Explicit
@@ -46,5 +46,3 @@ Local Classes:
 
 Class Members:
   - Eq.eq
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028580_local_resolution/ExplicitSelf.snap
+++ b/tests-integration/fixtures/resolving/1747028580_local_resolution/ExplicitSelf.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module ExplicitSelf
@@ -49,5 +49,3 @@ Local Classes:
 
 Class Members:
   - Eq.eq
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028580_local_resolution/Implicit.snap
+++ b/tests-integration/fixtures/resolving/1747028580_local_resolution/Implicit.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module Implicit
@@ -49,5 +49,3 @@ Local Classes:
 
 Class Members:
   - Eq.eq
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportExplicit.snap
+++ b/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportExplicit.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module ImportExplicit
@@ -56,5 +56,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportForLocalOnly.snap
+++ b/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportForLocalOnly.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module ImportForLocalOnly
@@ -39,5 +39,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportHiddenConstructor.snap
+++ b/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportHiddenConstructor.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module ImportHiddenConstructor
@@ -29,5 +29,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportQualifiedExplicit.snap
+++ b/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportQualifiedExplicit.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module ImportQualifiedExplicit
@@ -42,5 +42,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportQualifiedHiding.snap
+++ b/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportQualifiedHiding.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module ImportQualifiedHiding
@@ -40,5 +40,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportQualifiedImplicit.snap
+++ b/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportQualifiedImplicit.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module ImportQualifiedImplicit
@@ -50,5 +50,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportUnqualifiedExplicit.snap
+++ b/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportUnqualifiedExplicit.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module ImportUnqualifiedExplicit
@@ -42,5 +42,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportUnqualifiedHiding.snap
+++ b/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportUnqualifiedHiding.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module ImportUnqualifiedHiding
@@ -40,5 +40,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportUnqualifiedImplicit.snap
+++ b/tests-integration/fixtures/resolving/1747028640_import_resolution/ImportUnqualifiedImplicit.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module ImportUnqualifiedImplicit
@@ -50,5 +50,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028640_import_resolution/Library.snap
+++ b/tests-integration/fixtures/resolving/1747028640_import_resolution/Library.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module Library
@@ -44,5 +44,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028640_import_resolution/LibraryExplicit.snap
+++ b/tests-integration/fixtures/resolving/1747028640_import_resolution/LibraryExplicit.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module LibraryExplicit
@@ -29,5 +29,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028700_import_errors/DuplicateLocal.snap
+++ b/tests-integration/fixtures/resolving/1747028700_import_errors/DuplicateLocal.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 351
+assertion_line: 354
 expression: report
 ---
 module DuplicateLocal
@@ -26,9 +26,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:
-  - ExistingTerm { existing: (Idx::<File>(10), Idx::<IndexedTermItem>(0)), duplicate: (Idx::<File>(10), Idx::<IndexedTermItem>(1)) }
-  - ExistingType { existing: (Idx::<File>(10), Idx::<IndexedTypeItem>(0)), duplicate: (Idx::<File>(10), Idx::<IndexedTypeItem>(1)) }
-  - TermExportConflict { existing: (Idx::<File>(10), Idx::<IndexedTermItem>(0), Local), duplicate: (Idx::<File>(10), Idx::<IndexedTermItem>(1), Local) }
-  - TypeExportConflict { existing: (Idx::<File>(10), Idx::<IndexedTypeItem>(0), Local), duplicate: (Idx::<File>(10), Idx::<IndexedTypeItem>(1), Local) }

--- a/tests-integration/fixtures/resolving/1747028700_import_errors/DuplicateQualifiedImport.snap
+++ b/tests-integration/fixtures/resolving/1747028700_import_errors/DuplicateQualifiedImport.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module DuplicateQualifiedImport
@@ -39,5 +39,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028700_import_errors/InvalidConstructor.snap
+++ b/tests-integration/fixtures/resolving/1747028700_import_errors/InvalidConstructor.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module InvalidConstructor
@@ -24,5 +24,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028700_import_errors/InvalidImport.snap
+++ b/tests-integration/fixtures/resolving/1747028700_import_errors/InvalidImport.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 84
+assertion_line: 354
 expression: report
 ---
 module InvalidImport
@@ -38,9 +38,48 @@ Local Classes:
 
 Class Members:
 
-Errors:
-  - InvalidImportStatement { id: AstId<syntax::cst::ImportStatement>(7) }
-  - InvalidImportStatement { id: AstId<syntax::cst::ImportStatement>(5) }
-  - InvalidImportItem { id: AstId<syntax::cst::ImportItem>(13) }
-  - InvalidImportItem { id: AstId<syntax::cst::ImportItem>(15) }
-  - InvalidImportItem { id: AstId<syntax::cst::ImportItem>(14) }
+Diagnostics
+Error! · [InvalidImportStatement] · InvalidImport.purs:4:1
+  •
+  │
+  • Cannot import module ''
+  │
+  │   import invalidSyntax
+  │   ╰─────
+  •
+
+Error! · [InvalidImportStatement] · InvalidImport.purs:3:1
+  •
+  │
+  • Cannot import module 'MissingLibrary'
+  │
+  │   import MissingLibrary
+  │   ╰────────────────────
+  •
+
+Error! · [InvalidImportItem] · InvalidImport.purs:5:18
+  •
+  │
+  • Cannot import item 'missing'
+  │
+  │   import LibraryA (missing, Missing, Css(Css), Html(..))
+  │                    ╰──────
+  •
+
+Error! · [InvalidImportItem] · InvalidImport.purs:5:36
+  •
+  │
+  • Cannot import item 'Css(Css)'
+  │
+  │   import LibraryA (missing, Missing, Css(Css), Html(..))
+  │                                      ╰───────
+  •
+
+Error! · [InvalidImportItem] · InvalidImport.purs:5:27
+  •
+  │
+  • Cannot import item 'Missing'
+  │
+  │   import LibraryA (missing, Missing, Css(Css), Html(..))
+  │                             ╰──────
+  •

--- a/tests-integration/fixtures/resolving/1747028700_import_errors/LibraryA.snap
+++ b/tests-integration/fixtures/resolving/1747028700_import_errors/LibraryA.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module LibraryA
@@ -28,5 +28,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1747028700_import_errors/LibraryB.snap
+++ b/tests-integration/fixtures/resolving/1747028700_import_errors/LibraryB.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module LibraryB
@@ -26,5 +26,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1748017560_import_re_exported_constructor/Internal.snap
+++ b/tests-integration/fixtures/resolving/1748017560_import_re_exported_constructor/Internal.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module Internal
@@ -26,5 +26,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1748017560_import_re_exported_constructor/Library.snap
+++ b/tests-integration/fixtures/resolving/1748017560_import_re_exported_constructor/Library.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module Library
@@ -32,5 +32,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1748017560_import_re_exported_constructor/Main.snap
+++ b/tests-integration/fixtures/resolving/1748017560_import_re_exported_constructor/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module Main
@@ -32,5 +32,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1767471480_class_members/ClassLibrary.snap
+++ b/tests-integration/fixtures/resolving/1767471480_class_members/ClassLibrary.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module ClassLibrary
@@ -40,5 +40,3 @@ Class Members:
   - Eq.eq
   - Eq.notEq
   - Ord.compare
-
-Errors:

--- a/tests-integration/fixtures/resolving/1767471480_class_members/HiddenClass.snap
+++ b/tests-integration/fixtures/resolving/1767471480_class_members/HiddenClass.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module HiddenClass
@@ -36,5 +36,3 @@ Local Classes:
 Class Members:
   - Show.show (imported)
   - Ord.compare (imported)
-
-Errors:

--- a/tests-integration/fixtures/resolving/1767471480_class_members/ImportedClass.snap
+++ b/tests-integration/fixtures/resolving/1767471480_class_members/ImportedClass.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module ImportedClass
@@ -33,5 +33,3 @@ Class Members:
   - Show.show (imported)
   - Eq.eq (imported)
   - Eq.notEq (imported)
-
-Errors:

--- a/tests-integration/fixtures/resolving/1767471480_class_members/LocalClass.snap
+++ b/tests-integration/fixtures/resolving/1767471480_class_members/LocalClass.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module LocalClass
@@ -32,5 +32,3 @@ Local Classes:
 Class Members:
   - Functor.map
   - Apply.apply
-
-Errors:

--- a/tests-integration/fixtures/resolving/1767471480_class_members/ReExportConsumer.snap
+++ b/tests-integration/fixtures/resolving/1767471480_class_members/ReExportConsumer.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module ReExportConsumer
@@ -33,5 +33,3 @@ Class Members:
   - Show.show (imported)
   - Eq.eq (imported)
   - Eq.notEq (imported)
-
-Errors:

--- a/tests-integration/fixtures/resolving/1767471480_class_members/ReExporter.snap
+++ b/tests-integration/fixtures/resolving/1767471480_class_members/ReExporter.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module ReExporter
@@ -46,5 +46,3 @@ Class Members:
   - Eq.eq (imported)
   - Eq.notEq (imported)
   - Ord.compare (imported)
-
-Errors:

--- a/tests-integration/fixtures/resolving/1773505320_same_item_exports/Library.snap
+++ b/tests-integration/fixtures/resolving/1773505320_same_item_exports/Library.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module Library
@@ -28,5 +28,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1773505320_same_item_exports/Main.snap
+++ b/tests-integration/fixtures/resolving/1773505320_same_item_exports/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 73
+assertion_line: 354
 expression: report
 ---
 module Main
@@ -40,5 +40,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1781973000_constructor_selection_parent/Library.snap
+++ b/tests-integration/fixtures/resolving/1781973000_constructor_selection_parent/Library.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 84
+assertion_line: 354
 expression: report
 ---
 module Library
@@ -32,5 +32,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1781973000_constructor_selection_parent/Main.snap
+++ b/tests-integration/fixtures/resolving/1781973000_constructor_selection_parent/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 84
+assertion_line: 354
 expression: report
 ---
 module Main
@@ -30,5 +30,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1781973000_constructor_selection_parent/WrongExport.snap
+++ b/tests-integration/fixtures/resolving/1781973000_constructor_selection_parent/WrongExport.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 84
+assertion_line: 354
 expression: report
 ---
 module WrongExport
@@ -27,5 +27,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1781973000_constructor_selection_parent/WrongImport.snap
+++ b/tests-integration/fixtures/resolving/1781973000_constructor_selection_parent/WrongImport.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 84
+assertion_line: 354
 expression: report
 ---
 module WrongImport
@@ -30,5 +30,12 @@ Local Classes:
 
 Class Members:
 
-Errors:
-  - InvalidImportItem { id: AstId<syntax::cst::ImportItem>(8) }
+Diagnostics
+Error! · [InvalidImportItem] · WrongImport.purs:3:17
+  •
+  │
+  • Cannot import item 'A(B)'
+  │
+  │   import Library (A(B))
+  │                   ╰───
+  •

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/DuplicateClasses.snap
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/DuplicateClasses.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 351
+assertion_line: 354
 expression: report
 ---
 module DuplicateClasses
@@ -26,7 +26,3 @@ Local Classes:
   - Shared
 
 Class Members:
-
-Errors:
-  - ExistingType { existing: (Idx::<File>(10), Idx::<IndexedTypeItem>(0)), duplicate: (Idx::<File>(10), Idx::<IndexedTypeItem>(2)) }
-  - TypeExportConflict { existing: (Idx::<File>(10), Idx::<IndexedTypeItem>(0), Local), duplicate: (Idx::<File>(10), Idx::<IndexedTypeItem>(2), Local) }

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/HiddenReExport.snap
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/HiddenReExport.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 102
+assertion_line: 354
 expression: report
 ---
 module HiddenReExport
@@ -30,5 +30,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/LibraryA.snap
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/LibraryA.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 102
+assertion_line: 354
 expression: report
 ---
 module LibraryA
@@ -27,5 +27,3 @@ Local Classes:
 
 Class Members:
   - Shared.sharedA
-
-Errors:

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/LibraryB.snap
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/LibraryB.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 102
+assertion_line: 354
 expression: report
 ---
 module LibraryB
@@ -27,5 +27,3 @@ Local Classes:
 
 Class Members:
   - Shared.sharedB
-
-Errors:

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/Main.snap
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 351
+assertion_line: 354
 expression: report
 ---
 module Main
@@ -43,6 +43,3 @@ Local Classes:
 Class Members:
   - Shared.sharedA (imported)
   - Shared.sharedB (imported)
-
-Errors:
-  - TypeExportConflict { existing: (Idx::<File>(13), Idx::<IndexedTypeItem>(0), Import(AstId<syntax::cst::ImportStatement>(14))), duplicate: (Idx::<File>(12), Idx::<IndexedTypeItem>(0), Import(AstId<syntax::cst::ImportStatement>(10))) }

--- a/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/SameItem.snap
+++ b/tests-integration/fixtures/resolving/1786810320_class_re_export_conflicts/SameItem.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 102
+assertion_line: 354
 expression: report
 ---
 module SameItem
@@ -41,5 +41,3 @@ Local Classes:
 
 Class Members:
   - Shared.sharedA (imported)
-
-Errors:

--- a/tests-integration/fixtures/resolving/1786810320_duplicate_import_selections/Library.snap
+++ b/tests-integration/fixtures/resolving/1786810320_duplicate_import_selections/Library.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 102
+assertion_line: 354
 expression: report
 ---
 module Library
@@ -30,5 +30,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1786810320_duplicate_import_selections/Main.snap
+++ b/tests-integration/fixtures/resolving/1786810320_duplicate_import_selections/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 102
+assertion_line: 354
 expression: report
 ---
 module Main
@@ -32,5 +32,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1786810320_operator_imports_and_exports/Library.snap
+++ b/tests-integration/fixtures/resolving/1786810320_operator_imports_and_exports/Library.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 102
+assertion_line: 354
 expression: report
 ---
 module Library
@@ -30,5 +30,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1786810320_operator_imports_and_exports/Main.snap
+++ b/tests-integration/fixtures/resolving/1786810320_operator_imports_and_exports/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 102
+assertion_line: 354
 expression: report
 ---
 module Main
@@ -30,5 +30,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1786810320_type_declaration_grouping/Main.snap
+++ b/tests-integration/fixtures/resolving/1786810320_type_declaration_grouping/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 102
+assertion_line: 354
 expression: report
 ---
 module Main
@@ -39,5 +39,3 @@ Local Classes:
 
 Class Members:
   - Example.example
-
-Errors:

--- a/tests-integration/fixtures/resolving/1786810380_explicit_constructor_visibility/Library.snap
+++ b/tests-integration/fixtures/resolving/1786810380_explicit_constructor_visibility/Library.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 102
+assertion_line: 354
 expression: report
 ---
 module Library
@@ -25,5 +25,3 @@ Local Types:
 Local Classes:
 
 Class Members:
-
-Errors:

--- a/tests-integration/fixtures/resolving/1786810380_explicit_constructor_visibility/Main.snap
+++ b/tests-integration/fixtures/resolving/1786810380_explicit_constructor_visibility/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 102
+assertion_line: 354
 expression: report
 ---
 module Main
@@ -30,5 +30,12 @@ Local Classes:
 
 Class Members:
 
-Errors:
-  - InvalidImportItem { id: AstId<syntax::cst::ImportItem>(8) }
+Diagnostics
+Error! · [InvalidImportItem] · Main.purs:3:17
+  •
+  │
+  • Cannot import item 'Hidden(Hidden)'
+  │
+  │   import Library (Hidden(Hidden))
+  │                   ╰─────────────
+  •

--- a/tests-integration/src/fixtures.rs
+++ b/tests-integration/src/fixtures.rs
@@ -339,12 +339,15 @@ pub fn lowering(path: &Path) -> FixtureResult {
 pub fn resolving(path: &Path) -> FixtureResult {
     let folder = fixture_folder(path)?;
     let file = module_name(path)?;
+    let display_path = path.file_name().and_then(|name| name.to_str()).ok_or_else(|| {
+        invalid_data(format!("invariant violated: invalid fixture file name: {}", path.display()))
+    })?;
     let (engine, _) = crate::load_compiler(folder);
     let Some(id) = engine.module_file(&file) else {
         return Err(missing_module(path, &file).into());
     };
 
-    let report = crate::generated::basic::report_resolved(&engine, id, &file);
+    let report = crate::generated::basic::report_resolved(&engine, id, &file, display_path);
     let mut settings = insta::Settings::clone_current();
     settings.set_snapshot_path(snapshot_path(folder));
     settings.set_prepend_module_to_snapshot(false);

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -42,7 +42,7 @@ macro_rules! write_import_items {
     }};
 }
 
-pub fn report_resolved(engine: &QueryEngine, id: FileId, name: &str) -> String {
+pub fn report_resolved(engine: &QueryEngine, id: FileId, name: &str, path: &str) -> String {
     let resolved = engine.resolved(id).unwrap();
 
     let mut out = String::default();
@@ -104,9 +104,16 @@ pub fn report_resolved(engine: &QueryEngine, id: FileId, name: &str) -> String {
         writeln!(out, "  - {class_name}.{member_name}{locality}").unwrap();
     }
 
-    heading(&mut out, "Errors:");
-    for error in &resolved.errors {
-        writeln!(out, "  - {error:?}").unwrap();
+    let mut collected = collect_diagnostics(engine, &[id]).unwrap();
+    let collected = collected.pop().unwrap();
+    let diagnostics = collected
+        .checking_diagnostics()
+        .iter()
+        .filter(|diagnostic| diagnostic.source == "resolving");
+    let diagnostics: Vec<_> = diagnostics.cloned().collect();
+    if !diagnostics.is_empty() {
+        heading(&mut out, "Diagnostics");
+        out.push_str(&format_rich_with_path(&diagnostics, &collected.content, path, false));
     }
 
     out


### PR DESCRIPTION
## Summary

Resolving integration snapshots previously printed internal error values with Rust's debug representation, including unstable arena and AST IDs. Render resolving-owned diagnostics through the shared rich diagnostic formatter instead, matching checking snapshots with severity, diagnostic code, source location, message, and source excerpt.

The resolving harness now supplies the fixture filename to the renderer and omits empty diagnostic sections. Resolving snapshots have been regenerated through the integration-test runner.

## Verification

- `just t resolving`
- `cargo check -p tests-integration --tests`
