### PR TITLE
[backend] Make JavaScript initializer ordering linear and stack-safe

### DIFF
--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -27,7 +27,7 @@ use crate::module::{Module, module_filename, runtime_filename};
 use crate::tree::{BinaryOperator, ExpressionId, ObjectProperty, Tree, UnaryOperator};
 use crate::writer::{BindingCallTarget, Writer};
 
-use self::analysis::{VisitState, visit_initializer};
+use self::analysis::{cyclic_initializers, initializer_postorder};
 use self::inline::{is_abstraction, pattern_parameter};
 use self::structure::{
     collect_module_references, cyclic_instance_initializers, has_local_lazy_initializers,
@@ -3045,12 +3045,10 @@ fn sorted_value_declarations<'m>(
         dependencies[position].dedup();
     }
 
-    let mut states = vec![VisitState::Unvisited; values.len()];
-    let mut ordered = Vec::new();
-    for position in 0..values.len() {
-        visit_initializer(position, &dependencies, &mut states, &mut ordered)
-            .map_err(|state| generator.unsupported(state))?;
+    if cyclic_initializers(&dependencies).contains(&true) {
+        return Err(generator.unsupported(UnsupportedState::CyclicInitializers));
     }
+    let ordered = initializer_postorder(&dependencies);
     Ok(ordered.into_iter().map(|position| values[position]).collect_vec())
 }
 
@@ -3448,23 +3446,4 @@ fn collect_update_globals(
             }
         }
     }
-}
-
-fn reaches_initializer(
-    current: usize,
-    target: usize,
-    dependencies: &[Vec<usize>],
-    visited: &mut FxHashSet<usize>,
-) -> bool {
-    for dependency in &dependencies[current] {
-        if *dependency == target {
-            return true;
-        }
-        if visited.insert(*dependency)
-            && reaches_initializer(*dependency, target, dependencies, visited)
-        {
-            return true;
-        }
-    }
-    false
 }

--- a/compiler-backend/javascript/src/convert/generator/functional/render/analysis.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render/analysis.rs
@@ -1,30 +1,172 @@
-//! Dependency ordering for JavaScript initializers.
+//! Dependency ordering and cycle detection for JavaScript initializers.
+//!
+//! Initializers are identified by their position in a dependency graph, where
+//! `dependencies[position]` lists the positions that `position` refers to.
+//! Both algorithms use explicit work stacks and run in `O(V + E)` time, so a
+//! module with a long chain of initializers neither exhausts the stack nor
+//! spends quadratic time identifying cycles.
 
-use crate::error::UnsupportedState;
+/// Visits every initializer in depth-first postorder, following dependencies
+/// in the order they are listed and roots in increasing position order.
+///
+/// Emitting initializers in this order guarantees that an acyclic initializer
+/// is defined after everything it depends on.
+pub(super) fn initializer_postorder(dependencies: &[Vec<usize>]) -> Vec<usize> {
+    let mut visited = vec![false; dependencies.len()];
+    let mut ordered = Vec::with_capacity(dependencies.len());
+    let mut work_stack = vec![];
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub(super) enum VisitState {
-    Unvisited,
-    Visiting,
-    Visited,
+    for root in 0..dependencies.len() {
+        if visited[root] {
+            continue;
+        }
+        visited[root] = true;
+        work_stack.push((root, 0));
+
+        while let Some((position, next_dependency)) = work_stack.last_mut() {
+            let Some(&dependency) = dependencies[*position].get(*next_dependency) else {
+                ordered.push(*position);
+                work_stack.pop();
+                continue;
+            };
+            *next_dependency += 1;
+            if !visited[dependency] {
+                visited[dependency] = true;
+                work_stack.push((dependency, 0));
+            }
+        }
+    }
+
+    ordered
 }
 
-pub(super) fn visit_initializer(
-    position: usize,
-    dependencies: &[Vec<usize>],
-    states: &mut [VisitState],
-    ordered: &mut Vec<usize>,
-) -> Result<(), UnsupportedState> {
-    match states[position] {
-        VisitState::Visited => return Ok(()),
-        VisitState::Visiting => return Err(UnsupportedState::CyclicInitializers),
-        VisitState::Unvisited => {}
+/// Marks every initializer that participates in a cycle: each member of a
+/// multi-node cycle and each initializer that depends on itself. Acyclic
+/// initializers remain unmarked even when they depend on, or are depended
+/// upon by, a cycle.
+///
+/// This is Kosaraju's algorithm: a depth-first search over the transposed
+/// graph in reverse postorder visits exactly one strongly connected component
+/// at a time.
+pub(super) fn cyclic_initializers(dependencies: &[Vec<usize>]) -> Vec<bool> {
+    let mut dependents = vec![vec![]; dependencies.len()];
+    for (position, position_dependencies) in dependencies.iter().enumerate() {
+        for &dependency in position_dependencies {
+            dependents[dependency].push(position);
+        }
     }
-    states[position] = VisitState::Visiting;
-    for dependency in &dependencies[position] {
-        visit_initializer(*dependency, dependencies, states, ordered)?;
+
+    let mut cyclic = vec![false; dependencies.len()];
+    let mut assigned = vec![false; dependencies.len()];
+    let mut component = vec![];
+    let mut work_stack = vec![];
+
+    for &root in initializer_postorder(dependencies).iter().rev() {
+        if assigned[root] {
+            continue;
+        }
+        assigned[root] = true;
+        component.clear();
+        work_stack.push(root);
+
+        while let Some(position) = work_stack.pop() {
+            component.push(position);
+            for &dependent in &dependents[position] {
+                if !assigned[dependent] {
+                    assigned[dependent] = true;
+                    work_stack.push(dependent);
+                }
+            }
+        }
+
+        let depends_on_itself = || dependencies[root].contains(&root);
+        if component.len() > 1 || depends_on_itself() {
+            for &position in &component {
+                cyclic[position] = true;
+            }
+        }
     }
-    states[position] = VisitState::Visited;
-    ordered.push(position);
-    Ok(())
+
+    cyclic
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cyclic_initializers, initializer_postorder};
+
+    /// Builds a graph where each initializer depends on the next one.
+    fn chain(length: usize) -> Vec<Vec<usize>> {
+        let mut dependencies = vec![vec![]; length];
+        for position in 1..length {
+            dependencies[position - 1].push(position);
+        }
+        dependencies
+    }
+
+    /// Runs `test` on a thread whose stack is far too small for a recursive
+    /// traversal of a long chain, so recursion fails the test instead of
+    /// passing by virtue of the generous default test stack.
+    fn with_small_stack(test: impl FnOnce() + Send + 'static) {
+        let thread = std::thread::Builder::new()
+            .stack_size(64 * 1024)
+            .spawn(test)
+            .expect("failed to spawn small-stack thread");
+        thread.join().expect("test panicked on small-stack thread");
+    }
+
+    #[test]
+    fn postorder_defines_dependencies_first() {
+        let dependencies = vec![vec![1, 2], vec![2], vec![], vec![0]];
+
+        assert_eq!(initializer_postorder(&dependencies), vec![2, 1, 0, 3]);
+    }
+
+    #[test]
+    fn postorder_handles_long_chains_without_recursion() {
+        with_small_stack(|| {
+            let dependencies = chain(10_000);
+
+            let ordered = initializer_postorder(&dependencies);
+
+            assert_eq!(ordered, (0..10_000).rev().collect::<Vec<_>>());
+        });
+    }
+
+    #[test]
+    fn cycle_detection_handles_long_chains_without_recursion() {
+        with_small_stack(|| {
+            let dependencies = chain(10_000);
+
+            assert_eq!(cyclic_initializers(&dependencies), vec![false; 10_000]);
+        });
+    }
+
+    #[test]
+    fn multi_node_cycles_mark_every_member() {
+        let dependencies = vec![vec![1], vec![2], vec![0], vec![4], vec![3]];
+
+        assert_eq!(cyclic_initializers(&dependencies), vec![true, true, true, true, true]);
+    }
+
+    #[test]
+    fn self_edges_mark_a_single_initializer() {
+        let dependencies = vec![vec![0], vec![], vec![1]];
+
+        assert_eq!(cyclic_initializers(&dependencies), vec![true, false, false]);
+    }
+
+    #[test]
+    fn acyclic_initializers_connected_to_cycles_are_not_marked() {
+        // 0 depends on the cycle {1, 2}, and the cycle depends on 3.
+        let dependencies = vec![vec![1], vec![2], vec![1, 3], vec![]];
+
+        assert_eq!(cyclic_initializers(&dependencies), vec![false, true, true, false]);
+    }
+
+    #[test]
+    fn acyclic_graphs_have_no_cyclic_initializers() {
+        let dependencies = vec![vec![1, 2], vec![2], vec![], vec![0]];
+
+        assert_eq!(cyclic_initializers(&dependencies), vec![false; 4]);
+    }
 }

--- a/compiler-backend/javascript/src/convert/generator/functional/render/structure.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render/structure.rs
@@ -4,9 +4,9 @@ use functional::tree::{DeclarationKind, ExpressionKind, Global, GlobalId, Module
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use super::analysis::cyclic_initializers;
 use super::{
     collect_expression_globals, collect_expression_references, global_file, is_abstraction,
-    reaches_initializer,
 };
 
 pub(super) fn collect_module_references(module: &Module) -> Vec<Global> {
@@ -50,18 +50,12 @@ pub(super) fn cyclic_instance_initializers(module: &Module) -> FxHashSet<GlobalI
         initializer_dependencies[position].dedup();
     }
 
-    let mut cyclic_initializers = FxHashSet::default();
-    for (position, (global_id, _)) in initializers.iter().enumerate() {
-        let mut visited_initializers = FxHashSet::default();
-        if reaches_initializer(
-            position,
-            position,
-            &initializer_dependencies,
-            &mut visited_initializers,
-        ) {
-            cyclic_initializers.insert(*global_id);
-        }
-    }
+    let cyclic_positions = cyclic_initializers(&initializer_dependencies);
+    let cyclic_initializers = initializers
+        .iter()
+        .zip(cyclic_positions)
+        .filter_map(|((global_id, _), cyclic)| cyclic.then_some(*global_id))
+        .collect::<FxHashSet<_>>();
 
     let mut global_ids = cyclic_initializers.iter();
     let all_initializers_are_instances =


### PR DESCRIPTION
Closes #452.

## Problem

`sorted_value_declarations` ordered initializers with a recursive DFS, and `cyclic_instance_initializers` ran a recursive `reaches_initializer` from every node, which is quadratic in the number of initializers and recurses through the whole dependency chain.

## Change

`render/analysis.rs` now owns two `O(V + E)`, non-recursive routines over the position-indexed dependency graph both callers already build:

- `initializer_postorder`: the same DFS postorder as before, driven by an explicit work stack.
- `cyclic_initializers`: Kosaraju's strongly connected components over the transposed graph, marking every member of a multi-node cycle and any node with a self-edge, and nothing merely connected to a cycle.

Ordinary initializer ordering checks `cyclic_initializers` first (raising `CyclicInitializers` as before) and then takes the postorder; the lazy-to-lazy edge rule is unchanged. Cyclic instance detection uses the same routine instead of per-node reachability.

## Verification

- `cargo nextest run -p javascript`: unit coverage for a 10,000-node chain (run on a 64 KiB thread so recursion would fail), multi-node cycles, self-cycles, acyclic nodes connected to cycles, and a plain DAG.
- `just t backend`: all fixtures pass with no snapshot or generated-output changes.
- Release-mode microbenchmark on a chain of N initializers, best of 5, legacy vs. new:

| nodes | legacy cycles | new cycles | speedup |
|---:|---:|---:|---:|
| 1,000 | 12.88 ms | 56.76 µs | 227x |
| 10,000 | 1.31 s | 557.61 µs | 2349x |
| 20,000 | 5.35 s | 1.16 ms | 4602x |