### PR TITLE
[checking] Keep short unification paths inline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,7 @@ dependencies = [
  "pretty",
  "resolving",
  "rustc-hash",
+ "smallvec",
  "smol_str",
  "stabilizing",
  "sugar",

--- a/compiler-frontend/checking/Cargo.toml
+++ b/compiler-frontend/checking/Cargo.toml
@@ -18,6 +18,7 @@ pretty = "0.12"
 parsing = { version = "0.1.0", path = "../parsing" }
 resolving = { version = "0.1.0", path = "../resolving" }
 rustc-hash = "2.1.3"
+smallvec = "1.15.1"
 smol_str = "0.3.5"
 stabilizing = { version = "0.1.0", path = "../stabilizing" }
 sugar = { version = "0.1.0", path = "../sugar" }

--- a/compiler-frontend/checking/src/core/normalise.rs
+++ b/compiler-frontend/checking/src/core/normalise.rs
@@ -2,6 +2,7 @@
 
 use building_types::QueryResult;
 use itertools::Itertools;
+use smallvec::SmallVec;
 
 use crate::context::CheckContext;
 use crate::core::substitute::{NameToType, SubstituteName};
@@ -15,7 +16,7 @@ where
 {
     state: &'a mut CheckState,
     context: &'a CheckContext<'q, Q>,
-    compression: Vec<u32>,
+    compression: SmallVec<[u32; 4]>,
 }
 
 impl<'a, 'q, Q> ReductionContext<'a, 'q, Q>
@@ -23,7 +24,7 @@ where
     Q: ExternalQueries,
 {
     fn new(state: &'a mut CheckState, context: &'a CheckContext<'q, Q>) -> Self {
-        ReductionContext { state, context, compression: vec![] }
+        ReductionContext { state, context, compression: SmallVec::new() }
     }
 
     fn reduce_once(&mut self, id: TypeId) -> Option<TypeId> {


### PR DESCRIPTION
## Summary

Store the temporary unification path-compression chain in `SmallVec<[u32; 4]>`. Common short chains avoid heap allocation, while longer chains spill without changing traversal order or the unbounded, stack-safe behavior.

## Performance

Isolated allocation measurements during checking showed:

- Core: 14.67% fewer allocations and 3.34% fewer requested bytes
- Acme: 11.53% fewer allocations and 2.75% fewer requested bytes

Core wall time improved by 4%–7% in both alternating Criterion comparisons. Acme wall time was favorable but noisy. Scoped Core instructions were effectively flat (+0.09%), so this is specifically an allocator-cost optimization.

## Validation

- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (34/34)
- `just t checking` (no pending snapshots)