### PR TITLE
[checking] Store instance candidates in contiguous chains

### DIFF
--- a/compiler-frontend/checking/src/core/constraint.rs
+++ b/compiler-frontend/checking/src/core/constraint.rs
@@ -296,8 +296,8 @@ where
         }
 
         let search = instances::collect_instance_chains(state, context, constraint.key.wanted)?;
-        'chain: for chain in search.chains {
-            for candidate in chain {
+        'chain: for chain in search.chains() {
+            for &candidate in chain {
                 match matching::match_declared(state, context, constraint.key.wanted, candidate)? {
                     matching::MatchInstance::Match { unifications, constraints } => {
                         let constraints = fresh_scoped_constraints(state, &constraint, constraints);

--- a/compiler-frontend/checking/src/core/constraint/instances.rs
+++ b/compiler-frontend/checking/src/core/constraint/instances.rs
@@ -7,7 +7,7 @@ use files::FileId;
 use indexing::{
     DeriveId, IndexedModule, InstanceChainId, InstanceId, InstanceSourceItemId, TypeItemId,
 };
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 
 use crate::context::CheckContext;
 use crate::core::constraint::{CanonicalConstraint, CanonicalConstraintId};
@@ -48,8 +48,25 @@ pub struct InstanceCandidate {
 /// constraint solver would need to wait for these unification variables to
 /// be truly solved before constraint solving is abandoned.
 pub struct InstanceChains {
-    pub chains: Vec<Vec<InstanceCandidate>>,
+    candidates: Vec<InstanceCandidate>,
     pub blocking: Vec<u32>,
+}
+
+impl InstanceChains {
+    fn new(mut candidates: Vec<InstanceCandidate>, blocking: Vec<u32>) -> InstanceChains {
+        candidates.sort_by_key(|candidate| {
+            (
+                candidate.chain,
+                candidate.position,
+                candidate.chain.is_none().then_some(candidate.instance.signature),
+            )
+        });
+        InstanceChains { candidates, blocking }
+    }
+
+    pub fn chains(&self) -> impl Iterator<Item = &[InstanceCandidate]> {
+        self.candidates.chunk_by(|left, right| left.chain.is_some() && left.chain == right.chain)
+    }
 }
 
 pub fn validate_declared_instance_overlap<Q>(
@@ -161,8 +178,8 @@ where
     }
 
     let mut matches = vec![];
-    'chain: for chain in search.chains {
-        for candidate in chain {
+    'chain: for chain in search.chains() {
+        for &candidate in chain {
             if is_chain_sibling(candidate, current_chain, origin) {
                 continue;
             }
@@ -227,31 +244,7 @@ where
         }
     }
 
-    type Grouped = FxHashMap<InstanceChainKey, Vec<InstanceCandidate>>;
-
-    let mut grouped = Grouped::default();
-    let mut chains = vec![];
-
-    for instance in instances {
-        if let Some(chain) = instance.chain {
-            grouped.entry(chain).or_default().push(instance);
-        } else {
-            chains.push(vec![instance]);
-        }
-    }
-
-    for (_, mut chain) in grouped {
-        chain.sort_by_key(|instance| instance.position);
-        chains.push(chain);
-    }
-
-    chains.sort_by_key(|chain| {
-        chain
-            .first()
-            .map(|instance| (instance.chain, instance.position, instance.instance.signature))
-    });
-
-    Ok(InstanceChains { chains, blocking })
+    Ok(InstanceChains::new(instances, blocking))
 }
 
 fn instance_candidate_chain<Q>(

--- a/compiler-frontend/checking/src/source/derive/variance.rs
+++ b/compiler-frontend/checking/src/source/derive/variance.rs
@@ -843,7 +843,7 @@ where
         return Ok(false);
     };
     let instances = constraint::instances::collect_instance_chains(state, context, constraint)?;
-    for chain in instances.chains {
+    for chain in instances.chains() {
         for candidate in chain {
             let Some(candidate) =
                 toolkit::instance_info(state, context, candidate.instance.signature, class)?


### PR DESCRIPTION
## Change

Keep instance candidates in one stably sorted vector and expose chains as borrowed, nonempty slices. This removes the intermediate grouping map and per-chain/singleton vectors. Standalone identity, equal-key ordering, per-file chain scope, and blocking behavior are preserved, with an explicit ordering unit test.

This is one atomic compiler change against `main`, not stacked on another optimization. The branch contains only compiler changes and focused tests; benchmark helpers and raw reports are not committed or pushed.

## Independent measurement

Base: `fafeab9a815f5e3134989714d63a8f4cdd794e95` (the target `main` at measurement/publication preparation).
Head: `17523f95ccc4c6fc2b59699a63f0e66538197cd8`.

Workload: CLI compilation of package set **80.8.1**, core + acme, **631 packages / 7,356 PureScript sources**. This measures the compiler portion of the compatibility demo, not package preparation or Cargo startup.

| Metric | Base | This PR |
| --- | ---: | ---: |
| Allocation + reallocation requests | 103,866,163 | 100,968,044 (−2.79%) |
| Requested bytes, cumulative | 17,134,826,848 | 16,470,577,350 (−3.88%) |
| Paired wall-time change | — | −1.82% (exploratory 95% interval −7.17% to +3.38%) |

Normal-binary wall-time medians: 2.753 s → 2.741 s. The primary result is 2.9 million fewer allocation requests and 664 MB less requested allocation traffic. Isolated wall time is inconclusive.

Timing: 7 alternating paired rounds plus warmups, 12 Rayon threads, normal release binaries. Allocations: 3 paired rounds plus warmups, one thread, identical temporary counting-allocator examples in both revisions. Instrumented timings are **not** speed measurements. Requested bytes include full reallocation sizes; they are **not live memory or peak RSS**. No instruction-count claim is made.

Host: arm64 macOS / Darwin 25.6.0, 12 logical CPUs, 36 GiB RAM; Rust 1.97.0 (`2d8144b78`), LLVM 22.1.6. All comparisons were serialized. The initial timing session was superseded after competing background compute was reported; this table uses the complete rerun, not selected best samples. Intervals are exploratory paired bootstraps, not cross-machine guarantees. Other platforms should reproduce the comparison rather than inherit these percentages.

## Correctness and integration

`cargo check -p checking --tests`; 35 checking unit tests; full checking (378) and semantic (169) integration suites.

The full package comparison had 0 compiler errors, 0 verifier errors, and the same 36 warnings. Diagnostics and generated JavaScript matched the base byte-for-byte in the benchmark checks. All six local optimizations combined additionally passed 53 unit tests and 874 full checking/semantic/backend/LSP integration tests. Those combined results are validation only, not attributed as this PR's independent performance.

This is independent of the other optimization branches. Stable candidate order and chain semantics remain part of the compatibility contract.

## Reproduce independently on Linux or macOS

Prerequisites: a writable jj checkout of this repository, jj 0.45.1 or newer, Node.js 20+, Rust/Cargo (1.97.0 for matching the original toolchain), `rg`, `cc`, and the platform dependencies needed to build this Rust workspace. For a fresh checkout, use `jj git clone https://github.com/purefunctor/purescript-alexandrite.git` and enter it. Use the same Rust toolchain and build flags for both revisions.

The self-contained recipe below creates its helpers outside the checkout, fetches the source branch, prepares a fresh pinned corpus if needed, and builds **only this PR versus its base** in separate jj workspaces/target directories. It does not alter the caller's source files. It retains several GB of builds/output under `/tmp`; nothing is deleted. Builds finish before measurements begin. Stop other builds, tests, benchmarks, and compute-heavy work before running it; watch for indexing/thermal activity on interactive desktops.

Set `BENCHMARK_THREADS` for the machine (default 12), `BENCHMARK_ROUNDS` for timing samples (default 7), and optionally `BENCHMARK_FRESH_ROUNDS=5` for fresh-output measurements. To compare several PRs, reuse the exact prepared sources with `BENCHMARK_SOURCES=/absolute/path/to/corpus/sources`. The runner records exact revisions, tool versions, build flags, binary/helper hashes, raw measurements, diagnostic/output hashes, and summaries. Its corpus hash includes absolute paths, so compare content as well when moving the corpus between hosts.

The pinned base/head reproduce the reported atomic comparison. If `main` advances, rebase or integrate the PR onto that target and replace **both** revision variables accordingly; do not compare a stale PR head to an unrelated newer base and attribute all differences to this patch.

<details>
<summary>Copy-paste reproduction recipe (temporary helpers; no benchmark files in the PR)</summary>

```sh
set -eu
benchmark_repository="$(jj --ignore-working-copy root)"
jj --ignore-working-copy git fetch --remote origin --branch main --branch perf-instance-chains
benchmark_base=fafeab9a815f5e3134989714d63a8f4cdd794e95
benchmark_head=17523f95ccc4c6fc2b59699a63f0e66538197cd8
benchmark_helpers="$(mktemp -d /tmp/alexandrite-recipe.XXXXXX)"
benchmark_workspace_prefix="$(basename "$benchmark_helpers")"
mkdir -p "$benchmark_helpers/tests-compatibility/performance" "$benchmark_helpers/compiler-bin/examples"

cat > "$benchmark_helpers/tests-compatibility/performance/reproduce.mjs" <<'ALEXANDRITE_HELPER_0'
import { createHash } from 'node:crypto';
import { spawnSync } from 'node:child_process';
import { closeSync, existsSync, mkdirSync, mkdtempSync, openSync, readFileSync, readdirSync, realpathSync, writeFileSync } from 'node:fs';
import { basename, dirname, join, resolve } from 'node:path';
import { fileURLToPath } from 'node:url';
import { parseArgs } from 'node:util';

const { values } = parseArgs({ options: {
  base: { type: 'string' }, candidate: { type: 'string' }, sources: { type: 'string' },
  repository: { type: 'string' },
  output: { type: 'string', default: '/tmp' }, threads: { type: 'string', default: '1' },
  rounds: { type: 'string', default: '7' }, 'allocation-rounds': { type: 'string', default: '3' },
  'fresh-rounds': { type: 'string', default: '0' }, help: { type: 'boolean', default: false },
} });
if (values.help) {
  console.log(`Usage: node reproduce.mjs --base REV --candidate REV --sources DIRECTORY
  --repository DIRECTORY   jj checkout containing the commits (default: current checkout)
  --output DIRECTORY       Parent for a new retained run directory (default: /tmp)
  --threads N              Timing/fresh compiler threads (default: 1)
  --rounds N               Paired timing rounds (default: 7)
  --allocation-rounds N    Paired allocation rounds, using one thread (default: 3)
  --fresh-rounds N         Extra fresh-output timing rounds (default: 0, disabled)

Requires jj, Rust/Cargo, rg, cc, and Node.js 20+ on Linux or macOS.
Both revisions must already be present in the specified jj repository.`);
  process.exit(0);
}
for (const name of ['base', 'candidate', 'sources']) {
  if (!values[name]) throw new Error(`Missing --${name}; see --help`);
}
for (const name of ['threads', 'rounds', 'allocation-rounds', 'fresh-rounds']) {
  const minimum = name === 'fresh-rounds' ? 0 : 1;
  if (!/^\d+$/.test(values[name]) || !Number.isSafeInteger(Number(values[name])) || Number(values[name]) < minimum) {
    throw new Error(`--${name} must be an integer >= ${minimum}`);
  }
}
if (!['linux', 'darwin'].includes(process.platform)) throw new Error('Linux or macOS is required');

const harness = dirname(fileURLToPath(import.meta.url));
const helperRoot = resolve(harness, '../..');
function capture(command, arguments_, cwd = repository) {
  const result = spawnSync(command, arguments_, { cwd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
  if (result.error || result.status !== 0) throw new Error(`${command}: ${result.error || result.stderr || result.status}`);
  return result.stdout.trim();
}
const repository = capture('jj', ['--ignore-working-copy', 'root'], resolve(values.repository || process.cwd()));
function revision(expression) {
  const commit = capture('jj', ['--ignore-working-copy', 'log', '--no-graph', '-r', expression, '-T', 'commit_id ++ "\\n"']);
  if (!/^[0-9a-f]{40}$/.test(commit)) throw new Error(`Expected exactly one commit for ${expression}`);
  return commit;
}
const revisions = { baseline: revision(values.base), candidate: revision(values.candidate) };
const sources = realpathSync(values.sources);
const sourceFiles = capture('rg', ['--files', '--no-ignore', '--null', '-g', '*.purs', sources]);
if (!sourceFiles) throw new Error(`No PureScript sources found in ${sources}`);
const rustc = capture('rustc', ['-vV']);
const host = rustc.match(/^host: (.+)$/m)?.[1];
if (!host) throw new Error('Cannot determine the native Rust target');
const versions = {
  rustc, cargo: capture('cargo', ['--version']), jj: capture('jj', ['--version']),
  node: process.version, cc: capture('cc', ['--version']), rg: capture('rg', ['--version']),
};
mkdirSync(resolve(values.output), { recursive: true });
const output = mkdtempSync(join(resolve(values.output), 'alexandrite-performance-'));
console.log(`Retaining workspaces, builds, logs, and results in ${output}`);
const examplePath = 'compiler-bin/examples/measure-allocations.rs';
const example = readFileSync(join(helperRoot, examplePath));
const hash = content => createHash('sha256').update(content).digest('hex');
const provenance = {
  repository, revisions, sources, versions, options: values,
  environment: Object.fromEntries(Object.entries(process.env).filter(([name]) =>
    ['RUSTFLAGS', 'CARGO_ENCODED_RUSTFLAGS', 'RUSTC', 'RUSTC_WRAPPER', 'RUSTC_WORKSPACE_WRAPPER'].includes(name)
      || name.startsWith('CARGO_PROFILE_RELEASE_') || name.startsWith('CARGO_BUILD_'))),
  harness: Object.fromEntries(['reproduce.mjs', 'run.mjs', 'summarize.mjs', 'measure.c'].map(name =>
    [name, hash(readFileSync(join(harness, name)))])),
  allocationExampleSha256: hash(example), commands: [], variants: [], results: [],
};
function saveProvenance() {
  writeFileSync(join(output, 'provenance.json'), JSON.stringify(provenance, null, 2));
}
function execute(command, arguments_, cwd, logName, environment = process.env) {
  const log = join(output, logName);
  provenance.commands.push({ command, arguments: arguments_, cwd, log });
  saveProvenance();
  console.log(`${logName}: ${command} ${arguments_.join(' ')}`);
  const descriptor = openSync(log, 'wx');
  let result;
  try {
    result = spawnSync(command, arguments_, { cwd, env: environment, stdio: ['ignore', descriptor, descriptor] });
  } finally {
    closeSync(descriptor);
  }
  if (result.error || result.status !== 0) throw new Error(`${command} failed: ${result.error || result.status}; inspect ${log}`);
}

const controller = join(output, 'controller');
execute('jj', ['--ignore-working-copy', 'workspace', 'add', '--sparse-patterns', 'full',
  '--name', `${basename(output)}-controller`, '-r', 'root()', controller], repository, 'controller-workspace.log');
for (const [name, commit] of Object.entries(revisions)) {
  const workspace = join(output, name);
  const workspaceName = `${basename(output)}-${name}`;
  execute('jj', ['workspace', 'add', '--sparse-patterns', 'full', '--name', workspaceName, '-r', commit, workspace],
    controller, `${name}-workspace.log`);
  const allocationExample = join(workspace, examplePath);
  if (existsSync(allocationExample)) {
    if (!readFileSync(allocationExample).equals(example)) throw new Error(`Different allocation instrumentation already exists at ${allocationExample}`);
  } else {
    mkdirSync(dirname(allocationExample), { recursive: true });
    writeFileSync(allocationExample, example, { flag: 'wx' });
  }
  const target = join(output, `${name}-target`);
  execute('cargo', ['build', '--locked', '--release', '--target', host, '-p', 'purescript-alexandrite',
    '--bin', 'purescript-alexandrite', '--example', 'measure-allocations'], workspace, `${name}-build.log`,
    { ...process.env, CARGO_TARGET_DIR: target });
  const binary = join(target, host, 'release', 'purescript-alexandrite');
  const allocations = join(target, host, 'release', 'examples', 'measure-allocations');
  provenance.variants.push({
    name, revision: commit, workspace, workspaceName, target, binary, allocations,
    binarySha256: hash(readFileSync(binary)), allocationsSha256: hash(readFileSync(allocations)),
    cargoLockSha256: hash(readFileSync(join(workspace, 'Cargo.lock'))),
  });
  saveProvenance();
}
const measure = join(output, 'measure');
execute('cc', ['-O2', join(harness, 'measure.c'), '-o', measure], output, 'measure-build.log');
const results = join(output, 'results');
const manifest = join(output, 'manifest.json');
writeFileSync(manifest, JSON.stringify({ sources, cwd: output, measure, results, variants: provenance.variants }, null, 2));
for (const [mode, rounds, threads] of [
  ['timing', values.rounds, values.threads],
  ['allocations', values['allocation-rounds'], '1'],
  ['fresh', values['fresh-rounds'], values.threads],
]) {
  if (Number(rounds) === 0) continue;
  execute(process.execPath, [join(harness, 'run.mjs'), manifest, mode, rounds, threads], output, `${mode}.log`);
}
provenance.results = readdirSync(results).sort().map(name => join(results, name, 'results.json'));
saveProvenance();
execute(process.execPath, [join(harness, 'summarize.mjs'), ...provenance.results], output, 'summary.txt');
console.log(readFileSync(join(output, 'summary.txt'), 'utf8'));
console.log(`Complete. Exact revisions, toolchains, instrumentation and binary hashes: ${join(output, 'provenance.json')}`);
ALEXANDRITE_HELPER_0

cat > "$benchmark_helpers/tests-compatibility/performance/run.mjs" <<'ALEXANDRITE_HELPER_1'
import { createHash } from 'node:crypto';
import { spawnSync } from 'node:child_process';
import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
import { join, resolve } from 'node:path';
import os from 'node:os';

const [manifestPath, mode = 'timing', roundsText = '7', threadsText = '12'] = process.argv.slice(2);
if (!manifestPath || !['timing', 'allocations', 'fresh'].includes(mode)) {
  throw new Error('Usage: node run.mjs MANIFEST [timing|allocations|fresh] [rounds] [threads]');
}
const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
const rounds = Number(roundsText);
const threads = Number(threadsText);
if (!Number.isInteger(rounds) || rounds < 1 || !Number.isInteger(threads) || threads < 1) {
  throw new Error('Rounds and threads must be positive integers');
}
const discovery = spawnSync('rg', ['--files', '--no-ignore', '--null', '-g', '*.purs', resolve(manifest.sources)], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
if (discovery.error || discovery.status !== 0) throw new Error(discovery.error || discovery.stderr);
const sources = discovery.stdout.split('\0').filter(Boolean).sort();
const corpus = createHash('sha256');
for (const source of sources) {
  for (const path of [source, `${source.slice(0, -5)}.js`, `${source.slice(0, -5)}.jsx`]) {
    corpus.update(path).update('\0');
    if (existsSync(path)) {
      const content = readFileSync(path);
      corpus.update(String(content.length)).update('\0').update(content);
    } else {
      corpus.update('missing\0');
    }
  }
}
const binaries = manifest.variants.map(variant => ({
  name: variant.name,
  binarySha256: createHash('sha256').update(readFileSync(variant.binary)).digest('hex'),
  allocationsSha256: createHash('sha256').update(readFileSync(variant.allocations)).digest('hex'),
}));
mkdirSync(resolve(manifest.results), { recursive: true });
const resultsDirectory = mkdtempSync(join(resolve(manifest.results), `${mode}-${threads}-`));
const environment = { ...process.env, RAYON_NUM_THREADS: String(threads), NO_COLOR: '1' };
const rows = [];
let expectedDiagnostics;
let expectedOutput;

function outputDigest(directory) {
  const files = [];
  function visit(current, relative = '') {
    for (const entry of readdirSync(current, { withFileTypes: true })) {
      const path = join(relative, entry.name);
      if (entry.isDirectory()) visit(join(current, entry.name), path);
      else if (entry.isFile()) files.push(path);
    }
  }
  visit(directory);
  const hash = createHash('sha256');
  for (const file of files.sort()) hash.update(file).update('\0').update(readFileSync(join(directory, file)));
  return { files: files.length, sha256: hash.digest('hex') };
}

function run(variant, round) {
  const output = mode === 'fresh'
    ? mkdtempSync(join(resultsDirectory, `${variant.name}-${round}-output-`))
    : join(resultsDirectory, `${variant.name}-output`);
  const binary = mode === 'allocations' ? variant.allocations : variant.binary;
  const result = spawnSync(resolve(manifest.measure), [resolve(binary), 'compile', '--output', output, ...sources], {
    cwd: resolve(manifest.cwd), env: environment, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024,
  });
  const logName = `${variant.name}-${round}.stderr`;
  writeFileSync(join(resultsDirectory, logName), result.stderr || '');
  if (result.error || result.status !== 0) throw new Error(`${variant.name}: ${result.error || result.status}; inspect ${logName}`);
  const resource = JSON.parse(result.stdout.trim());
  const allocationLine = result.stderr.match(/^ALLOCATION_METRICS (.*)$/m);
  const allocations = allocationLine ? JSON.parse(allocationLine[1]) : undefined;
  if (mode === 'allocations' && !allocations) throw new Error('Missing allocation counters');
  const diagnostics = result.stderr.replace(/^ALLOCATION_METRICS .*\n?/m, '');
  const diagnosticsDigest = createHash('sha256').update(diagnostics).digest('hex');
  if (expectedDiagnostics && diagnosticsDigest !== expectedDiagnostics) throw new Error(`Diagnostics changed for ${variant.name}`);
  expectedDiagnostics = diagnosticsDigest;
  let generated;
  if (round === -1 || mode === 'fresh' || round === rounds - 1) {
    generated = outputDigest(output);
    if (expectedOutput && generated.sha256 !== expectedOutput.sha256) throw new Error(`Generated output changed for ${variant.name}`);
    expectedOutput = generated;
  }
  const row = { variant: variant.name, revision: variant.revision, round, ...resource, allocations, diagnosticsDigest, generated };
  rows.push(row);
  writeFileSync(join(resultsDirectory, 'results.json'), JSON.stringify({
    mode, rounds, threads, sourceCount: sources.length, corpus: corpus.copy().digest('hex'),
    host: { platform: os.platform(), release: os.release(), architecture: os.arch(), cpus: os.cpus().length, memory: os.totalmem() },
    manifest, binaries, rows,
  }, null, 2));
  console.log(JSON.stringify(row));
}

for (const variant of manifest.variants) run(variant, -1);
for (let round = 0; round < rounds; round++) {
  const order = round % 2 ? [...manifest.variants].reverse() : [...manifest.variants];
  for (const variant of order) run(variant, round);
}
console.log(`Results: ${resultsDirectory}`);
ALEXANDRITE_HELPER_1

cat > "$benchmark_helpers/tests-compatibility/performance/summarize.mjs" <<'ALEXANDRITE_HELPER_2'
import { readFileSync } from 'node:fs';

function median(values) {
  const sorted = [...values].sort((left, right) => left - right);
  const middle = Math.floor(sorted.length / 2);
  return sorted.length % 2 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
}

let seed = 20260905;
function random() {
  seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
  return seed / 4294967296;
}

function pairedInterval(ratios) {
  const samples = [];
  for (let iteration = 0; iteration < 20000; iteration++) {
    let logarithms = 0;
    for (let index = 0; index < ratios.length; index++) {
      logarithms += Math.log(ratios[Math.floor(random() * ratios.length)]);
    }
    samples.push(100 * (Math.exp(logarithms / ratios.length) - 1));
  }
  samples.sort((left, right) => left - right);
  return [samples[500], samples[19499]];
}

for (const path of process.argv.slice(2)) {
  const results = JSON.parse(readFileSync(path, 'utf8'));
  if (results.rows.length !== results.manifest.variants.length * (results.rounds + 1)) {
    throw new Error(`${path}: incomplete or duplicate results`);
  }
  for (const variant of results.manifest.variants) {
    for (let round = -1; round < results.rounds; round++) {
      const matching = results.rows.filter(row => row.variant === variant.name && row.round === round);
      if (matching.length !== 1 || matching[0].exit_code !== 0) {
        throw new Error(`${path}: invalid ${variant.name} round ${round}`);
      }
      if ((round === -1 || round === results.rounds - 1) && !matching[0].generated) {
        throw new Error(`${path}: missing output digest for ${variant.name} round ${round}`);
      }
    }
  }
  const rows = results.rows.filter(row => row.round >= 0);
  const baseline = rows.filter(row => row.variant === 'baseline');
  if (!baseline.length) throw new Error(`${path}: missing baseline`);
  const summary = [];
  for (const variant of results.manifest.variants) {
    const samples = rows.filter(row => row.variant === variant.name);
    const ratios = samples.map(row => row.wall_seconds / baseline.find(base => base.round === row.round).wall_seconds);
    summary.push({
      variant: variant.name, revision: variant.revision, samples: samples.length,
      wallMedian: median(samples.map(row => row.wall_seconds)),
      wallMinimum: Math.min(...samples.map(row => row.wall_seconds)),
      wallMaximum: Math.max(...samples.map(row => row.wall_seconds)),
      pairedWallChangePercent: 100 * (Math.exp(ratios.reduce((sum, ratio) => sum + Math.log(ratio), 0) / ratios.length) - 1),
      pairedWallBootstrap95Percent: pairedInterval(ratios),
      cpuMedian: median(samples.map(row => row.user_seconds + row.system_seconds)),
      peakResidentMedian: median(samples.map(row => row.peak_resident_bytes)),
      allocationRequestsMedian: samples[0].allocations ? median(samples.map(row => row.allocations.allocations + row.allocations.reallocations)) : undefined,
      requestedBytesMedian: samples[0].allocations ? median(samples.map(row => row.allocations.requested_bytes)) : undefined,
    });
  }
  console.log(JSON.stringify({ path, mode: results.mode, threads: results.threads, sourceCount: results.sourceCount, summary }, null, 2));
}
ALEXANDRITE_HELPER_2

cat > "$benchmark_helpers/tests-compatibility/performance/measure.c" <<'ALEXANDRITE_HELPER_3'
#include <errno.h>
#include <stdio.h>
#include <stdlib.h>
#include <sys/resource.h>
#include <sys/wait.h>
#include <time.h>
#include <unistd.h>

int main(int argument_count, char **arguments) {
    if (argument_count < 2) return 2;
    struct timespec start, finish;
    clock_gettime(CLOCK_MONOTONIC, &start);
    pid_t child = fork();
    if (child < 0) return 2;
    if (child == 0) {
        execv(arguments[1], arguments + 1);
        perror("execv");
        _exit(127);
    }
    struct rusage usage;
    int status;
    while (wait4(child, &status, 0, &usage) < 0) {
        if (errno != EINTR) return 2;
    }
    clock_gettime(CLOCK_MONOTONIC, &finish);
    double wall = finish.tv_sec - start.tv_sec + (finish.tv_nsec - start.tv_nsec) / 1e9;
    double user = usage.ru_utime.tv_sec + usage.ru_utime.tv_usec / 1e6;
    double system = usage.ru_stime.tv_sec + usage.ru_stime.tv_usec / 1e6;
#ifdef __APPLE__
    long resident_bytes = usage.ru_maxrss;
#else
    long resident_bytes = usage.ru_maxrss * 1024;
#endif
    int exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : 128 + WTERMSIG(status);
    printf("{\"wall_seconds\":%.9f,\"user_seconds\":%.6f,\"system_seconds\":%.6f,\"peak_resident_bytes\":%ld,\"exit_code\":%d}\n",
           wall, user, system, resident_bytes, exit_code);
    return exit_code;
}
ALEXANDRITE_HELPER_3

cat > "$benchmark_helpers/compiler-bin/examples/measure-allocations.rs" <<'ALEXANDRITE_HELPER_4'
use std::alloc::{GlobalAlloc, Layout, System};
use std::sync::atomic::{AtomicU64, Ordering};

struct CountingAllocator;

static ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
static REALLOCATIONS: AtomicU64 = AtomicU64::new(0);
static REQUESTED_BYTES: AtomicU64 = AtomicU64::new(0);

#[global_allocator]
static ALLOCATOR: CountingAllocator = CountingAllocator;

unsafe impl GlobalAlloc for CountingAllocator {
    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
        REQUESTED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
        unsafe { System.alloc(layout) }
    }

    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
        REQUESTED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
        unsafe { System.alloc_zeroed(layout) }
    }

    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, size: usize) -> *mut u8 {
        REALLOCATIONS.fetch_add(1, Ordering::Relaxed);
        REQUESTED_BYTES.fetch_add(size as u64, Ordering::Relaxed);
        unsafe { System.realloc(pointer, layout, size) }
    }

    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
        unsafe { System.dealloc(pointer, layout) }
    }
}

fn main() {
    purescript_alexandrite::run();
    let allocations = ALLOCATIONS.load(Ordering::Relaxed);
    let reallocations = REALLOCATIONS.load(Ordering::Relaxed);
    let requested_bytes = REQUESTED_BYTES.load(Ordering::Relaxed);
    eprintln!(
        "ALLOCATION_METRICS {{\"allocations\":{allocations},\"reallocations\":{reallocations},\"requested_bytes\":{requested_bytes}}}"
    );
}
ALEXANDRITE_HELPER_4


if [ -n "${BENCHMARK_SOURCES:-}" ]; then
  benchmark_sources="$BENCHMARK_SOURCES"
else
  jj --ignore-working-copy workspace add --sparse-patterns full \
    --name "$benchmark_workspace_prefix-prepare-controller" -r 'root()' "$benchmark_helpers/controller"
  (
    cd "$benchmark_helpers/controller"
    jj workspace add --sparse-patterns full --name "$benchmark_workspace_prefix-prepare" \
      -r "$benchmark_base" "$benchmark_helpers/prepare"
  )
  (
    cd "$benchmark_helpers/prepare"
    CARGO_TARGET_DIR="$benchmark_helpers/prepare-target" cargo run --locked --release \
      -p tests-compatibility -- prepare --package-set 80.8.1 \
      --preset core --preset acme --cache-dir "$benchmark_helpers/corpus"
  )
  benchmark_sources="$benchmark_helpers/corpus/sources"
fi
benchmark_source_count="$(rg --files --no-ignore -g '*.purs' "$benchmark_sources" | wc -l)"
test "$benchmark_source_count" -eq 7356 || {
  echo "Expected 7356 sources from package set 80.8.1; inspect the corpus before comparing." >&2
  exit 1
}
node "$benchmark_helpers/tests-compatibility/performance/reproduce.mjs" \
  --repository "$benchmark_repository" --base "$benchmark_base" --candidate "$benchmark_head" \
  --sources "$benchmark_sources" --threads "${BENCHMARK_THREADS:-12}" \
  --rounds "${BENCHMARK_ROUNDS:-7}" --allocation-rounds 3 \
  --fresh-rounds "${BENCHMARK_FRESH_ROUNDS:-0}"
```

</details>

Inspect the printed `summary.txt`, `provenance.json`, and each `results.json`. Normal timing and allocator runs are separate; ignore wall/CPU columns in allocation-mode summaries. The runner rejects failed runs, diagnostic/output differences, and incomplete result sets. Keep the raw samples when reporting an independent result.

