### PR TITLE
[checking] Skip empty skolem audits

### DIFF
--- a/compiler-frontend/checking/src/core/skolem.rs
+++ b/compiler-frontend/checking/src/core/skolem.rs
@@ -68,6 +68,9 @@ where
         let scopes = leading_scopes(context, expression.type_id);
         expected_skolems.extend(scopes);
     }
+    if expected_skolems.is_empty() {
+        return;
+    }
 
     let (errors, _) = collect_errors(
         &state.checked,
@@ -98,6 +101,9 @@ where
         Some(declaration),
         Pass::Discover,
     );
+    if expected_skolems.is_empty() {
+        return Ok(());
+    }
     let (errors, _) = collect_errors(
         &state.checked,
         &state.judgments,


### PR DESCRIPTION
## Summary

Skip the skolem audit traversal when there are no expected skolem scopes to escape.

Global checking returns after collecting an empty leading-scope set. Local checking still performs discovery first, then returns only if discovery found no expected scopes. Auditing remains unchanged whenever an escaped skolem can exist.

## Performance

Two isolated scoped Callgrind repetitions reduced Core checking instructions by 4.71% and 4.69%. Inclusive instructions fell approximately 74.7% in `skolem::collect_errors` and 74.9% in `skolem::inspect_type`. Wall-clock Core was favorable but noisy; Acme wall time was inconclusive.

## Validation

- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (34/34)
- focused skolem and overlap fixtures
- `just t checking` (no pending snapshots)