### PR TITLE
[checking] Represent declaration evidence abstractions with binders

### DIFF
--- a/compiler-backend/functional/src/convert/declaration.rs
+++ b/compiler-backend/functional/src/convert/declaration.rs
@@ -165,10 +165,7 @@ fn value_declaration(
     let body = equations(context, &value.equations)?;
     let mut evidence_parameters = Vec::new();
     for abstraction in value.abstractions.iter() {
-        if let checking_tree::DeclarationAbstraction::Evidence { evidence, .. } = abstraction {
-            let Evidence::Given(binder) = evidence else {
-                return Err(context.unsupported(UnsupportedState::InvalidInstancePrerequisite));
-            };
+        if let checking_tree::DeclarationAbstraction::Evidence { binder, .. } = abstraction {
             evidence_parameters.push(context.evidence_parameter(*binder)?);
         }
     }

--- a/compiler-frontend/checking/src/core/generalise.rs
+++ b/compiler-frontend/checking/src/core/generalise.rs
@@ -28,7 +28,7 @@ use crate::context::CheckContext;
 use crate::core::constraint::{CanonicalConstraintId, ConstraintInScope, compiler, elaborate};
 use crate::core::walk::{TypeWalker, WalkAction, walk_type};
 use crate::core::{ForallBinder, Name, Type, TypeId, normalise, zonk};
-use crate::evidence::Evidence;
+use crate::evidence::{Evidence, EvidenceBinderId};
 use crate::state::{CheckState, UnificationEntry, UnificationState};
 use crate::{ExternalQueries, safe_loop};
 
@@ -277,8 +277,7 @@ pub struct ConstraintErrors {
 
 pub struct ConstrainedByResiduals {
     pub type_id: TypeId,
-    pub constraints: Vec<TypeId>,
-    pub evidences: Vec<Evidence>,
+    pub constraints: Vec<GeneralisedConstraint>,
 }
 
 pub fn constrain_using_residuals<Q>(
@@ -292,11 +291,7 @@ where
     Q: ExternalQueries,
 {
     if residuals.is_empty() {
-        return Ok(ConstrainedByResiduals {
-            type_id: unconstrained,
-            constraints: vec![],
-            evidences: vec![],
-        });
+        return Ok(ConstrainedByResiduals { type_id: unconstrained, constraints: vec![] });
     }
 
     for residual in residuals.iter_mut() {
@@ -309,19 +304,12 @@ where
 
     let residuals = partial.into_iter().chain(residuals);
     let generalised = residuals.sorted_by_key(|constraint| constraint.key.wanted).collect_vec();
-    let generalised = finalise_generalised_constraints(state, context, generalised)?;
+    let constraints = finalise_generalised_constraints(state, context, generalised)?;
+    let constrained = constraints.iter().rfold(unconstrained, |inner, constraint| {
+        context.intern_constrained(constraint.constraint, inner)
+    });
 
-    let constraints = generalised
-        .iter()
-        .map(|generalised| state.canonicals.type_id(context, generalised.constraint));
-    let constraints = constraints.collect::<Vec<_>>();
-    let constrained = constraints
-        .iter()
-        .rfold(unconstrained, |inner, &constraint| context.intern_constrained(constraint, inner));
-    let evidences = generalised.into_iter().map(|generalised| generalised.evidence);
-    let evidences = evidences.collect();
-
-    Ok(ConstrainedByResiduals { type_id: constrained, constraints, evidences })
+    Ok(ConstrainedByResiduals { type_id: constrained, constraints })
 }
 
 type PrunedPartial = (Vec<ConstraintInScope>, Option<ConstraintInScope>);
@@ -446,9 +434,9 @@ where
     Ok(constraints.into_values().collect())
 }
 
-struct GeneralisedConstraint {
-    constraint: CanonicalConstraintId,
-    evidence: Evidence,
+pub struct GeneralisedConstraint {
+    pub constraint: TypeId,
+    pub binder: EvidenceBinderId,
 }
 
 fn finalise_generalised_constraints<Q>(
@@ -473,22 +461,17 @@ where
         minimise_by_superclasses(state, context, generalisable)?;
 
     let mut evidences = vec![];
-    let mut declaration_evidences = vec![];
+    let mut generalised = vec![];
     for constraint in &retained {
         let ConstraintInScope { key, evidence } = constraint;
-        let declaration_evidence = if constraint.is_partial(state, context) {
-            Evidence::Trivial
-        } else {
-            let canonical = state.canonicals.type_id(context, key.wanted);
-            let binder = state.checked.evidence.fresh_binder(canonical);
-            Evidence::Given(binder)
-        };
-
-        let proof = state.checked.evidence.allocate(declaration_evidence.clone());
+        let canonical = state.canonicals.type_id(context, key.wanted);
+        // These binders belong to the declaration, not the surrounding implication.
+        let binder = state.checked.evidence.fresh_binder(canonical);
+        let proof = state.checked.evidence.allocate(Evidence::Given(binder));
         state.checked.evidence.solve(evidence.wanted, proof);
 
         evidences.push((key.wanted, proof));
-        declaration_evidences.push(declaration_evidence);
+        generalised.push(GeneralisedConstraint { constraint: canonical, binder });
     }
 
     let projections = elaborate::elaborate_superclasses_with_evidence(state, context, &evidences)?;
@@ -502,12 +485,7 @@ where
         }
     }
 
-    let retained = retained.into_iter().zip(declaration_evidences);
-    let retained = retained.map(|(constraint, evidence)| GeneralisedConstraint {
-        constraint: constraint.key.wanted,
-        evidence,
-    });
-    Ok(retained.collect())
+    Ok(generalised)
 }
 
 struct MinimisedBySuperclasses {

--- a/compiler-frontend/checking/src/evidence.rs
+++ b/compiler-frontend/checking/src/evidence.rs
@@ -83,7 +83,8 @@ pub enum Evidence {
     Superclass { parent: EvidenceId, superclass: SuperclassId },
     /// Compiler-solved evidence with no materialised dictionary contents.
     ///
-    /// This proof does not remove its evidence application or abstraction.
+    /// This proof does not remove its evidence application. Evidence
+    /// abstractions introduce binders independently of the supplied proof.
     Trivial,
     /// Compiler-known evidence which must be materialised at runtime.
     Synthesized(SynthesizedEvidence),

--- a/compiler-frontend/checking/src/source/term_items.rs
+++ b/compiler-frontend/checking/src/source/term_items.rs
@@ -904,12 +904,13 @@ where
                     residuals,
                     &mut errors,
                 )?;
-                let inferred_constraints = !constrained.evidences.is_empty();
-                let abstractions = std::iter::zip(constrained.constraints, constrained.evidences)
-                    .map(|(constraint, evidence)| tree::DeclarationAbstraction::Evidence {
-                        constraint,
-                        evidence,
-                    });
+                let inferred_constraints = !constrained.constraints.is_empty();
+                let abstractions = constrained.constraints.into_iter().map(|constraint| {
+                    tree::DeclarationAbstraction::Evidence {
+                        constraint: constraint.constraint,
+                        binder: constraint.binder,
+                    }
+                });
                 let abstractions = abstractions.collect();
                 (constrained.type_id, abstractions, equations, inferred_constraints)
             }

--- a/compiler-frontend/checking/src/source/terms/equations.rs
+++ b/compiler-frontend/checking/src/source/terms/equations.rs
@@ -9,7 +9,6 @@ use building_types::QueryResult;
 use crate::context::CheckContext;
 use crate::core::{TypeId, signature, toolkit, unification};
 use crate::error::ErrorKind;
-use crate::evidence::Evidence;
 use crate::source::binder;
 use crate::source::terms::guarded;
 use crate::state::CheckState;
@@ -156,11 +155,8 @@ pub fn bind_signature_abstractions(
             tree::DeclarationAbstraction::Type { binder, rigid }
         }
         signature::SkolemisedAbstraction::Constraint { constraint } => {
-            let evidence = state.push_given(constraint);
-            tree::DeclarationAbstraction::Evidence {
-                constraint,
-                evidence: Evidence::Given(evidence),
-            }
+            let binder = state.push_given(constraint);
+            tree::DeclarationAbstraction::Evidence { constraint, binder }
         }
     });
     abstractions.collect()

--- a/compiler-frontend/checking/src/tree.rs
+++ b/compiler-frontend/checking/src/tree.rs
@@ -68,7 +68,7 @@ pub struct ValueDeclaration {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeclarationAbstraction {
     Type { binder: ForallBinderId, rigid: TypeId },
-    Evidence { constraint: TypeId, evidence: Evidence },
+    Evidence { constraint: TypeId, binder: EvidenceBinderId },
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/compiler-frontend/checking/src/tree/pretty.rs
+++ b/compiler-frontend/checking/src/tree/pretty.rs
@@ -561,9 +561,7 @@ where
 
         let mut evidence_names = EvidenceNames::new();
         for abstraction in value.abstractions.iter() {
-            if let DeclarationAbstraction::Evidence { evidence: Evidence::Given(binder), .. } =
-                abstraction
-            {
+            if let DeclarationAbstraction::Evidence { binder, .. } = abstraction {
                 self.evidence_binder_name(&mut evidence_names, *binder)?;
             }
         }
@@ -635,17 +633,20 @@ where
                     };
 
                     let mut evidence_names = EvidenceNames::new();
-                    let instance_evidences =
-                        instance.evidences.iter().map(|evidence| &evidence.evidence);
-                    let member_evidences =
+                    let instance_binders = instance.evidences.iter().filter_map(|evidence| {
+                        if let Evidence::Given(binder) = &evidence.evidence {
+                            Some(binder)
+                        } else {
+                            None
+                        }
+                    });
+                    let member_binders =
                         member.abstractions.iter().filter_map(|abstraction| match abstraction {
-                            DeclarationAbstraction::Evidence { evidence, .. } => Some(evidence),
+                            DeclarationAbstraction::Evidence { binder, .. } => Some(binder),
                             DeclarationAbstraction::Type { .. } => None,
                         });
-                    for evidence in instance_evidences.chain(member_evidences) {
-                        if let Evidence::Given(binder) = evidence {
-                            self.evidence_binder_name(&mut evidence_names, *binder)?;
-                        }
+                    for binder in instance_binders.chain(member_binders) {
+                        self.evidence_binder_name(&mut evidence_names, *binder)?;
                     }
 
                     let (signature, member_rigid_names) =
@@ -955,10 +956,10 @@ where
             for abstraction in declaration_abstractions {
                 // Type abstractions are omitted because the declaration's
                 // rendered signature already communicates its binders.
-                let DeclarationAbstraction::Evidence { evidence, .. } = abstraction else {
+                let DeclarationAbstraction::Evidence { binder, .. } = abstraction else {
                     continue;
                 };
-                let binder = self.evidence_name(evidence_names, evidence)?;
+                let binder = self.evidence_binder_name(evidence_names, *binder)?;
                 abstractions.push(self.arena.text(format!("\\{{{binder}}} ->")));
             }
             for &binder in equation.binders.iter() {
@@ -1031,9 +1032,7 @@ where
         self.assign_rigid_names(type_pretty, &rigid_names);
 
         for abstraction in declaration.value.abstractions.iter() {
-            if let DeclarationAbstraction::Evidence { evidence: Evidence::Given(binder), .. } =
-                abstraction
-            {
+            if let DeclarationAbstraction::Evidence { binder, .. } = abstraction {
                 self.evidence_binder_name(evidence_names, *binder)?;
             }
         }

--- a/tests-integration/fixtures/backend/1788675780_inferred_partial_value/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788675780_inferred_partial_value/Main.functional.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+cannot convert checked module Idx::<File>(45): instance prerequisite is not represented by given evidence

--- a/tests-integration/fixtures/backend/1788675780_inferred_partial_value/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788675780_inferred_partial_value/Main.functional.snap
@@ -3,4 +3,17 @@ source: tests-integration/tests/functional.rs
 assertion_line: 14
 expression: report
 ---
-cannot convert checked module Idx::<File>(45): instance prerequisite is not represented by given evidence
+@export constructor Just/1
+
+@export constructor Nothing/0
+
+@export test = \partialDict%1 ->
+  let
+    Just x%0 = { tag: "Just", _1: 1 }
+  in x%0
+
+@export foreign unsafePartial
+
+@export consumed = \partialDict%2 -> test partialDict%2
+
+@export discharged = unsafePartial (\partialDict%3 -> test partialDict%3)

--- a/tests-integration/fixtures/backend/1788675780_inferred_partial_value/Main.js
+++ b/tests-integration/fixtures/backend/1788675780_inferred_partial_value/Main.js
@@ -1,0 +1,1 @@
+export const unsafePartial = computation => computation({});

--- a/tests-integration/fixtures/backend/1788675780_inferred_partial_value/Main.purs
+++ b/tests-integration/fixtures/backend/1788675780_inferred_partial_value/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+data Maybe a = Just a | Nothing
+
+test =
+  let
+    Just x = Just 1
+  in
+    x
+
+foreign import unsafePartial :: forall a. (Partial => a) -> a
+
+consumed :: Partial => Int
+consumed = test
+
+discharged :: Int
+discharged = unsafePartial test

--- a/tests-integration/fixtures/backend/1788675780_inferred_partial_value/Main.snap
+++ b/tests-integration/fixtures/backend/1788675780_inferred_partial_value/Main.snap
@@ -1,0 +1,39 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+Just :: forall @a. a -> Main.Maybe a
+Nothing :: forall @a. Main.Maybe a
+test :: Prim.Partial => Prim.Int
+unsafePartial :: forall a. (Prim.Partial => a) -> a
+consumed :: Prim.Partial => Prim.Int
+discharged :: Prim.Int
+
+Types
+Maybe :: Prim.Type -> Prim.Type
+
+Roles
+Maybe = [Representational]
+
+Diagnostics
+Warning! · [MissingPatterns] · Main.purs:6:3
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Nothing
+  │
+  │     let
+  │     ╰──
+  •
+
+
+Backend Diagnostics
+Error! · [FunctionalCodegen] · Main.purs:1:1
+  •
+  │
+  • instance prerequisite is not represented by given evidence
+  │
+  │   module Main where
+  │   ╰────────────────
+  •

--- a/tests-integration/fixtures/backend/1788675780_inferred_partial_value/Main.snap
+++ b/tests-integration/fixtures/backend/1788675780_inferred_partial_value/Main.snap
@@ -26,14 +26,3 @@ Warning! · [MissingPatterns] · Main.purs:6:3
   │     let
   │     ╰──
   •
-
-
-Backend Diagnostics
-Error! · [FunctionalCodegen] · Main.purs:1:1
-  •
-  │
-  • instance prerequisite is not represented by given evidence
-  │
-  │   module Main where
-  │   ╰────────────────
-  •

--- a/tests-integration/fixtures/backend/1788675780_inferred_partial_value/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1788675780_inferred_partial_value/output/Main/foreign.js
@@ -1,0 +1,1 @@
+export const unsafePartial = computation => computation({});

--- a/tests-integration/fixtures/backend/1788675780_inferred_partial_value/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788675780_inferred_partial_value/output/Main/index.js
@@ -1,0 +1,23 @@
+import * as $foreign from "./foreign.js";
+export const Just = ($value0) => ({
+  tag: "Just",
+  _1: $value0
+});
+export const Nothing = "Nothing";
+export function test(partialDict) {
+  const $scrutinee = {
+    tag: "Just",
+    _1: 1 | 0
+  };
+  if ($scrutinee.tag === "Just") {
+    const { _1: x } = $scrutinee;
+    return x;
+  } else {
+    throw new Error("Pattern match failure");
+  }
+}
+export function consumed(partialDict) {
+  return /* @__PURE__ */ test(partialDict);
+}
+export const unsafePartial = $foreign["unsafePartial"];
+export const discharged = unsafePartial((partialDict) => /* @__PURE__ */ test(partialDict));

--- a/tests-integration/fixtures/backend/1788675780_inferred_partial_value/verify.mjs
+++ b/tests-integration/fixtures/backend/1788675780_inferred_partial_value/verify.mjs
@@ -1,0 +1,7 @@
+import { strictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+const partial = {};
+strictEqual(Main.test(partial), 1);
+strictEqual(Main.consumed(partial), 1);
+strictEqual(Main.discharged, 1);

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_function/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_function/Main.functional.snap
@@ -3,4 +3,18 @@ source: tests-integration/tests/functional.rs
 assertion_line: 14
 expression: report
 ---
-cannot convert checked module Idx::<File>(45): instance prerequisite is not represented by given evidence
+@export constructor Just/1
+
+@export constructor Nothing/0
+
+@export inferred = \partialDict%2 ->
+  \choice%1 ->
+    let
+      Just value%0 = choice%1
+    in value%0
+
+@export signed = \partialDict%3 -> \choice%4 -> inferred partialDict%3 choice%4
+
+@export foreign unsafePartial
+
+@export discharged = unsafePartial (\partialDict%5 -> inferred partialDict%5)

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_function/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_function/Main.functional.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+cannot convert checked module Idx::<File>(45): instance prerequisite is not represented by given evidence

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_function/Main.js
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_function/Main.js
@@ -1,0 +1,1 @@
+export const unsafePartial = computation => computation({});

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_function/Main.purs
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_function/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+data Maybe a = Just a | Nothing
+
+inferred choice =
+  let
+    Just value = choice
+  in
+    value
+
+signed :: forall a. Partial => Maybe a -> a
+signed choice = inferred choice
+
+foreign import unsafePartial :: forall a. (Partial => a) -> a
+
+discharged :: Maybe Int -> Int
+discharged = unsafePartial inferred

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_function/Main.snap
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_function/Main.snap
@@ -26,14 +26,3 @@ Warning! · [MissingPatterns] · Main.purs:6:3
   │     let
   │     ╰──
   •
-
-
-Backend Diagnostics
-Error! · [FunctionalCodegen] · Main.purs:1:1
-  •
-  │
-  • instance prerequisite is not represented by given evidence
-  │
-  │   module Main where
-  │   ╰────────────────
-  •

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_function/Main.snap
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_function/Main.snap
@@ -1,0 +1,39 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+Just :: forall @a. a -> Main.Maybe a
+Nothing :: forall @a. Main.Maybe a
+inferred :: forall t0. Prim.Partial => Main.Maybe t0 -> t0
+signed :: forall a. Prim.Partial => Main.Maybe a -> a
+unsafePartial :: forall a. (Prim.Partial => a) -> a
+discharged :: Main.Maybe Prim.Int -> Prim.Int
+
+Types
+Maybe :: Prim.Type -> Prim.Type
+
+Roles
+Maybe = [Representational]
+
+Diagnostics
+Warning! · [MissingPatterns] · Main.purs:6:3
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Nothing
+  │
+  │     let
+  │     ╰──
+  •
+
+
+Backend Diagnostics
+Error! · [FunctionalCodegen] · Main.purs:1:1
+  •
+  │
+  • instance prerequisite is not represented by given evidence
+  │
+  │   module Main where
+  │   ╰────────────────
+  •

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_function/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_function/output/Main/foreign.js
@@ -1,0 +1,1 @@
+export const unsafePartial = computation => computation({});

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_function/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_function/output/Main/index.js
@@ -1,0 +1,22 @@
+import * as $foreign from "./foreign.js";
+export const Just = ($value0) => ({
+  tag: "Just",
+  _1: $value0
+});
+export const Nothing = "Nothing";
+export function inferred(partialDict) {
+  const $closure = (choice) => {
+    if (choice.tag === "Just") {
+      const { _1: value } = choice;
+      return value;
+    } else {
+      throw new Error("Pattern match failure");
+    }
+  };
+  return $closure;
+}
+export function signed(partialDict) {
+  return (choice) => /* @__PURE__ */ inferred(partialDict)(choice);
+}
+export const unsafePartial = $foreign["unsafePartial"];
+export const discharged = unsafePartial((partialDict) => /* @__PURE__ */ inferred(partialDict));

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_function/verify.mjs
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_function/verify.mjs
@@ -1,0 +1,7 @@
+import { strictEqual, throws } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+for (const unwrap of [Main.inferred({}), Main.signed({}), Main.discharged]) {
+  strictEqual(unwrap(Main.Just(42)), 42);
+  throws(() => unwrap(Main.Nothing), { message: "Pattern match failure" });
+}

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/Main.functional.snap
@@ -3,4 +3,20 @@ source: tests-integration/tests/functional.rs
 assertion_line: 14
 expression: report
 ---
-cannot convert checked module Idx::<File>(45): instance prerequisite is not represented by given evidence
+@export constructor Just/1
+
+@export constructor Nothing/0
+
+@export select = \dictionary%0 -> dictionary%0.select
+
+@export instance selectInt = { select: \first%2 second%1 -> second%1 }
+
+@export mixed = \partialDict%7 selectDict%3 ->
+  \choice%6 fallback%5 ->
+    let
+      Just value%4 = choice%6
+    in select selectDict%3 value%4 fallback%5
+
+@export foreign unsafePartial
+
+@export discharged = unsafePartial (\partialDict%8 -> mixed partialDict%8 selectInt)

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/Main.functional.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+cannot convert checked module Idx::<File>(45): instance prerequisite is not represented by given evidence

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/Main.js
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/Main.js
@@ -1,0 +1,1 @@
+export const unsafePartial = computation => computation({});

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/Main.purs
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/Main.purs
@@ -1,0 +1,20 @@
+module Main where
+
+data Maybe a = Just a | Nothing
+
+class Select a where
+  select :: a -> a -> a
+
+instance selectInt :: Select Int where
+  select first second = second
+
+mixed choice fallback =
+  let
+    Just value = choice
+  in
+    select value fallback
+
+foreign import unsafePartial :: forall a. (Partial => a) -> a
+
+discharged :: Maybe Int -> Int -> Int
+discharged = unsafePartial mixed

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/Main.snap
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/Main.snap
@@ -34,14 +34,3 @@ Warning! · [MissingPatterns] · Main.purs:12:3
   │     let
   │     ╰──
   •
-
-
-Backend Diagnostics
-Error! · [FunctionalCodegen] · Main.purs:1:1
-  •
-  │
-  • instance prerequisite is not represented by given evidence
-  │
-  │   module Main where
-  │   ╰────────────────
-  •

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/Main.snap
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/Main.snap
@@ -1,0 +1,47 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+Just :: forall @a. a -> Main.Maybe a
+Nothing :: forall @a. Main.Maybe a
+select :: forall @a. Main.Select a => a -> a -> a
+mixed :: forall t0. Prim.Partial => Main.Select t0 => Main.Maybe t0 -> t0 -> t0
+unsafePartial :: forall a. (Prim.Partial => a) -> a
+discharged :: Main.Maybe Prim.Int -> Prim.Int -> Prim.Int
+
+Types
+Maybe :: Prim.Type -> Prim.Type
+Select :: Prim.Type -> Prim.Constraint
+
+Classes
+class forall (a :: Prim.Type). Main.Select a
+  select :: forall @a. Main.Select a => a -> a -> a
+
+Instances
+instance Main.Select Prim.Int
+
+Roles
+Maybe = [Representational]
+
+Diagnostics
+Warning! · [MissingPatterns] · Main.purs:12:3
+  •
+  │
+  • Pattern match is not exhaustive. Missing: Nothing
+  │
+  │     let
+  │     ╰──
+  •
+
+
+Backend Diagnostics
+Error! · [FunctionalCodegen] · Main.purs:1:1
+  •
+  │
+  • instance prerequisite is not represented by given evidence
+  │
+  │   module Main where
+  │   ╰────────────────
+  •

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/output/Main/foreign.js
@@ -1,0 +1,1 @@
+export const unsafePartial = computation => computation({});

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/output/Main/index.js
@@ -1,0 +1,27 @@
+import * as $foreign from "./foreign.js";
+export const Just = ($value0) => ({
+  tag: "Just",
+  _1: $value0
+});
+export const Nothing = "Nothing";
+export function select(dictionary) {
+  return dictionary.select;
+}
+export function mixed(partialDict) {
+  return (selectDict) => {
+    const $closure = (choice) => {
+      return (fallback) => {
+        if (choice.tag === "Just") {
+          const { _1: value } = choice;
+          return /* @__PURE__ */ select(selectDict)(value)(fallback);
+        } else {
+          throw new Error("Pattern match failure");
+        }
+      };
+    };
+    return $closure;
+  };
+}
+export const unsafePartial = $foreign["unsafePartial"];
+export const selectInt = { select: (first) => (second) => second };
+export const discharged = unsafePartial((partialDict) => /* @__PURE__ */ mixed(partialDict)(selectInt));

--- a/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/verify.mjs
+++ b/tests-integration/fixtures/backend/1788686760_inferred_partial_mixed_constraints/verify.mjs
@@ -1,0 +1,14 @@
+import { strictEqual, throws } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+const selectFirst = { select: first => second => first };
+const selectSecond = { select: first => second => second };
+strictEqual(Main.mixed({})(selectFirst)(Main.Just(47))(48), 47);
+strictEqual(Main.mixed({})(selectSecond)(Main.Just(47))(48), 48);
+strictEqual(Main.discharged(Main.Just(49))(50), 50);
+throws(() => Main.mixed({})(selectSecond)(Main.Nothing)(53), {
+  message: "Pattern match failure",
+});
+throws(() => Main.discharged(Main.Nothing)(54), {
+  message: "Pattern match failure",
+});

--- a/tests-integration/fixtures/backend/1788686760_partial_instance_member/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788686760_partial_instance_member/Main.functional.snap
@@ -1,0 +1,23 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export constructor Just/1
+
+@export constructor Nothing/0
+
+@export unwrap = \dictionary%0 -> dictionary%0.unwrap
+
+@export instance unwrapMaybe = {
+  unwrap:
+    \partialDict%3 ->
+      \choice%2 ->
+        let
+          Just value%1 = choice%2
+        in value%1
+}
+
+@export foreign unsafePartial
+
+@export discharged = unsafePartial (\partialDict%4 -> unwrap unwrapMaybe partialDict%4)

--- a/tests-integration/fixtures/backend/1788686760_partial_instance_member/Main.js
+++ b/tests-integration/fixtures/backend/1788686760_partial_instance_member/Main.js
@@ -1,0 +1,1 @@
+export const unsafePartial = computation => computation({});

--- a/tests-integration/fixtures/backend/1788686760_partial_instance_member/Main.purs
+++ b/tests-integration/fixtures/backend/1788686760_partial_instance_member/Main.purs
@@ -1,0 +1,18 @@
+module Main where
+
+data Maybe a = Just a | Nothing
+
+class Unwrap a where
+  unwrap :: Partial => a -> Int
+
+instance unwrapMaybe :: Unwrap (Maybe Int) where
+  unwrap choice =
+    let
+      Just value = choice
+    in
+      value
+
+foreign import unsafePartial :: forall a. (Partial => a) -> a
+
+discharged :: Maybe Int -> Int
+discharged = unsafePartial unwrap

--- a/tests-integration/fixtures/backend/1788686760_partial_instance_member/Main.snap
+++ b/tests-integration/fixtures/backend/1788686760_partial_instance_member/Main.snap
@@ -1,0 +1,25 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+Just :: forall @a. a -> Main.Maybe a
+Nothing :: forall @a. Main.Maybe a
+unwrap :: forall @a. Main.Unwrap a => Prim.Partial => a -> Prim.Int
+unsafePartial :: forall a. (Prim.Partial => a) -> a
+discharged :: Main.Maybe Prim.Int -> Prim.Int
+
+Types
+Maybe :: Prim.Type -> Prim.Type
+Unwrap :: Prim.Type -> Prim.Constraint
+
+Classes
+class forall (a :: Prim.Type). Main.Unwrap a
+  unwrap :: forall @a. Main.Unwrap a => Prim.Partial => a -> Prim.Int
+
+Instances
+instance Main.Unwrap (Main.Maybe Prim.Int)
+
+Roles
+Maybe = [Representational]

--- a/tests-integration/fixtures/backend/1788686760_partial_instance_member/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1788686760_partial_instance_member/output/Main/foreign.js
@@ -1,0 +1,1 @@
+export const unsafePartial = computation => computation({});

--- a/tests-integration/fixtures/backend/1788686760_partial_instance_member/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788686760_partial_instance_member/output/Main/index.js
@@ -1,0 +1,25 @@
+import * as $foreign from "./foreign.js";
+export const Just = ($value0) => ({
+  tag: "Just",
+  _1: $value0
+});
+export const Nothing = "Nothing";
+export function unwrap(dictionary) {
+  return dictionary.unwrap;
+}
+export const unsafePartial = $foreign["unsafePartial"];
+export const unwrapMaybe = /* @__PURE__ */ (() => {
+  const $closure = (partialDict) => {
+    const $closure$1 = (choice) => {
+      if (choice.tag === "Just") {
+        const { _1: value } = choice;
+        return value;
+      } else {
+        throw new Error("Pattern match failure");
+      }
+    };
+    return $closure$1;
+  };
+  return { unwrap: $closure };
+})();
+export const discharged = unsafePartial((partialDict) => /* @__PURE__ */ unwrap(unwrapMaybe)(partialDict));

--- a/tests-integration/fixtures/backend/1788686760_partial_instance_member/verify.mjs
+++ b/tests-integration/fixtures/backend/1788686760_partial_instance_member/verify.mjs
@@ -1,0 +1,5 @@
+import { strictEqual, throws } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+strictEqual(Main.discharged(Main.Just(46)), 46);
+throws(() => Main.discharged(Main.Nothing), { message: "Pattern match failure" });

--- a/tests-integration/fixtures/backend/1788686760_partial_local_binding/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788686760_partial_local_binding/Main.functional.snap
@@ -1,0 +1,16 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export constructor Just/1
+
+@export constructor Nothing/0
+
+@export local = \partialDict%4 ->
+  \choice%1 ->
+    (\wrapped%3 ->
+      let
+        Just value%2 = wrapped%3
+      in value%2)
+      choice%1

--- a/tests-integration/fixtures/backend/1788686760_partial_local_binding/Main.purs
+++ b/tests-integration/fixtures/backend/1788686760_partial_local_binding/Main.purs
@@ -1,0 +1,14 @@
+module Main where
+
+data Maybe a = Just a | Nothing
+
+local :: Partial => Maybe Int -> Int
+local choice =
+  let
+    unwrap wrapped =
+      let
+        Just value = wrapped
+      in
+        value
+  in
+    unwrap choice

--- a/tests-integration/fixtures/backend/1788686760_partial_local_binding/Main.snap
+++ b/tests-integration/fixtures/backend/1788686760_partial_local_binding/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+Just :: forall @a. a -> Main.Maybe a
+Nothing :: forall @a. Main.Maybe a
+local :: Prim.Partial => Main.Maybe Prim.Int -> Prim.Int
+
+Types
+Maybe :: Prim.Type -> Prim.Type
+
+Roles
+Maybe = [Representational]

--- a/tests-integration/fixtures/backend/1788686760_partial_local_binding/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788686760_partial_local_binding/output/Main/index.js
@@ -1,0 +1,19 @@
+export const Just = ($value0) => ({
+  tag: "Just",
+  _1: $value0
+});
+export const Nothing = "Nothing";
+export function local(partialDict) {
+  const $closure = (choice) => {
+    const $closure$1 = (wrapped) => {
+      if (wrapped.tag === "Just") {
+        const { _1: value } = wrapped;
+        return value;
+      } else {
+        throw new Error("Pattern match failure");
+      }
+    };
+    return $closure$1(choice);
+  };
+  return $closure;
+}

--- a/tests-integration/fixtures/backend/1788686760_partial_local_binding/verify.mjs
+++ b/tests-integration/fixtures/backend/1788686760_partial_local_binding/verify.mjs
@@ -1,0 +1,6 @@
+import { strictEqual, throws } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+const unwrap = Main.local({});
+strictEqual(unwrap(Main.Just(44)), 44);
+throws(() => unwrap(Main.Nothing), { message: "Pattern match failure" });

--- a/tests-integration/fixtures/backend/1788686760_partial_regression_instance_prerequisite/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788686760_partial_regression_instance_prerequisite/Main.functional.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export select = \dictionary%0 -> dictionary%0.select
+
+@export instance selectInt = { select: \first%2 second%1 -> second%1 }
+
+@export constructor Wrapped/1
+
+@export instance selectWrapped = \selectADict%3 ->
+  {
+    select:
+      \$wrapped%6@(Wrapped first%4) $wrapped%7@(Wrapped second%5) ->
+        { tag: "Wrapped", _1: select selectADict%3 first%4 second%5 }
+  }
+
+@export ordinaryPrerequisite = select (selectWrapped selectInt) { tag: "Wrapped", _1: 10 }
+  { tag: "Wrapped", _1: 20 }

--- a/tests-integration/fixtures/backend/1788686760_partial_regression_instance_prerequisite/Main.purs
+++ b/tests-integration/fixtures/backend/1788686760_partial_regression_instance_prerequisite/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+class Select a where
+  select :: a -> a -> a
+
+instance selectInt :: Select Int where
+  select first second = second
+
+data Wrapped a = Wrapped a
+
+instance selectWrapped :: Select a => Select (Wrapped a) where
+  select (Wrapped first) (Wrapped second) = Wrapped (select first second)
+
+ordinaryPrerequisite :: Wrapped Int
+ordinaryPrerequisite = select (Wrapped 10) (Wrapped 20)

--- a/tests-integration/fixtures/backend/1788686760_partial_regression_instance_prerequisite/Main.snap
+++ b/tests-integration/fixtures/backend/1788686760_partial_regression_instance_prerequisite/Main.snap
@@ -1,0 +1,24 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+select :: forall @a. Main.Select a => a -> a -> a
+Wrapped :: forall @a. a -> Main.Wrapped a
+ordinaryPrerequisite :: Main.Wrapped Prim.Int
+
+Types
+Select :: Prim.Type -> Prim.Constraint
+Wrapped :: Prim.Type -> Prim.Type
+
+Classes
+class forall (a :: Prim.Type). Main.Select a
+  select :: forall @a. Main.Select a => a -> a -> a
+
+Instances
+instance Main.Select Prim.Int
+instance forall a. Main.Select a => Main.Select (Main.Wrapped a)
+
+Roles
+Wrapped = [Representational]

--- a/tests-integration/fixtures/backend/1788686760_partial_regression_instance_prerequisite/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788686760_partial_regression_instance_prerequisite/output/Main/index.js
@@ -1,0 +1,36 @@
+export const Wrapped = ($value0) => ({
+  tag: "Wrapped",
+  _1: $value0
+});
+export function select(dictionary) {
+  return dictionary.select;
+}
+export function selectWrapped(selectADict) {
+  const $closure = ($wrapped) => {
+    if ($wrapped.tag === "Wrapped") {
+      const { _1: first } = $wrapped;
+      return ($wrapped$1) => {
+        if ($wrapped$1.tag === "Wrapped") {
+          const { _1: second } = $wrapped$1;
+          return {
+            tag: "Wrapped",
+            _1: /* @__PURE__ */ select(selectADict)(first)(second)
+          };
+        } else {
+          throw new Error("Pattern match failure");
+        }
+      };
+    } else {
+      throw new Error("Pattern match failure");
+    }
+  };
+  return { select: $closure };
+}
+export const selectInt = { select: (first) => (second) => second };
+export const ordinaryPrerequisite = /* @__PURE__ */ select(/* @__PURE__ */ selectWrapped(selectInt))({
+  tag: "Wrapped",
+  _1: 10 | 0
+})({
+  tag: "Wrapped",
+  _1: 20 | 0
+});

--- a/tests-integration/fixtures/backend/1788686760_partial_regression_instance_prerequisite/verify.mjs
+++ b/tests-integration/fixtures/backend/1788686760_partial_regression_instance_prerequisite/verify.mjs
@@ -1,0 +1,9 @@
+import { deepStrictEqual } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+
+deepStrictEqual(Main.ordinaryPrerequisite, Main.Wrapped(20));
+const selectFirst = { select: first => second => first };
+deepStrictEqual(
+  Main.selectWrapped(selectFirst).select(Main.Wrapped(51))(Main.Wrapped(52)),
+  Main.Wrapped(51),
+);

--- a/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/Library.purs
+++ b/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/Library.purs
@@ -1,0 +1,10 @@
+module Library where
+
+data Maybe a = Just a | Nothing
+
+unwrap :: forall a. Partial => Maybe a -> a
+unwrap choice =
+  let
+    Just value = choice
+  in
+    value

--- a/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/Main.functional.snap
@@ -3,4 +3,15 @@ source: tests-integration/tests/functional.rs
 assertion_line: 14
 expression: report
 ---
-cannot convert checked module Idx::<File>(46): instance prerequisite is not represented by given evidence
+@export forwarded = \partialDict%2 ->
+  \first%1 second%3 ->
+    {
+      first: (\wrapped%4 -> unwrap partialDict%2 wrapped%4) first%1,
+      second: unwrap partialDict%2 second%3
+    }
+
+@export signed = \partialDict%5 -> forwarded partialDict%5
+
+@export foreign unsafePartial
+
+@export discharged = unsafePartial (\partialDict%6 -> forwarded partialDict%6)

--- a/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/Main.functional.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+cannot convert checked module Idx::<File>(46): instance prerequisite is not represented by given evidence

--- a/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/Main.js
+++ b/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/Main.js
@@ -1,0 +1,1 @@
+export const unsafePartial = computation => computation({});

--- a/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/Main.purs
+++ b/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+import Library (Maybe, unwrap)
+
+forwarded first second =
+  let
+    extract wrapped = unwrap wrapped
+  in
+    { first: extract first, second: unwrap second }
+
+signed :: Partial => Maybe Int -> Maybe Int -> { first :: Int, second :: Int }
+signed = forwarded
+
+foreign import unsafePartial :: forall a. (Partial => a) -> a
+
+discharged :: Maybe Int -> Maybe Int -> { first :: Int, second :: Int }
+discharged = unsafePartial forwarded

--- a/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/Main.snap
+++ b/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/Main.snap
@@ -1,0 +1,27 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+forwarded ::
+  forall t0 t1.
+    Prim.Partial => Library.Maybe t0 -> Library.Maybe t1 -> { first :: t0, second :: t1 }
+signed ::
+  Prim.Partial =>
+  Library.Maybe Prim.Int -> Library.Maybe Prim.Int -> { first :: Prim.Int, second :: Prim.Int }
+unsafePartial :: forall a. (Prim.Partial => a) -> a
+discharged ::
+  Library.Maybe Prim.Int -> Library.Maybe Prim.Int -> { first :: Prim.Int, second :: Prim.Int }
+
+Types
+
+Backend Diagnostics
+Error! · [FunctionalCodegen] · Main.purs:1:1
+  •
+  │
+  • instance prerequisite is not represented by given evidence
+  │
+  │   module Main where
+  │   ╰────────────────
+  •

--- a/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/Main.snap
+++ b/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/Main.snap
@@ -15,13 +15,3 @@ discharged ::
   Library.Maybe Prim.Int -> Library.Maybe Prim.Int -> { first :: Prim.Int, second :: Prim.Int }
 
 Types
-
-Backend Diagnostics
-Error! · [FunctionalCodegen] · Main.purs:1:1
-  •
-  │
-  • instance prerequisite is not represented by given evidence
-  │
-  │   module Main where
-  │   ╰────────────────
-  •

--- a/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/output/Library/index.js
+++ b/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/output/Library/index.js
@@ -1,0 +1,16 @@
+export const Just = ($value0) => ({
+  tag: "Just",
+  _1: $value0
+});
+export const Nothing = "Nothing";
+export function unwrap(partialDict) {
+  const $closure = (choice) => {
+    if (choice.tag === "Just") {
+      const { _1: value } = choice;
+      return value;
+    } else {
+      throw new Error("Pattern match failure");
+    }
+  };
+  return $closure;
+}

--- a/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/output/Main/foreign.js
@@ -1,0 +1,1 @@
+export const unsafePartial = computation => computation({});

--- a/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/output/Main/index.js
@@ -1,0 +1,13 @@
+import * as Library from "../Library/index.js";
+import * as $foreign from "./foreign.js";
+export function forwarded(partialDict) {
+  return (first) => (second) => ({
+    first: ((wrapped) => /* @__PURE__ */ Library.unwrap(partialDict)(wrapped))(first),
+    second: /* @__PURE__ */ Library.unwrap(partialDict)(second)
+  });
+}
+export function signed(partialDict) {
+  return /* @__PURE__ */ forwarded(partialDict);
+}
+export const unsafePartial = $foreign["unsafePartial"];
+export const discharged = unsafePartial((partialDict) => /* @__PURE__ */ forwarded(partialDict));

--- a/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/verify.mjs
+++ b/tests-integration/fixtures/backend/1788709920_inferred_partial_forwarding/verify.mjs
@@ -1,0 +1,9 @@
+import { deepStrictEqual, throws } from "node:assert/strict";
+import * as Main from "./output/Main/index.js";
+import { Just, Nothing } from "./output/Library/index.js";
+
+for (const forwarded of [Main.forwarded({}), Main.signed({}), Main.discharged]) {
+  deepStrictEqual(forwarded(Just(41))(Just(42)), { first: 41, second: 42 });
+  throws(() => forwarded(Nothing)(Just(42)), { message: "Pattern match failure" });
+  throws(() => forwarded(Just(41))(Nothing), { message: "Pattern match failure" });
+}

--- a/tests-integration/fixtures/semantic/1784824200_case_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784824200_case_expressions/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 68
+assertion_line: 317
 expression: report
 ---
 data Choice :: Prim.Type -> Prim.Type
@@ -32,6 +32,6 @@ multiple = \first -> \second ->
     _, _ -> 0
 
 partial :: forall t0. Prim.Partial => Main.Choice t0 -> t0
-partial = \{trivial} -> \choice ->
+partial = \{partialDict} -> \choice ->
   case choice of
     (One value) -> value

--- a/tests-integration/fixtures/semantic/1784828400_partial_lambda_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784828400_partial_lambda_expressions/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 68
+assertion_line: 317
 expression: report
 ---
 data Maybe :: Prim.Type -> Prim.Type
@@ -12,4 +12,4 @@ checked :: Prim.Partial => Main.Maybe Prim.Int -> Prim.Int
 checked = \{partialDict} -> \(Just value) -> value
 
 inferred :: forall t0. Prim.Partial => Main.Maybe t0 -> t0
-inferred = \{trivial} -> \(Just value) -> value
+inferred = \{partialDict} -> \(Just value) -> value

--- a/tests-integration/fixtures/semantic/1784913480_binder_operator_chains/Main.snap
+++ b/tests-integration/fixtures/semantic/1784913480_binder_operator_chains/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 68
+assertion_line: 317
 expression: report
 ---
 data List :: Prim.Type -> Prim.Type
@@ -20,7 +20,7 @@ second :: forall a. Main.List a -> a
 second = \(Cons _ (Cons value _)) -> value
 
 inferred :: forall t0. Prim.Partial => Main.List t0 -> t0
-inferred = \{trivial} -> \(Cons value _) -> value
+inferred = \{partialDict} -> \(Cons value _) -> value
 
 second' :: forall a. Main.Snoc a -> a
 second' = \(Snoc (Snoc _ value) _) -> value


### PR DESCRIPTION
## Problem
Inferred Partial constraints could pass checking but fail functional conversion: generalization produced Trivial evidence where the backend expected a dictionary binder.

## Change
Represent declaration evidence abstractions with EvidenceBinderId and generalize every retained constraint, including Partial, to a scoped dictionary parameter. Keep constraint/binder pairs together so their ordering cannot diverge. Preserve Trivial on the proof/application side and leave instance-prerequisite validation unchanged.

The commit history first records independent failing fixtures, then applies the fix. Coverage includes inferred values, functions, mixed constraints, forwarding/local capture, signed declarations, instance members, and instance prerequisites. Node checks exercise dictionary ordering, discharge, return values, and incomplete-pattern failures.

## Verification
- cargo check -p checking -p functional --tests
- cargo nextest run -p checking -p functional: 40 passed
- Full just t checking, just t semantic, and just t backend: passed, no pending snapshots
- Generated snapshots and JavaScript reviewed
- Final tree verified identical to the reviewed preview