### PR TITLE
[checking] Reuse loaded types during folding

### DIFF
--- a/compiler-frontend/checking/src/core/fold.rs
+++ b/compiler-frontend/checking/src/core/fold.rs
@@ -47,23 +47,23 @@ where
 {
     let mut id = normalise::normalise(state, context, id)?;
 
-    safe_loop! {
+    let t = safe_loop! {
         let t = context.lookup_type(id);
         match folder.transform(state, context, id, &t)? {
             FoldAction::Replace(id) => return Ok(id),
             FoldAction::ReplaceThen(then_id) => {
                 let then_id = normalise::normalise(state, context, then_id)?;
                 if then_id == id {
-                    break;
+                    break context.lookup_type(id);
                 }
                 id = then_id;
                 continue;
             }
             FoldAction::Continue => {
-                break;
-            },
+                break t;
+            }
         }
-    }
+    };
 
     macro_rules! fold_pair {
         ($first:ident, $second:ident, $intern:ident) => {{
@@ -77,7 +77,6 @@ where
         }};
     }
 
-    let t = context.lookup_type(id);
     let result = match t {
         Type::Application(function, argument) => {
             fold_pair!(function, argument, intern_application)


### PR DESCRIPTION
## Summary

Reuse the `Type` already loaded while deciding a fold action instead of immediately performing the same interner lookup again before traversing its children.

`ReplaceThen` still normalizes and reloads when it changes the ID; the reuse applies only when the loaded value still corresponds to the ID being folded.

## Performance

Two isolated scoped Callgrind repetitions reduced Core checking instructions by 1.5105% and 1.5018%. The steadier wall-clock comparison measured Acme 4.59% faster (95% CI 2.38%–6.77%); Core wall time remained within noise.

## Validation

- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (34/34)
- `just t checking` (no pending snapshots)