### PR TITLE
[compiler-bin] Integrate watch with Spago projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,6 +3508,7 @@ name = "tests-e2e"
 version = "0.1.0"
 dependencies = [
  "insta",
+ "itertools 0.15.0",
  "purescript-alexandrite",
  "tempfile",
 ]

--- a/compiler-bin/src/cli.rs
+++ b/compiler-bin/src/cli.rs
@@ -51,8 +51,8 @@ pub enum Command {
     Test(TestOptions),
     /// Compile PureScript modules to JavaScript (experimental).
     Compile(CompileOptions),
-    /// Compile PureScript modules and rebuild when inputs change (experimental).
-    Watch(WatchOptions),
+    /// Build a Spago workspace or package and rebuild when inputs change.
+    Watch(ProjectBuildOptions),
     /// Documentation utilities.
     Docs(DocsOptions),
 }
@@ -126,16 +126,6 @@ pub struct CompileOptions {
     /// Full structured JSON diagnostics are not yet supported.
     #[arg(long)]
     pub json_errors: bool,
-}
-
-#[derive(Debug, Args)]
-pub struct WatchOptions {
-    #[command(flatten)]
-    pub build: BuildOptions,
-
-    /// PureScript source paths or glob patterns.
-    #[arg(value_name("INPUT"), required = true)]
-    pub inputs: Vec<PathBuf>,
 }
 
 #[derive(Debug, Args)]
@@ -341,7 +331,7 @@ mod tests {
         Cli::try_parse_from(argv).unwrap_err().kind()
     }
 
-    fn watch(args: &[&str]) -> WatchOptions {
+    fn watch(args: &[&str]) -> ProjectBuildOptions {
         let mut argv = vec!["alexandrite", "watch"];
         argv.extend(args);
         let cli = Cli::parse_from(argv);
@@ -408,13 +398,14 @@ mod tests {
     }
 
     #[test]
-    fn watch_accepts_compile_arguments() {
-        let options = watch(&["--output", "dist", "--quiet", "--color", "never", "src/**/*.purs"]);
+    fn watch_accepts_project_build_arguments() {
+        let options =
+            watch(&["--package", "application", "--output", "dist", "--quiet", "--color", "never"]);
 
-        assert_eq!(options.build.output, current_directory_path("dist"));
-        assert!(options.build.quiet);
-        assert_eq!(options.build.color, ColorChoice::Never);
-        assert_eq!(options.inputs, vec![PathBuf::from("src/**/*.purs")]);
+        assert_eq!(options.package.as_deref(), Some("application"));
+        assert_eq!(options.output, Some(current_directory_path("dist")));
+        assert!(options.quiet);
+        assert_eq!(options.color, ColorChoice::Never);
     }
 
     #[test]

--- a/compiler-bin/src/lib.rs
+++ b/compiler-bin/src/lib.rs
@@ -83,18 +83,8 @@ pub fn run() {
             });
         }
         cli::Command::Watch(options) => {
-            logging::start(logging::LoggingFilters {
-                query_log: options.build.logging.query_log,
-                checking_log: options.build.logging.checking_log,
-                lsp_log: LevelFilter::OFF,
-                docs_log: LevelFilter::OFF,
-            });
-            watch::start(watch::WatchConfig {
-                output: options.build.output,
-                inputs: options.inputs,
-                quiet: options.build.quiet,
-                color: options.build.color,
-            });
+            start_project_logging(&options.logging);
+            project::start(project::watch(project_build_config(options)));
         }
         cli::Command::Docs(options) => {
             logging::start(logging::LoggingFilters {

--- a/compiler-bin/src/project.rs
+++ b/compiler-bin/src/project.rs
@@ -7,6 +7,7 @@ use url::Url;
 
 use crate::cli::ColorChoice;
 use crate::compile::{self, CompileError};
+use crate::watch::{self, WatchError};
 use crate::workspace::{Workspace, WorkspaceError};
 use spago::{SpagoCommand, SpagoError};
 
@@ -21,6 +22,8 @@ pub enum ProjectError {
     Compile(#[from] CompileError),
     #[error(transparent)]
     Spago(#[from] SpagoError),
+    #[error(transparent)]
+    Watch(#[from] WatchError),
     #[error(transparent)]
     Workspace(#[from] WorkspaceError),
     #[error("invalid package name '{0}'; use lowercase letters, digits, and hyphens")]
@@ -156,6 +159,20 @@ pub fn build(config: BuildProjectConfig) -> Result<(), ProjectError> {
     compile_workspace(&workspace, &current_directory, &config)
 }
 
+pub fn watch(config: BuildProjectConfig) -> Result<(), ProjectError> {
+    let current_directory = env::current_dir().map_err(ProjectError::CurrentDirectory)?;
+    let workspace = Workspace::discover(&current_directory, config.package.as_deref())?;
+    let (inputs, output) = prepare_workspace_build(&workspace, &current_directory, &config)?;
+    watch::watch(watch::WatchConfig {
+        current_directory: workspace.root,
+        output,
+        inputs,
+        quiet: config.quiet,
+        color: config.color,
+    })?;
+    Ok(())
+}
+
 pub fn add(config: AddProjectConfig) -> Result<(), ProjectError> {
     let current_directory = env::current_dir().map_err(ProjectError::CurrentDirectory)?;
     let workspace = Workspace::discover(&current_directory, config.package.as_deref())?;
@@ -213,12 +230,21 @@ fn compile_workspace(
     current_directory: &Path,
     config: &BuildProjectConfig,
 ) -> Result<(), ProjectError> {
+    let (sources, output) = prepare_workspace_build(workspace, current_directory, config)?;
+    compile::compile_inputs(&workspace.root, &output, &sources, config.quiet, config.color)?;
+    Ok(())
+}
+
+fn prepare_workspace_build(
+    workspace: &Workspace,
+    current_directory: &Path,
+    config: &BuildProjectConfig,
+) -> Result<(Vec<PathBuf>, PathBuf), ProjectError> {
     let spago = SpagoCommand::new(current_directory)?;
     spago.fetch(workspace.selected.as_deref())?;
     let sources = spago.source_globs(workspace.selected.as_deref())?;
     let output = output(workspace, config);
-    compile::compile_inputs(&workspace.root, &output, &sources, config.quiet, config.color)?;
-    Ok(())
+    Ok((sources, output))
 }
 
 fn output(workspace: &Workspace, config: &BuildProjectConfig) -> PathBuf {

--- a/compiler-bin/src/watch.rs
+++ b/compiler-bin/src/watch.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, RecvTimeoutError};
 use std::time::Duration;
-use std::{fs, io, process};
+use std::{fs, io};
 
 use building::{DiskObservation, LifecycleChange, QueryError, ReloadFailure, SourceUnitKey};
 use console::Style;
@@ -22,6 +22,7 @@ const DEBOUNCE_DURATION: Duration = Duration::from_millis(100);
 const MODULE_DISPLAY_LIMIT: usize = 3;
 
 pub struct WatchConfig {
+    pub current_directory: PathBuf,
     pub output: PathBuf,
     pub inputs: Vec<PathBuf>,
     pub quiet: bool,
@@ -29,7 +30,7 @@ pub struct WatchConfig {
 }
 
 #[derive(Debug, Error)]
-enum WatchError {
+pub enum WatchError {
     #[error("failed to convert path to a file URL: {0}")]
     InvalidPath(PathBuf),
     #[error(transparent)]
@@ -42,18 +43,12 @@ enum WatchError {
     Walk(#[from] walk::Error),
 }
 
-pub fn start(config: WatchConfig) {
-    if let Err(error) = watch(config) {
-        eprintln!("Watch exited: {error}");
-        tracing::error!(?error, "Watch exited");
-        process::exit(1);
-    }
-}
-
-fn watch(config: WatchConfig) -> Result<(), WatchError> {
-    let current_directory = std::env::current_dir()?;
-    let (mut workspace, initial_change) =
-        WatchWorkspace::new(current_directory, config.inputs.clone(), config.output.clone())?;
+pub fn watch(config: WatchConfig) -> Result<(), WatchError> {
+    let (mut workspace, initial_change) = WatchWorkspace::new(
+        config.current_directory.clone(),
+        config.inputs.clone(),
+        config.output.clone(),
+    )?;
     let (sender, receiver) = mpsc::channel();
     let mut watcher = RecommendedWatcher::new(sender, notify::Config::default())?;
     for root in &workspace.watch_roots {
@@ -547,6 +542,7 @@ mod tests {
         let (temporary, mut workspace) = workspace();
         let output = temporary.path().join("output");
         let config = WatchConfig {
+            current_directory: temporary.path().to_path_buf(),
             output: output.clone(),
             inputs: vec![PathBuf::from("src/**/*.purs")],
             quiet: true,

--- a/tests-e2e/Cargo.toml
+++ b/tests-e2e/Cargo.toml
@@ -9,6 +9,7 @@ purescript-alexandrite = { path = "../compiler-bin" }
 
 [dev-dependencies]
 insta = "1.48.0"
+itertools = "0.15.0"
 tempfile = "3.27.0"
 
 [[bin]]

--- a/tests-e2e/tests/package_manager.rs
+++ b/tests-e2e/tests/package_manager.rs
@@ -10,3 +10,5 @@ mod run;
 mod support;
 #[path = "package_manager/test.rs"]
 mod test;
+#[path = "package_manager/watch.rs"]
+mod watch;

--- a/tests-e2e/tests/package_manager/support.rs
+++ b/tests-e2e/tests/package_manager/support.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Child, Command, Output};
 
 pub struct TestWorkspace {
     temporary: tempfile::TempDir,
@@ -48,18 +48,29 @@ impl TestWorkspace {
     }
 
     pub fn command_in(&self, directory: &str, arguments: &[&str]) -> Output {
-        let spago = spago_executable();
+        self.command_builder(directory, arguments).output().unwrap()
+    }
+
+    pub fn spawn(&self, arguments: &[&str]) -> Child {
+        self.spawn_in("", arguments)
+    }
+
+    pub fn spawn_in(&self, directory: &str, arguments: &[&str]) -> Child {
+        self.command_builder(directory, arguments).spawn().unwrap()
+    }
+
+    fn command_builder(&self, directory: &str, arguments: &[&str]) -> Command {
         let current_directory = self.path().join(directory);
         fs::create_dir_all(&current_directory).unwrap();
-        Command::new(env!("CARGO_BIN_EXE_alexandrite-e2e"))
+        let mut command = Command::new(env!("CARGO_BIN_EXE_alexandrite-e2e"));
+        command
             .args(arguments)
             .current_dir(current_directory)
             .env("ALEXANDRITE_SPAGO", env!("CARGO_BIN_EXE_spago-e2e"))
-            .env("ALEXANDRITE_E2E_SPAGO", spago)
+            .env("ALEXANDRITE_E2E_SPAGO", spago_executable())
             .env("ALEXANDRITE_E2E_SPAGO_LOG", self.path().join("spago-calls"))
-            .env("NO_COLOR", "1")
-            .output()
-            .unwrap()
+            .env("NO_COLOR", "1");
+        command
     }
 
     pub fn assert_spago_calls(&self, directory: &str, expected: &[&[&str]]) {

--- a/tests-e2e/tests/package_manager/support.rs
+++ b/tests-e2e/tests/package_manager/support.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Output};
+use std::process::{Child, Command, Output, Stdio};
 
 pub struct TestWorkspace {
     temporary: tempfile::TempDir,
@@ -56,7 +56,11 @@ impl TestWorkspace {
     }
 
     pub fn spawn_in(&self, directory: &str, arguments: &[&str]) -> Child {
-        self.command_builder(directory, arguments).spawn().unwrap()
+        self.command_builder(directory, arguments)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap()
     }
 
     fn command_builder(&self, directory: &str, arguments: &[&str]) -> Command {

--- a/tests-e2e/tests/package_manager/watch.rs
+++ b/tests-e2e/tests/package_manager/watch.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
-use std::process::Child;
+use std::process::{Child, Output};
 use std::thread;
 use std::time::{Duration, Instant};
+
+use itertools::Itertools;
 
 use super::support::TestWorkspace;
 
@@ -24,11 +26,12 @@ value = 42
 "#,
     );
 
-    let mut child = workspace.spawn(&["watch", "--quiet"]);
+    let child = workspace.spawn(&["watch"]);
     let output = workspace.path().join("output/Main/index.js");
-    wait_for_outputs(&mut child, &[output]);
-    child.kill().unwrap();
-    child.wait().unwrap();
+    let result = watch_until_outputs(child, &[output]);
+    insta::assert_snapshot!(normalized_watch_log(&result), @r#"
+    [TIME] 1 file changed: Main
+    "#);
 
     workspace.assert_spago_calls(
         "",
@@ -57,29 +60,60 @@ package:
     );
     workspace.write("packages/library/src/Library.purs", "module Library where\n");
 
-    let mut child = workspace.spawn_in("src", &["watch", "--quiet"]);
+    let child = workspace.spawn_in("src", &["watch"]);
     let outputs = [
         workspace.path().join("output/Application/index.js"),
         workspace.path().join("output/Library/index.js"),
     ];
-    wait_for_outputs(&mut child, &outputs);
-    child.kill().unwrap();
-    child.wait().unwrap();
+    let result = watch_until_outputs(child, &outputs);
+    insta::assert_snapshot!(normalized_watch_log(&result), @r#"
+    [TIME] 2 files changed: Application, Library
+    "#);
 
     workspace.assert_spago_calls("src", &[&["fetch"], &["sources", "--json"]]);
 }
 
-fn wait_for_outputs(child: &mut Child, outputs: &[PathBuf]) {
+fn watch_until_outputs(mut child: Child, outputs: &[PathBuf]) -> Output {
     let deadline = Instant::now() + Duration::from_secs(30);
     while !outputs.iter().all(|output| output.is_file()) {
         if let Some(status) = child.try_wait().unwrap() {
-            panic!("watch exited before compiling with status {status}");
+            let output = child.wait_with_output().unwrap();
+            panic!(
+                "watch exited before compiling with status {status}\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
         if Instant::now() >= deadline {
             child.kill().unwrap();
-            child.wait().unwrap();
-            panic!("watch did not compile within 30 seconds");
+            let output = child.wait_with_output().unwrap();
+            panic!(
+                "watch did not compile within 30 seconds\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
         thread::sleep(Duration::from_millis(50));
     }
+    child.kill().unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn normalized_watch_log(output: &Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout.lines().map(|line| {
+        let Some((timestamp, message)) = line.split_once("] ") else {
+            return line.to_owned();
+        };
+        let timestamp = timestamp.as_bytes();
+        let is_timestamp = timestamp.len() == 9
+            && timestamp[0] == b'['
+            && timestamp[3] == b':'
+            && timestamp[6] == b':'
+            && timestamp[1..3].iter().all(u8::is_ascii_digit)
+            && timestamp[4..6].iter().all(u8::is_ascii_digit)
+            && timestamp[7..9].iter().all(u8::is_ascii_digit);
+        if is_timestamp { format!("[TIME] {message}") } else { line.to_owned() }
+    });
+    lines.join("\n")
 }

--- a/tests-e2e/tests/package_manager/watch.rs
+++ b/tests-e2e/tests/package_manager/watch.rs
@@ -1,0 +1,85 @@
+use std::path::PathBuf;
+use std::process::Child;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use super::support::TestWorkspace;
+
+#[test]
+fn watches_a_single_package_with_real_spago() {
+    let workspace = TestWorkspace::empty();
+    workspace.write(
+        "spago.yaml",
+        r#"workspace: {}
+package:
+  name: application
+  dependencies: []
+"#,
+    );
+    workspace.write(
+        "src/Main.purs",
+        r#"module Main where
+
+value = 42
+"#,
+    );
+
+    let mut child = workspace.spawn(&["watch", "--quiet"]);
+    let output = workspace.path().join("output/Main/index.js");
+    wait_for_outputs(&mut child, &[output]);
+    child.kill().unwrap();
+    child.wait().unwrap();
+
+    workspace.assert_spago_calls(
+        "",
+        &[&["fetch", "-p", "application"], &["sources", "--json", "-p", "application"]],
+    );
+}
+
+#[test]
+fn watches_the_whole_workspace_from_a_root_package_subdirectory() {
+    let workspace = TestWorkspace::empty();
+    workspace.write(
+        "spago.yaml",
+        r#"workspace: {}
+package:
+  name: application
+  dependencies: []
+"#,
+    );
+    workspace.write("src/Application.purs", "module Application where\n");
+    workspace.write(
+        "packages/library/spago.yaml",
+        r#"package:
+  name: library
+  dependencies: []
+"#,
+    );
+    workspace.write("packages/library/src/Library.purs", "module Library where\n");
+
+    let mut child = workspace.spawn_in("src", &["watch", "--quiet"]);
+    let outputs = [
+        workspace.path().join("output/Application/index.js"),
+        workspace.path().join("output/Library/index.js"),
+    ];
+    wait_for_outputs(&mut child, &outputs);
+    child.kill().unwrap();
+    child.wait().unwrap();
+
+    workspace.assert_spago_calls("src", &[&["fetch"], &["sources", "--json"]]);
+}
+
+fn wait_for_outputs(child: &mut Child, outputs: &[PathBuf]) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while !outputs.iter().all(|output| output.is_file()) {
+        if let Some(status) = child.try_wait().unwrap() {
+            panic!("watch exited before compiling with status {status}");
+        }
+        if Instant::now() >= deadline {
+            child.kill().unwrap();
+            child.wait().unwrap();
+            panic!("watch did not compile within 30 seconds");
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}


### PR DESCRIPTION
## Summary

The watch command currently behaves like the low-level compile command: callers must supply source globs directly, so it bypasses the Spago workspace workflow used by build. This makes watch inconsistent with the other project commands and leaves package selection, dependency fetching, and workspace-relative output handling to the caller.

This change makes watch a Spago project command. Build and watch now share workspace preparation, including package selection, dependency fetching, source discovery, and output resolution. The watcher receives the workspace root explicitly so invocation from a package subdirectory behaves the same way as build.

## Testing

- `cargo check -p purescript-alexandrite --tests`
- `cargo nextest run -p purescript-alexandrite`
- `cargo nextest run -p tests-e2e --test package_manager -j 1`
- `just format`
- `git diff --check`