### PR TITLE
[backend] Optimize named effect bind continuations

### DIFF
--- a/compiler-backend/functional/src/convert/application.rs
+++ b/compiler-backend/functional/src/convert/application.rs
@@ -287,10 +287,10 @@ where
     }
 
     fn known_effect_application(
-        &self,
+        &mut self,
         function: ExpressionId,
         arguments: &[ExpressionId],
-    ) -> QueryResult<Option<EffectExpression>> {
+    ) -> ConversionResult<Option<EffectExpression>> {
         if let Some([value]) = self.known_thunk_instance_member_arguments(
             function,
             arguments,
@@ -301,7 +301,7 @@ where
         }
         if let Some([action, continuation]) =
             self.known_thunk_instance_member_arguments(function, arguments, "Control.Bind", "bind")?
-            && let Some((parameter, body)) = self.effect_continuation(*continuation)
+            && let Some((parameter, body)) = self.effect_continuation(*continuation)?
         {
             return Ok(Some(EffectExpression::Bind { action: *action, parameter, body }));
         }
@@ -315,7 +315,7 @@ where
                 "discardUnit",
             )?
             && self.known_thunk_instance(*bind_dictionary, None)?
-            && let Some((parameter, body)) = self.effect_continuation(*continuation)
+            && let Some((parameter, body)) = self.effect_continuation(*continuation)?
         {
             return Ok(Some(EffectExpression::Bind { action: *action, parameter, body }));
         }
@@ -335,27 +335,46 @@ where
         Ok(None)
     }
 
-    fn effect_continuation(&self, continuation: ExpressionId) -> Option<(Parameter, ExpressionId)> {
-        let ExpressionKind::Abstraction { parameters, body } = &self.storage[continuation].kind
-        else {
-            return None;
-        };
-        let [pattern] = parameters.as_ref() else { return None };
-        let parameter = match &self.storage[*pattern].kind {
-            PatternKind::Variable(parameter) => parameter.clone(),
-            PatternKind::Named { parameter, pattern }
-                if matches!(self.storage[*pattern].kind, PatternKind::Wildcard) =>
-            {
-                parameter.clone()
+    fn effect_continuation(
+        &mut self,
+        continuation: ExpressionId,
+    ) -> ConversionResult<Option<(Parameter, ExpressionId)>> {
+        if let ExpressionKind::Abstraction { parameters, body } = &self.storage[continuation].kind
+            && let [pattern] = parameters.as_ref()
+        {
+            let parameter = match &self.storage[*pattern].kind {
+                PatternKind::Variable(parameter) => Some(Parameter::clone(parameter)),
+                PatternKind::Named { parameter, pattern }
+                    if matches!(self.storage[*pattern].kind, PatternKind::Wildcard) =>
+                {
+                    Some(Parameter::clone(parameter))
+                }
+                PatternKind::Named { .. }
+                | PatternKind::Wildcard
+                | PatternKind::Literal(_)
+                | PatternKind::Array(_)
+                | PatternKind::Record(_)
+                | PatternKind::Constructor { .. } => None,
+            };
+            if let Some(parameter) = parameter {
+                return Ok(Some((parameter, *body)));
             }
-            PatternKind::Named { .. }
-            | PatternKind::Wildcard
-            | PatternKind::Literal(_)
-            | PatternKind::Array(_)
-            | PatternKind::Record(_)
-            | PatternKind::Constructor { .. } => return None,
-        };
-        Some((parameter, *body))
+        }
+
+        if !matches!(
+            self.storage[continuation].kind,
+            ExpressionKind::Global { .. } | ExpressionKind::Local { .. }
+        ) {
+            return Ok(None);
+        }
+
+        let parameter = self.fresh_parameter("bindValue".into())?;
+        let local = ExpressionKind::Local { parameter: Parameter::clone(&parameter) };
+
+        let value = self.expression(local);
+        let body = self.application(continuation, [value])?;
+
+        Ok(Some((parameter, body)))
     }
 
     fn uncurry_abstraction(

--- a/compiler-backend/functional/src/optimize.rs
+++ b/compiler-backend/functional/src/optimize.rs
@@ -151,7 +151,7 @@ fn binding_uses(
     binding_uses + local_uses(storage, body, parameter)
 }
 
-fn local_uses(storage: &Storage, expression: ExpressionId, parameter: LocalId) -> usize {
+pub fn local_uses(storage: &Storage, expression: ExpressionId, parameter: LocalId) -> usize {
     if matches!(
         &storage[expression].kind,
         ExpressionKind::Local { parameter: local } if local.id == parameter

--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -9,6 +9,7 @@ mod tail_call;
 use std::sync::Arc;
 
 use files::{FileId, ForeignSourceKind};
+use functional::optimize::local_uses;
 use functional::tree::{
     Binding, CaseAlternative, Declaration, DeclarationKind, EffectExpression,
     ExpressionId as FunctionalExpressionId, ExpressionKind, Global, GlobalId, Guard,
@@ -62,6 +63,7 @@ struct ForeignImport {
 #[derive(Debug)]
 enum LocalBinding {
     Direct(SmolStr),
+    Inline(ExpressionId),
     Lazy(SmolStr),
 }
 
@@ -191,6 +193,10 @@ impl FunctionContext {
 
     fn bind_direct(&mut self, parameter: &Parameter, name: SmolStr) {
         self.locals.insert(parameter.id, LocalBinding::Direct(name));
+    }
+
+    fn bind_inline(&mut self, parameter: &Parameter, expression: ExpressionId) {
+        self.locals.insert(parameter.id, LocalBinding::Inline(expression));
     }
 
     fn bind_lazy(&mut self, parameter: &Parameter, name: SmolStr) {
@@ -564,7 +570,7 @@ impl Generator<'_> {
             TailCallIdentity::Global(global) => self.global_names[&global].clone(),
             TailCallIdentity::Local(local) => match context.locals.get(&local) {
                 Some(LocalBinding::Direct(name)) => name.clone(),
-                Some(LocalBinding::Lazy(_)) | None => {
+                Some(LocalBinding::Inline(_) | LocalBinding::Lazy(_)) | None => {
                     unreachable!("invariant violated: tail-call profile has no direct local name")
                 }
             },
@@ -1665,7 +1671,10 @@ impl Generator<'_> {
                     && !self.lazy_global_names.contains_key(&global.id)
             }
             ExpressionKind::Local { parameter } => {
-                matches!(context.locals.get(&parameter.id), Some(LocalBinding::Direct(_)))
+                matches!(
+                    context.locals.get(&parameter.id),
+                    Some(LocalBinding::Direct(_) | LocalBinding::Inline(_))
+                )
             }
             ExpressionKind::Array { .. }
             | ExpressionKind::Record { .. }
@@ -2867,8 +2876,15 @@ fn execute_effect(
             Ok(())
         }
         CapturedEffect::Bind { action, parameter, body } => {
-            let (_, parameter_name) = execute_effect_action(renderer, action, &parameter.name)?;
-            renderer.context.bind_direct(&parameter, parameter_name);
+            if let CapturedEffectAction::Effect(effect) = &action
+                && let CapturedEffect::Pure { value } = effect.as_ref()
+                && local_uses(&renderer.generator.module.storage, body, parameter.id) <= 1
+            {
+                renderer.context.bind_inline(&parameter, *value);
+            } else {
+                let (_, parameter_name) = execute_effect_action(renderer, action, &parameter.name)?;
+                renderer.context.bind_direct(&parameter, parameter_name);
+            }
             renderer.generator.render_expression(
                 renderer.tree,
                 renderer.writer,
@@ -2935,8 +2951,12 @@ fn execute_effect_action(
             renderer.writer.constant(renderer.tree, &name, value, false);
         }
         CapturedEffectAction::Effect(effect) => {
-            renderer.writer.mutable(&name);
-            execute_effect(renderer, *effect, Destination::Assign(&name))?;
+            if let CapturedEffect::Pure { value } = effect.as_ref() {
+                renderer.writer.constant(renderer.tree, &name, *value, false);
+            } else {
+                renderer.writer.mutable(&name);
+                execute_effect(renderer, *effect, Destination::Assign(&name))?;
+            }
         }
     }
     Ok((renderer.tree.identifier(&name), name))
@@ -2950,6 +2970,7 @@ fn local_expression(
 ) -> ModuleResult<ExpressionId> {
     match context.locals.get(&parameter.id) {
         Some(LocalBinding::Direct(name)) => Ok(tree.identifier(name)),
+        Some(LocalBinding::Inline(expression)) => Ok(*expression),
         Some(LocalBinding::Lazy(name)) => {
             let accessor = tree.identifier(name);
             Ok(tree.call(accessor, vec![]))

--- a/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/Main.functional.snap
@@ -1,0 +1,17 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign equalInt
+
+@export foreign decrementInt
+
+@export namedContinuation = \$unit%0@(_) -> effect.pure 42
+
+@export namedBind = \$unit%1@(_) -> bind bindEffect1 (effect.pure "Unit") namedContinuation
+
+@export recursive[4] tailBind = \value%2 ->
+  if equalInt value%2 0
+    then effect.pure value%2
+    else effect.bind (effect.pure "Unit") \$unit%3 -> tailBind (decrementInt value%2)

--- a/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/Main.functional.snap
@@ -9,9 +9,10 @@ expression: report
 
 @export namedContinuation = \$unit%0@(_) -> effect.pure 42
 
-@export namedBind = \$unit%1@(_) -> bind bindEffect1 (effect.pure "Unit") namedContinuation
+@export namedBind = \$unit%2@(_) ->
+  effect.bind (effect.pure "Unit") \bindValue%1 -> namedContinuation bindValue%1
 
-@export recursive[4] tailBind = \value%2 ->
-  if equalInt value%2 0
-    then effect.pure value%2
-    else effect.bind (effect.pure "Unit") \$unit%3 -> tailBind (decrementInt value%2)
+@export recursive[4] tailBind = \value%3 ->
+  if equalInt value%3 0
+    then effect.pure value%3
+    else effect.bind (effect.pure "Unit") \$unit%4 -> tailBind (decrementInt value%3)

--- a/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/Main.js
+++ b/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/Main.js
@@ -1,0 +1,2 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;

--- a/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/Main.purs
+++ b/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/Main.purs
@@ -1,0 +1,20 @@
+module Main where
+
+import Control.Applicative (pure)
+import Control.Bind (bind)
+import Data.Unit (Unit(..))
+import Effect (Effect)
+
+foreign import equalInt :: Int -> Int -> Boolean
+foreign import decrementInt :: Int -> Int
+
+namedContinuation :: Unit -> Effect Int
+namedContinuation _ = pure 42
+
+namedBind :: Unit -> Effect Int
+namedBind _ = bind (pure Unit) namedContinuation
+
+tailBind :: Int -> Effect Int
+tailBind value =
+  if equalInt value 0 then pure value
+  else bind (pure Unit) (\_ -> tailBind (decrementInt value))

--- a/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/Main.snap
+++ b/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+equalInt :: Prim.Int -> Prim.Int -> Prim.Boolean
+decrementInt :: Prim.Int -> Prim.Int
+namedContinuation :: Data.Unit.Unit -> Effect.Effect Prim.Int
+namedBind :: Data.Unit.Unit -> Effect.Effect Prim.Int
+tailBind :: Prim.Int -> Effect.Effect Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Control.Applicative/index.js
+++ b/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Control.Applicative/index.js
@@ -1,0 +1,3 @@
+export function pure(dictionary) {
+  return dictionary.pure;
+}

--- a/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Control.Bind/index.js
+++ b/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Control.Bind/index.js
@@ -1,0 +1,7 @@
+export function bind(dictionary) {
+  return dictionary.bind;
+}
+export function discard(dictionary) {
+  return dictionary.discard;
+}
+export const discardUnit = { discard: (bindFDict) => /* @__PURE__ */ bind(bindFDict) };

--- a/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Data.Unit/index.js
+++ b/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Data.Unit/index.js
@@ -1,0 +1,1 @@
+export const Unit = "Unit";

--- a/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Effect/foreign.js
+++ b/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Effect/foreign.js
@@ -1,0 +1,4 @@
+export const mapEffect = transform => action => () => transform(action());
+export const applyEffect = functionAction => valueAction => () => functionAction()(valueAction());
+export const pureEffect = value => () => value;
+export const bindEffect = action => continuation => () => continuation(action())();

--- a/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Effect/index.js
+++ b/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Effect/index.js
@@ -1,0 +1,22 @@
+import * as $foreign from "./foreign.js";
+export const mapEffect = $foreign["mapEffect"];
+export const applyEffect = $foreign["applyEffect"];
+export const pureEffect = $foreign["pureEffect"];
+export const bindEffect = $foreign["bindEffect"];
+export const functorEffect = { map: mapEffect };
+export const applyEffect1 = {
+  Functor0: () => functorEffect,
+  apply: applyEffect
+};
+export const applicativeEffect = {
+  Apply0: () => applyEffect1,
+  pure: pureEffect
+};
+export const bindEffect1 = {
+  Apply0: () => applyEffect1,
+  bind: bindEffect
+};
+export const monadEffect = {
+  Applicative0: () => applicativeEffect,
+  Bind1: () => bindEffect1
+};

--- a/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Main/foreign.js
@@ -1,0 +1,2 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;

--- a/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Main/index.js
@@ -6,9 +6,7 @@ export function namedContinuation($unit) {
 }
 export function namedBind($unit) {
   return () => {
-    let bindValue;
-    bindValue = "Unit";
-    return namedContinuation(bindValue)();
+    return namedContinuation("Unit")();
   };
 }
 export function tailBind(value) {
@@ -21,8 +19,6 @@ export function tailBind(value) {
         };
       } else {
         return () => {
-          let $unit;
-          $unit = "Unit";
           const $tailArgument = decrementInt($currentArgument0);
           return [
             true,

--- a/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Main/index.js
@@ -1,5 +1,3 @@
-import * as Control_Bind from "../Control.Bind/index.js";
-import * as Effect from "../Effect/index.js";
 import * as $foreign from "./foreign.js";
 export function namedContinuation($unit) {
   return () => {
@@ -7,11 +5,11 @@ export function namedContinuation($unit) {
   };
 }
 export function namedBind($unit) {
-  const $function = Control_Bind.bind(Effect.bindEffect1);
-  const $effect = () => {
-    return "Unit";
+  return () => {
+    let bindValue;
+    bindValue = "Unit";
+    return namedContinuation(bindValue)();
   };
-  return /* @__PURE__ */ $function($effect)(namedContinuation);
 }
 export function tailBind(value) {
   const $tail_tailBind = ($state, $argument0) => {

--- a/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/output/Main/index.js
@@ -1,0 +1,52 @@
+import * as Control_Bind from "../Control.Bind/index.js";
+import * as Effect from "../Effect/index.js";
+import * as $foreign from "./foreign.js";
+export function namedContinuation($unit) {
+  return () => {
+    return 42 | 0;
+  };
+}
+export function namedBind($unit) {
+  const $function = Control_Bind.bind(Effect.bindEffect1);
+  const $effect = () => {
+    return "Unit";
+  };
+  return /* @__PURE__ */ $function($effect)(namedContinuation);
+}
+export function tailBind(value) {
+  const $tail_tailBind = ($state, $argument0) => {
+    while (true) {
+      const $currentArgument0 = $argument0;
+      if (equalInt($currentArgument0)(0 | 0)) {
+        return () => {
+          return [false, $currentArgument0];
+        };
+      } else {
+        return () => {
+          let $unit;
+          $unit = "Unit";
+          const $tailArgument = decrementInt($currentArgument0);
+          return [
+            true,
+            0,
+            $tailArgument
+          ];
+        };
+      }
+    }
+  };
+  const $initialStep = $tail_tailBind(0, value);
+  return () => {
+    let $step;
+    $step = $initialStep;
+    while (true) {
+      const $result = $step();
+      if (!$result[0]) {
+        return $result[1];
+      }
+      $step = $tail_tailBind($result[1], $result[2]);
+    }
+  };
+}
+export const equalInt = $foreign["equalInt"];
+export const decrementInt = $foreign["decrementInt"];

--- a/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/verify.mjs
+++ b/tests-integration/fixtures/backend/1788249900_manual_effect_bind_calls/verify.mjs
@@ -1,0 +1,5 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.namedBind("Unit")(), 42);
+strictEqual(Main.tailBind(100_000)(), 0);

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/BindOperator.purs
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/BindOperator.purs
@@ -1,0 +1,5 @@
+module BindOperator ((>>=)) where
+
+import Control.Bind (bind)
+
+infixl 1 bind as >>=

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/Main.functional.snap
@@ -1,0 +1,17 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign equalInt
+
+@export foreign decrementInt
+
+@export namedContinuation = \$unit%0@(_) -> effect.pure 42
+
+@export namedBind = \$unit%1@(_) -> bind bindEffect1 (effect.pure "Unit") namedContinuation
+
+@export recursive[4] tailBind = \value%2 ->
+  if equalInt value%2 0
+    then effect.pure value%2
+    else effect.bind (effect.pure "Unit") \$unit%3 -> tailBind (decrementInt value%2)

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/Main.functional.snap
@@ -9,9 +9,10 @@ expression: report
 
 @export namedContinuation = \$unit%0@(_) -> effect.pure 42
 
-@export namedBind = \$unit%1@(_) -> bind bindEffect1 (effect.pure "Unit") namedContinuation
+@export namedBind = \$unit%2@(_) ->
+  effect.bind (effect.pure "Unit") \bindValue%1 -> namedContinuation bindValue%1
 
-@export recursive[4] tailBind = \value%2 ->
-  if equalInt value%2 0
-    then effect.pure value%2
-    else effect.bind (effect.pure "Unit") \$unit%3 -> tailBind (decrementInt value%2)
+@export recursive[4] tailBind = \value%3 ->
+  if equalInt value%3 0
+    then effect.pure value%3
+    else effect.bind (effect.pure "Unit") \$unit%4 -> tailBind (decrementInt value%3)

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/Main.js
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/Main.js
@@ -1,0 +1,2 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/Main.purs
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/Main.purs
@@ -1,0 +1,20 @@
+module Main where
+
+import BindOperator ((>>=))
+import Control.Applicative (pure)
+import Data.Unit (Unit(..))
+import Effect (Effect)
+
+foreign import equalInt :: Int -> Int -> Boolean
+foreign import decrementInt :: Int -> Int
+
+namedContinuation :: Unit -> Effect Int
+namedContinuation _ = pure 42
+
+namedBind :: Unit -> Effect Int
+namedBind _ = pure Unit >>= namedContinuation
+
+tailBind :: Int -> Effect Int
+tailBind value =
+  if equalInt value 0 then pure value
+  else pure Unit >>= \_ -> tailBind (decrementInt value)

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/Main.snap
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+equalInt :: Prim.Int -> Prim.Int -> Prim.Boolean
+decrementInt :: Prim.Int -> Prim.Int
+namedContinuation :: Data.Unit.Unit -> Effect.Effect Prim.Int
+namedBind :: Data.Unit.Unit -> Effect.Effect Prim.Int
+tailBind :: Prim.Int -> Effect.Effect Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Control.Applicative/index.js
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Control.Applicative/index.js
@@ -1,0 +1,3 @@
+export function pure(dictionary) {
+  return dictionary.pure;
+}

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Control.Bind/index.js
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Control.Bind/index.js
@@ -1,0 +1,7 @@
+export function bind(dictionary) {
+  return dictionary.bind;
+}
+export function discard(dictionary) {
+  return dictionary.discard;
+}
+export const discardUnit = { discard: (bindFDict) => /* @__PURE__ */ bind(bindFDict) };

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Data.Unit/index.js
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Data.Unit/index.js
@@ -1,0 +1,1 @@
+export const Unit = "Unit";

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Effect/foreign.js
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Effect/foreign.js
@@ -1,0 +1,4 @@
+export const mapEffect = transform => action => () => transform(action());
+export const applyEffect = functionAction => valueAction => () => functionAction()(valueAction());
+export const pureEffect = value => () => value;
+export const bindEffect = action => continuation => () => continuation(action())();

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Effect/index.js
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Effect/index.js
@@ -1,0 +1,22 @@
+import * as $foreign from "./foreign.js";
+export const mapEffect = $foreign["mapEffect"];
+export const applyEffect = $foreign["applyEffect"];
+export const pureEffect = $foreign["pureEffect"];
+export const bindEffect = $foreign["bindEffect"];
+export const functorEffect = { map: mapEffect };
+export const applyEffect1 = {
+  Functor0: () => functorEffect,
+  apply: applyEffect
+};
+export const applicativeEffect = {
+  Apply0: () => applyEffect1,
+  pure: pureEffect
+};
+export const bindEffect1 = {
+  Apply0: () => applyEffect1,
+  bind: bindEffect
+};
+export const monadEffect = {
+  Applicative0: () => applicativeEffect,
+  Bind1: () => bindEffect1
+};

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Main/foreign.js
@@ -1,0 +1,2 @@
+export const equalInt = left => right => left === right;
+export const decrementInt = value => value - 1;

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Main/index.js
@@ -6,9 +6,7 @@ export function namedContinuation($unit) {
 }
 export function namedBind($unit) {
   return () => {
-    let bindValue;
-    bindValue = "Unit";
-    return namedContinuation(bindValue)();
+    return namedContinuation("Unit")();
   };
 }
 export function tailBind(value) {
@@ -21,8 +19,6 @@ export function tailBind(value) {
         };
       } else {
         return () => {
-          let $unit;
-          $unit = "Unit";
           const $tailArgument = decrementInt($currentArgument0);
           return [
             true,

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Main/index.js
@@ -1,5 +1,3 @@
-import * as Control_Bind from "../Control.Bind/index.js";
-import * as Effect from "../Effect/index.js";
 import * as $foreign from "./foreign.js";
 export function namedContinuation($unit) {
   return () => {
@@ -7,11 +5,11 @@ export function namedContinuation($unit) {
   };
 }
 export function namedBind($unit) {
-  const $function = Control_Bind.bind(Effect.bindEffect1);
-  const $effect = () => {
-    return "Unit";
+  return () => {
+    let bindValue;
+    bindValue = "Unit";
+    return namedContinuation(bindValue)();
   };
-  return /* @__PURE__ */ $function($effect)(namedContinuation);
 }
 export function tailBind(value) {
   const $tail_tailBind = ($state, $argument0) => {

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/output/Main/index.js
@@ -1,0 +1,52 @@
+import * as Control_Bind from "../Control.Bind/index.js";
+import * as Effect from "../Effect/index.js";
+import * as $foreign from "./foreign.js";
+export function namedContinuation($unit) {
+  return () => {
+    return 42 | 0;
+  };
+}
+export function namedBind($unit) {
+  const $function = Control_Bind.bind(Effect.bindEffect1);
+  const $effect = () => {
+    return "Unit";
+  };
+  return /* @__PURE__ */ $function($effect)(namedContinuation);
+}
+export function tailBind(value) {
+  const $tail_tailBind = ($state, $argument0) => {
+    while (true) {
+      const $currentArgument0 = $argument0;
+      if (equalInt($currentArgument0)(0 | 0)) {
+        return () => {
+          return [false, $currentArgument0];
+        };
+      } else {
+        return () => {
+          let $unit;
+          $unit = "Unit";
+          const $tailArgument = decrementInt($currentArgument0);
+          return [
+            true,
+            0,
+            $tailArgument
+          ];
+        };
+      }
+    }
+  };
+  const $initialStep = $tail_tailBind(0, value);
+  return () => {
+    let $step;
+    $step = $initialStep;
+    while (true) {
+      const $result = $step();
+      if (!$result[0]) {
+        return $result[1];
+      }
+      $step = $tail_tailBind($result[1], $result[2]);
+    }
+  };
+}
+export const equalInt = $foreign["equalInt"];
+export const decrementInt = $foreign["decrementInt"];

--- a/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/verify.mjs
+++ b/tests-integration/fixtures/backend/1788249900_operator_effect_bind_calls/verify.mjs
@@ -1,0 +1,5 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.namedBind("Unit")(), 42);
+strictEqual(Main.tailBind(100_000)(), 0);

--- a/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/Main.functional.snap
@@ -1,0 +1,7 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export sharedBind = \$unit%1@(_) ->
+  effect.bind (effect.pure 42) \value%0 -> effect.pure { left: value%0, right: value%0 }

--- a/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/Main.purs
+++ b/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+import Control.Applicative (pure)
+import Control.Bind (bind)
+import Data.Unit (Unit)
+import Effect (Effect)
+
+sharedBind :: Unit -> Effect { left :: Int, right :: Int }
+sharedBind _ = bind (pure 42) (\value -> pure { left: value, right: value })

--- a/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/Main.snap
+++ b/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+sharedBind :: Data.Unit.Unit -> Effect.Effect { left :: Prim.Int, right :: Prim.Int }
+
+Types

--- a/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/output/Control.Applicative/index.js
+++ b/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/output/Control.Applicative/index.js
@@ -1,0 +1,3 @@
+export function pure(dictionary) {
+  return dictionary.pure;
+}

--- a/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/output/Control.Bind/index.js
+++ b/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/output/Control.Bind/index.js
@@ -1,0 +1,7 @@
+export function bind(dictionary) {
+  return dictionary.bind;
+}
+export function discard(dictionary) {
+  return dictionary.discard;
+}
+export const discardUnit = { discard: (bindFDict) => /* @__PURE__ */ bind(bindFDict) };

--- a/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/output/Effect/foreign.js
+++ b/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/output/Effect/foreign.js
@@ -1,0 +1,4 @@
+export const mapEffect = transform => action => () => transform(action());
+export const applyEffect = functionAction => valueAction => () => functionAction()(valueAction());
+export const pureEffect = value => () => value;
+export const bindEffect = action => continuation => () => continuation(action())();

--- a/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/output/Effect/index.js
+++ b/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/output/Effect/index.js
@@ -1,0 +1,22 @@
+import * as $foreign from "./foreign.js";
+export const mapEffect = $foreign["mapEffect"];
+export const applyEffect = $foreign["applyEffect"];
+export const pureEffect = $foreign["pureEffect"];
+export const bindEffect = $foreign["bindEffect"];
+export const functorEffect = { map: mapEffect };
+export const applyEffect1 = {
+  Functor0: () => functorEffect,
+  apply: applyEffect
+};
+export const applicativeEffect = {
+  Apply0: () => applyEffect1,
+  pure: pureEffect
+};
+export const bindEffect1 = {
+  Apply0: () => applyEffect1,
+  bind: bindEffect
+};
+export const monadEffect = {
+  Applicative0: () => applicativeEffect,
+  Bind1: () => bindEffect1
+};

--- a/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/output/Main/index.js
@@ -1,7 +1,6 @@
 export function sharedBind($unit) {
   return () => {
-    let value;
-    value = 42 | 0;
+    const value = 42 | 0;
     const $value = {
       left: value,
       right: value

--- a/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/output/Main/index.js
@@ -1,0 +1,11 @@
+export function sharedBind($unit) {
+  return () => {
+    let value;
+    value = 42 | 0;
+    const $value = {
+      left: value,
+      right: value
+    };
+    return $value;
+  };
+}

--- a/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/verify.mjs
+++ b/tests-integration/fixtures/backend/1788251580_shared_pure_effect_bind_value/verify.mjs
@@ -1,0 +1,4 @@
+import { deepStrictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+deepStrictEqual(Main.sharedBind("Unit")(), { left: 42, right: 42 });

--- a/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/Main.functional.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign makeContinuation
+
+@export computedBind = \$unit%0@(_) ->
+  bind bindEffect1 (effect.pure "Unit") (makeContinuation "Unit")

--- a/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/Main.js
+++ b/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/Main.js
@@ -1,0 +1,12 @@
+let constructions = 0;
+
+export const makeContinuation = () => {
+  constructions += 1;
+  return () => () => 42;
+};
+
+export const resetConstructions = () => {
+  constructions = 0;
+};
+
+export const readConstructions = () => constructions;

--- a/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/Main.purs
+++ b/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Control.Applicative (pure)
+import Control.Bind (bind)
+import Data.Unit (Unit(..))
+import Effect (Effect)
+
+foreign import makeContinuation :: Unit -> (Unit -> Effect Int)
+
+computedBind :: Unit -> Effect Int
+computedBind _ = bind (pure Unit) (makeContinuation Unit)

--- a/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/Main.snap
+++ b/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/Main.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+makeContinuation :: Data.Unit.Unit -> Data.Unit.Unit -> Effect.Effect Prim.Int
+computedBind :: Data.Unit.Unit -> Effect.Effect Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/output/Control.Applicative/index.js
+++ b/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/output/Control.Applicative/index.js
@@ -1,0 +1,3 @@
+export function pure(dictionary) {
+  return dictionary.pure;
+}

--- a/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/output/Control.Bind/index.js
+++ b/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/output/Control.Bind/index.js
@@ -1,0 +1,7 @@
+export function bind(dictionary) {
+  return dictionary.bind;
+}
+export function discard(dictionary) {
+  return dictionary.discard;
+}
+export const discardUnit = { discard: (bindFDict) => /* @__PURE__ */ bind(bindFDict) };

--- a/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/output/Data.Unit/index.js
+++ b/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/output/Data.Unit/index.js
@@ -1,0 +1,1 @@
+export const Unit = "Unit";

--- a/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/output/Effect/foreign.js
+++ b/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/output/Effect/foreign.js
@@ -1,0 +1,4 @@
+export const mapEffect = transform => action => () => transform(action());
+export const applyEffect = functionAction => valueAction => () => functionAction()(valueAction());
+export const pureEffect = value => () => value;
+export const bindEffect = action => continuation => () => continuation(action())();

--- a/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/output/Effect/index.js
+++ b/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/output/Effect/index.js
@@ -1,0 +1,22 @@
+import * as $foreign from "./foreign.js";
+export const mapEffect = $foreign["mapEffect"];
+export const applyEffect = $foreign["applyEffect"];
+export const pureEffect = $foreign["pureEffect"];
+export const bindEffect = $foreign["bindEffect"];
+export const functorEffect = { map: mapEffect };
+export const applyEffect1 = {
+  Functor0: () => functorEffect,
+  apply: applyEffect
+};
+export const applicativeEffect = {
+  Apply0: () => applyEffect1,
+  pure: pureEffect
+};
+export const bindEffect1 = {
+  Apply0: () => applyEffect1,
+  bind: bindEffect
+};
+export const monadEffect = {
+  Applicative0: () => applicativeEffect,
+  Bind1: () => bindEffect1
+};

--- a/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/output/Main/foreign.js
@@ -1,0 +1,12 @@
+let constructions = 0;
+
+export const makeContinuation = () => {
+  constructions += 1;
+  return () => () => 42;
+};
+
+export const resetConstructions = () => {
+  constructions = 0;
+};
+
+export const readConstructions = () => constructions;

--- a/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/output/Main/index.js
@@ -1,0 +1,11 @@
+import * as Control_Bind from "../Control.Bind/index.js";
+import * as Effect from "../Effect/index.js";
+import * as $foreign from "./foreign.js";
+export function computedBind($unit) {
+  const $function = Control_Bind.bind(Effect.bindEffect1);
+  const $effect = () => {
+    return "Unit";
+  };
+  return /* @__PURE__ */ $function($effect)(makeContinuation("Unit"));
+}
+export const makeContinuation = $foreign["makeContinuation"];

--- a/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/verify.mjs
+++ b/tests-integration/fixtures/backend/1788253380_computed_effect_bind_continuation_timing/verify.mjs
@@ -1,0 +1,11 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+import { readConstructions, resetConstructions } from "./output/Main/foreign.js";
+
+resetConstructions();
+const effect = Main.computedBind("Unit");
+strictEqual(readConstructions(), 1);
+strictEqual(effect(), 42);
+strictEqual(readConstructions(), 1);
+strictEqual(effect(), 42);
+strictEqual(readConstructions(), 1);

--- a/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/Control.Monad.ST.Internal.js
+++ b/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/Control.Monad.ST.Internal.js
@@ -1,0 +1,4 @@
+export const map_ = transform => action => () => transform(action());
+export const pure_ = value => () => value;
+export const bind_ = action => continuation => () => continuation(action())();
+export const run = action => action();

--- a/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/Control.Monad.ST.Internal.purs
+++ b/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/Control.Monad.ST.Internal.purs
@@ -1,0 +1,32 @@
+module Control.Monad.ST.Internal where
+
+import Control.Applicative (class Applicative)
+import Control.Apply (class Apply)
+import Control.Bind (class Bind)
+import Control.Monad (class Monad)
+import Data.Functor (class Functor)
+
+foreign import data Region :: Type
+foreign import data ST :: Region -> Type -> Type
+
+foreign import map_ :: forall region a b. (a -> b) -> ST region a -> ST region b
+foreign import pure_ :: forall region a. a -> ST region a
+foreign import bind_ :: forall region a b. ST region a -> (a -> ST region b) -> ST region b
+foreign import run :: forall a. (forall region. ST region a) -> a
+
+instance functorST :: Functor (ST region) where
+  map = map_
+
+instance applyST :: Apply (ST region) where
+  apply functionAction argumentAction =
+    bind_ functionAction \function ->
+      bind_ argumentAction \argument ->
+        pure_ (function argument)
+
+instance applicativeST :: Applicative (ST region) where
+  pure = pure_
+
+instance bindST :: Bind (ST region) where
+  bind = bind_
+
+instance monadST :: Monad (ST region)

--- a/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/Main.functional.snap
@@ -5,6 +5,7 @@ expression: report
 ---
 @export namedContinuation = \$unit%0@(_) -> effect.pure 42
 
-@export namedBind = \$unit%1@(_) -> bind bindST (effect.pure "Unit") namedContinuation
+@export namedBind = \$unit%2@(_) ->
+  effect.bind (effect.pure "Unit") \bindValue%1 -> namedContinuation bindValue%1
 
-@export runNamedBind = \$unit%2@(_) -> run (namedBind "Unit")
+@export runNamedBind = \$unit%3@(_) -> run (namedBind "Unit")

--- a/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/Main.functional.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export namedContinuation = \$unit%0@(_) -> effect.pure 42
+
+@export namedBind = \$unit%1@(_) -> bind bindST (effect.pure "Unit") namedContinuation
+
+@export runNamedBind = \$unit%2@(_) -> run (namedBind "Unit")

--- a/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/Main.purs
+++ b/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+import Control.Applicative (pure)
+import Control.Bind (bind)
+import Control.Monad.ST.Internal (ST, run)
+import Data.Unit (Unit(..))
+
+namedContinuation :: forall region. Unit -> ST region Int
+namedContinuation _ = pure 42
+
+namedBind :: forall region. Unit -> ST region Int
+namedBind _ = bind (pure Unit) namedContinuation
+
+runNamedBind :: Unit -> Int
+runNamedBind _ = run (namedBind Unit)

--- a/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/Main.snap
+++ b/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/Main.snap
@@ -1,0 +1,17 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+namedContinuation ::
+  forall (region :: Control.Monad.ST.Internal.Region).
+    Data.Unit.Unit ->
+    Control.Monad.ST.Internal.ST (region :: Control.Monad.ST.Internal.Region) Prim.Int
+namedBind ::
+  forall (region :: Control.Monad.ST.Internal.Region).
+    Data.Unit.Unit ->
+    Control.Monad.ST.Internal.ST (region :: Control.Monad.ST.Internal.Region) Prim.Int
+runNamedBind :: Data.Unit.Unit -> Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Control.Applicative/index.js
+++ b/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Control.Applicative/index.js
@@ -1,0 +1,3 @@
+export function pure(dictionary) {
+  return dictionary.pure;
+}

--- a/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Control.Bind/index.js
+++ b/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Control.Bind/index.js
@@ -1,0 +1,7 @@
+export function bind(dictionary) {
+  return dictionary.bind;
+}
+export function discard(dictionary) {
+  return dictionary.discard;
+}
+export const discardUnit = { discard: (bindFDict) => /* @__PURE__ */ bind(bindFDict) };

--- a/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Control.Monad.ST.Internal/foreign.js
+++ b/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Control.Monad.ST.Internal/foreign.js
@@ -1,0 +1,4 @@
+export const map_ = transform => action => () => transform(action());
+export const pure_ = value => () => value;
+export const bind_ = action => continuation => () => continuation(action())();
+export const run = action => action();

--- a/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Control.Monad.ST.Internal/index.js
+++ b/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Control.Monad.ST.Internal/index.js
@@ -1,0 +1,22 @@
+import * as $foreign from "./foreign.js";
+export const map_ = $foreign["map_"];
+export const pure_ = $foreign["pure_"];
+export const bind_ = $foreign["bind_"];
+export const run = $foreign["run"];
+export const functorST = { map: map_ };
+export const applyST = {
+  Functor0: () => functorST,
+  apply: (functionAction) => (argumentAction) => bind_(functionAction)(($function) => bind_(argumentAction)((argument) => pure_($function(argument))))
+};
+export const applicativeST = {
+  Apply0: () => applyST,
+  pure: pure_
+};
+export const bindST = {
+  Apply0: () => applyST,
+  bind: bind_
+};
+export const monadST = {
+  Applicative0: () => applicativeST,
+  Bind1: () => bindST
+};

--- a/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Data.Unit/index.js
+++ b/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Data.Unit/index.js
@@ -1,0 +1,1 @@
+export const Unit = "Unit";

--- a/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Main/index.js
@@ -6,9 +6,7 @@ export function namedContinuation($unit) {
 }
 export function namedBind($unit) {
   return () => {
-    let bindValue;
-    bindValue = "Unit";
-    return namedContinuation(bindValue)();
+    return namedContinuation("Unit")();
   };
 }
 export function runNamedBind($unit) {

--- a/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Main/index.js
@@ -1,0 +1,17 @@
+import * as Control_Bind from "../Control.Bind/index.js";
+import * as Control_Monad_ST_Internal from "../Control.Monad.ST.Internal/index.js";
+export function namedContinuation($unit) {
+  return () => {
+    return 42 | 0;
+  };
+}
+export function namedBind($unit) {
+  const $function = Control_Bind.bind(Control_Monad_ST_Internal.bindST);
+  const $effect = () => {
+    return "Unit";
+  };
+  return /* @__PURE__ */ $function($effect)(namedContinuation);
+}
+export function runNamedBind($unit) {
+  return Control_Monad_ST_Internal.run(namedBind("Unit"));
+}

--- a/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/output/Main/index.js
@@ -1,4 +1,3 @@
-import * as Control_Bind from "../Control.Bind/index.js";
 import * as Control_Monad_ST_Internal from "../Control.Monad.ST.Internal/index.js";
 export function namedContinuation($unit) {
   return () => {
@@ -6,11 +5,11 @@ export function namedContinuation($unit) {
   };
 }
 export function namedBind($unit) {
-  const $function = Control_Bind.bind(Control_Monad_ST_Internal.bindST);
-  const $effect = () => {
-    return "Unit";
+  return () => {
+    let bindValue;
+    bindValue = "Unit";
+    return namedContinuation(bindValue)();
   };
-  return /* @__PURE__ */ $function($effect)(namedContinuation);
 }
 export function runNamedBind($unit) {
   return Control_Monad_ST_Internal.run(namedBind("Unit"));

--- a/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/verify.mjs
+++ b/tests-integration/fixtures/backend/1788253440_named_st_bind_continuation/verify.mjs
@@ -1,0 +1,4 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.runNamedBind("Unit"), 42);

--- a/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/Main.functional.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export foreign makeContinuation
+
+@export localBind = \$unit%2@(_) ->
+  let
+    continuation%0 = makeContinuation "Unit"
+  in effect.bind (effect.pure "Unit") \bindValue%1 -> continuation%0 bindValue%1

--- a/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/Main.js
+++ b/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/Main.js
@@ -1,0 +1,12 @@
+let constructions = 0;
+
+export const makeContinuation = () => {
+  constructions += 1;
+  return () => () => 42;
+};
+
+export const resetConstructions = () => {
+  constructions = 0;
+};
+
+export const readConstructions = () => constructions;

--- a/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/Main.purs
+++ b/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/Main.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Control.Applicative (pure)
+import Control.Bind (bind)
+import Data.Unit (Unit(..))
+import Effect (Effect)
+
+foreign import makeContinuation :: Unit -> (Unit -> Effect Int)
+
+localBind :: Unit -> Effect Int
+localBind _ =
+  let continuation = makeContinuation Unit
+  in bind (pure Unit) continuation

--- a/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/Main.snap
+++ b/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/Main.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+makeContinuation :: Data.Unit.Unit -> Data.Unit.Unit -> Effect.Effect Prim.Int
+localBind :: Data.Unit.Unit -> Effect.Effect Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/output/Control.Applicative/index.js
+++ b/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/output/Control.Applicative/index.js
@@ -1,0 +1,3 @@
+export function pure(dictionary) {
+  return dictionary.pure;
+}

--- a/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/output/Control.Bind/index.js
+++ b/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/output/Control.Bind/index.js
@@ -1,0 +1,7 @@
+export function bind(dictionary) {
+  return dictionary.bind;
+}
+export function discard(dictionary) {
+  return dictionary.discard;
+}
+export const discardUnit = { discard: (bindFDict) => /* @__PURE__ */ bind(bindFDict) };

--- a/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/output/Data.Unit/index.js
+++ b/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/output/Data.Unit/index.js
@@ -1,0 +1,1 @@
+export const Unit = "Unit";

--- a/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/output/Effect/foreign.js
+++ b/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/output/Effect/foreign.js
@@ -1,0 +1,4 @@
+export const mapEffect = transform => action => () => transform(action());
+export const applyEffect = functionAction => valueAction => () => functionAction()(valueAction());
+export const pureEffect = value => () => value;
+export const bindEffect = action => continuation => () => continuation(action())();

--- a/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/output/Effect/index.js
+++ b/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/output/Effect/index.js
@@ -1,0 +1,22 @@
+import * as $foreign from "./foreign.js";
+export const mapEffect = $foreign["mapEffect"];
+export const applyEffect = $foreign["applyEffect"];
+export const pureEffect = $foreign["pureEffect"];
+export const bindEffect = $foreign["bindEffect"];
+export const functorEffect = { map: mapEffect };
+export const applyEffect1 = {
+  Functor0: () => functorEffect,
+  apply: applyEffect
+};
+export const applicativeEffect = {
+  Apply0: () => applyEffect1,
+  pure: pureEffect
+};
+export const bindEffect1 = {
+  Apply0: () => applyEffect1,
+  bind: bindEffect
+};
+export const monadEffect = {
+  Applicative0: () => applicativeEffect,
+  Bind1: () => bindEffect1
+};

--- a/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/output/Main/foreign.js
@@ -1,0 +1,12 @@
+let constructions = 0;
+
+export const makeContinuation = () => {
+  constructions += 1;
+  return () => () => 42;
+};
+
+export const resetConstructions = () => {
+  constructions = 0;
+};
+
+export const readConstructions = () => constructions;

--- a/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/output/Main/index.js
@@ -1,0 +1,8 @@
+import * as $foreign from "./foreign.js";
+export function localBind($unit) {
+  const continuation = makeContinuation("Unit");
+  return () => {
+    return continuation("Unit")();
+  };
+}
+export const makeContinuation = $foreign["makeContinuation"];

--- a/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/verify.mjs
+++ b/tests-integration/fixtures/backend/1788257280_local_effect_bind_continuation/verify.mjs
@@ -1,0 +1,11 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+import { readConstructions, resetConstructions } from "./output/Main/foreign.js";
+
+resetConstructions();
+const effect = Main.localBind("Unit");
+strictEqual(readConstructions(), 1);
+strictEqual(effect(), 42);
+strictEqual(readConstructions(), 1);
+strictEqual(effect(), 42);
+strictEqual(readConstructions(), 1);

--- a/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/Main.functional.snap
@@ -1,0 +1,8 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export nestedBind = \$unit%2@(_) ->
+  effect.bind (effect.bind (effect.pure "Unit") \$unit%0 -> effect.pure 42)
+    \value%1 -> effect.pure value%1

--- a/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/Main.purs
+++ b/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+import Control.Applicative (pure)
+import Control.Bind (bind)
+import Data.Unit (Unit(..))
+import Effect (Effect)
+
+nestedBind :: Unit -> Effect Int
+nestedBind _ =
+  bind
+    (bind (pure Unit) (\_ -> pure 42))
+    (\value -> pure value)

--- a/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/Main.snap
+++ b/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+nestedBind :: Data.Unit.Unit -> Effect.Effect Prim.Int
+
+Types

--- a/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/output/Control.Applicative/index.js
+++ b/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/output/Control.Applicative/index.js
@@ -1,0 +1,3 @@
+export function pure(dictionary) {
+  return dictionary.pure;
+}

--- a/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/output/Control.Bind/index.js
+++ b/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/output/Control.Bind/index.js
@@ -1,0 +1,7 @@
+export function bind(dictionary) {
+  return dictionary.bind;
+}
+export function discard(dictionary) {
+  return dictionary.discard;
+}
+export const discardUnit = { discard: (bindFDict) => /* @__PURE__ */ bind(bindFDict) };

--- a/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/output/Data.Unit/index.js
+++ b/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/output/Data.Unit/index.js
@@ -1,0 +1,1 @@
+export const Unit = "Unit";

--- a/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/output/Effect/foreign.js
+++ b/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/output/Effect/foreign.js
@@ -1,0 +1,4 @@
+export const mapEffect = transform => action => () => transform(action());
+export const applyEffect = functionAction => valueAction => () => functionAction()(valueAction());
+export const pureEffect = value => () => value;
+export const bindEffect = action => continuation => () => continuation(action())();

--- a/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/output/Effect/index.js
+++ b/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/output/Effect/index.js
@@ -1,0 +1,22 @@
+import * as $foreign from "./foreign.js";
+export const mapEffect = $foreign["mapEffect"];
+export const applyEffect = $foreign["applyEffect"];
+export const pureEffect = $foreign["pureEffect"];
+export const bindEffect = $foreign["bindEffect"];
+export const functorEffect = { map: mapEffect };
+export const applyEffect1 = {
+  Functor0: () => functorEffect,
+  apply: applyEffect
+};
+export const applicativeEffect = {
+  Apply0: () => applyEffect1,
+  pure: pureEffect
+};
+export const bindEffect1 = {
+  Apply0: () => applyEffect1,
+  bind: bindEffect
+};
+export const monadEffect = {
+  Applicative0: () => applicativeEffect,
+  Bind1: () => bindEffect1
+};

--- a/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/output/Main/index.js
@@ -1,0 +1,7 @@
+export function nestedBind($unit) {
+  return () => {
+    let value;
+    value = 42 | 0;
+    return value;
+  };
+}

--- a/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/verify.mjs
+++ b/tests-integration/fixtures/backend/1788257340_nested_effect_bind_action/verify.mjs
@@ -1,0 +1,4 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.nestedBind("Unit")(), 42);


### PR DESCRIPTION
## Motivation

Explicit `bind` and `(>>=)` calls using the `Effect` or `ST` dictionaries only reached native effect lowering when their continuation was already a one-argument lambda. Named continuations therefore retained generic dictionary calls, including `Window.navigator browserWindow >>= Navigator.platform` in the Alexandrite website.

## Changes

- Eta-expand named global and local continuations while converting canonical Effect/ST binds.
- Leave computed continuations generic so their construction timing is unchanged.
- Inline unshared pure bind values in generated JavaScript and emit shared pure values as `const`.
- Preserve mutable destinations for nested non-pure effect actions.
- Add dedicated backend fixtures for manual bind calls, the `(>>=)` alias, shared values, computed-continuation timing, named ST continuations, local continuations, and nested bind actions.

## Verification

- `cargo check -p functional --tests`
- `cargo check -p javascript --tests`
- `just t backend`
- Built `purefunctor/purescript-alexandrite-website` with this compiler and confirmed `Landing.Index` directly sequences its named `Navigator.platform` continuation.