### PR TITLE
[resolving] Reject local instance name conflicts

### DIFF
--- a/compiler-frontend/diagnostics/src/convert.rs
+++ b/compiler-frontend/diagnostics/src/convert.rs
@@ -5,7 +5,7 @@ use functional::tree::{GlobalId, InstanceIdentity};
 use functional::{
     ModuleError as FunctionalModuleError, UnsupportedState as FunctionalUnsupportedState,
 };
-use indexing::{IndexedTypeItemKind, IndexingError};
+use indexing::{IndexedTypeItemKind, IndexingError, InstanceSourceItemId, OrderedTermItemId};
 use itertools::Itertools;
 use javascript::{
     ModuleDiagnostic as JavaScriptModuleDiagnostic, ModuleError as JavaScriptModuleError,
@@ -306,6 +306,44 @@ impl ToDiagnostics for ResolvingError {
         Q: ExternalQueries,
     {
         match self {
+            ResolvingError::InstanceNameConflict { name, instance, existing } => {
+                let pointer = match instance {
+                    InstanceSourceItemId::Instance(id) => {
+                        context.stabilized.syntax_ptr(context.indexed.items[*id].id)
+                    }
+                    InstanceSourceItemId::Derive(id) => {
+                        context.stabilized.syntax_ptr(context.indexed.items[*id].id)
+                    }
+                };
+                let Some(span) = pointer.and_then(|pointer| context.span_from_syntax_ptr(&pointer))
+                else {
+                    return vec![];
+                };
+                let (code, message, pointer) = match existing {
+                    OrderedTermItemId::Term(id) => (
+                        "RedefinedIdent",
+                        format!("Instance name '{name}' conflicts with a local value declaration"),
+                        context.indexed.term_item_ptr(context.stabilized, *id).next(),
+                    ),
+                    OrderedTermItemId::Instance(id) => (
+                        "DuplicateInstance",
+                        format!("Instance name '{name}' has been defined multiple times"),
+                        context.stabilized.syntax_ptr(context.indexed.items[*id].id),
+                    ),
+                    OrderedTermItemId::Derive(id) => (
+                        "DuplicateInstance",
+                        format!("Instance name '{name}' has been defined multiple times"),
+                        context.stabilized.syntax_ptr(context.indexed.items[*id].id),
+                    ),
+                };
+                let mut diagnostic = Diagnostic::error(code, message, span, "resolving");
+                if let Some(span) =
+                    pointer.and_then(|pointer| context.span_from_syntax_ptr(&pointer))
+                {
+                    diagnostic = diagnostic.with_related(span, "Conflicting declaration");
+                }
+                vec![diagnostic]
+            }
             ResolvingError::TermExportConflict { .. }
             | ResolvingError::TypeExportConflict { .. }
             | ResolvingError::ExistingTerm { .. }

--- a/compiler-frontend/resolving/src/algorithm.rs
+++ b/compiler-frontend/resolving/src/algorithm.rs
@@ -2,8 +2,9 @@ use building_types::QueryResult;
 use files::FileId;
 use indexing::{
     ExportKind, ImplicitItems, ImportItemId, ImportKind, IndexedImport, IndexedModule,
-    IndexedTypeItemKind, TermItemId, TypeItemId,
+    IndexedTypeItemKind, InstanceSourceItemId, OrderedTermItemId, TermItemId, TypeItemId,
 };
+use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
 
 use crate::{
@@ -25,10 +26,41 @@ pub(super) fn resolve_module(queries: &impl ExternalQueries, file: FileId) -> Qu
     let indexed = queries.indexed(file)?;
 
     let mut state = State::default();
+    validate_instance_names(&mut state, &indexed);
     resolve_imports(queries, &mut state, &indexed)?;
     resolve_exports(&mut state, &indexed, file);
 
     Ok(state)
+}
+
+fn validate_instance_names(state: &mut State, indexed: &IndexedModule) {
+    let mut instances = FxHashMap::default();
+    for &instance in indexed.items.instance_sources() {
+        let (name, item) = match instance {
+            InstanceSourceItemId::Instance(id) => {
+                (&indexed.items[id].name, OrderedTermItemId::Instance(id))
+            }
+            InstanceSourceItemId::Derive(id) => {
+                (&indexed.items[id].name, OrderedTermItemId::Derive(id))
+            }
+        };
+        let Some(name) = name else { continue };
+        let existing = *instances.entry(name).or_insert(item);
+        if existing != item {
+            state.errors.push(ResolvingError::InstanceNameConflict {
+                name: SmolStr::clone(name),
+                instance,
+                existing,
+            });
+        }
+        if let Some(term) = indexed.names.terms.lookup(name) {
+            state.errors.push(ResolvingError::InstanceNameConflict {
+                name: SmolStr::clone(name),
+                instance,
+                existing: OrderedTermItemId::Term(term),
+            });
+        }
+    }
 }
 
 fn resolve_imports(

--- a/compiler-frontend/resolving/src/error.rs
+++ b/compiler-frontend/resolving/src/error.rs
@@ -1,11 +1,19 @@
 use files::FileId;
-use indexing::{ImportId, ImportItemId, TermItemId, TypeItemId};
+use indexing::{
+    ImportId, ImportItemId, InstanceSourceItemId, OrderedTermItemId, TermItemId, TypeItemId,
+};
+use smol_str::SmolStr;
 
 use crate::ExportSource;
 
 /// The kind of errors produced during name resolution.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ResolvingError {
+    InstanceNameConflict {
+        name: SmolStr,
+        instance: InstanceSourceItemId,
+        existing: OrderedTermItemId,
+    },
     TermExportConflict {
         existing: (FileId, TermItemId, ExportSource),
         duplicate: (FileId, TermItemId, ExportSource),

--- a/tests-integration/fixtures/backend/1788759960_foreign_instance_name_conflict/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788759960_foreign_instance_name_conflict/Main.functional.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+cannot convert checked module Idx::<File>(45): runtime export name "classInt" refers to conflicting globals Term(Idx::<File>(45), Idx::<IndexedTermItem>(0)) and Instance(Declared(Idx::<File>(45), AstId<syntax::cst::InstanceDeclaration>(15)))

--- a/tests-integration/fixtures/backend/1788759960_foreign_instance_name_conflict/Main.js
+++ b/tests-integration/fixtures/backend/1788759960_foreign_instance_name_conflict/Main.js
@@ -1,0 +1,1 @@
+export const classInt = 42;

--- a/tests-integration/fixtures/backend/1788759960_foreign_instance_name_conflict/Main.purs
+++ b/tests-integration/fixtures/backend/1788759960_foreign_instance_name_conflict/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+class Class :: Type -> Constraint
+class Class a
+
+foreign import classInt :: Int
+instance classInt :: Class Int
+
+test :: Int
+test = classInt

--- a/tests-integration/fixtures/backend/1788759960_foreign_instance_name_conflict/Main.snap
+++ b/tests-integration/fixtures/backend/1788759960_foreign_instance_name_conflict/Main.snap
@@ -1,11 +1,11 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 299
-expression: report
+assertion_line: 278
+expression: diagnostics_report
 ---
 Terms
 classInt :: Prim.Int
-test :: Prim.Array Prim.Int
+test :: Prim.Int
 
 Types
 Class :: Prim.Type -> Prim.Constraint
@@ -14,16 +14,16 @@ Classes
 class forall (a :: Prim.Type). Main.Class a
 
 Instances
-instance Main.Class
+instance Main.Class Prim.Int
 
 Diagnostics
-Error! · [RedefinedIdent] · Main.purs:6:1
+Error! · [RedefinedIdent] · Main.purs:7:1
   •
   │
   • Instance name 'classInt' conflicts with a local value declaration
   │
-  │   instance classInt :: Class
-  │   ╰─────────────────────────
+  │   instance classInt :: Class Int
+  │   ╰─────────────────────────────
   │
   • Conflicting declaration
   │
@@ -31,19 +31,14 @@ Error! · [RedefinedIdent] · Main.purs:6:1
   │   ╰─────────────────────────────
   •
 
-Error! · [InstanceHeadMismatch] · Main.purs:1:1
-  •
-  │
-  • Instance head mismatch: expected 1 arguments, got 0
-  │
-  │   module Main where
-  │   ╰────────────────
-  •
 
-Error! · [CannotUnify] · Main.purs:1:1
+Backend Diagnostics
+Error! · [FunctionalCodegen] · Main.purs:1:1
   •
   │
-  • Cannot unify 'Type -> Constraint' with 'Constraint'
+  • runtime export name "classInt" refers to conflicting globals Term(Idx::<File>(45),
+  │ Idx::<IndexedTermItem>(0)) and Instance(Declared(Idx::<File>(45),
+  │ AstId<syntax::cst::InstanceDeclaration>(15)))
   │
   │   module Main where
   │   ╰────────────────

--- a/tests-integration/fixtures/backend/1788759960_hidden_foreign_instance_name_conflict/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788759960_hidden_foreign_instance_name_conflict/Main.functional.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+foreign classInt
+
+@export instance classInt = {  }
+
+@export test = classInt

--- a/tests-integration/fixtures/backend/1788759960_hidden_foreign_instance_name_conflict/Main.js
+++ b/tests-integration/fixtures/backend/1788759960_hidden_foreign_instance_name_conflict/Main.js
@@ -1,0 +1,1 @@
+export const classInt = 42;

--- a/tests-integration/fixtures/backend/1788759960_hidden_foreign_instance_name_conflict/Main.purs
+++ b/tests-integration/fixtures/backend/1788759960_hidden_foreign_instance_name_conflict/Main.purs
@@ -1,0 +1,10 @@
+module Main (test) where
+
+class Class :: Type -> Constraint
+class Class a
+
+foreign import classInt :: Int
+instance classInt :: Class Int
+
+test :: Int
+test = classInt

--- a/tests-integration/fixtures/backend/1788759960_hidden_foreign_instance_name_conflict/Main.snap
+++ b/tests-integration/fixtures/backend/1788759960_hidden_foreign_instance_name_conflict/Main.snap
@@ -1,36 +1,23 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 354
-expression: report
+assertion_line: 278
+expression: diagnostics_report
 ---
-module Main
+Terms
+classInt :: Prim.Int
+test :: Prim.Int
 
-Unqualified Imports:
+Types
+Class :: Prim.Type -> Prim.Constraint
 
-Qualified Imports:
+Classes
+class forall (a :: Prim.Type). Main.Class a
 
-Exported Terms:
-  - classInt
-  - test
-
-Exported Types:
-
-Exported Classes:
-  - Class
-
-Local Terms:
-  - classInt
-  - test
-
-Local Types:
-
-Local Classes:
-  - Class
-
-Class Members:
+Instances
+instance Main.Class Prim.Int
 
 Diagnostics
-Error! · [RedefinedIdent] · Main.purs:6:1
+Error! · [RedefinedIdent] · Main.purs:7:1
   •
   │
   • Instance name 'classInt' conflicts with a local value declaration

--- a/tests-integration/fixtures/backend/1788759960_hidden_foreign_instance_name_conflict/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1788759960_hidden_foreign_instance_name_conflict/output/Main/foreign.js
@@ -1,0 +1,1 @@
+export const classInt = 42;

--- a/tests-integration/fixtures/backend/1788759960_hidden_foreign_instance_name_conflict/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788759960_hidden_foreign_instance_name_conflict/output/Main/index.js
@@ -1,0 +1,5 @@
+import * as $foreign from "./foreign.js";
+const classInt = $foreign["classInt"];
+const classInt$1 = {};
+export const test = classInt;
+export { classInt$1 as classInt };

--- a/tests-integration/fixtures/backend/1788759960_hidden_instance_foreign_name_conflict/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788759960_hidden_instance_foreign_name_conflict/Main.functional.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export instance classInt = {  }
+
+foreign classInt
+
+@export test = classInt

--- a/tests-integration/fixtures/backend/1788759960_hidden_instance_foreign_name_conflict/Main.js
+++ b/tests-integration/fixtures/backend/1788759960_hidden_instance_foreign_name_conflict/Main.js
@@ -1,0 +1,1 @@
+export const classInt = 42;

--- a/tests-integration/fixtures/backend/1788759960_hidden_instance_foreign_name_conflict/Main.purs
+++ b/tests-integration/fixtures/backend/1788759960_hidden_instance_foreign_name_conflict/Main.purs
@@ -1,0 +1,10 @@
+module Main (test) where
+
+class Class :: Type -> Constraint
+class Class a
+
+instance classInt :: Class Int
+foreign import classInt :: Int
+
+test :: Int
+test = classInt

--- a/tests-integration/fixtures/backend/1788759960_hidden_instance_foreign_name_conflict/Main.snap
+++ b/tests-integration/fixtures/backend/1788759960_hidden_instance_foreign_name_conflict/Main.snap
@@ -1,33 +1,20 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 354
-expression: report
+assertion_line: 278
+expression: diagnostics_report
 ---
-module Main
+Terms
+classInt :: Prim.Int
+test :: Prim.Int
 
-Unqualified Imports:
+Types
+Class :: Prim.Type -> Prim.Constraint
 
-Qualified Imports:
+Classes
+class forall (a :: Prim.Type). Main.Class a
 
-Exported Terms:
-  - classInt
-  - test
-
-Exported Types:
-
-Exported Classes:
-  - Class
-
-Local Terms:
-  - classInt
-  - test
-
-Local Types:
-
-Local Classes:
-  - Class
-
-Class Members:
+Instances
+instance Main.Class Prim.Int
 
 Diagnostics
 Error! · [RedefinedIdent] · Main.purs:6:1

--- a/tests-integration/fixtures/backend/1788759960_hidden_instance_foreign_name_conflict/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1788759960_hidden_instance_foreign_name_conflict/output/Main/foreign.js
@@ -1,0 +1,1 @@
+export const classInt = 42;

--- a/tests-integration/fixtures/backend/1788759960_hidden_instance_foreign_name_conflict/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788759960_hidden_instance_foreign_name_conflict/output/Main/index.js
@@ -1,0 +1,4 @@
+import * as $foreign from "./foreign.js";
+const classInt$1 = $foreign["classInt"];
+export const classInt = {};
+export const test = classInt$1;

--- a/tests-integration/fixtures/backend/1788759960_instance_foreign_name_conflict/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788759960_instance_foreign_name_conflict/Main.functional.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+cannot convert checked module Idx::<File>(45): runtime export name "classInt" refers to conflicting globals Instance(Declared(Idx::<File>(45), AstId<syntax::cst::InstanceDeclaration>(13))) and Term(Idx::<File>(45), Idx::<IndexedTermItem>(0))

--- a/tests-integration/fixtures/backend/1788759960_instance_foreign_name_conflict/Main.js
+++ b/tests-integration/fixtures/backend/1788759960_instance_foreign_name_conflict/Main.js
@@ -1,0 +1,1 @@
+export const classInt = 42;

--- a/tests-integration/fixtures/backend/1788759960_instance_foreign_name_conflict/Main.purs
+++ b/tests-integration/fixtures/backend/1788759960_instance_foreign_name_conflict/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+class Class :: Type -> Constraint
+class Class a
+
+instance classInt :: Class Int
+foreign import classInt :: Int
+
+test :: Int
+test = classInt

--- a/tests-integration/fixtures/backend/1788759960_instance_foreign_name_conflict/Main.snap
+++ b/tests-integration/fixtures/backend/1788759960_instance_foreign_name_conflict/Main.snap
@@ -1,11 +1,11 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 299
-expression: report
+assertion_line: 278
+expression: diagnostics_report
 ---
 Terms
 classInt :: Prim.Int
-test :: Prim.Array Prim.Int
+test :: Prim.Int
 
 Types
 Class :: Prim.Type -> Prim.Constraint
@@ -14,7 +14,7 @@ Classes
 class forall (a :: Prim.Type). Main.Class a
 
 Instances
-instance Main.Class
+instance Main.Class Prim.Int
 
 Diagnostics
 Error! · [RedefinedIdent] · Main.purs:6:1
@@ -22,8 +22,8 @@ Error! · [RedefinedIdent] · Main.purs:6:1
   │
   • Instance name 'classInt' conflicts with a local value declaration
   │
-  │   instance classInt :: Class
-  │   ╰─────────────────────────
+  │   instance classInt :: Class Int
+  │   ╰─────────────────────────────
   │
   • Conflicting declaration
   │
@@ -31,19 +31,14 @@ Error! · [RedefinedIdent] · Main.purs:6:1
   │   ╰─────────────────────────────
   •
 
-Error! · [InstanceHeadMismatch] · Main.purs:1:1
-  •
-  │
-  • Instance head mismatch: expected 1 arguments, got 0
-  │
-  │   module Main where
-  │   ╰────────────────
-  •
 
-Error! · [CannotUnify] · Main.purs:1:1
+Backend Diagnostics
+Error! · [FunctionalCodegen] · Main.purs:1:1
   •
   │
-  • Cannot unify 'Type -> Constraint' with 'Constraint'
+  • runtime export name "classInt" refers to conflicting globals Instance(Declared(Idx::<File>(45),
+  │ AstId<syntax::cst::InstanceDeclaration>(13))) and Term(Idx::<File>(45),
+  │ Idx::<IndexedTermItem>(0))
   │
   │   module Main where
   │   ╰────────────────

--- a/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/Library.purs
+++ b/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/Library.purs
@@ -1,0 +1,8 @@
+module Library where
+
+class Class :: Type -> Constraint
+class Class a
+instance dictionary :: Class Int
+
+imported :: Int
+imported = 42

--- a/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/Main.functional.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export instance imported = {  }
+
+@export instance classString1 = {  }
+
+@export instance local = {  }
+
+@export foreign dictionary
+
+@export foreign classString
+
+@export test = imported
+
+@export shadow = \local%0 -> local%0
+
+@export record = { local: dictionary }

--- a/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/Main.js
+++ b/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/Main.js
@@ -1,0 +1,2 @@
+export const dictionary = 42;
+export const classString = 43;

--- a/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/Main.purs
+++ b/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/Main.purs
@@ -1,0 +1,22 @@
+module Main where
+
+import Library (imported)
+
+class Class :: Type -> Constraint
+class Class a
+
+instance imported :: Class Int
+instance Class String
+instance local :: Class Boolean
+
+foreign import dictionary :: Int
+foreign import classString :: Int
+
+test :: Int
+test = imported
+
+shadow :: Int -> Int
+shadow local = local
+
+record :: { local :: Int }
+record = { local: dictionary }

--- a/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/Main.snap
+++ b/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/Main.snap
@@ -1,0 +1,22 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 278
+expression: diagnostics_report
+---
+Terms
+dictionary :: Prim.Int
+classString :: Prim.Int
+test :: Prim.Int
+shadow :: Prim.Int -> Prim.Int
+record :: { local :: Prim.Int }
+
+Types
+Class :: Prim.Type -> Prim.Constraint
+
+Classes
+class forall (a :: Prim.Type). Main.Class a
+
+Instances
+instance Main.Class Prim.Int
+instance Main.Class Prim.String
+instance Main.Class Prim.Boolean

--- a/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/output/Library/index.js
+++ b/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/output/Library/index.js
@@ -1,0 +1,2 @@
+export const dictionary = {};
+export const imported = 42 | 0;

--- a/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/output/Main/foreign.js
+++ b/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/output/Main/foreign.js
@@ -1,0 +1,2 @@
+export const dictionary = 42;
+export const classString = 43;

--- a/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/output/Main/index.js
+++ b/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/output/Main/index.js
@@ -1,0 +1,12 @@
+import * as Library from "../Library/index.js";
+import * as $foreign from "./foreign.js";
+export function shadow(local$1) {
+  return local$1;
+}
+export const dictionary = $foreign["dictionary"];
+export const classString = $foreign["classString"];
+export const imported = {};
+export const classString1 = {};
+export const local = {};
+export const test = Library.imported;
+export const record = { local: dictionary };

--- a/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/verify.mjs
+++ b/tests-integration/fixtures/backend/1788759960_instance_name_namespace_boundaries/verify.mjs
@@ -1,0 +1,8 @@
+import assert from "node:assert/strict";
+
+import * as main from "./output/Main/index.js";
+
+assert.equal(main.test, 42);
+assert.equal(main.shadow(7), 7);
+assert.equal(main.record.local, 42);
+assert.equal(main.classString, 43);

--- a/tests-integration/fixtures/resolving/1788751080_instance_name_namespace_boundaries/Library.purs
+++ b/tests-integration/fixtures/resolving/1788751080_instance_name_namespace_boundaries/Library.purs
@@ -1,0 +1,8 @@
+module Library where
+
+class Class :: Type -> Constraint
+class Class a
+instance dictionary :: Class Int
+
+imported :: Int
+imported = 42

--- a/tests-integration/fixtures/resolving/1788751080_instance_name_namespace_boundaries/Library.snap
+++ b/tests-integration/fixtures/resolving/1788751080_instance_name_namespace_boundaries/Library.snap
@@ -1,0 +1,28 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 354
+expression: report
+---
+module Library
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+  - imported
+
+Exported Types:
+
+Exported Classes:
+  - Class
+
+Local Terms:
+  - imported
+
+Local Types:
+
+Local Classes:
+  - Class
+
+Class Members:

--- a/tests-integration/fixtures/resolving/1788751080_instance_name_namespace_boundaries/Main.js
+++ b/tests-integration/fixtures/resolving/1788751080_instance_name_namespace_boundaries/Main.js
@@ -1,0 +1,2 @@
+export const dictionary = 42;
+export const classString = 43;

--- a/tests-integration/fixtures/resolving/1788751080_instance_name_namespace_boundaries/Main.purs
+++ b/tests-integration/fixtures/resolving/1788751080_instance_name_namespace_boundaries/Main.purs
@@ -1,0 +1,22 @@
+module Main where
+
+import Library (imported)
+
+class Class :: Type -> Constraint
+class Class a
+
+instance imported :: Class Int
+instance Class String
+instance local :: Class Boolean
+
+foreign import dictionary :: Int
+foreign import classString :: Int
+
+test :: Int
+test = imported
+
+shadow :: Int -> Int
+shadow local = local
+
+record :: { local :: Int }
+record = { local: dictionary }

--- a/tests-integration/fixtures/resolving/1788751080_instance_name_namespace_boundaries/Main.snap
+++ b/tests-integration/fixtures/resolving/1788751080_instance_name_namespace_boundaries/Main.snap
@@ -1,0 +1,43 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 354
+expression: report
+---
+module Main
+
+Unqualified Imports:
+
+Terms:
+  - imported is Explicit
+
+Types:
+
+Classes:
+
+Qualified Imports:
+
+Exported Terms:
+  - dictionary
+  - test
+  - classString
+  - shadow
+  - record
+
+Exported Types:
+
+Exported Classes:
+  - Class
+
+Local Terms:
+  - dictionary
+  - test
+  - classString
+  - shadow
+  - record
+
+Local Types:
+
+Local Classes:
+  - Class
+
+Class Members:

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Derived.js
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Derived.js
@@ -1,0 +1,2 @@
+export const first = 1;
+export const second = 2;

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Derived.purs
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Derived.purs
@@ -1,0 +1,14 @@
+module Derived where
+
+class Class :: Type -> Constraint
+class Class a
+instance base :: Class Int
+
+newtype First = First Int
+newtype Second = Second Int
+
+derive newtype instance first :: Class First
+foreign import first :: Int
+
+foreign import second :: Int
+derive newtype instance second :: Class Second

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Derived.snap
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Derived.snap
@@ -1,0 +1,38 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 354
+expression: report
+---
+module Derived
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+  - Second
+  - second
+  - First
+  - first
+
+Exported Types:
+  - Second
+  - First
+
+Exported Classes:
+  - Class
+
+Local Terms:
+  - Second
+  - second
+  - First
+  - first
+
+Local Types:
+  - Second
+  - First
+
+Local Classes:
+  - Class
+
+Class Members:

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Derived.snap
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Derived.snap
@@ -36,3 +36,32 @@ Local Classes:
   - Class
 
 Class Members:
+
+Diagnostics
+Error! · [RedefinedIdent] · Derived.purs:10:1
+  •
+  │
+  • Instance name 'first' conflicts with a local value declaration
+  │
+  │   derive newtype instance first :: Class First
+  │   ╰───────────────────────────────────────────
+  │
+  • Conflicting declaration
+  │
+  │   foreign import first :: Int
+  │   ╰──────────────────────────
+  •
+
+Error! · [RedefinedIdent] · Derived.purs:14:1
+  •
+  │
+  • Instance name 'second' conflicts with a local value declaration
+  │
+  │   derive newtype instance second :: Class Second
+  │   ╰─────────────────────────────────────────────
+  │
+  • Conflicting declaration
+  │
+  │   foreign import second :: Int
+  │   ╰───────────────────────────
+  •

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/DuplicateInstances.purs
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/DuplicateInstances.purs
@@ -1,0 +1,16 @@
+module DuplicateInstances where
+
+class Class :: Type -> Constraint
+class Class a
+
+instance duplicate :: Class Int
+instance duplicate :: Class String
+
+newtype First = First Int
+newtype Second = Second Int
+newtype Third = Third Int
+
+derive newtype instance duplicate :: Class First
+derive newtype instance derived :: Class Second
+instance derived :: Class Boolean
+derive newtype instance derived :: Class Third

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/DuplicateInstances.snap
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/DuplicateInstances.snap
@@ -36,3 +36,60 @@ Local Classes:
   - Class
 
 Class Members:
+
+Diagnostics
+Error! · [DuplicateInstance] · DuplicateInstances.purs:7:1
+  •
+  │
+  • Instance name 'duplicate' has been defined multiple times
+  │
+  │   instance duplicate :: Class String
+  │   ╰─────────────────────────────────
+  │
+  • Conflicting declaration
+  │
+  │   instance duplicate :: Class Int
+  │   ╰──────────────────────────────
+  •
+
+Error! · [DuplicateInstance] · DuplicateInstances.purs:13:1
+  •
+  │
+  • Instance name 'duplicate' has been defined multiple times
+  │
+  │   derive newtype instance duplicate :: Class First
+  │   ╰───────────────────────────────────────────────
+  │
+  • Conflicting declaration
+  │
+  │   instance duplicate :: Class Int
+  │   ╰──────────────────────────────
+  •
+
+Error! · [DuplicateInstance] · DuplicateInstances.purs:15:1
+  •
+  │
+  • Instance name 'derived' has been defined multiple times
+  │
+  │   instance derived :: Class Boolean
+  │   ╰────────────────────────────────
+  │
+  • Conflicting declaration
+  │
+  │   derive newtype instance derived :: Class Second
+  │   ╰──────────────────────────────────────────────
+  •
+
+Error! · [DuplicateInstance] · DuplicateInstances.purs:16:1
+  •
+  │
+  • Instance name 'derived' has been defined multiple times
+  │
+  │   derive newtype instance derived :: Class Third
+  │   ╰─────────────────────────────────────────────
+  │
+  • Conflicting declaration
+  │
+  │   derive newtype instance derived :: Class Second
+  │   ╰──────────────────────────────────────────────
+  •

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/DuplicateInstances.snap
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/DuplicateInstances.snap
@@ -1,0 +1,38 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 354
+expression: report
+---
+module DuplicateInstances
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+  - Second
+  - Third
+  - First
+
+Exported Types:
+  - Second
+  - Third
+  - First
+
+Exported Classes:
+  - Class
+
+Local Terms:
+  - Second
+  - Third
+  - First
+
+Local Types:
+  - Second
+  - Third
+  - First
+
+Local Classes:
+  - Class
+
+Class Members:

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/ForeignFirst.js
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/ForeignFirst.js
@@ -1,0 +1,1 @@
+export const classInt = 42;

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/ForeignFirst.purs
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/ForeignFirst.purs
@@ -1,0 +1,10 @@
+module ForeignFirst where
+
+class Class :: Type -> Constraint
+class Class a
+
+foreign import classInt :: Int
+instance classInt :: Class Int
+
+test :: Int
+test = classInt

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/ForeignFirst.snap
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/ForeignFirst.snap
@@ -1,0 +1,30 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 354
+expression: report
+---
+module ForeignFirst
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+  - classInt
+  - test
+
+Exported Types:
+
+Exported Classes:
+  - Class
+
+Local Terms:
+  - classInt
+  - test
+
+Local Types:
+
+Local Classes:
+  - Class
+
+Class Members:

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/ForeignFirst.snap
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/ForeignFirst.snap
@@ -28,3 +28,18 @@ Local Classes:
   - Class
 
 Class Members:
+
+Diagnostics
+Error! · [RedefinedIdent] · ForeignFirst.purs:7:1
+  •
+  │
+  • Instance name 'classInt' conflicts with a local value declaration
+  │
+  │   instance classInt :: Class Int
+  │   ╰─────────────────────────────
+  │
+  • Conflicting declaration
+  │
+  │   foreign import classInt :: Int
+  │   ╰─────────────────────────────
+  •

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Hidden.js
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Hidden.js
@@ -1,0 +1,1 @@
+export const classInt = 42;

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Hidden.purs
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Hidden.purs
@@ -1,0 +1,10 @@
+module Hidden (test) where
+
+class Class :: Type -> Constraint
+class Class a
+
+instance classInt :: Class Int
+foreign import classInt :: Int
+
+test :: Int
+test = classInt

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Hidden.snap
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Hidden.snap
@@ -26,3 +26,18 @@ Local Classes:
   - Class
 
 Class Members:
+
+Diagnostics
+Error! · [RedefinedIdent] · Hidden.purs:6:1
+  •
+  │
+  • Instance name 'classInt' conflicts with a local value declaration
+  │
+  │   instance classInt :: Class Int
+  │   ╰─────────────────────────────
+  │
+  • Conflicting declaration
+  │
+  │   foreign import classInt :: Int
+  │   ╰─────────────────────────────
+  •

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Hidden.snap
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Hidden.snap
@@ -1,0 +1,28 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 354
+expression: report
+---
+module Hidden
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+  - test
+
+Exported Types:
+
+Exported Classes:
+
+Local Terms:
+  - classInt
+  - test
+
+Local Types:
+
+Local Classes:
+  - Class
+
+Class Members:

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/HiddenForeignFirst.js
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/HiddenForeignFirst.js
@@ -1,0 +1,1 @@
+export const classInt = 42;

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/HiddenForeignFirst.purs
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/HiddenForeignFirst.purs
@@ -1,0 +1,10 @@
+module HiddenForeignFirst (test) where
+
+class Class :: Type -> Constraint
+class Class a
+
+foreign import classInt :: Int
+instance classInt :: Class Int
+
+test :: Int
+test = classInt

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/HiddenForeignFirst.snap
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/HiddenForeignFirst.snap
@@ -26,3 +26,18 @@ Local Classes:
   - Class
 
 Class Members:
+
+Diagnostics
+Error! · [RedefinedIdent] · HiddenForeignFirst.purs:7:1
+  •
+  │
+  • Instance name 'classInt' conflicts with a local value declaration
+  │
+  │   instance classInt :: Class Int
+  │   ╰─────────────────────────────
+  │
+  • Conflicting declaration
+  │
+  │   foreign import classInt :: Int
+  │   ╰─────────────────────────────
+  •

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/HiddenForeignFirst.snap
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/HiddenForeignFirst.snap
@@ -1,0 +1,28 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 354
+expression: report
+---
+module HiddenForeignFirst
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+  - test
+
+Exported Types:
+
+Exported Classes:
+
+Local Terms:
+  - classInt
+  - test
+
+Local Types:
+
+Local Classes:
+  - Class
+
+Class Members:

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Main.js
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Main.js
@@ -1,0 +1,1 @@
+export const classInt = 42;

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Main.purs
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+class Class :: Type -> Constraint
+class Class a
+
+instance classInt :: Class Int
+foreign import classInt :: Int
+
+test :: Int
+test = classInt

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Main.snap
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Main.snap
@@ -1,0 +1,30 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 354
+expression: report
+---
+module Main
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+  - classInt
+  - test
+
+Exported Types:
+
+Exported Classes:
+  - Class
+
+Local Terms:
+  - classInt
+  - test
+
+Local Types:
+
+Local Classes:
+  - Class
+
+Class Members:

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Members.purs
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Members.purs
@@ -1,0 +1,13 @@
+module Members where
+
+class Class a where
+  classInt :: a
+
+instance classInt :: Class Int where
+  classInt = 42
+
+instance classString :: Other String where
+  classString = "value"
+
+class Other a where
+  classString :: a

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Members.snap
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Members.snap
@@ -32,3 +32,32 @@ Local Classes:
 Class Members:
   - Class.classInt
   - Other.classString
+
+Diagnostics
+Error! · [RedefinedIdent] · Members.purs:6:1
+  •
+  │
+  • Instance name 'classInt' conflicts with a local value declaration
+  │
+  │   instance classInt :: Class Int where
+  │   ╰───────────────────────────────────
+  │
+  • Conflicting declaration
+  │
+  │     classInt :: a
+  │     ╰────────────
+  •
+
+Error! · [RedefinedIdent] · Members.purs:9:1
+  •
+  │
+  • Instance name 'classString' conflicts with a local value declaration
+  │
+  │   instance classString :: Other String where
+  │   ╰─────────────────────────────────────────
+  │
+  • Conflicting declaration
+  │
+  │     classString :: a
+  │     ╰───────────────
+  •

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Members.snap
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Members.snap
@@ -1,0 +1,34 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 354
+expression: report
+---
+module Members
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+  - classString
+  - classInt
+
+Exported Types:
+
+Exported Classes:
+  - Class
+  - Other
+
+Local Terms:
+  - classString
+  - classInt
+
+Local Types:
+
+Local Classes:
+  - Class
+  - Other
+
+Class Members:
+  - Class.classInt
+  - Other.classString

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Values.purs
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Values.purs
@@ -1,0 +1,12 @@
+module Values where
+
+class Class :: Type -> Constraint
+class Class a
+
+instance classInt :: Class Int
+classInt :: Int
+classInt = 42
+
+classString :: String
+classString = "value"
+instance classString :: Class String

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Values.snap
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Values.snap
@@ -1,0 +1,30 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 354
+expression: report
+---
+module Values
+
+Unqualified Imports:
+
+Qualified Imports:
+
+Exported Terms:
+  - classString
+  - classInt
+
+Exported Types:
+
+Exported Classes:
+  - Class
+
+Local Terms:
+  - classString
+  - classInt
+
+Local Types:
+
+Local Classes:
+  - Class
+
+Class Members:

--- a/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Values.snap
+++ b/tests-integration/fixtures/resolving/1788751080_local_instance_name_conflicts/Values.snap
@@ -28,3 +28,32 @@ Local Classes:
   - Class
 
 Class Members:
+
+Diagnostics
+Error! · [RedefinedIdent] · Values.purs:6:1
+  •
+  │
+  • Instance name 'classInt' conflicts with a local value declaration
+  │
+  │   instance classInt :: Class Int
+  │   ╰─────────────────────────────
+  │
+  • Conflicting declaration
+  │
+  │   classInt :: Int
+  │   ╰──────────────
+  •
+
+Error! · [RedefinedIdent] · Values.purs:12:1
+  •
+  │
+  • Instance name 'classString' conflicts with a local value declaration
+  │
+  │   instance classString :: Class String
+  │   ╰───────────────────────────────────
+  │
+  • Conflicting declaration
+  │
+  │   classString :: String
+  │   ╰────────────────────
+  •


### PR DESCRIPTION
## Motivation
Explicit instance names must not reuse local value names, even when the value is hidden from exports. Previously these conflicts could reach the backend, where only conflicting runtime exports were rejected.

## Changes
- Validate local explicit instance and derive names during resolution without making instance names expression- or import-resolvable.
- Report the conflicting source declarations while retaining the backend guard and its cascading diagnostic.
- Cover both declaration orders, hidden exports, and legal namespace boundaries with generated snapshots, real FFI, runtime verification, and analyzer diagnostics tests.

The commit stack separates baseline regression fixtures from the fix. Language behavior was checked against PureScript 0.15.16.

## Validation
- Full resolving, checking, and backend integration categories pass with no pending snapshots.
- Analyzer diagnostics tests: 2 passed.
- cargo check -p tests-integration -p tests-e2e --tests
- just format
- git diff --check