### PR TITLE
[diagnostics] Explain code generation failures with source diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,7 +1501,9 @@ checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
+ "regex",
  "similar 2.7.0",
+ "strip-ansi-escapes",
  "tempfile",
 ]
 
@@ -3346,6 +3348,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3995,6 +4006,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "waitpid-any"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3587,6 +3587,7 @@ dependencies = [
  "insta",
  "itertools 0.15.0",
  "purescript-alexandrite",
+ "regex",
  "tempfile",
 ]
 

--- a/compiler-backend/functional/src/convert.rs
+++ b/compiler-backend/functional/src/convert.rs
@@ -103,9 +103,9 @@ where
     fn new(queries: &'c Q, file_id: FileId) -> ConversionResult<Context<'c, Q>> {
         let content = queries.content(file_id)?;
         let (parsed, _) = queries.parsed(file_id)?;
-        let module_name = parsed
-            .module_name(&content)
-            .expect("invariant violated: checked module has no source module name");
+        let module_name = parsed.module_name(&content).filter(|name| !name.is_empty()).ok_or(
+            ModuleError::Unsupported { file_id, state: UnsupportedState::MissingModuleName },
+        )?;
         let indexed = queries.indexed(file_id)?;
         let lowered = queries.lowered(file_id)?;
         let grouped = queries.grouped(file_id)?;

--- a/compiler-backend/functional/src/error.rs
+++ b/compiler-backend/functional/src/error.rs
@@ -16,6 +16,8 @@ pub enum ModuleError {
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum UnsupportedState {
+    #[error("source module has no module name")]
+    MissingModuleName,
     #[error("checked binder {0:?} contains an error")]
     BinderError(checked_tree::BinderId),
     #[error("record update contains an error")]

--- a/compiler-frontend/diagnostics/src/convert.rs
+++ b/compiler-frontend/diagnostics/src/convert.rs
@@ -9,6 +9,7 @@ use indexing::{IndexedTypeItemKind, IndexingError, InstanceSourceItemId, Ordered
 use itertools::Itertools;
 use javascript::{
     ModuleDiagnostic as JavaScriptModuleDiagnostic, ModuleError as JavaScriptModuleError,
+    UnsupportedState as JavaScriptUnsupportedState,
 };
 use lowering::LoweringError;
 use resolving::ResolvingError;
@@ -45,21 +46,131 @@ impl ToDiagnostics for FunctionalModuleError {
     where
         Q: ExternalQueries,
     {
-        let FunctionalModuleError::Unsupported { state, .. } = self;
+        let FunctionalModuleError::Unsupported { file_id, state } = self;
+        let local_global_span = |global| {
+            let source_file = match global {
+                GlobalId::Term(file, _) | GlobalId::Generated(file, _) => file,
+                GlobalId::Instance(InstanceIdentity::Declared(file, _))
+                | GlobalId::Instance(InstanceIdentity::Derived(file, _)) => file,
+            };
+            (source_file == *file_id).then(|| global_span(context, global)).flatten()
+        };
+        let module = codegen_module_name(context);
         let span = match state {
+            FunctionalUnsupportedState::BinderError(id) => {
+                use checking::tree::BinderSource;
+                let pointer = match context.checked.tree[*id].source {
+                    BinderSource::Binder(id) => context.stabilized.syntax_ptr(id),
+                    BinderSource::DoStatement(id) => context.stabilized.syntax_ptr(id),
+                    BinderSource::Operator(id) => context.stabilized.syntax_ptr(id),
+                    BinderSource::Section(id) => context.stabilized.syntax_ptr(id),
+                    BinderSource::Generated { derive, .. } => context.stabilized.syntax_ptr(derive),
+                };
+                pointer.and_then(|pointer| context.span_from_syntax_ptr(&pointer))
+            }
+            FunctionalUnsupportedState::PatternBindingError(id) => context
+                .stabilized
+                .syntax_ptr(*id)
+                .and_then(|pointer| context.span_from_syntax_ptr(&pointer)),
+            FunctionalUnsupportedState::MissingRuntimeExportOperatorResolution { term_id: id } => {
+                global_span(context, GlobalId::Term(*file_id, *id))
+            }
+            FunctionalUnsupportedState::MissingLocalDeclaration(id) => {
+                context.lowered.tree.get_let_binding(*id).and_then(|_| {
+                    context
+                        .span_from_error_crumb(&checking::error::ErrorCrumb::CheckingLetName(*id))
+                })
+            }
+            FunctionalUnsupportedState::ConflictingRuntimeExport { duplicate, .. } => {
+                local_global_span(*duplicate)
+            }
             FunctionalUnsupportedState::InvalidStyleXUse { declaration, .. }
             | FunctionalUnsupportedState::InvalidStyleXContext { declaration, .. } => {
-                global_span(context, *declaration)
+                local_global_span(*declaration)
             }
             _ => None,
         };
-        vec![Diagnostic::error(
+        let term_name = |id| {
+            context
+                .indexed
+                .items
+                .iter_terms()
+                .find_map(|(candidate, item)| (candidate == id).then_some(item))
+                .and_then(|item| item.name.as_ref())
+        };
+        let reason = match state {
+            FunctionalUnsupportedState::MissingModuleName =>
+                "A module header with a module name is required.".to_owned(),
+            FunctionalUnsupportedState::BinderError(_) =>
+                "A pattern could not be translated from its checked representation.".to_owned(),
+            FunctionalUnsupportedState::RecordUpdateError =>
+                "A record update contains an error.".to_owned(),
+            FunctionalUnsupportedState::PatternBindingError(_) =>
+                "A pattern binding in a let expression contains an error.".to_owned(),
+            FunctionalUnsupportedState::UnsolvedEvidence(_) =>
+                "An unresolved type class constraint remains in the checked code.".to_owned(),
+            FunctionalUnsupportedState::CyclicEvidence(_) =>
+                "The compiler encountered a cycle while constructing type class dictionaries.\n\nThis is an unsupported internal compiler state.".to_owned(),
+            FunctionalUnsupportedState::MissingTermDeclaration(_) =>
+                "The checked representation of a top-level declaration is unavailable.".to_owned(),
+            FunctionalUnsupportedState::MissingInstanceDeclaration =>
+                "The checked representation of an instance declaration is unavailable.".to_owned(),
+            FunctionalUnsupportedState::MissingLocalDeclaration(id) => {
+                let declaration = context.lowered.tree.get_let_binding(*id)
+                    .and_then(|_| context.lowered.tree.get_let_binding_group(*id).name.as_ref())
+                    .map(|name| format!("local declaration '{name}'"))
+                    .unwrap_or_else(|| "a local declaration".to_owned());
+                format!("The checked representation of {declaration} is unavailable.")
+            }
+            FunctionalUnsupportedState::MissingEquation =>
+                "A checked value declaration has no defining equations.".to_owned(),
+            FunctionalUnsupportedState::ConflictingRuntimeExport { name, .. } =>
+                format!("More than one declaration exports the runtime name '{name}'."),
+            FunctionalUnsupportedState::MissingRuntimeExportOperatorResolution { term_id } => {
+                let operator = term_name(*term_id)
+                    .map(|name| format!("exported operator '{name}'"))
+                    .unwrap_or_else(|| "an exported operator".to_owned());
+                format!("The runtime implementation of {operator} could not be resolved.")
+            }
+            FunctionalUnsupportedState::InvalidInstancePrerequisite =>
+                "An instance prerequisite has an unsupported dictionary representation.\n\nThis is an unsupported internal compiler state.".to_owned(),
+            FunctionalUnsupportedState::LocalIdentityOverflow =>
+                "The compiler's limit on local bindings was exceeded.".to_owned(),
+            FunctionalUnsupportedState::GeneratedGlobalIdentityOverflow =>
+                "The compiler's limit on generated top-level declarations was exceeded.".to_owned(),
+            FunctionalUnsupportedState::InvalidStyleXUse { function, .. } =>
+                format!("'Alexandrite.StyleX.{function}' must be called directly with all of its arguments.\n\nIt cannot be passed around as a function or partially applied."),
+            FunctionalUnsupportedState::InvalidStyleXContext { function, requirement, .. } =>
+                format!("'Alexandrite.StyleX.{function}' {requirement}."),
+            FunctionalUnsupportedState::VirtualModuleRuntimeReference { module_name, item_name } =>
+                format!("'{module_name}.{item_name}' is a compile-time declaration and cannot be used at runtime."),
+        };
+        let mut diagnostic = Diagnostic::error(
             "FunctionalCodegen",
-            state.to_string(),
+            format!("Cannot generate JavaScript for {module}.\n\n{reason}"),
             span.unwrap_or_else(|| context.module_span()),
             "functional",
-        )]
+        );
+        if let FunctionalUnsupportedState::ConflictingRuntimeExport { existing, .. } = state
+            && let Some(span) = local_global_span(*existing)
+        {
+            diagnostic = diagnostic
+                .with_related(span, "The other declaration exports the same runtime name");
+        }
+        vec![diagnostic]
     }
+}
+
+fn codegen_module_name<Q>(context: &DiagnosticsContext<'_, Q>) -> String
+where
+    Q: ExternalQueries,
+{
+    cst::Module::cast(context.root.clone())
+        .and_then(|module| module.header())
+        .and_then(|header| header.name())
+        .filter(|name| !name.syntax().text(context.content).is_empty())
+        .map(|name| format!("module '{}'", name.syntax().text(context.content)))
+        .unwrap_or_else(|| "this module".to_owned())
 }
 
 impl ToDiagnostics for JavaScriptModuleError {
@@ -69,12 +180,24 @@ impl ToDiagnostics for JavaScriptModuleError {
     {
         match self {
             JavaScriptModuleError::Functional(error) => error.to_diagnostics(context),
-            JavaScriptModuleError::Unsupported { state, .. } => vec![Diagnostic::error(
-                "JavaScriptCodegen",
-                state.to_string(),
-                context.module_span(),
-                "javascript",
-            )],
+            JavaScriptModuleError::Unsupported { state, .. } => {
+                let reason = match state {
+                    JavaScriptUnsupportedState::InvalidNumber { value } => format!(
+                        "The number literal '{value}' cannot be represented as a finite JavaScript number."
+                    ),
+                    JavaScriptUnsupportedState::MissingGlobal { .. } =>
+                        "The compiler could not find a JavaScript declaration for a referenced value.\n\nThis is an unsupported internal compiler state.".to_owned(),
+                    JavaScriptUnsupportedState::MissingLocal { .. } =>
+                        "The compiler could not find a JavaScript binding for a referenced local value.\n\nThis is an unsupported internal compiler state.".to_owned(),
+                };
+                let module = codegen_module_name(context);
+                vec![Diagnostic::error(
+                    "JavaScriptCodegen",
+                    format!("Cannot generate JavaScript for {module}.\n\n{reason}"),
+                    context.module_span(),
+                    "javascript",
+                )]
+            }
         }
     }
 }

--- a/compiler-frontend/diagnostics/src/render.rs
+++ b/compiler-frontend/diagnostics/src/render.rs
@@ -98,7 +98,11 @@ pub fn format_rich_with_path(
         let wrapped = textwrap::wrap(&diagnostic.message, message_width);
         for (index, line) in wrapped.iter().enumerate() {
             let gutter = if index == 0 { &branch } else { &stem };
-            output.push_str(&format!("{gutter} {}\n", paint_quoted_text(line, color)));
+            if line.is_empty() {
+                output.push_str(&format!("{gutter}\n"));
+            } else {
+                output.push_str(&format!("{gutter} {}\n", paint_quoted_text(line, color)));
+            }
         }
         output.push_str(&format!("{stem}\n"));
         render_rich_source(
@@ -115,8 +119,12 @@ pub fn format_rich_with_path(
             let wrapped = textwrap::wrap(&related.message, message_width);
             for (index, line) in wrapped.iter().enumerate() {
                 let gutter = if index == 0 { &branch } else { &stem };
-                let message = paint_quoted_text(&line, color);
-                output.push_str(&format!("{gutter} {message}\n"));
+                if line.is_empty() {
+                    output.push_str(&format!("{gutter}\n"));
+                } else {
+                    let message = paint_quoted_text(line, color);
+                    output.push_str(&format!("{gutter} {message}\n"));
+                }
             }
             output.push_str(&format!("{stem}\n"));
             render_rich_source(

--- a/tests-e2e/Cargo.toml
+++ b/tests-e2e/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 purescript-alexandrite = { path = "../compiler-bin" }
 
 [dev-dependencies]
-insta = "1.48.0"
+insta = { version = "1.48.0", features = ["filters"] }
 itertools = "0.15.0"
 tempfile = "3.27.0"
 

--- a/tests-e2e/Cargo.toml
+++ b/tests-e2e/Cargo.toml
@@ -10,6 +10,7 @@ purescript-alexandrite = { path = "../compiler-bin" }
 [dev-dependencies]
 insta = { version = "1.48.0", features = ["filters"] }
 itertools = "0.15.0"
+regex = "1.12.2"
 tempfile = "3.27.0"
 
 [[bin]]

--- a/tests-e2e/tests/package_manager/build.rs
+++ b/tests-e2e/tests/package_manager/build.rs
@@ -3,7 +3,9 @@ use super::support::{TestWorkspace, assert_success};
 fn diagnostic_settings(workspace: &TestWorkspace) -> insta::Settings {
     let mut settings = insta::Settings::clone_current();
     settings.set_strip_ansi_escape_codes(true);
-    let workspace_path = regex::escape(&workspace.path().to_string_lossy());
+    let workspace_path = std::fs::canonicalize(workspace.path()).unwrap();
+    let workspace_path = workspace_path.to_string_lossy();
+    let workspace_path = regex::escape(workspace_path.trim_start_matches(r"\\?\"));
     settings.add_filter(&format!(r"{workspace_path}[/\\]"), "");
     settings.add_filter(r"src\\Main\.purs", "src/Main.purs");
     settings.add_filter(

--- a/tests-e2e/tests/package_manager/build.rs
+++ b/tests-e2e/tests/package_manager/build.rs
@@ -1,5 +1,23 @@
 use super::support::{TestWorkspace, assert_success};
 
+fn diagnostic_settings() -> insta::Settings {
+    let mut settings = insta::Settings::clone_current();
+    settings.set_strip_ansi_escape_codes(true);
+    settings.add_filter(r"src\\Main\.purs", "src/Main.purs");
+    settings.add_filter(
+        concat!(
+            r"(?m)^(?:Reading Spago workspace configuration\.\.\.",
+            r"|✓ Selecting package to build: application",
+            r#"|Adding dependency ranges to the config in "spago.yaml""#,
+            r"|Downloading dependencies\.\.\.",
+            r"|No lockfile found, generating it\.\.\.",
+            r"|Lockfile written to spago.lock\. Please commit this file\.)\r?\n(?:\r?\n)*",
+        ),
+        "",
+    );
+    settings
+}
+
 #[test]
 fn builds_a_single_package_with_real_spago() {
     let workspace = TestWorkspace::empty();
@@ -58,7 +76,8 @@ broken = missing
         String::from_utf8_lossy(&output.stderr)
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("'missing' is not in scope"), "unexpected stderr:\n{stderr}");
+    let _settings = diagnostic_settings().bind_to_scope();
+    insta::assert_snapshot!("resilient_source_diagnostics", stderr);
 
     let generated = workspace.read("output/Main/index.js");
     assert!(generated.contains("Generated code reached a source error"));
@@ -96,13 +115,14 @@ second = first
     let strict = workspace.command(&["build", "--quiet"]);
     assert!(!strict.status.success());
     let stderr = String::from_utf8_lossy(&strict.stderr);
-    assert!(stderr.contains("JavaScriptInitializerCycle"), "unexpected stderr:\n{stderr}");
+    let _settings = diagnostic_settings().bind_to_scope();
+    insta::assert_snapshot!("strict_initializer_cycle_diagnostics", stderr);
     assert!(!workspace.path().join("output/Main/index.js").exists());
 
     let resilient = workspace.command(&["build", "--quiet", "--resilient"]);
     assert!(!resilient.status.success());
     let stderr = String::from_utf8_lossy(&resilient.stderr);
-    assert!(stderr.contains("JavaScriptInitializerCycle"), "unexpected stderr:\n{stderr}");
+    insta::assert_snapshot!("resilient_initializer_cycle_diagnostics", stderr);
     let generated = workspace.read("output/Main/index.js");
     assert!(generated.contains("Top-level value initializer cycle"));
     assert!(!generated.contains("@__PURE__"));
@@ -142,14 +162,8 @@ partialProps = props
     let output = workspace.command(&["build", "--quiet"]);
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("FunctionalCodegen"), "unexpected stderr:\n{stderr}");
-    assert!(
-        stderr.contains(
-            "Alexandrite.StyleX.props must be used as a direct, saturated intrinsic call"
-        ),
-        "unexpected stderr:\n{stderr}"
-    );
-    assert!(!stderr.contains("failed to generate JavaScript"), "unexpected stderr:\n{stderr}");
+    let _settings = diagnostic_settings().bind_to_scope();
+    insta::assert_snapshot!("backend_failure_diagnostics", stderr);
     assert!(!workspace.path().join("output/Main/index.js").exists());
     workspace.assert_spago_calls(
         "",

--- a/tests-e2e/tests/package_manager/build.rs
+++ b/tests-e2e/tests/package_manager/build.rs
@@ -1,8 +1,10 @@
 use super::support::{TestWorkspace, assert_success};
 
-fn diagnostic_settings() -> insta::Settings {
+fn diagnostic_settings(workspace: &TestWorkspace) -> insta::Settings {
     let mut settings = insta::Settings::clone_current();
     settings.set_strip_ansi_escape_codes(true);
+    let workspace_path = regex::escape(&workspace.path().to_string_lossy());
+    settings.add_filter(&format!(r"{workspace_path}[/\\]"), "");
     settings.add_filter(r"src\\Main\.purs", "src/Main.purs");
     settings.add_filter(
         concat!(
@@ -76,7 +78,7 @@ broken = missing
         String::from_utf8_lossy(&output.stderr)
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let _settings = diagnostic_settings().bind_to_scope();
+    let _settings = diagnostic_settings(&workspace).bind_to_scope();
     insta::assert_snapshot!("resilient_source_diagnostics", stderr);
 
     let generated = workspace.read("output/Main/index.js");
@@ -115,7 +117,7 @@ second = first
     let strict = workspace.command(&["build", "--quiet"]);
     assert!(!strict.status.success());
     let stderr = String::from_utf8_lossy(&strict.stderr);
-    let _settings = diagnostic_settings().bind_to_scope();
+    let _settings = diagnostic_settings(&workspace).bind_to_scope();
     insta::assert_snapshot!("strict_initializer_cycle_diagnostics", stderr);
     assert!(!workspace.path().join("output/Main/index.js").exists());
 
@@ -162,7 +164,7 @@ partialProps = props
     let output = workspace.command(&["build", "--quiet"]);
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let _settings = diagnostic_settings().bind_to_scope();
+    let _settings = diagnostic_settings(&workspace).bind_to_scope();
     insta::assert_snapshot!("backend_failure_diagnostics", stderr);
     assert!(!workspace.path().join("output/Main/index.js").exists());
     workspace.assert_spago_calls(

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__build__backend_failure_diagnostics.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__build__backend_failure_diagnostics.snap
@@ -1,0 +1,18 @@
+---
+source: tests-e2e/tests/package_manager/build.rs
+expression: stderr
+---
+Error! · [FunctionalCodegen] · src/Main.purs:5:1
+  •
+  │
+  • Cannot generate JavaScript for module 'Main'.
+  │
+  │ 'Alexandrite.StyleX.props' must be called directly with all of its arguments.
+  │
+  │ It cannot be passed around as a function or partially applied.
+  │
+  │   partialProps :: Style -> Props
+  │   ╰─────────────────────────────
+  •
+
+compilation failed

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__build__resilient_initializer_cycle_diagnostics.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__build__resilient_initializer_cycle_diagnostics.snap
@@ -1,0 +1,19 @@
+---
+source: tests-e2e/tests/package_manager/build.rs
+expression: stderr
+---
+Error! · [JavaScriptInitializerCycle] · src/Main.purs:6:1
+  •
+  │
+  • This declaration is cyclic with other declarations
+  │
+  │   second :: Int
+  │   ╰────────────
+  │
+  • This declaration is a member of the same cycle
+  │
+  │   first :: Int
+  │   ╰───────────
+  •
+
+compilation failed

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__build__resilient_source_diagnostics.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__build__resilient_source_diagnostics.snap
@@ -1,0 +1,23 @@
+---
+source: tests-e2e/tests/package_manager/build.rs
+expression: stderr
+---
+Error! · [NotInScope] · src/Main.purs:5:10
+  •
+  │
+  • 'missing' is not in scope
+  │
+  │   broken = missing
+  │            ╰──────
+  •
+
+Error! · [CannotUnify] · src/Main.purs:5:10
+  •
+  │
+  • Cannot unify 'Type' with '?[invalid kind]'
+  │
+  │   broken = missing
+  │            ╰──────
+  •
+
+compilation failed

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__build__strict_initializer_cycle_diagnostics.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__build__strict_initializer_cycle_diagnostics.snap
@@ -1,0 +1,19 @@
+---
+source: tests-e2e/tests/package_manager/build.rs
+expression: stderr
+---
+Error! · [JavaScriptInitializerCycle] · src/Main.purs:6:1
+  •
+  │
+  • This declaration is cyclic with other declarations
+  │
+  │   second :: Int
+  │   ╰────────────
+  │
+  • This declaration is a member of the same cycle
+  │
+  │   first :: Int
+  │   ╰───────────
+  •
+
+compilation failed

--- a/tests-integration/fixtures/backend/1787994720_stylex_unsupported_use/Main.snap
+++ b/tests-integration/fixtures/backend/1787994720_stylex_unsupported_use/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 280
+assertion_line: 294
 expression: diagnostics_report
 ---
 Terms
@@ -12,7 +12,11 @@ Backend Diagnostics
 Error! · [FunctionalCodegen] · Main.purs:5:1
   •
   │
-  • Alexandrite.StyleX.props must be used as a direct, saturated intrinsic call
+  • Cannot generate JavaScript for module 'Main'.
+  │
+  │ 'Alexandrite.StyleX.props' must be called directly with all of its arguments.
+  │
+  │ It cannot be passed around as a function or partially applied.
   │
   │   partialProps :: Style -> Props
   │   ╰─────────────────────────────

--- a/tests-integration/fixtures/backend/1788013200_stylex_conditional_unsupported_use/Main.snap
+++ b/tests-integration/fixtures/backend/1788013200_stylex_conditional_unsupported_use/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 280
+assertion_line: 294
 expression: diagnostics_report
 ---
 Terms
@@ -12,7 +12,11 @@ Backend Diagnostics
 Error! · [FunctionalCodegen] · Main.purs:5:1
   •
   │
-  • Alexandrite.StyleX.conditional must be used as a direct, saturated intrinsic call
+  • Cannot generate JavaScript for module 'Main'.
+  │
+  │ 'Alexandrite.StyleX.conditional' must be called directly with all of its arguments.
+  │
+  │ It cannot be passed around as a function or partially applied.
   │
   │   partialConditional :: Style -> Style
   │   ╰───────────────────────────────────

--- a/tests-integration/fixtures/backend/1788371160_style_x_conditional_case_escape/Main.snap
+++ b/tests-integration/fixtures/backend/1788371160_style_x_conditional_case_escape/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 280
+assertion_line: 294
 expression: diagnostics_report
 ---
 Terms
@@ -12,7 +12,9 @@ Backend Diagnostics
 Error! · [FunctionalCodegen] · Main.purs:5:1
   •
   │
-  • Alexandrite.StyleX.ancestor must be used directly in a conditionalValue case array
+  • Cannot generate JavaScript for module 'Main'.
+  │
+  │ 'Alexandrite.StyleX.ancestor' must be used directly in a conditionalValue case array.
   │
   │   escaped = When.ancestor ":hover" "red"
   │   ╰─────────────────────────────────────

--- a/tests-integration/fixtures/backend/1788371160_style_x_marker_must_be_exported/Main.snap
+++ b/tests-integration/fixtures/backend/1788371160_style_x_marker_must_be_exported/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 280
+assertion_line: 294
 expression: diagnostics_report
 ---
 Terms
@@ -13,7 +13,9 @@ Backend Diagnostics
 Error! · [FunctionalCodegen] · Main.purs:5:1
   •
   │
-  • Alexandrite.StyleX.defineMarker must initialize an exported top-level value
+  • Cannot generate JavaScript for module 'Main'.
+  │
+  │ 'Alexandrite.StyleX.defineMarker' must initialize an exported top-level value.
   │
   │   marker = StyleX.defineMarker
   │   ╰───────────────────────────

--- a/tests-integration/fixtures/backend/1788371160_style_x_static_context_escape/Main.snap
+++ b/tests-integration/fixtures/backend/1788371160_style_x_static_context_escape/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 280
+assertion_line: 294
 expression: diagnostics_report
 ---
 Terms
@@ -12,7 +12,9 @@ Backend Diagnostics
 Error! · [FunctionalCodegen] · Main.purs:5:1
   •
   │
-  • Alexandrite.StyleX.color must be used inside defineVars or createTheme
+  • Cannot generate JavaScript for module 'Main'.
+  │
+  │ 'Alexandrite.StyleX.color' must be used inside defineVars or createTheme.
   │
   │   escaped = Types.color "red"
   │   ╰──────────────────────────

--- a/tests-integration/fixtures/backend/1788759960_foreign_instance_name_conflict/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788759960_foreign_instance_name_conflict/Main.functional.snap
@@ -1,6 +1,0 @@
----
-source: tests-integration/tests/functional.rs
-assertion_line: 14
-expression: report
----
-cannot convert checked module Idx::<File>(45): runtime export name "classInt" refers to conflicting globals Term(Idx::<File>(45), Idx::<IndexedTermItem>(0)) and Instance(Declared(Idx::<File>(45), AstId<syntax::cst::InstanceDeclaration>(15)))

--- a/tests-integration/fixtures/backend/1788759960_foreign_instance_name_conflict/Main.snap
+++ b/tests-integration/fixtures/backend/1788759960_foreign_instance_name_conflict/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 298
+assertion_line: 294
 expression: diagnostics_report
 ---
 Terms
@@ -33,11 +33,18 @@ Error! · [RedefinedIdent] · Main.purs:7:1
 
 
 Backend Diagnostics
-Error! · [FunctionalCodegen] · Main.purs:1:1
+Error! · [FunctionalCodegen] · Main.purs:7:1
   •
   │
-  • runtime export name "classInt" refers to conflicting declarations
+  • Cannot generate JavaScript for module 'Main'.
   │
-  │   module Main where
-  │   ╰────────────────
+  │ More than one declaration exports the runtime name 'classInt'.
+  │
+  │   instance classInt :: Class Int
+  │   ╰─────────────────────────────
+  │
+  • The other declaration exports the same runtime name
+  │
+  │   foreign import classInt :: Int
+  │   ╰─────────────────────────────
   •

--- a/tests-integration/fixtures/backend/1788759960_instance_foreign_name_conflict/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788759960_instance_foreign_name_conflict/Main.functional.snap
@@ -1,6 +1,0 @@
----
-source: tests-integration/tests/functional.rs
-assertion_line: 14
-expression: report
----
-cannot convert checked module Idx::<File>(45): runtime export name "classInt" refers to conflicting globals Instance(Declared(Idx::<File>(45), AstId<syntax::cst::InstanceDeclaration>(13))) and Term(Idx::<File>(45), Idx::<IndexedTermItem>(0))

--- a/tests-integration/fixtures/backend/1788759960_instance_foreign_name_conflict/Main.snap
+++ b/tests-integration/fixtures/backend/1788759960_instance_foreign_name_conflict/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 298
+assertion_line: 294
 expression: diagnostics_report
 ---
 Terms
@@ -33,11 +33,18 @@ Error! · [RedefinedIdent] · Main.purs:6:1
 
 
 Backend Diagnostics
-Error! · [FunctionalCodegen] · Main.purs:1:1
+Error! · [FunctionalCodegen] · Main.purs:7:1
   •
   │
-  • runtime export name "classInt" refers to conflicting declarations
+  • Cannot generate JavaScript for module 'Main'.
   │
-  │   module Main where
-  │   ╰────────────────
+  │ More than one declaration exports the runtime name 'classInt'.
+  │
+  │   foreign import classInt :: Int
+  │   ╰─────────────────────────────
+  │
+  • The other declaration exports the same runtime name
+  │
+  │   instance classInt :: Class Int
+  │   ╰─────────────────────────────
   •

--- a/tests-integration/fixtures/backend/1788764580_functional_missing_declaration_diagnostic/Main.purs
+++ b/tests-integration/fixtures/backend/1788764580_functional_missing_declaration_diagnostic/Main.purs
@@ -1,0 +1,3 @@
+module Main where
+
+missing :: Int

--- a/tests-integration/fixtures/backend/1788764580_functional_missing_declaration_diagnostic/Main.snap
+++ b/tests-integration/fixtures/backend/1788764580_functional_missing_declaration_diagnostic/Main.snap
@@ -1,0 +1,21 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 294
+expression: diagnostics_report
+---
+Terms
+missing :: Prim.Int
+
+Types
+
+Backend Diagnostics
+Error! · [FunctionalCodegen] · Main.purs:1:1
+  •
+  │
+  • Cannot generate JavaScript for module 'Main'.
+  │
+  │ The checked representation of a top-level declaration is unavailable.
+  │
+  │   module Main where
+  │   ╰────────────────
+  •

--- a/tests-integration/fixtures/backend/1788764580_functional_operator_diagnostic/Main.purs
+++ b/tests-integration/fixtures/backend/1788764580_functional_operator_diagnostic/Main.purs
@@ -1,0 +1,3 @@
+module Main where
+
+infixl 5 missing as +++

--- a/tests-integration/fixtures/backend/1788764580_functional_operator_diagnostic/Main.snap
+++ b/tests-integration/fixtures/backend/1788764580_functional_operator_diagnostic/Main.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 294
+expression: diagnostics_report
+---
+Terms
+
+Types
+
+Backend Diagnostics
+Error! · [FunctionalCodegen] · Main.purs:3:1
+  •
+  │
+  • Cannot generate JavaScript for module 'Main'.
+  │
+  │ The runtime implementation of exported operator '+++' could not be resolved.
+  │
+  │   infixl 5 missing as +++
+  │   ╰──────────────────────
+  •

--- a/tests-integration/fixtures/backend/1788764580_functional_pattern_diagnostic/Main.purs
+++ b/tests-integration/fixtures/backend/1788764580_functional_pattern_diagnostic/Main.purs
@@ -1,0 +1,4 @@
+module Main where
+
+test :: Int -> Int
+test Missing = 1

--- a/tests-integration/fixtures/backend/1788764580_functional_pattern_diagnostic/Main.snap
+++ b/tests-integration/fixtures/backend/1788764580_functional_pattern_diagnostic/Main.snap
@@ -1,0 +1,21 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 294
+expression: diagnostics_report
+---
+Terms
+test :: Prim.Int -> Prim.Int
+
+Types
+
+Backend Diagnostics
+Error! · [FunctionalCodegen] · Main.purs:4:6
+  •
+  │
+  • Cannot generate JavaScript for module 'Main'.
+  │
+  │ A pattern could not be translated from its checked representation.
+  │
+  │   test Missing = 1
+  │        ╰──────
+  •

--- a/tests-integration/fixtures/backend/1788765120_dependency_codegen_diagnostic/Library.purs
+++ b/tests-integration/fixtures/backend/1788765120_dependency_codegen_diagnostic/Library.purs
@@ -1,0 +1,4 @@
+module Library where
+
+value :: Number
+value = 1.0e999

--- a/tests-integration/fixtures/backend/1788765120_dependency_codegen_diagnostic/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788765120_dependency_codegen_diagnostic/Main.functional.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export test = value

--- a/tests-integration/fixtures/backend/1788765120_dependency_codegen_diagnostic/Main.purs
+++ b/tests-integration/fixtures/backend/1788765120_dependency_codegen_diagnostic/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Library (value)
+
+test :: Number
+test = value

--- a/tests-integration/fixtures/backend/1788765120_dependency_codegen_diagnostic/Main.snap
+++ b/tests-integration/fixtures/backend/1788765120_dependency_codegen_diagnostic/Main.snap
@@ -1,0 +1,21 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 294
+expression: diagnostics_report
+---
+Terms
+test :: Prim.Number
+
+Types
+
+Backend Diagnostics
+Error! · [JavaScriptCodegen] · Library.purs:1:1
+  •
+  │
+  • Cannot generate JavaScript for module 'Library'.
+  │
+  │ The number literal '1.0e999' cannot be represented as a finite JavaScript number.
+  │
+  │   module Library where
+  │   ╰───────────────────
+  •

--- a/tests-integration/fixtures/backend/1788765120_javascript_number_diagnostic/Main.functional.snap
+++ b/tests-integration/fixtures/backend/1788765120_javascript_number_diagnostic/Main.functional.snap
@@ -1,0 +1,6 @@
+---
+source: tests-integration/tests/functional.rs
+assertion_line: 14
+expression: report
+---
+@export test = 1.0e999

--- a/tests-integration/fixtures/backend/1788765120_javascript_number_diagnostic/Main.purs
+++ b/tests-integration/fixtures/backend/1788765120_javascript_number_diagnostic/Main.purs
@@ -1,0 +1,4 @@
+module Main where
+
+test :: Number
+test = 1.0e999

--- a/tests-integration/fixtures/backend/1788765120_javascript_number_diagnostic/Main.snap
+++ b/tests-integration/fixtures/backend/1788765120_javascript_number_diagnostic/Main.snap
@@ -1,0 +1,21 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 294
+expression: diagnostics_report
+---
+Terms
+test :: Prim.Number
+
+Types
+
+Backend Diagnostics
+Error! · [JavaScriptCodegen] · Main.purs:1:1
+  •
+  │
+  • Cannot generate JavaScript for module 'Main'.
+  │
+  │ The number literal '1.0e999' cannot be represented as a finite JavaScript number.
+  │
+  │   module Main where
+  │   ╰────────────────
+  •

--- a/tests-integration/fixtures/lsp/1788269400_backend_diagnostics/Main.snap
+++ b/tests-integration/fixtures/lsp/1788269400_backend_diagnostics/Main.snap
@@ -1,8 +1,12 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 388
+assertion_line: 386
 expression: report
 ---
 Diagnostics
 
-4:0..4:30 analyzer/functional [FunctionalCodegen] Alexandrite.StyleX.props must be used as a direct, saturated intrinsic call
+4:0..4:30 analyzer/functional [FunctionalCodegen] Cannot generate JavaScript for module 'Main'.
+
+'Alexandrite.StyleX.props' must be called directly with all of its arguments.
+
+It cannot be passed around as a function or partially applied.

--- a/tests-integration/fixtures/lsp/1788765120_missing_module_header_diagnostic/Main.purs
+++ b/tests-integration/fixtures/lsp/1788765120_missing_module_header_diagnostic/Main.purs
@@ -1,0 +1,1 @@
+-- diagnostics

--- a/tests-integration/fixtures/lsp/1788765120_missing_module_header_diagnostic/Main.snap
+++ b/tests-integration/fixtures/lsp/1788765120_missing_module_header_diagnostic/Main.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 411
+expression: report
+---
+Diagnostics
+
+0:0..1:0 analyzer/functional [FunctionalCodegen] Cannot generate JavaScript for this module.
+
+A module header with a module name is required.

--- a/tests-integration/src/fixtures.rs
+++ b/tests-integration/src/fixtures.rs
@@ -263,7 +263,7 @@ pub fn backend(path: &Path) -> FixtureResult {
     let checking_report = crate::generated::basic::report_checked(&engine, id, display_path);
     let foreign_report = crate::generated::basic::report_foreign(&engine, id, display_path);
     let backend_report = crate::generated::basic::report_backend(&engine, id, display_path);
-    let diagnostics_report = format!("{checking_report}{foreign_report}{backend_report}");
+    let mut diagnostics_report = format!("{checking_report}{foreign_report}{backend_report}");
     let generated = tempfile::tempdir()?;
     let output = generated.path().join("output");
     std::fs::create_dir(&output)?;
@@ -284,7 +284,28 @@ pub fn backend(path: &Path) -> FixtureResult {
                 }
             }
         }
-        Err(error) if backend_report.is_empty() => return Err(error.into()),
+        Err(error) if backend_report.is_empty() => {
+            let (javascript::ModuleError::Functional(functional::ModuleError::Unsupported {
+                file_id,
+                ..
+            })
+            | javascript::ModuleError::Unsupported { file_id, .. }) = error;
+            let source_url = Url::parse(&files.path(file_id))?;
+            let source_path = source_url
+                .to_file_path()
+                .map_err(|()| invalid_data(format!("source URL is not a file: {source_url}")))?;
+            let display_path = match source_path.strip_prefix(&fixture) {
+                Ok(relative) => relative,
+                Err(_) => Path::new(source_path.file_name().ok_or_else(|| {
+                    invalid_data(format!("source path has no file name: {}", source_path.display()))
+                })?),
+            };
+            diagnostics_report.push_str(&crate::generated::basic::report_backend(
+                &engine,
+                file_id,
+                &display_path.to_string_lossy(),
+            ));
+        }
         Err(_) => {}
     }
     run_javascript_verification(&fixture, generated.path())?;
@@ -395,9 +416,18 @@ pub fn lsp(path: &Path) -> FixtureResult {
     let folder = fixture_folder(path)?;
     let file = module_name(path)?;
     let (engine, files) = crate::load_compiler(folder)?;
-    let Some(id) = engine.module_file(&file) else {
-        return Err(missing_module(path, &file).into());
-    };
+    let source_path = snapshot_path(folder).join(path.file_name().ok_or_else(|| {
+        invalid_data(format!("fixture path has no file name: {}", path.display()))
+    })?);
+    let source_url = Url::from_file_path(&source_path).map_err(|()| {
+        invalid_data(format!(
+            "fixture path cannot be converted to a URL: {}",
+            source_path.display()
+        ))
+    })?;
+    let id = files.id(source_url.as_str()).ok_or_else(|| {
+        invalid_data(format!("fixture source was not loaded: {}", source_path.display()))
+    })?;
 
     let report = crate::generated::lsp::report(&engine, &files, id);
     let mut settings = insta::Settings::clone_current();


### PR DESCRIPTION
## Intent

Follow up on #477 to replace raw code-generation IDs and terse backend failure strings with readable source-oriented diagnostics. Rebased onto `main` after the registry-fixture migration in #475.

## Changes

- Convert every functional and JavaScript typed unsupported-state variant to explicit diagnostic prose, with paragraph separation and trustworthy source/module context. Keep structured backend errors and their engineering-oriented Display implementations intact.
- Point runtime-export collisions to both declarations while retaining the existing resolving diagnostic and backend rejection.
- Report dependency code-generation failures against the dependency source instead of leaking a boxed raw error. Preserve registry-backed loading, temporary runtime output, and fixture-owned JavaScript comparisons from #475.
- Keep functional failures in canonical backend diagnostic snapshots rather than duplicate functional-IR snapshots, following #475. Do not restore the deleted standalone diagnostics test file or add an invalid-IR scaffold.
- Handle missing/empty module names with a typed diagnostic before output generation. The source reproducer previously attempted an invalid output path and reported Permission denied.
- Render blank paragraph gutters without trailing spaces.
- Use Insta snapshots for four E2E build diagnostic outputs. Normalize ANSI, temporary workspace paths (including Windows canonical paths), and narrowly identified Spago chatter. Keep exit status, generated output, and Spago-call assertions separate.

## Verification after rebase

With Node 22.23.2 and the pinned E2E tools:

- `just integration-prepare`: prepared 41 registry packages.
- `just t backend --verbose`: 242 passed, no pending snapshots; includes functional snapshots and JavaScript execution checks.
- `just t lsp --verbose`: 120 passed, no pending snapshots.
- `just t checking --verbose`: 378 passed, no pending snapshots.
- `just t resolving --verbose`: 58 passed, no pending snapshots.
- `just t lowering --verbose`: 32 passed, no pending snapshots.
- `just t semantic --verbose`: 169 passed, no pending snapshots.
- `cargo nextest run -p tests-integration --test functional`: 121 passed.
- `just e2e`: 16 passed, including full diagnostic snapshots from actual compiler executions. No snapshot regeneration was necessary after the rebase.
- `cargo check -p functional -p javascript -p diagnostics -p tests-integration -p tests-e2e --tests`: passed.
- Ordinary Clippy for those five packages with `--tests`: passed with existing warnings. Strict `-D warnings` is blocked by unchanged `compiler-backend/javascript/src/convert/generator/names.rs:144` (redundant closure); E2E also encounters the existing `compiler-bin/src/compile.rs:133` too-many-arguments warning.
- `just format` and `git diff --check`: passed.

Before the rebase, direct CLI checks also compiled collision, partial StyleX application, non-finite number, and headerless fixtures with `compile --quiet --color never`. Each exited 1 with readable paragraphs and no raw FileId/GlobalId/Idx/AstId/EvidenceVarId text. Collision still reports both RedefinedIdent and FunctionalCodegen. The previous head passed E2E CI on Linux, macOS, and Windows; the rebased head requires fresh CI results.

## Scope and limits

Oracle was consulted after tracing the presentation paths. This covers typed code-generation failures, not a blanket rewrite of renderer invariant assertions or unrelated I/O/query failures. Safe generic text is used when error payloads do not establish source ownership or may contain generated binding names.

Fixtures directly exercise collisions, StyleX restrictions, missing top-level declarations, invalid patterns, unresolved exported operators, invalid JavaScript numbers (including a dependency), and missing module headers. Other internal variants have exhaustive prose conversion but no source reproducer here; no corrupted-IR test scaffold was added.

Codecov gates failed on the previous head (patch 63.50%; project 85.94%, target 85.96%). No gates were disabled and no coverage fix is claimed; fresh coverage after the registry rebase is pending. Cargo also reports an existing future-incompatibility notice for proc-macro-error2.