### PR TITLE
[checking] Skip normalization for irreducible type heads

### DIFF
--- a/compiler-core/building/src/engine.rs
+++ b/compiler-core/building/src/engine.rs
@@ -1347,6 +1347,10 @@ impl checking::ExternalQueries for QueryEngine {
         self.interned.checking.intern_type(t)
     }
 
+    fn lookup_type_flags(&self, id: checking::TypeId) -> checking::core::TypeFlags {
+        self.interned.checking.lookup_type_flags(id)
+    }
+
     fn intern_forall_binder(
         &self,
         binder: checking::core::ForallBinder,

--- a/compiler-frontend/checking/src/context.rs
+++ b/compiler-frontend/checking/src/context.rs
@@ -19,7 +19,7 @@ use sugar::{Bracketed, Sectioned};
 
 use crate::core::{
     CheckedSynonym, Depth, ForallBinder, ForallBinderId, Name, RowField, RowType, RowTypeId, Type,
-    TypeId,
+    TypeFlags, TypeId,
 };
 use crate::{CheckedModule, ExternalQueries};
 
@@ -311,6 +311,10 @@ where
     /// Looks up the [`Type`] for the given [`TypeId`].
     pub fn lookup_type(&self, id: TypeId) -> Type {
         self.queries.lookup_type(id)
+    }
+
+    pub fn lookup_type_flags(&self, id: TypeId) -> TypeFlags {
+        self.queries.lookup_type_flags(id)
     }
 
     /// Looks up the [`ForallBinder`] for the given [`ForallBinderId`].

--- a/compiler-frontend/checking/src/core.rs
+++ b/compiler-frontend/checking/src/core.rs
@@ -276,6 +276,23 @@ pub enum Type {
     Unknown(SmolStrId),
 }
 
+/// Immutable properties of an interned type's outermost node.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TypeFlags(u8);
+
+impl TypeFlags {
+    const MAY_NORMALISE: u8 = 1 << 0;
+
+    pub(crate) fn new(may_normalise: bool) -> TypeFlags {
+        TypeFlags(if may_normalise { TypeFlags::MAY_NORMALISE } else { 0 })
+    }
+
+    /// Whether head normalisation may change this type.
+    pub fn may_normalise(self) -> bool {
+        self.0 & TypeFlags::MAY_NORMALISE != 0
+    }
+}
+
 /// The role of a type parameter for safe coercions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Role {

--- a/compiler-frontend/checking/src/core/normalise.rs
+++ b/compiler-frontend/checking/src/core/normalise.rs
@@ -101,6 +101,10 @@ pub fn normalise<Q>(
 where
     Q: ExternalQueries,
 {
+    if !context.lookup_type_flags(id).may_normalise() {
+        return Ok(id);
+    }
+
     let mut reduction = ReductionContext::new(state, context);
 
     let id = safe_loop! {

--- a/compiler-frontend/checking/src/interners.rs
+++ b/compiler-frontend/checking/src/interners.rs
@@ -1,10 +1,10 @@
 use smol_str::SmolStr;
 
-use crate::core::{ForallBinder, ForallBinderId, RowType, RowTypeId, Type, TypeId};
+use crate::core::{ForallBinder, ForallBinderId, RowType, RowTypeId, Type, TypeFlags, TypeId};
 
 #[derive(Default)]
 pub struct CoreInterners {
-    types: interner::parallel::Interner<Type>,
+    types: interner::parallel::Interner<Type, TypeFlags>,
     forall_binders: interner::parallel::Interner<ForallBinder>,
     row_types: interner::parallel::Interner<RowType>,
     smol_strs: interner::parallel::Interner<SmolStr>,
@@ -12,11 +12,29 @@ pub struct CoreInterners {
 
 impl CoreInterners {
     pub fn intern_type(&self, t: Type) -> TypeId {
-        self.types.intern(t)
+        let flags = self.type_flags(&t);
+        self.types.intern_with_metadata(t, flags)
     }
 
     pub fn lookup_type(&self, id: TypeId) -> Type {
         self.types[id].clone()
+    }
+
+    pub fn lookup_type_flags(&self, id: TypeId) -> TypeFlags {
+        self.types.metadata(id)
+    }
+
+    fn type_flags(&self, t: &Type) -> TypeFlags {
+        let may_normalise = match *t {
+            Type::Unification(_) => true,
+            Type::Row(row_id) => {
+                let row = &self.row_types[row_id];
+                row.tail.is_some_and(|tail| matches!(self.types[tail], Type::Row(_)))
+            }
+            _ => false,
+        };
+
+        TypeFlags::new(may_normalise)
     }
 
     pub fn intern_forall_binder(&self, b: ForallBinder) -> ForallBinderId {
@@ -41,5 +59,44 @@ impl CoreInterners {
 
     pub fn lookup_smol_str(&self, id: crate::core::SmolStrId) -> SmolStr {
         self.smol_strs[id].clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use smol_str::SmolStr;
+
+    use super::CoreInterners;
+    use crate::core::{RowField, RowType, Type};
+
+    #[test]
+    fn normalisation_flags_describe_head_reductions() {
+        let interners = CoreInterners::default();
+
+        let integer = interners.intern_type(Type::Integer(0));
+        let unification = interners.intern_type(Type::Unification(0));
+        let application = interners.intern_type(Type::Application(integer, unification));
+
+        assert!(!interners.lookup_type_flags(integer).may_normalise());
+        assert!(interners.lookup_type_flags(unification).may_normalise());
+        assert!(!interners.lookup_type_flags(application).may_normalise());
+        let closed_row = RowType::from_closed(Arc::from([RowField {
+            label: SmolStr::new("inner"),
+            id: integer,
+        }]));
+        let closed_row = interners.intern_row_type(closed_row);
+        let closed_row = interners.intern_type(Type::Row(closed_row));
+
+        let nested_row = RowType::from_open(
+            Arc::from([RowField { label: SmolStr::new("outer"), id: integer }]),
+            closed_row,
+        );
+        let nested_row = interners.intern_row_type(nested_row);
+        let nested_row = interners.intern_type(Type::Row(nested_row));
+
+        assert!(!interners.lookup_type_flags(closed_row).may_normalise());
+        assert!(interners.lookup_type_flags(nested_row).may_normalise());
     }
 }

--- a/compiler-frontend/checking/src/lib.rs
+++ b/compiler-frontend/checking/src/lib.rs
@@ -55,6 +55,8 @@ pub trait ExternalQueries:
 
     fn intern_type(&self, t: Type) -> TypeId;
 
+    fn lookup_type_flags(&self, id: TypeId) -> core::TypeFlags;
+
     fn intern_forall_binder(&self, b: ForallBinder) -> ForallBinderId;
 
     fn intern_row_type(&self, r: RowType) -> RowTypeId;

--- a/docs/src/wasm/src/engine.rs
+++ b/docs/src/wasm/src/engine.rs
@@ -426,6 +426,10 @@ impl checking::ExternalQueries for WasmQueryEngine {
         self.interned.checking.intern_type(t)
     }
 
+    fn lookup_type_flags(&self, id: checking::core::TypeId) -> checking::core::TypeFlags {
+        self.interned.checking.lookup_type_flags(id)
+    }
+
     fn intern_forall_binder(
         &self,
         binder: checking::core::ForallBinder,


### PR DESCRIPTION
## Summary

Record immutable outer-head normalization metadata alongside each interned type, then return immediately when head normalization cannot change that type.

The flag deliberately describes only the operation performed by `normalise`: unification variables can be rewritten, and row heads can flatten nested row tails. Applications containing unification variables remain unflagged because normalization does not recursively rewrite their arguments.

## Performance

On the Core compatibility corpus, two isolated scoped Callgrind runs reduced instructions inside `checking::check_module` by 6.830% and 6.834%. Wall-clock comparisons were favorable but noisy, so the deterministic instruction reduction is the primary claim.

## Validation

- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (35/35)
- `just t checking` (no pending snapshots)