### PR TITLE
[functional] Cache rendered instance names during conversion

### DIFF
--- a/compiler-backend/functional/src/convert.rs
+++ b/compiler-backend/functional/src/convert.rs
@@ -5,6 +5,7 @@ mod declaration;
 mod evidence;
 mod expression;
 
+use std::cell::RefCell;
 use std::sync::Arc;
 
 use building_types::{QueryError, QueryResult};
@@ -89,6 +90,7 @@ struct Context<'c, Q> {
     evidence_keys: EvidenceKeys,
     evidence_scopes: Vec<EvidenceScope>,
     evidence_hoisting: EvidenceHoisting,
+    instance_names: RefCell<FxHashMap<InstanceIdentity, SmolStr>>,
 
     storage: Storage,
 }
@@ -150,6 +152,7 @@ where
             evidence_keys: EvidenceKeys::default(),
             evidence_scopes: Vec::new(),
             evidence_hoisting: EvidenceHoisting::default(),
+            instance_names: RefCell::new(FxHashMap::default()),
 
             storage: Storage::default(),
         })
@@ -734,6 +737,9 @@ where
     }
 
     fn instance_name(&self, identity: InstanceIdentity) -> QueryResult<SmolStr> {
+        if let Some(name) = self.instance_names.borrow().get(&identity) {
+            return Ok(SmolStr::clone(name));
+        }
         let origin = match identity {
             InstanceIdentity::Declared(file_id, id) => {
                 InstanceCandidateOrigin::Instance(file_id, id)
@@ -741,7 +747,9 @@ where
             InstanceIdentity::Derived(file_id, id) => InstanceCandidateOrigin::Derive(file_id, id),
         };
         let pretty = checking::tree::pretty::Pretty::new(self.queries, &self.checked);
-        pretty.render_instance_name(self.file_id, origin)
+        let name = pretty.render_instance_name(self.file_id, origin)?;
+        self.instance_names.borrow_mut().insert(identity, SmolStr::clone(&name));
+        Ok(name)
     }
 
     fn record_pun_source(


### PR DESCRIPTION
## Summary

Cache rendered functional-backend instance names by `InstanceIdentity` for the lifetime of one module conversion.

Instance names are requested repeatedly while converting evidence. Rendering each request constructs a fresh checked-tree pretty printer and arena. The module-local cache preserves the existing text and ordering while avoiding duplicate renders, and is discarded when conversion finishes.

## Performance

Release-mode direct functional conversion over the 7,356-module ACME corpus, with checked queries warmed and baseline/candidate runs interleaved:

- one thread median: 2648.909 ms → 2181.168 ms (-17.7%)
- eight threads median: 840.560 ms → 626.152 ms (-25.5%)
- 155,744 render requests represented 52,490 module-local distinct identities (66.3% reusable)
- allocation events: 30,622,300 → 25,393,418 (-17.1%)
- requested allocation bytes: 2.182 GB → 1.577 GB (-27.7%)

Representative targeted medians:

- `Tecton.Internal`: 619.2 ms → 493.6 ms
- `Rito.Interpret`: 74.4 ms → 7.1 ms
- `Axon.Header.Typed`: 130.2 ms → 81.4 ms
- all nine `org-doc` modules: 140.4 ms → 35.7 ms

`Yoga.SQLite.Schema`, which had much less reuse, showed no independent timing improvement. Full-corpus results still justify the contained cache.

## Verification

- `cargo check -p functional --tests`
- `cargo check -p checking --tests`
- `cargo nextest run -p functional`
- `just t backend`
- `just format`
- `git diff --check`
- `just compatibility origin/main` (no introduced diagnostics)

Targeted normalized functional-tree and generated JavaScript hashes were byte-identical before and after the change.
