### PR TITLE
[backend] Parallelize diagnostic generation

### DIFF
--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -243,6 +243,8 @@ fn report_diagnostics(
         progress::phase(&progress, source_ids.len(), "Analyse", config.progress);
     let checking_progress =
         progress::phase(&progress, source_ids.len(), "Elaborate", config.progress);
+    let generating_progress =
+        progress::phase(&progress, source_ids.len(), "Generate", config.progress);
 
     let module_names = source_ids.par_iter().map(|&file_id| {
         let engine = compilation.snapshot();
@@ -274,6 +276,18 @@ fn report_diagnostics(
     });
     elaborated.collect::<Result<Vec<_>, _>>()?;
     progress::finish(&checking_progress);
+
+    let generated = source_ids.par_iter().zip(&module_names).map(|(&file_id, module_name)| {
+        let engine = compilation.snapshot();
+        if let Some(module_name) = module_name {
+            progress::set_message(&generating_progress, module_name);
+        }
+        let _ = engine.javascript(file_id)?;
+        generating_progress.inc(1);
+        Ok::<_, CompileError>(())
+    });
+    generated.collect::<Result<Vec<_>, _>>()?;
+    progress::finish(&generating_progress);
 
     let engine = compilation.snapshot();
     let diagnostics = diagnostics::collect_diagnostics(&engine, source_ids)?;

--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -181,7 +181,7 @@ pub(crate) fn build(
         return Ok(BuildOutcome::Diagnostics);
     }
 
-    let modules = generate_modules(compilation, &source_ids, config.progress)?;
+    let modules = collect_modules(compilation, &source_ids)?;
     let outputs = write_modules(compilation, &modules, config.output, config.progress)?;
     if has_errors { Ok(BuildOutcome::Diagnostics) } else { Ok(BuildOutcome::Succeeded(outputs)) }
 }
@@ -322,37 +322,21 @@ fn report_diagnostics(
     Ok(has_errors)
 }
 
-fn generate_modules(
+fn collect_modules(
     compilation: &CompilationState,
     source_ids: &[FileId],
-    show_progress: bool,
 ) -> Result<Vec<Arc<javascript::Module>>, CompileError> {
     let mut pending = source_ids.to_vec();
     let mut visited = HashSet::new();
 
-    let initial_total = source_ids.iter().copied().collect::<HashSet<_>>().len();
-    let progress = progress::bar(initial_total, "Codegen", show_progress);
-    let mut first_frontier = true;
     let mut modules = vec![];
     while !pending.is_empty() {
         let frontier = pending.drain(..).filter(|file_id| visited.insert(*file_id));
         let frontier = frontier.collect::<Vec<_>>();
-        if first_frontier {
-            first_frontier = false;
-        } else {
-            let frontier_len = frontier.len() as u64;
-            progress.inc_length(frontier_len);
-        }
 
         let generated = frontier.par_iter().map(|&file_id| {
             let engine = compilation.snapshot();
-            let content = engine.content(file_id)?;
-            let (parsed, _) = engine.parsed(file_id)?;
-            if let Some(module_name) = parsed.module_name(&content) {
-                progress::set_message(&progress, &module_name);
-            }
             let module = engine.javascript(file_id)?.ok();
-            progress.inc(1);
             Ok::<_, CompileError>(module)
         });
         let generated = generated.collect::<Result<Vec<_>, _>>()?;
@@ -362,7 +346,6 @@ fn generate_modules(
             modules.push(module);
         }
     }
-    progress::finish(&progress);
 
     Ok(modules)
 }
@@ -381,7 +364,7 @@ fn write_modules(
         outputs.insert(runtime);
     }
 
-    let progress = progress::bar(modules.len(), "Output", show_progress);
+    let progress = progress::bar(modules.len(), "Write", show_progress);
     let module_outputs = modules.par_iter().map(|module| -> Result<Vec<PathBuf>, CompileError> {
         progress::set_message(&progress, module.name());
         let output_path = output.join(module.filename());


### PR DESCRIPTION
## Summary

Backend diagnostics made `collect_diagnostics` the first caller of the JavaScript query. Because diagnostic collection walks source files serially, first-time backend generation was serialized before `generate_modules` reached its Rayon loop.

Warm JavaScript queries in a dedicated parallel CLI progress phase after elaboration and before diagnostic collection. Inner backend errors remain cached for conversion to diagnostics, while outer query failures continue to propagate. The existing dependency traversal in `generate_modules` is unchanged.

## Performance

Release compilation of the prepared 7,356-module compatibility corpus:

- Before: 12.63, 12.85, 12.83, 12.54, 12.74 seconds (median 12.74 seconds)
- After: 9.80, 9.50, 9.46, 9.24, 9.18 seconds (median 9.46 seconds)

This reduces median wall time by 25.7% in the benchmark orb.

## Verification

- `cargo check -p purescript-alexandrite --tests`
- `cargo nextest run -p purescript-alexandrite` (72 passed)
- Focused E2E tests for backend failure diagnostics, resilient output, and initializer-cycle resilience (3 passed)
- `just format`
- `git diff --check`