### PR TITLE
[checking] Avoid singleton substitution maps

### DIFF
--- a/compiler-frontend/checking/src/core/substitute.rs
+++ b/compiler-frontend/checking/src/core/substitute.rs
@@ -63,7 +63,12 @@ impl RigidRenaming {
 /// removing the need for capture-avoiding substitutions. This property
 /// is extremely useful for for instantiation.
 pub struct SubstituteName<'a> {
-    bindings: &'a NameToType,
+    bindings: NameBindings<'a>,
+}
+
+enum NameBindings<'a> {
+    One(Name, TypeId),
+    Many(&'a NameToType),
 }
 
 impl SubstituteName<'_> {
@@ -77,8 +82,8 @@ impl SubstituteName<'_> {
     where
         Q: ExternalQueries,
     {
-        let bindings = NameToType::from_iter([(name, replacement)]);
-        fold_type(state, context, in_type, &mut SubstituteName { bindings: &bindings })
+        let bindings = NameBindings::One(name, replacement);
+        fold_type(state, context, in_type, &mut SubstituteName { bindings })
     }
 
     pub fn many<Q>(
@@ -90,6 +95,7 @@ impl SubstituteName<'_> {
     where
         Q: ExternalQueries,
     {
+        let bindings = NameBindings::Many(bindings);
         fold_type(state, context, in_type, &mut SubstituteName { bindings })
     }
 }
@@ -105,13 +111,18 @@ impl TypeFold for SubstituteName<'_> {
     where
         Q: ExternalQueries,
     {
-        if let Type::Rigid(name, _, _) = t
-            && let Some(id) = self.bindings.get(name)
-        {
-            Ok(FoldAction::Replace(*id))
-        } else {
-            Ok(FoldAction::Continue)
+        if let Type::Rigid(name, _, _) = t {
+            let replacement = match self.bindings {
+                NameBindings::One(original, replacement) if original == *name => Some(replacement),
+                NameBindings::One(_, _) => None,
+                NameBindings::Many(bindings) => bindings.get(name).copied(),
+            };
+            if let Some(replacement) = replacement {
+                return Ok(FoldAction::Replace(replacement));
+            }
         }
+
+        Ok(FoldAction::Continue)
     }
 }
 


### PR DESCRIPTION
## Summary

Represent `SubstituteName::one` as an inline `(Name, TypeId)` pair instead of constructing a one-entry `FxHashMap`. Multi-name substitution continues to borrow and query `NameToType`, preserving the existing path.

This removes heap allocation and hashing from a frequent type-fold operation without changing substitution or fold semantics.

## Measurements

Release-built ACME verification covered 631 packages and 7,356 source files. Temporary scoped allocator counters measured 508,568 singleton substitutions and showed that this change removed exactly 508,568 allocation requests and 58,993,888 requested bytes (116 bytes per call). Across all measured substitution scopes, allocation calls fell 18.84% and requested bytes fell 31.71%.

Five interleaved baseline/candidate samples:

- One thread: median wall 17.61 → 17.06 seconds (-3.12%); median user 16.12 → 15.48 seconds (-3.97%); median RSS unchanged.
- Eight threads (best setting on the measurement orb): median wall 5.28 → 4.83 seconds (-8.52%); mean wall 5.186 → 4.902 seconds (-5.48%); median user 18.02 → 17.56 seconds (-2.55%).

All 20 ACME reports were byte-identical. Reports for `org-doc`, `tecton`, `yoga-sqlite`, `react-basic-dom`, and `prelude` were also byte-identical.

## Verification

- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (34 passed)
- `just t checking` (all passed, no pending snapshots)
- `just compatibility origin/main` (no introduced or fixed diagnostics; base and candidate reports byte-identical)
- `just format`
- `git diff --check`