### PR TITLE
[compiler-bin] Use terminal foreground for completed progress

### DIFF
--- a/compiler-bin/src/progress.rs
+++ b/compiler-bin/src/progress.rs
@@ -70,9 +70,7 @@ fn configure(progress: &ProgressBar, phase: &'static str) {
         .max(1);
     let phase_text = move |state: &ProgressState, writer: &mut dyn fmt::Write| {
         if state.is_finished() {
-            let style = phase_style(theme_mode, 255);
-            write!(writer, "{}", style.apply_to(phase))
-                .expect("writing to a formatter cannot fail");
+            writer.write_str(phase).expect("writing to a formatter cannot fail");
             return;
         }
 


### PR DESCRIPTION
## Summary

Completed progress phase labels currently retain the shimmer's maximum grayscale intensity. When terminal theme detection disagrees with the displayed background, this can leave white labels on a light background after compilation finishes.

Render completed phase labels with the terminal's default foreground instead. This matches the adjacent progress statistics and adapts naturally to both light and dark themes, while preserving the theme-aware shimmer during active work.

## Verification

- `cargo check -p purescript-alexandrite --tests`
- `cargo nextest run -p purescript-alexandrite` (71 passed)
- `just format --check`