### PR TITLE
[checking] Build semantic evidence with SmolStrBuilder

### DIFF
--- a/compiler-frontend/checking/src/tree/pretty.rs
+++ b/compiler-frontend/checking/src/tree/pretty.rs
@@ -49,6 +49,27 @@ enum ExpressionPrecedence {
     Atom,
 }
 
+#[derive(Clone, Copy)]
+enum EvidencePrecedence {
+    Application,
+    Atom,
+}
+
+impl EvidencePrecedence {
+    fn append_projection(self, output: &mut SmolStrBuilder, parent: &str, field: &str) {
+        match self {
+            EvidencePrecedence::Application => {
+                output.push('(');
+                output.push_str(parent);
+                output.push(')');
+            }
+            EvidencePrecedence::Atom => output.push_str(parent),
+        }
+        output.push('.');
+        output.push_str(field);
+    }
+}
+
 fn character_literal(value: char) -> String {
     match value {
         '\n' => "'\\n'".to_string(),
@@ -1798,10 +1819,12 @@ where
             Evidence(&'a Evidence),
             Variable(EvidenceVarId),
             Text(&'static str),
+            Precedence(EvidencePrecedence),
             Superclass { prefix: SmolStrBuilder, superclass: SuperclassId },
         }
 
         let mut rendered = SmolStrBuilder::new();
+        let mut precedence = EvidencePrecedence::Atom;
         let mut pending = vec![Pending::Evidence(evidence)];
         while let Some(next) = pending.pop() {
             match next {
@@ -1812,14 +1835,27 @@ where
                     EvidenceState::Solved(proof) => {
                         pending.push(Pending::Evidence(&self.checked.evidence[proof]));
                     }
-                    EvidenceState::Unsolved => rendered.push_str("unsolved"),
-                    EvidenceState::Error => rendered.push_str("error"),
+                    EvidenceState::Unsolved => {
+                        rendered.push_str("unsolved");
+                        precedence = EvidencePrecedence::Atom;
+                    }
+                    EvidenceState::Error => {
+                        rendered.push_str("error");
+                        precedence = EvidencePrecedence::Atom;
+                    }
                 },
                 Pending::Evidence(Evidence::Given(binder)) => {
                     rendered.push_str(&self.evidence_binder_name(names, *binder)?);
+                    precedence = EvidencePrecedence::Atom;
                 }
                 Pending::Evidence(Evidence::Instance { origin, subgoals }) => {
                     rendered.push_str(&self.instance_dictionary_name(*origin)?);
+                    let instance_precedence = if subgoals.is_empty() {
+                        EvidencePrecedence::Atom
+                    } else {
+                        EvidencePrecedence::Application
+                    };
+                    pending.push(Pending::Precedence(instance_precedence));
                     for subgoal in subgoals.iter().rev() {
                         pending.push(Pending::Text("}"));
                         pending.push(Pending::Variable(*subgoal));
@@ -1833,23 +1869,22 @@ where
                     });
                     pending.push(Pending::Evidence(&self.checked.evidence[*parent]));
                 }
-                Pending::Evidence(Evidence::Trivial) => rendered.push_str("trivial"),
+                Pending::Evidence(Evidence::Trivial) => {
+                    rendered.push_str("trivial");
+                    precedence = EvidencePrecedence::Atom;
+                }
                 Pending::Evidence(Evidence::Synthesized(evidence)) => {
                     rendered.push_str(&synthesized_evidence_name(evidence));
+                    precedence = EvidencePrecedence::Atom;
                 }
                 Pending::Text(text) => rendered.push_str(text),
+                Pending::Precedence(completed) => precedence = completed,
                 Pending::Superclass { prefix, superclass } => {
                     let parent = rendered.finish();
                     rendered = prefix;
-                    if parent.contains(' ') {
-                        rendered.push('(');
-                        rendered.push_str(&parent);
-                        rendered.push(')');
-                    } else {
-                        rendered.push_str(&parent);
-                    }
-                    rendered.push('.');
-                    rendered.push_str(&self.superclass_field_name(superclass)?);
+                    let field = self.superclass_field_name(superclass)?;
+                    precedence.append_projection(&mut rendered, &parent, &field);
+                    precedence = EvidencePrecedence::Atom;
                 }
             }
         }
@@ -2102,5 +2137,39 @@ fn synthesized_evidence_name(evidence: &SynthesizedEvidence) -> SmolStr {
         SynthesizedEvidence::Reflectable(ReflectableEvidence::Ordering(
             ReflectableOrdering::Greater,
         )) => REFLECTABLE_GREATER_EVIDENCE,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use smol_str::SmolStrBuilder;
+
+    use super::EvidencePrecedence;
+
+    #[test]
+    fn atomic_evidence_projections_do_not_depend_on_text_contents() {
+        for parent in ["childDict", "childInt", "childDict.parentDict", "isSymbol(\"two words\")"] {
+            let mut output = SmolStrBuilder::new();
+            output.push_str("useParent {");
+            EvidencePrecedence::Atom.append_projection(&mut output, parent, "parentDict");
+            output.push('}');
+            assert_eq!(output.finish(), format!("useParent {{{parent}.parentDict}}"));
+        }
+    }
+
+    #[test]
+    fn application_evidence_is_parenthesized_before_projection() {
+        let mut output = SmolStrBuilder::new();
+        EvidencePrecedence::Application.append_projection(
+            &mut output,
+            "childInt {parentInt}",
+            "parentDict",
+        );
+        let parent = output.finish();
+        assert_eq!(parent, "(childInt {parentInt}).parentDict");
+
+        let mut output = SmolStrBuilder::new();
+        EvidencePrecedence::Atom.append_projection(&mut output, &parent, "ancestorDict");
+        assert_eq!(output.finish(), "(childInt {parentInt}).parentDict.ancestorDict");
     }
 }

--- a/compiler-frontend/checking/src/tree/pretty.rs
+++ b/compiler-frontend/checking/src/tree/pretty.rs
@@ -1798,77 +1798,62 @@ where
             Evidence(&'a Evidence),
             Variable(EvidenceVarId),
             Text(&'static str),
-            Superclass { opening: usize, spaces_before: usize, superclass: SuperclassId },
+            Superclass { prefix: SmolStrBuilder, superclass: SuperclassId },
         }
 
-        let mut fragments: Vec<SmolStr> = vec![];
-        let mut space_fragments = 0;
+        let mut rendered = SmolStrBuilder::new();
         let mut pending = vec![Pending::Evidence(evidence)];
         while let Some(next) = pending.pop() {
-            let fragment = match next {
+            match next {
                 Pending::Evidence(Evidence::Variable(evidence)) => {
                     pending.push(Pending::Variable(*evidence));
-                    continue;
                 }
                 Pending::Variable(evidence) => match self.checked.evidence[evidence].state {
                     EvidenceState::Solved(proof) => {
                         pending.push(Pending::Evidence(&self.checked.evidence[proof]));
-                        continue;
                     }
-                    EvidenceState::Unsolved => SmolStr::new_static("unsolved"),
-                    EvidenceState::Error => SmolStr::new_static("error"),
+                    EvidenceState::Unsolved => rendered.push_str("unsolved"),
+                    EvidenceState::Error => rendered.push_str("error"),
                 },
                 Pending::Evidence(Evidence::Given(binder)) => {
-                    self.evidence_binder_name(names, *binder)?
+                    rendered.push_str(&self.evidence_binder_name(names, *binder)?);
                 }
                 Pending::Evidence(Evidence::Instance { origin, subgoals }) => {
-                    let instance = self.instance_dictionary_name(*origin)?;
+                    rendered.push_str(&self.instance_dictionary_name(*origin)?);
                     for subgoal in subgoals.iter().rev() {
                         pending.push(Pending::Text("}"));
                         pending.push(Pending::Variable(*subgoal));
                         pending.push(Pending::Text(" {"));
                     }
-                    instance
                 }
                 Pending::Evidence(Evidence::Superclass { parent, superclass }) => {
-                    // Reserve the opening parenthesis so wrapping a deep parent never
-                    // shifts or copies its already emitted text.
-                    let opening = fragments.len();
-                    fragments.push(SmolStr::new_static(""));
                     pending.push(Pending::Superclass {
-                        opening,
-                        spaces_before: space_fragments,
+                        prefix: std::mem::take(&mut rendered),
                         superclass: *superclass,
                     });
                     pending.push(Pending::Evidence(&self.checked.evidence[*parent]));
-                    continue;
                 }
-                Pending::Evidence(Evidence::Trivial) => SmolStr::new_static("trivial"),
+                Pending::Evidence(Evidence::Trivial) => rendered.push_str("trivial"),
                 Pending::Evidence(Evidence::Synthesized(evidence)) => {
-                    synthesized_evidence_name(evidence)
+                    rendered.push_str(&synthesized_evidence_name(evidence));
                 }
-                Pending::Text(text) => SmolStr::new_static(text),
-                Pending::Superclass { opening, spaces_before, superclass } => {
-                    // Only the parent has emitted text since entry. Counting space-bearing
-                    // fragments preserves `parent.contains(' ')`, including quoted spaces,
-                    // without rescanning the parent at every projection.
-                    if space_fragments != spaces_before {
-                        fragments[opening] = SmolStr::new_static("(");
-                        fragments.push(SmolStr::new_static(")"));
+                Pending::Text(text) => rendered.push_str(text),
+                Pending::Superclass { prefix, superclass } => {
+                    let parent = rendered.finish();
+                    rendered = prefix;
+                    if parent.contains(' ') {
+                        rendered.push('(');
+                        rendered.push_str(&parent);
+                        rendered.push(')');
+                    } else {
+                        rendered.push_str(&parent);
                     }
-                    let field = self.superclass_field_name(superclass)?;
-                    format_smolstr!(".{field}")
+                    rendered.push('.');
+                    rendered.push_str(&self.superclass_field_name(superclass)?);
                 }
-            };
-            space_fragments += usize::from(fragment.contains(' '));
-            fragments.push(fragment);
+            }
         }
-
-        let mut output = SmolStrBuilder::new();
-        for fragment in fragments {
-            output.push_str(&fragment);
-        }
-        Ok(output.finish())
+        Ok(rendered.finish())
     }
 
     fn instance_dictionary_name(&self, origin: InstanceCandidateOrigin) -> QueryResult<SmolStr> {

--- a/compiler-frontend/checking/src/tree/pretty.rs
+++ b/compiler-frontend/checking/src/tree/pretty.rs
@@ -2139,37 +2139,3 @@ fn synthesized_evidence_name(evidence: &SynthesizedEvidence) -> SmolStr {
         )) => REFLECTABLE_GREATER_EVIDENCE,
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use smol_str::SmolStrBuilder;
-
-    use super::EvidencePrecedence;
-
-    #[test]
-    fn atomic_evidence_projections_do_not_depend_on_text_contents() {
-        for parent in ["childDict", "childInt", "childDict.parentDict", "isSymbol(\"two words\")"] {
-            let mut output = SmolStrBuilder::new();
-            output.push_str("useParent {");
-            EvidencePrecedence::Atom.append_projection(&mut output, parent, "parentDict");
-            output.push('}');
-            assert_eq!(output.finish(), format!("useParent {{{parent}.parentDict}}"));
-        }
-    }
-
-    #[test]
-    fn application_evidence_is_parenthesized_before_projection() {
-        let mut output = SmolStrBuilder::new();
-        EvidencePrecedence::Application.append_projection(
-            &mut output,
-            "childInt {parentInt}",
-            "parentDict",
-        );
-        let parent = output.finish();
-        assert_eq!(parent, "(childInt {parentInt}).parentDict");
-
-        let mut output = SmolStrBuilder::new();
-        EvidencePrecedence::Atom.append_projection(&mut output, &parent, "ancestorDict");
-        assert_eq!(output.finish(), "(childInt {parentInt}).parentDict.ancestorDict");
-    }
-}

--- a/compiler-frontend/checking/src/tree/pretty.rs
+++ b/compiler-frontend/checking/src/tree/pretty.rs
@@ -1786,13 +1786,7 @@ where
         names: &mut EvidenceNames,
         evidence: EvidenceVarId,
     ) -> QueryResult<SmolStr> {
-        match self.checked.evidence[evidence].state {
-            EvidenceState::Solved(proof) => {
-                self.evidence_name(names, &self.checked.evidence[proof])
-            }
-            EvidenceState::Unsolved => Ok(SmolStr::new("unsolved")),
-            EvidenceState::Error => Ok(SmolStr::new("error")),
-        }
+        self.evidence_name(names, &Evidence::Variable(evidence))
     }
 
     fn evidence_name(
@@ -1804,57 +1798,77 @@ where
             Evidence(&'a Evidence),
             Variable(EvidenceVarId),
             Text(&'static str),
-            Superclass { start: usize, superclass: SuperclassId },
+            Superclass { opening: usize, spaces_before: usize, superclass: SuperclassId },
         }
 
-        let mut rendered = String::new();
+        let mut fragments: Vec<SmolStr> = vec![];
+        let mut space_fragments = 0;
         let mut pending = vec![Pending::Evidence(evidence)];
         while let Some(next) = pending.pop() {
-            match next {
+            let fragment = match next {
                 Pending::Evidence(Evidence::Variable(evidence)) => {
                     pending.push(Pending::Variable(*evidence));
+                    continue;
                 }
                 Pending::Variable(evidence) => match self.checked.evidence[evidence].state {
                     EvidenceState::Solved(proof) => {
                         pending.push(Pending::Evidence(&self.checked.evidence[proof]));
+                        continue;
                     }
-                    EvidenceState::Unsolved => rendered.push_str("unsolved"),
-                    EvidenceState::Error => rendered.push_str("error"),
+                    EvidenceState::Unsolved => SmolStr::new_static("unsolved"),
+                    EvidenceState::Error => SmolStr::new_static("error"),
                 },
                 Pending::Evidence(Evidence::Given(binder)) => {
-                    rendered.push_str(&self.evidence_binder_name(names, *binder)?);
+                    self.evidence_binder_name(names, *binder)?
                 }
                 Pending::Evidence(Evidence::Instance { origin, subgoals }) => {
-                    rendered.push_str(&self.instance_dictionary_name(*origin)?);
+                    let instance = self.instance_dictionary_name(*origin)?;
                     for subgoal in subgoals.iter().rev() {
                         pending.push(Pending::Text("}"));
                         pending.push(Pending::Variable(*subgoal));
                         pending.push(Pending::Text(" {"));
                     }
+                    instance
                 }
                 Pending::Evidence(Evidence::Superclass { parent, superclass }) => {
+                    // Reserve the opening parenthesis so wrapping a deep parent never
+                    // shifts or copies its already emitted text.
+                    let opening = fragments.len();
+                    fragments.push(SmolStr::new_static(""));
                     pending.push(Pending::Superclass {
-                        start: rendered.len(),
+                        opening,
+                        spaces_before: space_fragments,
                         superclass: *superclass,
                     });
                     pending.push(Pending::Evidence(&self.checked.evidence[*parent]));
+                    continue;
                 }
-                Pending::Evidence(Evidence::Trivial) => rendered.push_str("trivial"),
+                Pending::Evidence(Evidence::Trivial) => SmolStr::new_static("trivial"),
                 Pending::Evidence(Evidence::Synthesized(evidence)) => {
-                    rendered.push_str(&synthesized_evidence_name(evidence));
+                    synthesized_evidence_name(evidence)
                 }
-                Pending::Text(text) => rendered.push_str(text),
-                Pending::Superclass { start, superclass } => {
-                    if rendered[start..].contains(' ') {
-                        rendered.insert(start, '(');
-                        rendered.push(')');
+                Pending::Text(text) => SmolStr::new_static(text),
+                Pending::Superclass { opening, spaces_before, superclass } => {
+                    // Only the parent has emitted text since entry. Counting space-bearing
+                    // fragments preserves `parent.contains(' ')`, including quoted spaces,
+                    // without rescanning the parent at every projection.
+                    if space_fragments != spaces_before {
+                        fragments[opening] = SmolStr::new_static("(");
+                        fragments.push(SmolStr::new_static(")"));
                     }
-                    rendered.push('.');
-                    rendered.push_str(&self.superclass_field_name(superclass)?);
+                    let field = self.superclass_field_name(superclass)?;
+                    format_smolstr!(".{field}")
                 }
-            }
+            };
+            space_fragments += usize::from(fragment.contains(' '));
+            fragments.push(fragment);
         }
-        Ok(SmolStr::new(rendered))
+
+        let mut output = SmolStrBuilder::new();
+        for fragment in fragments {
+            output.push_str(&fragment);
+        }
+        Ok(output.finish())
     }
 
     fn instance_dictionary_name(&self, origin: InstanceCandidateOrigin) -> QueryResult<SmolStr> {


### PR DESCRIPTION
## Summary
Adapt PR #479 to current main and purefunctor’s preferred direct-rendering approach. Main already traverses evidence iteratively; this keeps that algorithm and replaces the String output buffer with SmolStrBuilder. Superclass parents render into a temporary builder before being appended to the saved prefix, preserving existing parentheses and naming order.

The branch preserves the local implementation history: the flat-fragment adaptation followed by the requested direct-builder revision. The final diff changes only the evidence pretty printer. The existing unified compiler fixture covers the original deep-row regression at 10,000 fields, so no duplicate fixture is added.

## Verification
- Full `just t compiler`: passed, no pending snapshots or changed expectations.
- `cargo nextest run -p checking`: 35 passed.
- `cargo check -p checking --tests`: passed.
- `just format` and `git diff --check`: passed.
- Confirmed all 10,000 fields and the complete evidence chain in the existing semantic golden.