### PR TITLE
[checking] Prefilter instance overlap validation

### DIFF
--- a/compiler-frontend/checking/src/core/constraint/instances.rs
+++ b/compiler-frontend/checking/src/core/constraint/instances.rs
@@ -64,12 +64,6 @@ where
         return Ok(());
     };
 
-    let Some(OverlappingDeclaredCandidates { matches, wanted }) =
-        collect_overlapping_declared_candidates(state, context, origin, instance)?
-    else {
-        return Ok(());
-    };
-
     let Some(current_position) = context
         .indexed
         .items
@@ -80,15 +74,21 @@ where
         return Ok(());
     };
 
-    let overlap = matches.iter().any(|candidate| {
-        should_report_overlap(context, candidate.origin, origin, current_position)
-    });
+    let Some(OverlappingDeclaredCandidates { matches, wanted }) =
+        collect_overlapping_declared_candidates(
+            state,
+            context,
+            origin,
+            current_position,
+            instance,
+        )?
+    else {
+        return Ok(());
+    };
 
-    if overlap {
-        let constraint = state.canonicals.type_id(context, wanted);
-        let instances = matches.iter().map(|candidate| candidate.instance.signature).collect();
-        state.insert_error(ErrorKind::OverlappingInstances { constraint, instances });
-    }
+    let constraint = state.canonicals.type_id(context, wanted);
+    let instances = matches.iter().map(|candidate| candidate.instance.signature).collect();
+    state.insert_error(ErrorKind::OverlappingInstances { constraint, instances });
 
     Ok(())
 }
@@ -126,6 +126,7 @@ fn collect_overlapping_declared_candidates<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     origin: InstanceCandidateOrigin,
+    origin_position: usize,
     instance: CheckedInstance,
 ) -> QueryResult<Option<OverlappingDeclaredCandidates>>
 where
@@ -160,6 +161,28 @@ where
         }
     }
 
+    let reportable_overlap = search.chains.iter().flatten().filter(|candidate| {
+        !is_chain_sibling(**candidate, current_chain, origin)
+            && should_report_overlap(context, candidate.origin, origin, origin_position)
+    });
+    let mut found = false;
+    for candidate in reportable_overlap {
+        if constraint::matching::declared_instances_overlap(
+            state,
+            context,
+            instance,
+            candidate.instance,
+        )? {
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        return Ok(None);
+    }
+
+    // Preserve the complete candidate list used by overlap diagnostics. This
+    // second pass only runs for an instance that will produce a diagnostic.
     let mut matches = vec![];
     'chain: for chain in search.chains {
         for candidate in chain {


### PR DESCRIPTION
## Summary

Before structurally matching instance heads during declaration validation, exclude the current declaration, later local declarations, and same-chain siblings because none can trigger an overlap diagnostic for the declaration being checked.

When a reportable overlap is found, the original complete collection pass still runs. Diagnostics therefore retain the same complete instance list rather than exposing the prefilter through observable output.

## Performance

Isolated scoped Callgrind measurements reduced:

- Core checking-body instructions by 2.64%
- overlap-validation instructions by 27.79%
- declared-overlap matching instructions by 32.17%

Wall-clock direction was favorable but too noisy for a reliable magnitude claim.

## Validation

- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (34/34)
- `just t checking overlapping` (all selected fixtures)
- Core+Acme compatibility: 631 packages, 0 introduced or fixed diagnostics