### PR TITLE
[lowering] Decode string literal escapes

### DIFF
--- a/compiler-backend/functional/src/convert/application.rs
+++ b/compiler-backend/functional/src/convert/application.rs
@@ -60,7 +60,7 @@ where
             let arity = self.constructor_arity(file_id, term_id)?;
             if known_arguments.len() == arity {
                 let tag = self.expression(ExpressionKind::Literal {
-                    literal: Literal::String(global.item_name),
+                    literal: Literal::String(global.item_name.into()),
                 });
                 let mut fields = Vec::with_capacity(known_arguments.len() + 1);
                 let field = self.label_field("tag".into());

--- a/compiler-backend/functional/src/convert/expression.rs
+++ b/compiler-backend/functional/src/convert/expression.rs
@@ -77,7 +77,7 @@ pub(super) fn convert_expression(
             }
             let global = context.term_global(file_id, term_id)?;
             if context.constructor_arity(file_id, term_id)? == 0 {
-                ExpressionKind::Literal { literal: Literal::String(global.item_name) }
+                ExpressionKind::Literal { literal: Literal::String(global.item_name.into()) }
             } else {
                 ExpressionKind::Constructor { global }
             }

--- a/compiler-backend/functional/src/tree.rs
+++ b/compiler-backend/functional/src/tree.rs
@@ -158,7 +158,7 @@ pub struct SuperclassIdentity {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Literal {
-    String(SmolStr),
+    String(lowering::StringLiteral),
     Char(char),
     Boolean(bool),
     Integer(i32),
@@ -300,14 +300,14 @@ pub struct RecordPatternField {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SynthesizedEvidence {
-    IsSymbol(SmolStr),
+    IsSymbol(lowering::StringLiteral),
     Reflectable(ReflectableEvidence),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReflectableEvidence {
     Integer(i32),
-    String(SmolStr),
+    String(lowering::StringLiteral),
     Boolean(bool),
     Ordering(ReflectableOrdering),
 }

--- a/compiler-backend/javascript/src/convert/generator/functional/render/syntax.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render/syntax.rs
@@ -17,7 +17,7 @@ pub(super) fn literal_expression(
     file_id: FileId,
 ) -> ModuleResult<ExpressionId> {
     match literal {
-        Literal::String(value) => Ok(tree.string(value.as_str())),
+        Literal::String(value) => Ok(tree.string_utf16(value.as_utf16())),
         Literal::Char(value) => Ok(tree.string(value.to_string())),
         Literal::Boolean(value) => Ok(tree.boolean(*value)),
         Literal::Integer(value) => Ok(integer_expression(tree, *value)),
@@ -146,7 +146,7 @@ pub(super) fn synthesized_evidence_expression(
 ) -> ExpressionId {
     match evidence {
         SynthesizedEvidence::IsSymbol(symbol) => {
-            let symbol = tree.string(symbol.as_str());
+            let symbol = tree.string_utf16(symbol.as_utf16());
             let reflect = tree.arrow(vec![SmolStr::new_static("$proxy")], symbol);
             tree.object(vec![ObjectProperty::Field {
                 name: "reflectSymbol".to_owned(),
@@ -156,7 +156,7 @@ pub(super) fn synthesized_evidence_expression(
         SynthesizedEvidence::Reflectable(evidence) => {
             let value = match evidence {
                 ReflectableEvidence::Integer(value) => integer_expression(tree, *value),
-                ReflectableEvidence::String(value) => tree.string(value.as_str()),
+                ReflectableEvidence::String(value) => tree.string_utf16(value.as_utf16()),
                 ReflectableEvidence::Boolean(value) => tree.boolean(*value),
                 ReflectableEvidence::Ordering(ordering) => {
                     let tag = match ordering {

--- a/compiler-backend/javascript/src/tree.rs
+++ b/compiler-backend/javascript/src/tree.rs
@@ -107,6 +107,19 @@ impl<'a> Tree<'a> {
         self.allocate(expression)
     }
 
+    pub(crate) fn string_utf16(&mut self, value: &[u16]) -> ExpressionId {
+        let (value, lone_surrogates) = oxc_string_value(value);
+        let value = self.text(&value);
+        let expression = Expression::new_string_literal_with_lone_surrogates(
+            SPAN,
+            value,
+            None,
+            lone_surrogates,
+            &self.builder,
+        );
+        self.allocate(expression)
+    }
+
     pub(crate) fn number(&mut self, value: impl AsRef<str>) -> ExpressionId {
         let raw = value.as_ref();
         let number = raw.parse().expect("invariant violated: JavaScript number is invalid");
@@ -325,6 +338,29 @@ impl<'a> Tree<'a> {
     }
 }
 
+fn oxc_string_value(value: &[u16]) -> (String, bool) {
+    let lone_surrogates = char::decode_utf16(value.iter().copied()).any(|item| item.is_err());
+    if !lone_surrogates {
+        let value = String::from_utf16(value).unwrap_or_else(|_| {
+            unreachable!("invariant violated: well-formed UTF-16 failed to decode")
+        });
+        return (value, false);
+    }
+
+    let mut encoded = String::new();
+    for item in char::decode_utf16(value.iter().copied()) {
+        match item {
+            Ok('\u{fffd}') => encoded.push_str("\u{fffd}fffd"),
+            Ok(character) => encoded.push(character),
+            Err(error) => {
+                encoded.push('\u{fffd}');
+                encoded.push_str(&format!("{:04x}", error.unpaired_surrogate()));
+            }
+        }
+    }
+    (encoded, true)
+}
+
 fn property_is_identifier(name: &str) -> bool {
     let mut characters = name.chars();
     let Some(initial) = characters.next() else {
@@ -334,4 +370,17 @@ fn property_is_identifier(name: &str) -> bool {
     let valid_subsequent = characters
         .all(|character| character.is_ascii_alphanumeric() || character == '_' || character == '$');
     valid_initial && valid_subsequent
+}
+
+#[cfg(test)]
+mod tests {
+    use super::oxc_string_value;
+
+    #[test]
+    fn oxc_string_value_preserves_utf16_code_units() {
+        let (value, lone_surrogates) = oxc_string_value(&[0xd800, 0xfffd, 0xdfff, 0xd800, 0xdc00]);
+
+        assert!(lone_surrogates);
+        assert_eq!(value, "\u{fffd}d800\u{fffd}fffd\u{fffd}dfff\u{10000}");
+    }
 }

--- a/compiler-frontend/checking/src/core.rs
+++ b/compiler-frontend/checking/src/core.rs
@@ -261,7 +261,7 @@ pub enum Type {
     /// A type-level integer literal, `42`.
     Integer(i32),
     /// A type-level string literal, `"life"`.
-    String(lowering::StringKind, SmolStrId),
+    String(lowering::StringKind, lowering::StringLiteral),
     /// A row type, see [`RowType`].
     Row(RowTypeId),
 

--- a/compiler-frontend/checking/src/core/constraint/compiler.rs
+++ b/compiler-frontend/checking/src/core/constraint/compiler.rs
@@ -8,9 +8,6 @@ pub mod prim_type_error;
 
 use std::sync::Arc;
 
-use building_types::QueryResult;
-use smol_str::SmolStr;
-
 use crate::context::CheckContext;
 use crate::core::fold::{FoldAction, TypeFold, fold_type};
 use crate::core::unification::{CanUnify, can_unify};
@@ -18,6 +15,7 @@ use crate::core::{RowField, RowType, SmolStrId, Type, TypeId, normalise};
 use crate::evidence::{ReflectableEvidence, ReflectableOrdering, SynthesizedEvidence};
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
+use building_types::QueryResult;
 
 use super::CanonicalConstraintId;
 use super::matching::MatchInstance;
@@ -155,16 +153,12 @@ pub fn extract_symbol<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     id: TypeId,
-) -> QueryResult<Option<SmolStr>>
+) -> QueryResult<Option<lowering::StringLiteral>>
 where
     Q: ExternalQueries,
 {
     let id = recursively_normalise(state, context, id)?;
-    if let Type::String(_, id) = context.lookup_type(id) {
-        Ok(Some(context.queries.lookup_smol_str(id)))
-    } else {
-        Ok(None)
-    }
+    if let Type::String(_, value) = context.lookup_type(id) { Ok(Some(value)) } else { Ok(None) }
 }
 
 pub fn extract_row<Q>(
@@ -188,8 +182,14 @@ pub fn intern_symbol<Q>(context: &CheckContext<Q>, value: &str) -> TypeId
 where
     Q: ExternalQueries,
 {
-    let smol_str_id = context.queries.intern_smol_str(SmolStr::new(value));
-    context.queries.intern_type(Type::String(lowering::StringKind::String, smol_str_id))
+    intern_symbol_literal(context, value.into())
+}
+
+pub fn intern_symbol_literal<Q>(context: &CheckContext<Q>, value: lowering::StringLiteral) -> TypeId
+where
+    Q: ExternalQueries,
+{
+    context.queries.intern_type(Type::String(lowering::StringKind::String, value))
 }
 
 pub fn intern_integer<Q>(context: &CheckContext<Q>, value: i32) -> TypeId

--- a/compiler-frontend/checking/src/core/constraint/compiler/prim_row.rs
+++ b/compiler-frontend/checking/src/core/constraint/compiler/prim_row.rs
@@ -224,7 +224,9 @@ where
         return Ok(None);
     };
 
-    let label_symbol = extract_symbol(state, context, label)?;
+    let label_symbol = extract_symbol(state, context, label)?
+        .and_then(|value| value.to_utf8().ok())
+        .map(SmolStr::from);
     let tail_row = extract_row(state, context, tail)?;
     let row_row = extract_row(state, context, row)?;
 
@@ -285,7 +287,10 @@ where
         return Ok(Some(MatchInstance::empty()));
     }
 
-    let Some(label_value) = extract_symbol(state, context, label)? else {
+    let Some(label_value) = extract_symbol(state, context, label)?
+        .and_then(|value| value.to_utf8().ok())
+        .map(SmolStr::from)
+    else {
         return Ok(Some(matching::blocking_constraint(state, context, &[label])?));
     };
 

--- a/compiler-frontend/checking/src/core/constraint/compiler/prim_symbol.rs
+++ b/compiler-frontend/checking/src/core/constraint/compiler/prim_symbol.rs
@@ -8,7 +8,7 @@ use crate::core::constraint::matching::{self, MatchInstance};
 use crate::core::{Type, TypeId, normalise};
 use crate::state::CheckState;
 
-use super::{extract_symbol, intern_symbol, match_equality};
+use super::{extract_symbol, intern_symbol, intern_symbol_literal, match_equality};
 
 pub fn match_append<Q>(
     state: &mut CheckState,
@@ -28,11 +28,16 @@ where
 
     let matched = match (left_symbol, right_symbol, appended_symbol) {
         (Some(left_value), Some(right_value), _) => {
-            let result = intern_symbol(context, &format!("{left_value}{right_value}"));
+            let result = intern_symbol_literal(context, left_value.append(&right_value));
             match_equality(state, context, appended, result)?
         }
         (_, Some(right_value), Some(appended_value)) => {
-            let Some(left_value) = appended_value.strip_suffix(right_value.as_str()) else {
+            let (Ok(right_value), Ok(appended_value)) =
+                (right_value.to_utf8(), appended_value.to_utf8())
+            else {
+                return Ok(Some(MatchInstance::Apart));
+            };
+            let Some(left_value) = appended_value.strip_suffix(&right_value) else {
                 return Ok(Some(MatchInstance::Apart));
             };
 
@@ -40,7 +45,12 @@ where
             match_equality(state, context, left, result)?
         }
         (Some(left_value), _, Some(appended_value)) => {
-            let Some(right_value) = appended_value.strip_prefix(left_value.as_str()) else {
+            let (Ok(left_value), Ok(appended_value)) =
+                (left_value.to_utf8(), appended_value.to_utf8())
+            else {
+                return Ok(Some(MatchInstance::Apart));
+            };
+            let Some(right_value) = appended_value.strip_prefix(&left_value) else {
                 return Ok(Some(MatchInstance::Apart));
             };
 
@@ -99,21 +109,34 @@ where
 
     let matched = match (&head_symbol, &tail_symbol, &symbol_symbol) {
         (Some(head_value), Some(tail_value), _) => {
+            let Ok(head_value) = head_value.to_utf8() else {
+                return Ok(Some(MatchInstance::Apart));
+            };
+            if tail_value.to_utf8().is_err() {
+                return Ok(Some(MatchInstance::Apart));
+            }
             let mut chars = head_value.chars();
             let (Some(ch), None) = (chars.next(), chars.next()) else {
                 return Ok(Some(MatchInstance::Apart));
             };
 
-            let result = intern_symbol(context, &format!("{ch}{tail_value}"));
+            let head_value = lowering::StringLiteral::from(ch.to_string());
+            let result = intern_symbol_literal(context, head_value.append(tail_value));
             match_equality(state, context, symbol, result)?
         }
         (_, _, Some(symbol_value)) => {
+            let Ok(symbol_value) = symbol_value.to_utf8() else {
+                return Ok(Some(MatchInstance::Apart));
+            };
             let mut chars = symbol_value.chars();
             let Some(head_char) = chars.next() else {
                 return Ok(Some(MatchInstance::Apart));
             };
 
             if let Some(head_value) = head_symbol {
+                let Ok(head_value) = head_value.to_utf8() else {
+                    return Ok(Some(MatchInstance::Apart));
+                };
                 let mut head_chars = head_value.chars();
                 if head_chars.next() != Some(head_char) || head_chars.next().is_some() {
                     return Ok(Some(MatchInstance::Apart));

--- a/compiler-frontend/checking/src/core/constraint/compiler/prim_type_error.rs
+++ b/compiler-frontend/checking/src/core/constraint/compiler/prim_type_error.rs
@@ -32,8 +32,11 @@ where
     Q: ExternalQueries,
 {
     let id = normalise::expand(state, context, id)?;
-    if let Type::String(_, smol_str_id) = context.lookup_type(id) {
-        Ok(Some(context.queries.lookup_smol_str(smol_str_id)))
+    if let Type::String(_, value) = context.lookup_type(id) {
+        let text = value
+            .to_utf8()
+            .unwrap_or_else(|_| lowering::literal::encode_normal_string_content(&value));
+        Ok(Some(SmolStr::from(text)))
     } else {
         Ok(None)
     }
@@ -43,13 +46,13 @@ fn extract_symbol_with_kind<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     id: TypeId,
-) -> QueryResult<Option<(StringKind, SmolStr)>>
+) -> QueryResult<Option<(StringKind, lowering::StringLiteral)>>
 where
     Q: ExternalQueries,
 {
     let id = normalise::expand(state, context, id)?;
-    if let Type::String(kind, smol_id) = context.lookup_type(id) {
-        Ok(Some((kind, context.queries.lookup_smol_str(smol_id))))
+    if let Type::String(kind, value) = context.lookup_type(id) {
+        Ok(Some((kind, value)))
     } else {
         Ok(None)
     }
@@ -64,13 +67,20 @@ fn is_valid_label(s: &str) -> bool {
     chars.all(|c| c.is_alphanumeric() || c == '_' || c == '\'')
 }
 
-fn render_label(kind: StringKind, text: &str) -> SmolStr {
-    if is_valid_label(text) {
-        SmolStr::new(text)
-    } else {
-        match kind {
-            StringKind::String => SmolStr::new(format!(r#""{text}""#)),
-            StringKind::RawString => SmolStr::new(format!(r#""""{text}""""#)),
+fn render_label(kind: StringKind, value: &lowering::StringLiteral) -> SmolStr {
+    if let Ok(text) = value.to_utf8()
+        && is_valid_label(&text)
+    {
+        return SmolStr::from(text);
+    }
+
+    match kind {
+        StringKind::String => lowering::literal::encode_normal_string(value).into(),
+        StringKind::RawString => {
+            let text = value.to_utf8().unwrap_or_else(|_| {
+                unreachable!("invariant violated: raw string contains a lone surrogate")
+            });
+            SmolStr::new(format!(r#""""{text}""""#))
         }
     }
 }
@@ -117,7 +127,7 @@ where
             return Err(RenderStuck::Blocked(u));
         }
         Ok(extract_symbol_with_kind(state, context, symbol)?
-            .map(|(kind, text)| render_label(kind, &text)))
+            .map(|(kind, value)| render_label(kind, &value)))
     } else if constructor == prim.beside {
         let &[left, right] = arguments.as_slice() else { return Ok(None) };
         let Some(left_rendered) = render_doc(state, context, left)? else {

--- a/compiler-frontend/checking/src/core/exhaustive.rs
+++ b/compiler-frontend/checking/src/core/exhaustive.rs
@@ -36,7 +36,7 @@ pub enum PatternConstructor {
     Boolean(bool),
     Integer(i32),
     Number(bool, SmolStr),
-    String(SmolStr),
+    String(lowering::StringLiteral),
     Char(char),
 }
 
@@ -132,7 +132,7 @@ impl PatternConstructor {
             }
             PatternConstructor::String(ref s) => {
                 assert!(fields.is_empty(), "String constructor has arity 0");
-                PatternConstructor::String(SmolStr::clone(s))
+                PatternConstructor::String(s.clone())
             }
             PatternConstructor::Char(c) => {
                 assert!(fields.is_empty(), "Char constructor has arity 0");
@@ -867,7 +867,7 @@ enum ConstructorKey {
     Boolean(bool),
     Integer(i32),
     Number(bool, SmolStr),
-    String(SmolStr),
+    String(lowering::StringLiteral),
     Char(char),
 }
 
@@ -888,7 +888,7 @@ impl ConstructorKey {
                 ConstructorKey::Number(*negative, n)
             }
             PatternConstructor::String(s) => {
-                let s = SmolStr::clone(s);
+                let s = s.clone();
                 ConstructorKey::String(s)
             }
             PatternConstructor::Char(c) => ConstructorKey::Char(*c),

--- a/compiler-frontend/checking/src/core/exhaustive/convert.rs
+++ b/compiler-frontend/checking/src/core/exhaustive/convert.rs
@@ -67,7 +67,7 @@ where
         lowering::BinderKind::Wildcard => Ok(state.allocate_wildcard(t)),
         lowering::BinderKind::String { value, .. } => {
             if let Some(value) = value {
-                let constructor = PatternConstructor::String(SmolStr::clone(value));
+                let constructor = PatternConstructor::String(value.clone());
                 Ok(state.allocate_constructor(constructor, t))
             } else {
                 Ok(state.allocate_wildcard(t))

--- a/compiler-frontend/checking/src/core/exhaustive/pretty.rs
+++ b/compiler-frontend/checking/src/core/exhaustive/pretty.rs
@@ -134,13 +134,7 @@ where
             builder.push('\'');
             builder.finish()
         }
-        PatternConstructor::String(s) => {
-            let mut builder = SmolStrBuilder::default();
-            builder.push('"');
-            builder.push_str(s);
-            builder.push('"');
-            builder.finish()
-        }
+        PatternConstructor::String(s) => lowering::literal::encode_normal_string(s).into(),
         PatternConstructor::Integer(i) => SmolStr::from(i.to_string()),
         PatternConstructor::Number(negative, n) => {
             let mut builder = SmolStrBuilder::default();

--- a/compiler-frontend/checking/src/core/pretty.rs
+++ b/compiler-frontend/checking/src/core/pretty.rs
@@ -509,7 +509,9 @@ where
             Type::String(kind, string_id) => {
                 let string = self.lookup_smol_str(string_id);
                 match kind {
-                    StringKind::String => self.arena.text(format!("\"{string}\"")),
+                    StringKind::String => {
+                        self.arena.text(lowering::literal::encode_normal_string(&string))
+                    }
                     StringKind::RawString => self.arena.text(format!("\"\"\"{string}\"\"\"")),
                 }
             }

--- a/compiler-frontend/checking/src/core/pretty.rs
+++ b/compiler-frontend/checking/src/core/pretty.rs
@@ -506,15 +506,17 @@ where
                 self.parens_if(negative, integer)
             }
 
-            Type::String(kind, string_id) => {
-                let string = self.lookup_smol_str(string_id);
-                match kind {
-                    StringKind::String => {
-                        self.arena.text(lowering::literal::encode_normal_string(&string))
-                    }
-                    StringKind::RawString => self.arena.text(format!("\"\"\"{string}\"\"\"")),
+            Type::String(kind, string) => match kind {
+                StringKind::String => {
+                    self.arena.text(lowering::literal::encode_normal_string(&string))
                 }
-            }
+                StringKind::RawString => {
+                    let string = string.to_utf8().unwrap_or_else(|_| {
+                        unreachable!("invariant violated: raw string contains a lone surrogate")
+                    });
+                    self.arena.text(format!("\"\"\"{string}\"\"\""))
+                }
+            },
 
             Type::Row(row_id) => {
                 let row = self.lookup_row_type(row_id);

--- a/compiler-frontend/checking/src/evidence.rs
+++ b/compiler-frontend/checking/src/evidence.rs
@@ -8,7 +8,6 @@ use std::ops::{Index, IndexMut};
 
 use files::FileId;
 use indexing::TypeItemId;
-use smol_str::SmolStr;
 
 use crate::TypeId;
 pub use crate::core::constraint::instances::InstanceCandidateOrigin;
@@ -53,14 +52,14 @@ pub struct EvidenceBinder {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SynthesizedEvidence {
-    IsSymbol(SmolStr),
+    IsSymbol(lowering::StringLiteral),
     Reflectable(ReflectableEvidence),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReflectableEvidence {
     Integer(i32),
-    String(SmolStr),
+    String(lowering::StringLiteral),
     Boolean(bool),
     Ordering(ReflectableOrdering),
 }

--- a/compiler-frontend/checking/src/source/binder.rs
+++ b/compiler-frontend/checking/src/source/binder.rs
@@ -367,7 +367,7 @@ where
             }
 
             let binder_kind = value.as_ref().map_or(tree::BinderKind::Error, |value| {
-                tree::BinderKind::String { value: SmolStr::clone(value) }
+                tree::BinderKind::String { value: value.clone() }
             });
             (inferred_type, binder_kind)
         }

--- a/compiler-frontend/checking/src/source/derive/generic.rs
+++ b/compiler-frontend/checking/src/source/derive/generic.rs
@@ -117,8 +117,8 @@ where
     let field_types = instantiate_constructor_fields(state, context, constructor_type, arguments)?;
     let fields_rep = build_fields_rep(context, known_generic, &field_types);
 
-    let string_id = context.queries.intern_smol_str(constructor_name);
-    let name = context.queries.intern_type(Type::String(StringKind::String, string_id));
+    let name =
+        context.queries.intern_type(Type::String(StringKind::String, constructor_name.into()));
     let constructor = context.intern_application(known_generic.constructor, name);
     Ok(context.intern_application(constructor, fields_rep))
 }

--- a/compiler-frontend/checking/src/source/terms.rs
+++ b/compiler-frontend/checking/src/source/terms.rs
@@ -530,7 +530,7 @@ where
             let Some(value) = value else {
                 return Ok(allocate_error_expression(state, context.prim.string));
             };
-            let kind = tree::ExpressionKind::String { kind: *kind, value: SmolStr::clone(value) };
+            let kind = tree::ExpressionKind::String { kind: *kind, value: value.clone() };
             Ok(allocate_expression(state, context.prim.string, kind))
         }
 

--- a/compiler-frontend/checking/src/source/types.rs
+++ b/compiler-frontend/checking/src/source/types.rs
@@ -246,10 +246,9 @@ where
         }
 
         lowering::TypeKind::String { kind, value } => {
-            let value = value.clone().unwrap_or(MISSING_NAME);
-            let id = context.queries.intern_smol_str(value);
+            let value = value.clone().unwrap_or_else(|| MISSING_NAME.as_str().into());
 
-            let t = context.queries.intern_type(Type::String(*kind, id));
+            let t = context.queries.intern_type(Type::String(*kind, value));
             let k = context.prim.symbol;
 
             Ok((t, k))

--- a/compiler-frontend/checking/src/tree.rs
+++ b/compiler-frontend/checking/src/tree.rs
@@ -315,7 +315,7 @@ pub enum BinderKind {
     Variable,
     Named { name: SmolStr, binder: BinderId },
     Wildcard,
-    String { value: SmolStr },
+    String { value: lowering::StringLiteral },
     Char { value: char },
     Boolean { value: bool },
     Array { elements: Arc<[BinderId]> },
@@ -344,7 +344,7 @@ pub enum VariableResolution {
 #[derive(Debug, PartialEq, Eq)]
 pub enum ExpressionKind {
     Error,
-    String { kind: lowering::StringKind, value: SmolStr },
+    String { kind: lowering::StringKind, value: lowering::StringLiteral },
     Char { value: char },
     Boolean { value: bool },
     Integer { value: i32 },

--- a/compiler-frontend/checking/src/tree/pretty.rs
+++ b/compiler-frontend/checking/src/tree/pretty.rs
@@ -1459,7 +1459,7 @@ where
             ExpressionKind::Error => Ok(self.arena.text("<error>")),
             ExpressionKind::String { kind, value } => match kind {
                 lowering::StringKind::String => {
-                    let text = format!("\"{value}\"");
+                    let text = lowering::literal::encode_normal_string(value);
                     Ok(self.arena.text(text))
                 }
                 lowering::StringKind::RawString => {

--- a/compiler-frontend/checking/src/tree/pretty.rs
+++ b/compiler-frontend/checking/src/tree/pretty.rs
@@ -1343,7 +1343,7 @@ where
             }
             BinderKind::Wildcard => Ok(self.arena.text("_")),
             BinderKind::String { value } => {
-                let text = format!("{:?}", value.as_str());
+                let text = lowering::literal::encode_normal_string(value);
                 Ok(self.arena.text(text))
             }
             BinderKind::Char { value } => {
@@ -1463,6 +1463,9 @@ where
                     Ok(self.arena.text(text))
                 }
                 lowering::StringKind::RawString => {
+                    let value = value.to_utf8().unwrap_or_else(|_| {
+                        unreachable!("invariant violated: raw string contains a lone surrogate")
+                    });
                     let text = format!("\"\"\"{value}\"\"\"");
                     Ok(self.arena.text(text))
                 }

--- a/compiler-frontend/diagnostics/src/convert.rs
+++ b/compiler-frontend/diagnostics/src/convert.rs
@@ -145,6 +145,25 @@ impl ToDiagnostics for LoweringError {
                 vec![Diagnostic::error("NotInScope", message, span, "lowering")]
             }
 
+            LoweringError::InvalidStringEscape { source } => {
+                let ptr = match source {
+                    lowering::StringLiteralSource::Expression(id) => {
+                        context.stabilized.syntax_ptr(*id)
+                    }
+                    lowering::StringLiteralSource::Binder(id) => context.stabilized.syntax_ptr(*id),
+                    lowering::StringLiteralSource::Type(id) => context.stabilized.syntax_ptr(*id),
+                };
+                let Some(ptr) = ptr else { return vec![] };
+                let Some(span) = context.span_from_syntax_ptr(&ptr) else { return vec![] };
+
+                vec![Diagnostic::error(
+                    "InvalidStringEscape",
+                    "Invalid escape sequence in string literal",
+                    span,
+                    "lowering",
+                )]
+            }
+
             LoweringError::RecursiveSynonym(group) => convert_recursive_group(
                 context,
                 &group.group,

--- a/compiler-frontend/lowering/src/algorithm/recursive.rs
+++ b/compiler-frontend/lowering/src/algorithm/recursive.rs
@@ -38,12 +38,18 @@ fn string_literal_text(source: &str, token: SyntaxToken) -> Option<StringLiteral
 }
 
 fn string_literal(
+    state: &mut State,
     source: &str,
+    literal_source: StringLiteralSource,
     string: Option<SyntaxToken>,
     raw_string: Option<SyntaxToken>,
 ) -> (StringKind, Option<StringLiteral>) {
     if let Some(value) = string {
-        (StringKind::String, string_literal_text(source, value))
+        let value = string_literal_text(source, value);
+        if value.is_none() {
+            state.errors.push(LoweringError::InvalidStringEscape { source: literal_source });
+        }
+        (StringKind::String, value)
     } else if let Some(value) = raw_string {
         (StringKind::RawString, string_literal_text(source, value))
     } else {
@@ -172,7 +178,10 @@ fn lower_binder_kind(
         }
         cst::Binder::BinderWildcard(_) => BinderKind::Wildcard,
         cst::Binder::BinderString(cst) => {
-            let (kind, value) = string_literal(context.source, cst.string(), cst.raw_string());
+            let source =
+                StringLiteralSource::Binder(context.stabilized.lookup_cst(cst).expect_id());
+            let (kind, value) =
+                string_literal(state, context.source, source, cst.string(), cst.raw_string());
             BinderKind::String { kind, value }
         }
         cst::Binder::BinderChar(cst) => {
@@ -520,7 +529,9 @@ fn lower_expression_kind(
         cst::Expression::ExpressionString(cst) => {
             let string = child_token(cst.syntax(), SyntaxKind::STRING);
             let raw_string = child_token(cst.syntax(), SyntaxKind::RAW_STRING);
-            let (kind, value) = string_literal(context.source, string, raw_string);
+            let source =
+                StringLiteralSource::Expression(context.stabilized.lookup_cst(cst).expect_id());
+            let (kind, value) = string_literal(state, context.source, source, string, raw_string);
             ExpressionKind::String { kind, value }
         }
         cst::Expression::ExpressionChar(cst) => {
@@ -1114,7 +1125,9 @@ fn lower_type_kind(
             TypeKind::OperatorChain { head, tail }
         }
         cst::Type::TypeString(cst) => {
-            let (kind, value) = string_literal(context.source, cst.string(), cst.raw_string());
+            let source = StringLiteralSource::Type(context.stabilized.lookup_cst(cst).expect_id());
+            let (kind, value) =
+                string_literal(state, context.source, source, cst.string(), cst.raw_string());
             TypeKind::String { kind, value }
         }
         cst::Type::TypeVariable(cst) => {

--- a/compiler-frontend/lowering/src/algorithm/recursive.rs
+++ b/compiler-frontend/lowering/src/algorithm/recursive.rs
@@ -9,21 +9,28 @@ use stabilizing::ExpectId;
 use syntax::ast::AstNode;
 use syntax::{SyntaxKind, SyntaxNode, SyntaxToken, cst};
 
+use crate::literal::{decode_normal_string, decode_raw_string};
 use crate::*;
 
 use super::{Context, ItemGraph, LetBindingContext, State};
 
-fn string_text(source: &str, token: SyntaxToken) -> SmolStr {
+fn string_text(source: &str, token: SyntaxToken) -> Option<SmolStr> {
     let text = token.text(source);
-    string_text_from_token_text(text)
-}
-
-fn string_text_from_token_text(original: &str) -> SmolStr {
-    let text = original
-        .strip_prefix("\"\"\"")
-        .and_then(|t| t.strip_suffix("\"\"\""))
-        .or_else(|| original.strip_prefix('"').and_then(|t| t.strip_suffix('"')));
-    SmolStr::from(text.unwrap_or(original))
+    if text.starts_with("\"\"\"") {
+        if text.len() >= 6 && text.ends_with("\"\"\"") {
+            decode_raw_string(text)
+        } else {
+            Some(SmolStr::from(text))
+        }
+    } else if text.starts_with('"') {
+        if text.len() >= 2 && text.ends_with('"') {
+            decode_normal_string(text)
+        } else {
+            Some(SmolStr::from(text))
+        }
+    } else {
+        Some(SmolStr::from(text))
+    }
 }
 
 fn string_literal(
@@ -32,9 +39,9 @@ fn string_literal(
     raw_string: Option<SyntaxToken>,
 ) -> (StringKind, Option<SmolStr>) {
     if let Some(value) = string {
-        (StringKind::String, Some(string_text(source, value)))
+        (StringKind::String, string_text(source, value))
     } else if let Some(value) = raw_string {
-        (StringKind::RawString, Some(string_text(source, value)))
+        (StringKind::RawString, string_text(source, value))
     } else {
         (StringKind::String, None)
     }
@@ -179,7 +186,7 @@ fn lower_binder_kind(
                 cst::RecordItem::RecordField(cst) => {
                     let name = cst.name().and_then(|cst| {
                         let token = cst.text()?;
-                        Some(string_text(context.source, token))
+                        string_text(context.source, token)
                     });
                     let value = cst.binder().map(|cst| lower_binder(state, context, &cst));
                     BinderRecordItem::RecordField { name, value }
@@ -189,7 +196,7 @@ fn lower_binder_kind(
 
                     let name = cst.name().and_then(|cst| {
                         let token = cst.text()?;
-                        Some(string_text(context.source, token))
+                        string_text(context.source, token)
                     });
 
                     if let Some(name) = &name {
@@ -538,7 +545,7 @@ fn lower_expression_kind(
                 cst::RecordItem::RecordField(cst) => {
                     let name = cst.name().and_then(|cst| {
                         let token = cst.text()?;
-                        Some(string_text(context.source, token))
+                        string_text(context.source, token)
                     });
                     let value = cst.expression().map(|cst| lower_expression(state, context, &cst));
                     ExpressionRecordItem::RecordField { name, value }
@@ -548,7 +555,7 @@ fn lower_expression_kind(
 
                     let name = cst.name().and_then(|cst| {
                         let token = cst.text()?;
-                        Some(string_text(context.source, token))
+                        string_text(context.source, token)
                     });
                     let resolution = name.as_ref().and_then(|name| {
                         let qualifier: Option<&str> = None;
@@ -573,7 +580,7 @@ fn lower_expression_kind(
                 .map(|cst| {
                     let id = context.stabilized.lookup_cst(&cst).expect_id();
                     let token = cst.name()?.text()?;
-                    let name = string_text(context.source, token);
+                    let name = string_text(context.source, token)?;
                     Some(RecordAccessLabel { id, name })
                 })
                 .collect();
@@ -954,7 +961,7 @@ fn lower_record_updates(
             cst::RecordUpdate::RecordUpdateLeaf(cst) => {
                 let name = cst.name().and_then(|cst| {
                     let token = cst.text()?;
-                    Some(string_text(context.source, token))
+                    string_text(context.source, token)
                 });
                 let expression = cst.expression().map(|cst| lower_expression(state, context, &cst));
                 RecordUpdate::Leaf { name, expression }
@@ -962,7 +969,7 @@ fn lower_record_updates(
             cst::RecordUpdate::RecordUpdateBranch(cst) => {
                 let name = cst.name().and_then(|cst| {
                     let token = cst.text()?;
-                    Some(string_text(context.source, token))
+                    string_text(context.source, token)
                 });
                 let updates =
                     recover! { lower_record_updates(state, context, &cst.record_updates()?) };
@@ -1252,7 +1259,7 @@ pub(crate) fn lower_type_variable_binding(
 fn lower_row_item(state: &mut State, context: &Context, cst: &cst::TypeRowItem) -> TypeRowItem {
     let name = cst.name().and_then(|cst| {
         let token = cst.text()?;
-        Some(string_text(context.source, token))
+        string_text(context.source, token)
     });
     let type_ = cst.type_().map(|t| lower_type(state, context, &t));
     TypeRowItem { name, type_ }

--- a/compiler-frontend/lowering/src/algorithm/recursive.rs
+++ b/compiler-frontend/lowering/src/algorithm/recursive.rs
@@ -9,27 +9,31 @@ use stabilizing::ExpectId;
 use syntax::ast::AstNode;
 use syntax::{SyntaxKind, SyntaxNode, SyntaxToken, cst};
 
-use crate::literal::{decode_normal_string, decode_raw_string};
+use crate::literal::{StringLiteral, decode_normal_string, decode_raw_string};
 use crate::*;
 
 use super::{Context, ItemGraph, LetBindingContext, State};
 
 fn string_text(source: &str, token: SyntaxToken) -> Option<SmolStr> {
+    string_literal_text(source, token)?.to_utf8().ok().map(SmolStr::from)
+}
+
+fn string_literal_text(source: &str, token: SyntaxToken) -> Option<StringLiteral> {
     let text = token.text(source);
     if text.starts_with("\"\"\"") {
         if text.len() >= 6 && text.ends_with("\"\"\"") {
             decode_raw_string(text)
         } else {
-            Some(SmolStr::from(text))
+            Some(StringLiteral::from(text))
         }
     } else if text.starts_with('"') {
         if text.len() >= 2 && text.ends_with('"') {
             decode_normal_string(text)
         } else {
-            Some(SmolStr::from(text))
+            Some(StringLiteral::from(text))
         }
     } else {
-        Some(SmolStr::from(text))
+        Some(StringLiteral::from(text))
     }
 }
 
@@ -37,11 +41,11 @@ fn string_literal(
     source: &str,
     string: Option<SyntaxToken>,
     raw_string: Option<SyntaxToken>,
-) -> (StringKind, Option<SmolStr>) {
+) -> (StringKind, Option<StringLiteral>) {
     if let Some(value) = string {
-        (StringKind::String, string_text(source, value))
+        (StringKind::String, string_literal_text(source, value))
     } else if let Some(value) = raw_string {
-        (StringKind::RawString, string_text(source, value))
+        (StringKind::RawString, string_literal_text(source, value))
     } else {
         (StringKind::String, None)
     }

--- a/compiler-frontend/lowering/src/error.rs
+++ b/compiler-frontend/lowering/src/error.rs
@@ -7,8 +7,16 @@ use syntax::cst;
 #[derive(Debug, PartialEq, Eq)]
 pub enum LoweringError {
     NotInScope(NotInScope),
+    InvalidStringEscape { source: StringLiteralSource },
     RecursiveSynonym(RecursiveGroup),
     RecursiveKinds(RecursiveGroup),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum StringLiteralSource {
+    Expression(AstId<cst::ExpressionString>),
+    Binder(AstId<cst::BinderString>),
+    Type(AstId<cst::TypeString>),
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/compiler-frontend/lowering/src/lib.rs
+++ b/compiler-frontend/lowering/src/lib.rs
@@ -4,6 +4,7 @@ mod recover;
 mod algorithm;
 
 pub mod error;
+pub mod literal;
 pub mod scope;
 pub mod source;
 pub mod tree;

--- a/compiler-frontend/lowering/src/lib.rs
+++ b/compiler-frontend/lowering/src/lib.rs
@@ -14,6 +14,7 @@ use std::slice;
 use std::sync::Arc;
 
 pub use error::*;
+pub use literal::StringLiteral;
 pub use scope::*;
 pub use source::*;
 pub use tree::*;

--- a/compiler-frontend/lowering/src/literal.rs
+++ b/compiler-frontend/lowering/src/literal.rs
@@ -1,31 +1,83 @@
+use std::fmt;
+use std::sync::Arc;
+
 use smol_str::SmolStr;
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StringLiteral(Arc<[u16]>);
+
+impl StringLiteral {
+    pub fn from_utf16(value: impl Into<Arc<[u16]>>) -> StringLiteral {
+        StringLiteral(value.into())
+    }
+
+    pub fn as_utf16(&self) -> &[u16] {
+        &self.0
+    }
+
+    pub fn to_utf8(&self) -> Result<String, std::string::FromUtf16Error> {
+        String::from_utf16(&self.0)
+    }
+
+    pub fn append(&self, suffix: &StringLiteral) -> StringLiteral {
+        let mut value = Vec::with_capacity(self.0.len() + suffix.0.len());
+        value.extend_from_slice(&self.0);
+        value.extend_from_slice(&suffix.0);
+        StringLiteral::from_utf16(value)
+    }
+}
+
+impl fmt::Debug for StringLiteral {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&encode_normal_string(self))
+    }
+}
+
+impl From<&str> for StringLiteral {
+    fn from(value: &str) -> StringLiteral {
+        let value = value.encode_utf16().collect::<Vec<_>>();
+        StringLiteral::from_utf16(value)
+    }
+}
+
+impl From<String> for StringLiteral {
+    fn from(value: String) -> StringLiteral {
+        StringLiteral::from(value.as_str())
+    }
+}
+
+impl From<SmolStr> for StringLiteral {
+    fn from(value: SmolStr) -> StringLiteral {
+        StringLiteral::from(value.as_str())
+    }
+}
 
 fn is_string_gap_character(character: char) -> bool {
     matches!(character, ' ' | '\r' | '\n')
 }
 
-pub fn decode_normal_string(original: &str) -> Option<SmolStr> {
+pub fn decode_normal_string(original: &str) -> Option<StringLiteral> {
     let text = original.strip_prefix('"')?.strip_suffix('"')?;
     let mut characters = text.chars().peekable();
-    let mut decoded = String::with_capacity(text.len());
+    let mut decoded = Vec::with_capacity(text.len());
 
     while let Some(character) = characters.next() {
         if matches!(character, '\r' | '\n') {
             return None;
         }
         if character != '\\' {
-            decoded.push(character);
+            decoded.extend(character.encode_utf16(&mut [0; 2]).iter().copied());
             continue;
         }
 
         let escaped = characters.next()?;
         match escaped {
-            't' => decoded.push('\t'),
-            'r' => decoded.push('\r'),
-            'n' => decoded.push('\n'),
-            '"' => decoded.push('"'),
-            '\'' => decoded.push('\''),
-            '\\' => decoded.push('\\'),
+            't' => decoded.push('\t' as u16),
+            'r' => decoded.push('\r' as u16),
+            'n' => decoded.push('\n' as u16),
+            '"' => decoded.push('"' as u16),
+            '\'' => decoded.push('\'' as u16),
+            '\\' => decoded.push('\\' as u16),
             'x' => {
                 let mut hexadecimal = String::new();
                 for _ in 0..6 {
@@ -37,7 +89,12 @@ pub fn decode_normal_string(original: &str) -> Option<SmolStr> {
                     hexadecimal.push(character);
                 }
                 let value = u32::from_str_radix(&hexadecimal, 16).unwrap_or(0);
-                decoded.push(char::from_u32(value)?);
+                if value <= u16::MAX as u32 {
+                    decoded.push(value as u16);
+                } else {
+                    let character = char::from_u32(value)?;
+                    decoded.extend(character.encode_utf16(&mut [0; 2]).iter().copied());
+                }
             }
             gap if is_string_gap_character(gap) => {
                 while characters.peek().is_some_and(|character| is_string_gap_character(*character))
@@ -52,18 +109,29 @@ pub fn decode_normal_string(original: &str) -> Option<SmolStr> {
         }
     }
 
-    Some(SmolStr::from(decoded))
+    Some(StringLiteral::from_utf16(decoded))
 }
 
-pub fn decode_raw_string(original: &str) -> Option<SmolStr> {
+pub fn decode_raw_string(original: &str) -> Option<StringLiteral> {
     let text = original.strip_prefix("\"\"\"")?.strip_suffix("\"\"\"")?;
-    Some(SmolStr::from(text))
+    Some(StringLiteral::from(text))
 }
 
-pub fn encode_normal_string(value: &str) -> String {
-    let mut literal = String::with_capacity(value.len() + 2);
-    literal.push('"');
-    for character in value.chars() {
+pub fn encode_normal_string(value: &StringLiteral) -> String {
+    let content = encode_normal_string_content(value);
+    format!("\"{content}\"")
+}
+
+pub fn encode_normal_string_content(value: &StringLiteral) -> String {
+    let mut literal = String::with_capacity(value.as_utf16().len());
+    for character in char::decode_utf16(value.as_utf16().iter().copied()) {
+        let character = match character {
+            Ok(character) => character,
+            Err(error) => {
+                literal.push_str(&format!("\\x{:06x}", error.unpaired_surrogate()));
+                continue;
+            }
+        };
         match character {
             '\n' => literal.push_str("\\n"),
             '\r' => literal.push_str("\\r"),
@@ -76,20 +144,29 @@ pub fn encode_normal_string(value: &str) -> String {
             character => literal.push(character),
         }
     }
-    literal.push('"');
     literal
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_normal_string, decode_raw_string, encode_normal_string};
+    use super::{StringLiteral, decode_normal_string, decode_raw_string, encode_normal_string};
 
     #[test]
     fn normal_strings_round_trip_every_unicode_scalar_value() {
         let value = (0..=0x10ffff).filter_map(char::from_u32).collect::<String>();
+        let value = StringLiteral::from(value);
         let encoded = encode_normal_string(&value);
 
-        assert_eq!(decode_normal_string(&encoded).as_deref(), Some(value.as_str()));
+        assert_eq!(decode_normal_string(&encoded), Some(value));
+    }
+
+    #[test]
+    fn normal_strings_round_trip_every_utf16_code_unit() {
+        let value = (u16::MIN..=u16::MAX).collect::<Vec<_>>();
+        let value = StringLiteral::from_utf16(value);
+        let encoded = encode_normal_string(&value);
+
+        assert_eq!(decode_normal_string(&encoded), Some(value));
     }
 
     #[test]
@@ -97,8 +174,9 @@ mod tests {
         let cases = ["", "\"\\'", "\0abcdef", "\u{1f}0123456789", "\n\r\t"];
 
         for value in cases {
-            let encoded = encode_normal_string(value);
-            assert_eq!(decode_normal_string(&encoded).as_deref(), Some(value), "{encoded}");
+            let value = StringLiteral::from(value);
+            let encoded = encode_normal_string(&value);
+            assert_eq!(decode_normal_string(&encoded), Some(value), "{encoded}");
         }
     }
 
@@ -114,7 +192,11 @@ mod tests {
         ];
 
         for (source, expected) in cases {
-            assert_eq!(decode_normal_string(source).as_deref(), Some(expected), "{source}");
+            assert_eq!(
+                decode_normal_string(source),
+                Some(StringLiteral::from(expected)),
+                "{source}"
+            );
         }
     }
 
@@ -123,7 +205,11 @@ mod tests {
         let cases = [("\"a\\ \r\n\\b\"", "ab"), ("\"a\\ \r\n\"", "a")];
 
         for (source, expected) in cases {
-            assert_eq!(decode_normal_string(source).as_deref(), Some(expected), "{source:?}");
+            assert_eq!(
+                decode_normal_string(source),
+                Some(StringLiteral::from(expected)),
+                "{source:?}"
+            );
         }
     }
 
@@ -144,15 +230,21 @@ mod tests {
     }
 
     #[test]
-    fn normal_strings_reject_values_outside_the_unicode_scalar_domain() {
-        for source in [r#""\xD800""#, r#""\xDFFF""#, r#""\x110000""#] {
-            assert_eq!(decode_normal_string(source), None, "{source}");
-        }
+    fn normal_strings_preserve_lone_surrogates_as_utf16() {
+        let value = decode_normal_string(r#""\xD800x\xDFFF""#).unwrap();
+        assert_eq!(value.as_utf16(), &[0xd800, b'x' as u16, 0xdfff]);
+        assert_eq!(encode_normal_string(&value), r#""\x00d800x\x00dfff""#);
+    }
+
+    #[test]
+    fn normal_strings_reject_values_outside_the_code_point_domain() {
+        assert_eq!(decode_normal_string(r#""\x110000""#), None);
     }
 
     #[test]
     fn raw_strings_preserve_escape_spelling() {
         let source = "\"\"\"\\n\\\"quoted\\\"\"\"\"";
-        assert_eq!(decode_raw_string(source).as_deref(), Some(r#"\n\"quoted\""#));
+        let expected = StringLiteral::from(r#"\n\"quoted\""#);
+        assert_eq!(decode_raw_string(source), Some(expected));
     }
 }

--- a/compiler-frontend/lowering/src/literal.rs
+++ b/compiler-frontend/lowering/src/literal.rs
@@ -1,0 +1,158 @@
+use smol_str::SmolStr;
+
+fn is_string_gap_character(character: char) -> bool {
+    matches!(character, ' ' | '\r' | '\n')
+}
+
+pub fn decode_normal_string(original: &str) -> Option<SmolStr> {
+    let text = original.strip_prefix('"')?.strip_suffix('"')?;
+    let mut characters = text.chars().peekable();
+    let mut decoded = String::with_capacity(text.len());
+
+    while let Some(character) = characters.next() {
+        if matches!(character, '\r' | '\n') {
+            return None;
+        }
+        if character != '\\' {
+            decoded.push(character);
+            continue;
+        }
+
+        let escaped = characters.next()?;
+        match escaped {
+            't' => decoded.push('\t'),
+            'r' => decoded.push('\r'),
+            'n' => decoded.push('\n'),
+            '"' => decoded.push('"'),
+            '\'' => decoded.push('\''),
+            '\\' => decoded.push('\\'),
+            'x' => {
+                let mut hexadecimal = String::new();
+                for _ in 0..6 {
+                    let Some(character) =
+                        characters.next_if(|character| character.is_ascii_hexdigit())
+                    else {
+                        break;
+                    };
+                    hexadecimal.push(character);
+                }
+                let value = u32::from_str_radix(&hexadecimal, 16).unwrap_or(0);
+                decoded.push(char::from_u32(value)?);
+            }
+            gap if is_string_gap_character(gap) => {
+                while characters.peek().is_some_and(|character| is_string_gap_character(*character))
+                {
+                    characters.next();
+                }
+                if characters.next_if_eq(&'\\').is_none() && characters.peek().is_some() {
+                    return None;
+                }
+            }
+            _ => return None,
+        }
+    }
+
+    Some(SmolStr::from(decoded))
+}
+
+pub fn decode_raw_string(original: &str) -> Option<SmolStr> {
+    let text = original.strip_prefix("\"\"\"")?.strip_suffix("\"\"\"")?;
+    Some(SmolStr::from(text))
+}
+
+pub fn encode_normal_string(value: &str) -> String {
+    let mut literal = String::with_capacity(value.len() + 2);
+    literal.push('"');
+    for character in value.chars() {
+        match character {
+            '\n' => literal.push_str("\\n"),
+            '\r' => literal.push_str("\\r"),
+            '\t' => literal.push_str("\\t"),
+            '\\' => literal.push_str("\\\\"),
+            '"' => literal.push_str("\\\""),
+            character if character.is_control() => {
+                literal.push_str(&format!("\\x{:06x}", character as u32));
+            }
+            character => literal.push(character),
+        }
+    }
+    literal.push('"');
+    literal
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode_normal_string, decode_raw_string, encode_normal_string};
+
+    #[test]
+    fn normal_strings_round_trip_every_unicode_scalar_value() {
+        let value = (0..=0x10ffff).filter_map(char::from_u32).collect::<String>();
+        let encoded = encode_normal_string(&value);
+
+        assert_eq!(decode_normal_string(&encoded).as_deref(), Some(value.as_str()));
+    }
+
+    #[test]
+    fn normal_strings_round_trip_escape_boundaries() {
+        let cases = ["", "\"\\'", "\0abcdef", "\u{1f}0123456789", "\n\r\t"];
+
+        for value in cases {
+            let encoded = encode_normal_string(value);
+            assert_eq!(decode_normal_string(&encoded).as_deref(), Some(value), "{encoded}");
+        }
+    }
+
+    #[test]
+    fn normal_strings_decode_escape_boundaries() {
+        let cases = [
+            (r#""\xZ""#, "\0Z"),
+            (r#""\x1G""#, "\u{1}G"),
+            (r#""\x12345G""#, "\u{12345}G"),
+            (r#""\x000041B""#, "AB"),
+            (r#""\x10FFFF0""#, "\u{10ffff}0"),
+            (r#""\t\r\n\"\'\\""#, "\t\r\n\"'\\"),
+        ];
+
+        for (source, expected) in cases {
+            assert_eq!(decode_normal_string(source).as_deref(), Some(expected), "{source}");
+        }
+    }
+
+    #[test]
+    fn normal_strings_decode_gaps() {
+        let cases = [("\"a\\ \r\n\\b\"", "ab"), ("\"a\\ \r\n\"", "a")];
+
+        for (source, expected) in cases {
+            assert_eq!(decode_normal_string(source).as_deref(), Some(expected), "{source:?}");
+        }
+    }
+
+    #[test]
+    fn normal_strings_reject_invalid_escapes_and_gaps() {
+        let cases = [
+            r#""\q""#,
+            r#""trailing\"#,
+            "\"a\\\t\\b\"",
+            "\"a\\\u{a0}\\b\"",
+            "\"a\\ q\"",
+            "\"line\nfeed\"",
+        ];
+
+        for source in cases {
+            assert_eq!(decode_normal_string(source), None, "{source:?}");
+        }
+    }
+
+    #[test]
+    fn normal_strings_reject_values_outside_the_unicode_scalar_domain() {
+        for source in [r#""\xD800""#, r#""\xDFFF""#, r#""\x110000""#] {
+            assert_eq!(decode_normal_string(source), None, "{source}");
+        }
+    }
+
+    #[test]
+    fn raw_strings_preserve_escape_spelling() {
+        let source = "\"\"\"\\n\\\"quoted\\\"\"\"\"";
+        assert_eq!(decode_raw_string(source).as_deref(), Some(r#"\n\"quoted\""#));
+    }
+}

--- a/compiler-frontend/lowering/src/tree.rs
+++ b/compiler-frontend/lowering/src/tree.rs
@@ -11,6 +11,7 @@ use la_arena::{Arena, ArenaMap, Idx};
 use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
 
+use crate::literal::StringLiteral;
 use crate::source::*;
 use crate::{Scc, TermVariableResolution, TypeVariableResolution};
 
@@ -36,7 +37,7 @@ pub enum BinderKind {
     Variable { variable: Option<SmolStr> },
     Named { named: Option<SmolStr>, binder: Option<BinderId> },
     Wildcard,
-    String { kind: StringKind, value: Option<SmolStr> },
+    String { kind: StringKind, value: Option<StringLiteral> },
     Char { value: Option<char> },
     Boolean { boolean: bool },
     Array { array: Arc<[BinderId]> },
@@ -145,7 +146,7 @@ pub enum ExpressionKind {
     Hole,
     String {
         kind: StringKind,
-        value: Option<SmolStr>,
+        value: Option<StringLiteral>,
     },
     Char {
         value: Option<char>,
@@ -210,7 +211,7 @@ pub enum TypeKind {
     Kinded { type_: Option<TypeId>, kind: Option<TypeId> },
     Operator { resolution: Option<(FileId, TypeItemId)> },
     OperatorChain { head: Option<TypeId>, tail: Arc<[OperatorPair<TypeId>]> },
-    String { kind: StringKind, value: Option<SmolStr> },
+    String { kind: StringKind, value: Option<StringLiteral> },
     Variable { name: Option<SmolStr>, resolution: Option<TypeVariableResolution> },
     Wildcard,
     Record { items: Arc<[TypeRowItem]>, tail: Option<TypeId> },

--- a/compiler-lsp/documentation/src/render.rs
+++ b/compiler-lsp/documentation/src/render.rs
@@ -112,8 +112,11 @@ impl<'a> TypeEncoder<'a> {
                 reference: self.resolve_type_reference(file_id, type_id)?,
             },
             checking::Type::Integer(value) => schema::Type::Integer { value },
-            checking::Type::String(kind, value_id) => {
-                let value = self.engine.lookup_smol_str(value_id).to_string();
+            checking::Type::String(kind, value) => {
+                let value = match value.to_utf8() {
+                    Ok(value) => schema::StringLiteralValue::Utf8(value),
+                    Err(_) => schema::StringLiteralValue::Utf16(value.as_utf16().to_vec()),
+                };
                 schema::Type::String { kind: kind.into(), value }
             }
             checking::Type::Row(row_id) => {

--- a/compiler-lsp/documentation/src/schema.rs
+++ b/compiler-lsp/documentation/src/schema.rs
@@ -142,7 +142,7 @@ pub enum Type {
     Kinded { expression: Box<Type>, kind: Box<Type> },
     Constructor { reference: TypeReference },
     Integer { value: i32 },
-    String { kind: StringLiteralKind, value: String },
+    String { kind: StringLiteralKind, value: StringLiteralValue },
     Row { fields: Vec<TypeRowField>, tail: Option<Box<Type>> },
     Rigid { name: String, kind: Box<Type> },
     Unification { id: u32 },
@@ -180,6 +180,14 @@ pub struct TypeRowField {
 pub enum StringLiteralKind {
     String,
     RawString,
+}
+
+#[derive(Serialize, Deserialize, TS)]
+#[ts(export_to = "docs-schema.ts")]
+#[serde(untagged)]
+pub enum StringLiteralValue {
+    Utf8(String),
+    Utf16(Vec<u16>),
 }
 
 impl From<lowering::StringKind> for StringLiteralKind {

--- a/tests-integration/fixtures/backend/1788159240_ordinary_string_escapes/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788159240_ordinary_string_escapes/Main.functional.snap
@@ -5,6 +5,6 @@ expression: report
 ---
 @export json = "[\"ann\"]"
 
-@export escaped = "tab:\t carriage-return:\r newline:\n quotes:\"' backslash:\\ unicode:☃ null:\0"
+@export escaped = "tab:\t carriage-return:\r newline:\n quotes:\"' backslash:\\ unicode:☃ null:\x000000"
 
 @export gap = "hello world"

--- a/tests-integration/fixtures/backend/1788159240_ordinary_string_escapes/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788159240_ordinary_string_escapes/Main.functional.snap
@@ -3,8 +3,8 @@ source: tests-integration/tests/functional.rs
 assertion_line: 14
 expression: report
 ---
-@export json = "[\\\"ann\\\"]"
+@export json = "[\"ann\"]"
 
-@export escaped = "tab:\\t carriage-return:\\r newline:\\n quotes:\\\"\\' backslash:\\\\ unicode:\\x2603 null:\\x"
+@export escaped = "tab:\t carriage-return:\r newline:\n quotes:\"' backslash:\\ unicode:☃ null:\0"
 
-@export gap = "hello \\\n  \\world"
+@export gap = "hello world"

--- a/tests-integration/fixtures/backend/1788159240_ordinary_string_escapes/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788159240_ordinary_string_escapes/Main.functional.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export json = "[\\\"ann\\\"]"
+
+@export escaped = "tab:\\t carriage-return:\\r newline:\\n quotes:\\\"\\' backslash:\\\\ unicode:\\x2603 null:\\x"
+
+@export gap = "hello \\\n  \\world"

--- a/tests-integration/fixtures/backend/1788159240_ordinary_string_escapes/Main.purs
+++ b/tests-integration/fixtures/backend/1788159240_ordinary_string_escapes/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+json :: String
+json = "[\"ann\"]"
+
+escaped :: String
+escaped = "tab:\t carriage-return:\r newline:\n quotes:\"\' backslash:\\ unicode:\x2603 null:\x"
+
+gap :: String
+gap = "hello \
+  \world"

--- a/tests-integration/fixtures/backend/1788159240_ordinary_string_escapes/Main.snap
+++ b/tests-integration/fixtures/backend/1788159240_ordinary_string_escapes/Main.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+json :: Prim.String
+escaped :: Prim.String
+gap :: Prim.String
+
+Types

--- a/tests-integration/fixtures/backend/1788159240_ordinary_string_escapes/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788159240_ordinary_string_escapes/output/Main/index.js
@@ -1,3 +1,3 @@
-export const json = "[\\\"ann\\\"]";
-export const escaped = "tab:\\t carriage-return:\\r newline:\\n quotes:\\\"\\' backslash:\\\\ unicode:\\x2603 null:\\x";
-export const gap = "hello \\\n  \\world";
+export const json = "[\"ann\"]";
+export const escaped = "tab:	 carriage-return:\r newline:\n quotes:\"' backslash:\\ unicode:☃ null:\0";
+export const gap = "hello world";

--- a/tests-integration/fixtures/backend/1788159240_ordinary_string_escapes/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788159240_ordinary_string_escapes/output/Main/index.js
@@ -1,0 +1,3 @@
+export const json = "[\\\"ann\\\"]";
+export const escaped = "tab:\\t carriage-return:\\r newline:\\n quotes:\\\"\\' backslash:\\\\ unicode:\\x2603 null:\\x";
+export const gap = "hello \\\n  \\world";

--- a/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/Main.functional.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+cannot convert checked module Idx::<File>(43): checked expression Idx::<Expression>(0) contains an error

--- a/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/Main.functional.snap
@@ -3,4 +3,17 @@ source: tests-integration/tests/functional.rs
 assertion_line: 14
 expression: report
 ---
-cannot convert checked module Idx::<File>(43): checked expression Idx::<Expression>(0) contains an error
+@export lead = "\x00d800"
+
+@export trail = "\x00dfff"
+
+@export escapedPair = "𐀀"
+
+@export scalar = "𐀀"
+
+@export matchesLead = \$string%0 ->
+  case $string%0 of
+    "\x00d800" ->
+      true
+    _ ->
+      false

--- a/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/Main.purs
+++ b/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+lead :: String
+lead = "\xD800"
+
+trail :: String
+trail = "\xDFFF"
+
+escapedPair :: String
+escapedPair = "\xD800\xDC00"
+
+scalar :: String
+scalar = "\x10000"
+
+matchesLead :: String -> Boolean
+matchesLead "\xD800" = true
+matchesLead _ = false

--- a/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/Main.snap
+++ b/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/Main.snap
@@ -11,13 +11,3 @@ scalar :: Prim.String
 matchesLead :: Prim.String -> Prim.Boolean
 
 Types
-
-Diagnostics
-Warning! · [RedundantPattern] · Main.purs:15:1
-  •
-  │
-  • Pattern match has redundant patterns: _
-  │
-  │   matchesLead :: String -> Boolean
-  │   ╰───────────────────────────────
-  •

--- a/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/Main.snap
+++ b/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/Main.snap
@@ -1,0 +1,23 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+lead :: Prim.String
+trail :: Prim.String
+escapedPair :: Prim.String
+scalar :: Prim.String
+matchesLead :: Prim.String -> Prim.Boolean
+
+Types
+
+Diagnostics
+Warning! · [RedundantPattern] · Main.purs:15:1
+  •
+  │
+  • Pattern match has redundant patterns: _
+  │
+  │   matchesLead :: String -> Boolean
+  │   ╰───────────────────────────────
+  •

--- a/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/output/Main/index.js
@@ -1,0 +1,10 @@
+export function matchesLead($string) {
+  if ($string === "\ud800") {
+    return true;
+  }
+  return false;
+}
+export const lead = "\ud800";
+export const trail = "\udfff";
+export const escapedPair = "𐀀";
+export const scalar = "𐀀";

--- a/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/output/error.txt
+++ b/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/output/error.txt
@@ -1,1 +1,0 @@
-cannot convert checked module Idx::<File>(43): checked expression Idx::<Expression>(0) contains an error

--- a/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/output/error.txt
+++ b/tests-integration/fixtures/backend/1788161700_lone_surrogate_strings/output/error.txt
@@ -1,0 +1,1 @@
+cannot convert checked module Idx::<File>(43): checked expression Idx::<Expression>(0) contains an error

--- a/tests-integration/fixtures/checking/1788162540_invalid_normal_string_escapes/Main.purs
+++ b/tests-integration/fixtures/checking/1788162540_invalid_normal_string_escapes/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+invalidExpression :: String
+invalidExpression = "\q"
+
+invalidBinder :: String -> Boolean
+invalidBinder "\q" = true
+invalidBinder _ = false
+
+type InvalidType = "\q"

--- a/tests-integration/fixtures/checking/1788162540_invalid_normal_string_escapes/Main.snap
+++ b/tests-integration/fixtures/checking/1788162540_invalid_normal_string_escapes/Main.snap
@@ -1,0 +1,24 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 299
+expression: report
+---
+Terms
+invalidExpression :: Prim.String
+invalidBinder :: Prim.String -> Prim.Boolean
+
+Types
+InvalidType :: Prim.Symbol
+
+Synonyms
+type InvalidType = "<MissingName>"
+
+Diagnostics
+Warning! · [RedundantPattern] · Main.purs:6:1
+  •
+  │
+  • Pattern match has redundant patterns: _
+  │
+  │   invalidBinder :: String -> Boolean
+  │   ╰─────────────────────────────────
+  •

--- a/tests-integration/fixtures/checking/1788162540_invalid_normal_string_escapes/Main.snap
+++ b/tests-integration/fixtures/checking/1788162540_invalid_normal_string_escapes/Main.snap
@@ -14,6 +14,33 @@ Synonyms
 type InvalidType = "<MissingName>"
 
 Diagnostics
+Error! · [InvalidStringEscape] · Main.purs:4:21
+  •
+  │
+  • Invalid escape sequence in string literal
+  │
+  │   invalidExpression = "\q"
+  │                       ╰───
+  •
+
+Error! · [InvalidStringEscape] · Main.purs:7:15
+  •
+  │
+  • Invalid escape sequence in string literal
+  │
+  │   invalidBinder "\q" = true
+  │                 ╰───
+  •
+
+Error! · [InvalidStringEscape] · Main.purs:10:20
+  •
+  │
+  • Invalid escape sequence in string literal
+  │
+  │   type InvalidType = "\q"
+  │                      ╰───
+  •
+
 Warning! · [RedundantPattern] · Main.purs:6:1
   •
   │

--- a/tests-integration/fixtures/lowering/1787790600_escaped_multiline_string_gaps/Main.snap
+++ b/tests-integration/fixtures/lowering/1787790600_escaped_multiline_string_gaps/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 331
+assertion_line: 334
 expression: report
 ---
 module Main
@@ -9,6 +9,6 @@ Expressions:
 
 "hello \
   \world"@2:9
-  -> string String "hello \\\n  \\world"
+  -> string String "hello world"
 
 Types:


### PR DESCRIPTION
## Intent

Ordinary string escapes were preserved as source spelling instead of decoded values, forcing fixtures and migrated code to use raw strings. Decoding into Rust UTF-8 alone would still reject lone surrogate escapes that PureScript and JavaScript represent as UTF-16 code units.

## Changes

- Decode ordinary string escapes during lowering while preserving raw-string spelling semantics.
- Store literal payloads as UTF-16 so expressions, binders, type-level symbols, synthesized evidence, and generated JavaScript preserve lone surrogates.
- Emit dedicated `InvalidStringEscape` lowering diagnostics for invalid expression, binder, and type literals.
- Add regression fixtures for ordinary escapes, lone surrogates, and invalid escapes, plus exhaustive round-trip coverage for every Unicode scalar and UTF-16 code unit.

## Validation

- `cargo check --workspace --all-targets`
- Clippy with warnings denied for affected crates
- Lowering, checking, and JavaScript unit tests
- Full lowering, semantic, checking, and backend integration suites