### PR TITLE
[checking] Borrow interned values and reduce redundant compiler work

### DIFF
--- a/compiler-backend/functional/src/convert.rs
+++ b/compiler-backend/functional/src/convert.rs
@@ -122,11 +122,8 @@ where
             }
         }
 
-        let binders = lowered.tree.iter_binder();
-        let mut binders = binders.collect_vec();
-        binders.sort_unstable_by_key(|(binder_id, _)| *binder_id);
         let mut record_pun_names = FxHashMap::default();
-        for (_, binder) in binders {
+        for (_, binder) in lowered.tree.iter_binder() {
             let lowering::BinderKind::Record { record } = binder else { continue };
             for field in record.iter() {
                 let lowering::BinderRecordItem::RecordPun { id, name: Some(name) } = field else {

--- a/compiler-backend/functional/src/convert.rs
+++ b/compiler-backend/functional/src/convert.rs
@@ -355,7 +355,7 @@ where
             _ => match binder.source {
                 checking_tree::BinderSource::Binder(source) => self.source_binder_name(source),
                 checking_tree::BinderSource::Generated { name, .. } => {
-                    self.queries.lookup_smol_str(name)
+                    SmolStr::clone(self.queries.lookup_smol_str(name))
                 }
                 checking_tree::BinderSource::Section(source) => {
                     format_smolstr!("section{}", source.into_raw().get())
@@ -398,7 +398,7 @@ where
         type_id: checking::TypeId,
         fallback: SmolStr,
     ) -> QueryResult<SmolStr> {
-        let name = match self.queries.lookup_type(type_id) {
+        let name = match *self.queries.lookup_type(type_id) {
             checking::Type::Application(function, _)
             | checking::Type::KindApplication(function, _)
             | checking::Type::Kinded(function, _)
@@ -428,7 +428,9 @@ where
         } else {
             self.queries.checked(rigid.file)?
         };
-        Ok(checked.lookup_name(rigid).map(|name| self.queries.lookup_smol_str(name)))
+        Ok(checked
+            .lookup_name(rigid)
+            .map(|name| SmolStr::clone(self.queries.lookup_smol_str(name))))
     }
 
     fn parameter(&mut self, source: BindingSource, name: SmolStr) -> ConversionResult<Parameter> {
@@ -538,7 +540,7 @@ where
     fn constraint_class_name(&self, constraint: checking::TypeId) -> QueryResult<Option<SmolStr>> {
         let mut current = constraint;
         loop {
-            match self.queries.lookup_type(current) {
+            match *self.queries.lookup_type(current) {
                 checking::Type::Application(function, _)
                 | checking::Type::KindApplication(function, _)
                 | checking::Type::Kinded(function, _) => current = function,

--- a/compiler-backend/functional/src/convert/evidence.rs
+++ b/compiler-backend/functional/src/convert/evidence.rs
@@ -601,13 +601,17 @@ where
         &mut self,
         declarations: &mut Vec<Declaration>,
     ) -> ConversionResult<()> {
+        let occurrences = std::mem::take(&mut self.evidence_hoisting.occurrences);
+        if occurrences.is_empty() {
+            return Ok(());
+        }
+
         let roots = declarations.iter().filter_map(|declaration| match declaration.kind {
             DeclarationKind::Value(expression) => Some(expression),
             DeclarationKind::Constructor { .. } | DeclarationKind::Foreign => None,
         });
         let reachable = reachable_expressions(&self.storage, roots);
         let unsafe_instances = unsafe_local_instances(&self.storage, declarations);
-        let occurrences = std::mem::take(&mut self.evidence_hoisting.occurrences);
 
         let mut candidates = Vec::new();
         for (key, mut occurrences) in occurrences {
@@ -1010,6 +1014,14 @@ fn unsafe_local_instances(
     storage: &Storage,
     declarations: &[Declaration],
 ) -> FxHashSet<InstanceIdentity> {
+    let has_instances = declarations.iter().any(|declaration| {
+        matches!(declaration.global.id, GlobalId::Instance(_))
+            && matches!(declaration.kind, DeclarationKind::Value(_))
+    });
+    if !has_instances {
+        return FxHashSet::default();
+    }
+
     let values = declarations.iter().filter_map(|declaration| match declaration.kind {
         DeclarationKind::Value(expression) => {
             Some((declaration.global.id, declaration.recursive_group, expression))

--- a/compiler-backend/functional/src/convert/evidence.rs
+++ b/compiler-backend/functional/src/convert/evidence.rs
@@ -896,7 +896,7 @@ where
         let mut current = constraint;
         let mut arguments = vec![];
         loop {
-            match self.queries.lookup_type(current) {
+            match *self.queries.lookup_type(current) {
                 checking::Type::Application(function, argument) => {
                     arguments.push(argument);
                     current = function;
@@ -931,7 +931,7 @@ where
         if *fragments >= MAX_EVIDENCE_NAME_FRAGMENTS {
             return Ok(());
         }
-        match self.queries.lookup_type(type_id) {
+        match *self.queries.lookup_type(type_id) {
             checking::Type::Application(function, argument) => {
                 self.append_evidence_type_name(name, function, fragments)?;
                 self.append_evidence_type_name(name, argument, fragments)?;

--- a/compiler-backend/functional/src/convert/stylex.rs
+++ b/compiler-backend/functional/src/convert/stylex.rs
@@ -175,14 +175,14 @@ where
         result_type: checking::TypeId,
         call: StyleXRootCall,
     ) -> ConversionResult<Option<ExpressionId>> {
-        let checking::Type::Application(_, mut row_type) = self.queries.lookup_type(result_type)
+        let checking::Type::Application(_, mut row_type) = *self.queries.lookup_type(result_type)
         else {
             return Ok(None);
         };
 
         let mut labels = vec![];
         loop {
-            let checking::Type::Row(row_id) = self.queries.lookup_type(row_type) else {
+            let checking::Type::Row(row_id) = *self.queries.lookup_type(row_type) else {
                 return Ok(None);
             };
             let row = self.queries.lookup_row_type(row_id);

--- a/compiler-backend/functional/src/optimize.rs
+++ b/compiler-backend/functional/src/optimize.rs
@@ -240,40 +240,47 @@ fn is_simple_expression(
     expression: ExpressionId,
     recursive_globals: &FxHashSet<GlobalId>,
 ) -> bool {
-    match &storage[expression].kind {
-        ExpressionKind::Literal { .. }
-        | ExpressionKind::Constructor { .. }
-        | ExpressionKind::Local { .. }
-        | ExpressionKind::Abstraction { .. }
-        | ExpressionKind::UncurriedAbstraction { .. }
-        | ExpressionKind::SynthesizedEvidence { .. }
-        | ExpressionKind::TrivialEvidence => true,
-        ExpressionKind::Global { global } => !recursive_globals.contains(&global.id),
-        ExpressionKind::Array { elements } => elements
-            .iter()
-            .all(|element| is_simple_expression(storage, *element, recursive_globals)),
-        ExpressionKind::Record { fields } => fields
-            .iter()
-            .all(|field| is_simple_expression(storage, field.expression, recursive_globals)),
-        ExpressionKind::Project { record, .. } | ExpressionKind::Unary { value: record, .. } => {
-            is_simple_expression(storage, *record, recursive_globals)
+    let mut pending = vec![expression];
+    while let Some(expression) = pending.pop() {
+        match &storage[expression].kind {
+            ExpressionKind::Literal { .. }
+            | ExpressionKind::Constructor { .. }
+            | ExpressionKind::Local { .. }
+            | ExpressionKind::Abstraction { .. }
+            | ExpressionKind::UncurriedAbstraction { .. }
+            | ExpressionKind::SynthesizedEvidence { .. }
+            | ExpressionKind::TrivialEvidence => {}
+            ExpressionKind::Global { global } => {
+                if recursive_globals.contains(&global.id) {
+                    return false;
+                }
+            }
+            ExpressionKind::Array { elements } => pending.extend(elements.iter().rev().copied()),
+            ExpressionKind::Record { fields } => {
+                pending.extend(fields.iter().rev().map(|field| field.expression));
+            }
+            ExpressionKind::Project { record, .. }
+            | ExpressionKind::Unary { value: record, .. } => {
+                pending.push(*record);
+            }
+            ExpressionKind::Binary { left, right, .. } => {
+                pending.push(*right);
+                pending.push(*left);
+            }
+            ExpressionKind::RecordUpdate { .. }
+            | ExpressionKind::Error
+            | ExpressionKind::Application { .. }
+            | ExpressionKind::UncurriedApplication { .. }
+            | ExpressionKind::StyleX(_)
+            | ExpressionKind::IfThenElse { .. }
+            | ExpressionKind::Case { .. }
+            | ExpressionKind::Guarded { .. }
+            | ExpressionKind::Let { .. }
+            | ExpressionKind::LetPattern { .. }
+            | ExpressionKind::Effect { .. } => return false,
         }
-        ExpressionKind::Binary { left, right, .. } => {
-            is_simple_expression(storage, *left, recursive_globals)
-                && is_simple_expression(storage, *right, recursive_globals)
-        }
-        ExpressionKind::RecordUpdate { .. }
-        | ExpressionKind::Error
-        | ExpressionKind::Application { .. }
-        | ExpressionKind::UncurriedApplication { .. }
-        | ExpressionKind::StyleX(_)
-        | ExpressionKind::IfThenElse { .. }
-        | ExpressionKind::Case { .. }
-        | ExpressionKind::Guarded { .. }
-        | ExpressionKind::Let { .. }
-        | ExpressionKind::LetPattern { .. }
-        | ExpressionKind::Effect { .. } => false,
     }
+    true
 }
 
 pub fn for_each_expression_child(kind: &ExpressionKind, mut visit: impl FnMut(ExpressionId)) {
@@ -439,6 +446,42 @@ mod tests {
         assert_eq!(local_uses(&storage, root, LocalId(0)), 1);
         substitute_local(&mut storage, root, LocalId(0), replacement);
         assert_eq!(local_uses(&storage, root, LocalId(0)), 0);
+
+        let parameter = Parameter { id: LocalId(1), name: "bound".into() };
+        let body = storage.allocate_expression(Expression {
+            kind: ExpressionKind::Local { parameter: Parameter::clone(&parameter) },
+        });
+        let binding = storage.allocate_expression(Expression {
+            kind: ExpressionKind::Let {
+                recursive: false,
+                bindings: [Binding { parameter, expression: root, source_order: 0 }].into(),
+                body,
+            },
+        });
+        inline_simple_bindings(&mut storage, binding, &FxHashSet::default());
+        assert_eq!(storage[binding].kind, storage[root].kind);
+        assert_eq!(local_uses(&storage, binding, LocalId(1)), 0);
+    }
+
+    #[test]
+    fn simplicity_preserves_abstraction_boundaries_and_recursive_globals() {
+        let mut storage = Storage::default();
+        let global = GlobalId::Generated(files::FileId::new(0), crate::tree::GeneratedGlobalId(0));
+        let body = storage.allocate_expression(Expression {
+            kind: ExpressionKind::Global {
+                global: crate::tree::Global { id: global, item_name: "recursive".into() },
+            },
+        });
+        let recursive_globals = FxHashSet::from_iter([global]);
+        assert!(is_simple_expression(&storage, body, &FxHashSet::default()));
+        assert!(!is_simple_expression(&storage, body, &recursive_globals));
+        for kind in [
+            ExpressionKind::Abstraction { parameters: [].into(), body },
+            ExpressionKind::UncurriedAbstraction { parameters: [].into(), body },
+        ] {
+            let abstraction = storage.allocate_expression(Expression { kind });
+            assert!(is_simple_expression(&storage, abstraction, &recursive_globals));
+        }
     }
 
     #[test]

--- a/compiler-backend/functional/src/optimize.rs
+++ b/compiler-backend/functional/src/optimize.rs
@@ -386,10 +386,15 @@ fn try_for_each_update_child<Error>(
     updates: &[RecordUpdate],
     visit: &mut impl FnMut(ExpressionId) -> Result<(), Error>,
 ) -> Result<(), Error> {
-    for update in updates {
+    let mut pending = vec![updates.iter()];
+    while let Some(updates) = pending.last_mut() {
+        let Some(update) = updates.next() else {
+            pending.pop();
+            continue;
+        };
         match update {
             RecordUpdate::Leaf { expression, .. } => visit(*expression)?,
-            RecordUpdate::Branch { updates, .. } => try_for_each_update_child(updates, visit)?,
+            RecordUpdate::Branch { updates, .. } => pending.push(updates.iter()),
         }
     }
     Ok(())
@@ -496,6 +501,34 @@ mod tests {
             storage[negation].kind,
             ExpressionKind::Unary { operator: UnaryOperator::IntegerNegate, value: local }
         );
+    }
+
+    #[test]
+    fn deep_record_updates_do_not_use_the_call_stack() {
+        let (mut storage, local, replacement) = nested_arrays(0);
+        let field = Field { identity: FieldIdentity::Label("field".into()), name: "field".into() };
+        let mut updates: Arc<[RecordUpdate]> =
+            Arc::from([RecordUpdate::Leaf { field: Field::clone(&field), expression: local }]);
+        let mut retained = Vec::new();
+        for _ in 0..100_000 {
+            retained.push(Arc::clone(&updates));
+            updates = Arc::from([RecordUpdate::Branch { field: Field::clone(&field), updates }]);
+        }
+        let root = storage.allocate_expression(Expression {
+            kind: ExpressionKind::RecordUpdate { record: replacement, updates },
+        });
+
+        assert_eq!(visited_children(&storage[root].kind), vec![replacement, local]);
+        inline_simple_bindings(&mut storage, root, &FxHashSet::default());
+        assert_eq!(local_uses(&storage, root, LocalId(0)), 1);
+        substitute_local(&mut storage, root, LocalId(0), replacement);
+        assert_eq!(local_uses(&storage, root, LocalId(0)), 0);
+
+        // Retained levels keep recursive Arc destruction out of this traversal test.
+        drop(storage);
+        while let Some(updates) = retained.pop() {
+            drop(updates);
+        }
     }
 
     #[test]

--- a/compiler-backend/functional/src/optimize.rs
+++ b/compiler-backend/functional/src/optimize.rs
@@ -1,6 +1,7 @@
 //! Simplification of functional trees before backend-specific code generation.
 
 use std::convert::Infallible;
+use std::sync::Arc;
 
 use rustc_hash::FxHashSet;
 use smol_str::{SmolStr, format_smolstr};
@@ -54,22 +55,49 @@ fn optimize_expression(
     recursive_globals: &FxHashSet<GlobalId>,
     visited: &mut FxHashSet<ExpressionId>,
 ) {
-    if !visited.insert(expression) {
-        return;
+    enum Pending {
+        Enter(ExpressionId),
+        Fold(ExpressionId),
+        Inline(ExpressionId, Arc<[Binding]>, ExpressionId),
     }
 
-    let kind = storage[expression].kind.clone();
-    for_each_expression_child(&kind, |child| {
-        optimize_expression(storage, child, recursive_globals, visited);
-    });
-
-    if fold_literal_negation(storage, expression) {
-        return;
+    let mut pending = vec![Pending::Enter(expression)];
+    while let Some(work) = pending.pop() {
+        match work {
+            Pending::Enter(expression) => {
+                if !visited.insert(expression) {
+                    continue;
+                }
+                let kind = &storage[expression].kind;
+                if let ExpressionKind::Let { recursive: false, bindings, body } = kind {
+                    // Inlining uses the entry-time bindings even if descendants mutate storage.
+                    pending.push(Pending::Inline(expression, Arc::clone(bindings), *body));
+                } else {
+                    pending.push(Pending::Fold(expression));
+                }
+                let children_start = pending.len();
+                for_each_expression_child(kind, |child| pending.push(Pending::Enter(child)));
+                pending[children_start..].reverse();
+            }
+            Pending::Fold(expression) => {
+                fold_literal_negation(storage, expression);
+            }
+            Pending::Inline(expression, bindings, body) => {
+                if !fold_literal_negation(storage, expression) {
+                    inline_bindings(storage, expression, &bindings, body, recursive_globals);
+                }
+            }
+        }
     }
+}
 
-    let ExpressionKind::Let { recursive: false, bindings, body } = kind else {
-        return;
-    };
+fn inline_bindings(
+    storage: &mut Storage,
+    expression: ExpressionId,
+    bindings: &[Binding],
+    body: ExpressionId,
+    recursive_globals: &FxHashSet<GlobalId>,
+) {
     let mut bindings = bindings.to_vec();
     while let Some(position) = bindings.iter().position(|binding| {
         let uses = binding_uses(storage, &bindings, body, binding.parameter.id);
@@ -156,16 +184,18 @@ fn binding_uses(
 }
 
 pub fn local_uses(storage: &Storage, expression: ExpressionId, parameter: LocalId) -> usize {
-    if matches!(
-        &storage[expression].kind,
-        ExpressionKind::Local { parameter: local } if local.id == parameter
-    ) {
-        return 1;
-    }
     let mut uses = 0;
-    for_each_expression_child(&storage[expression].kind, |child| {
-        uses += local_uses(storage, child, parameter);
-    });
+    let mut pending = vec![expression];
+    while let Some(expression) = pending.pop() {
+        let kind = &storage[expression].kind;
+        if matches!(kind, ExpressionKind::Local { parameter: local } if local.id == parameter) {
+            uses += 1;
+            continue;
+        }
+        let children_start = pending.len();
+        for_each_expression_child(kind, |child| pending.push(child));
+        pending[children_start..].reverse();
+    }
     uses
 }
 
@@ -175,18 +205,18 @@ fn substitute_local(
     parameter: LocalId,
     replacement: ExpressionId,
 ) {
-    if matches!(
-        &storage[expression].kind,
-        ExpressionKind::Local { parameter: local } if local.id == parameter
-    ) {
-        let replacement = storage[replacement].kind.clone();
-        storage.replace_expression_kind(expression, replacement);
-        return;
+    let mut pending = vec![expression];
+    while let Some(expression) = pending.pop() {
+        let kind = &storage[expression].kind;
+        if matches!(kind, ExpressionKind::Local { parameter: local } if local.id == parameter) {
+            let replacement = ExpressionKind::clone(&storage[replacement].kind);
+            storage.replace_expression_kind(expression, replacement);
+            continue;
+        }
+        let children_start = pending.len();
+        for_each_expression_child(kind, |child| pending.push(child));
+        pending[children_start..].reverse();
     }
-    let kind = storage[expression].kind.clone();
-    for_each_expression_child(&kind, |child| {
-        substitute_local(storage, child, parameter, replacement);
-    });
 }
 
 fn is_trivial_expression(
@@ -369,7 +399,7 @@ fn try_for_each_update_child<Error>(
 mod tests {
     use super::*;
     use crate::stylex::{StyleXConditionalCase, StyleXExpression, StyleXWhenRelation};
-    use crate::tree::{Field, FieldIdentity};
+    use crate::tree::{Expression, Field, FieldIdentity, Parameter};
 
     fn expression(index: u32) -> ExpressionId {
         ExpressionId::from_raw(index.into())
@@ -379,6 +409,93 @@ mod tests {
         let mut children = Vec::new();
         for_each_expression_child(kind, |child| children.push(child));
         children
+    }
+
+    fn nested_arrays(depth: usize) -> (Storage, ExpressionId, ExpressionId) {
+        let mut storage = Storage::default();
+        let replacement = storage.allocate_expression(Expression {
+            kind: ExpressionKind::Literal { literal: Literal::Integer(42) },
+        });
+        let local =
+            ExpressionKind::Local { parameter: Parameter { id: LocalId(0), name: "value".into() } };
+        let mut root = storage.allocate_expression(Expression { kind: local });
+        for _ in 0..depth {
+            root = storage.allocate_expression(Expression {
+                kind: ExpressionKind::Array { elements: [root].into() },
+            });
+        }
+        (storage, root, replacement)
+    }
+
+    #[test]
+    fn deep_traversals_do_not_use_the_call_stack() {
+        let (mut storage, root, replacement) = nested_arrays(100_000);
+        inline_simple_bindings(&mut storage, root, &FxHashSet::default());
+        assert_eq!(local_uses(&storage, root, LocalId(0)), 1);
+        substitute_local(&mut storage, root, LocalId(0), replacement);
+        assert_eq!(local_uses(&storage, root, LocalId(0)), 0);
+    }
+
+    #[test]
+    fn local_uses_counts_shared_subtree_occurrences() {
+        let (mut storage, shared, _) = nested_arrays(3);
+        let root = storage.allocate_expression(Expression {
+            kind: ExpressionKind::Array { elements: [shared, shared, shared].into() },
+        });
+        assert_eq!(local_uses(&storage, root, LocalId(0)), 3);
+        assert_eq!(local_uses(&storage, root, LocalId(1)), 0);
+    }
+
+    #[test]
+    fn substitution_does_not_descend_into_a_new_replacement() {
+        let (mut storage, replacement, _) = nested_arrays(1);
+        let target = storage.allocate_expression(Expression {
+            kind: ExpressionKind::Local {
+                parameter: Parameter { id: LocalId(0), name: "target".into() },
+            },
+        });
+        substitute_local(&mut storage, target, LocalId(0), replacement);
+        assert_eq!(storage[target].kind, storage[replacement].kind);
+        assert_eq!(local_uses(&storage, target, LocalId(0)), 1);
+    }
+
+    #[test]
+    fn optimization_preserves_dfs_order_and_does_not_revisit_mutated_shared_nodes() {
+        let (mut storage, local, value) = nested_arrays(0);
+        let negation = storage.allocate_expression(Expression {
+            kind: ExpressionKind::Unary { operator: UnaryOperator::IntegerNegate, value: local },
+        });
+        let binding = storage.allocate_expression(Expression {
+            kind: ExpressionKind::Let {
+                recursive: false,
+                bindings: [Binding {
+                    parameter: Parameter { id: LocalId(0), name: "value".into() },
+                    expression: value,
+                    source_order: 0,
+                }]
+                .into(),
+                body: negation,
+            },
+        });
+        let later_negation = storage.allocate_expression(Expression {
+            kind: ExpressionKind::Unary { operator: UnaryOperator::IntegerNegate, value: local },
+        });
+        let root = storage.allocate_expression(Expression {
+            kind: ExpressionKind::Array { elements: [binding, negation, later_negation].into() },
+        });
+        let mut visited = FxHashSet::default();
+        optimize_expression(&mut storage, root, &FxHashSet::default(), &mut visited);
+        assert_eq!(visited.len(), 6);
+        assert_eq!(storage[local].kind, storage[value].kind);
+        assert_eq!(
+            storage[binding].kind,
+            ExpressionKind::Literal { literal: Literal::Integer(-42) }
+        );
+        assert_eq!(storage[later_negation].kind, storage[binding].kind);
+        assert_eq!(
+            storage[negation].kind,
+            ExpressionKind::Unary { operator: UnaryOperator::IntegerNegate, value: local }
+        );
     }
 
     #[test]

--- a/compiler-backend/javascript/src/convert/generator/functional/render.rs
+++ b/compiler-backend/javascript/src/convert/generator/functional/render.rs
@@ -14,8 +14,8 @@ use functional::optimize::{for_each_expression_child, local_uses};
 use functional::tree::{
     Binding, CaseAlternative, Declaration, DeclarationKind, EffectExpression,
     ExpressionId as FunctionalExpressionId, ExpressionKind, Global, GlobalId, Guard,
-    GuardedAlternative, LocalId, Module as FunctionalModule, Parameter, PatternId, PatternKind,
-    RecordUpdate,
+    GuardedAlternative, LocalId, Module as FunctionalModule, ModuleDependency, Parameter,
+    PatternId, PatternKind, RecordUpdate,
 };
 use itertools::Itertools;
 use oxc_allocator::Allocator;
@@ -48,6 +48,7 @@ const INITIALIZER_CYCLE_MESSAGE: &str = "Top-level value initializer cycle";
 
 pub(crate) struct Generator<'m> {
     module: &'m FunctionalModule,
+    module_dependencies: FxHashMap<FileId, &'m ModuleDependency>,
     global_names: FxHashMap<GlobalId, SmolStr>,
     external_module_namespaces: FxHashMap<FileId, SmolStr>,
     external_named_imports: FxHashMap<GlobalId, SmolStr>,
@@ -270,6 +271,11 @@ impl<'m> Generator<'m> {
             global_names.insert(declaration.global.id, name);
         }
 
+        let mut module_dependencies = FxHashMap::default();
+        for dependency in module.dependencies.iter() {
+            module_dependencies.entry(dependency.file_id).or_insert(dependency);
+        }
+
         let external_references = collect_module_references(module);
         let stylex_references = collect_stylex_references(module);
         let stylex_reference_ids =
@@ -277,10 +283,8 @@ impl<'m> Generator<'m> {
         let mut external_named_imports = FxHashMap::default();
         for global in stylex_references {
             let file_id = global_file(global.id);
-            let dependency = module
-                .dependencies
-                .iter()
-                .find(|dependency| dependency.file_id == file_id)
+            let dependency = module_dependencies
+                .get(&file_id)
                 .expect("invariant violated: external global has no module dependency");
             let preferred = format_smolstr!("{}_{}", dependency.module_name, global.item_name);
             let name = allocator.allocate(preferred.replace('.', "_"));
@@ -291,10 +295,8 @@ impl<'m> Generator<'m> {
             external_references.iter().filter(|global| !stylex_reference_ids.contains(&global.id))
         {
             let file_id = global_file(global.id);
-            let dependency = module
-                .dependencies
-                .iter()
-                .find(|dependency| dependency.file_id == file_id)
+            let dependency = module_dependencies
+                .get(&file_id)
                 .expect("invariant violated: external global has no module dependency");
             external_module_namespaces
                 .entry(file_id)
@@ -357,6 +359,7 @@ impl<'m> Generator<'m> {
 
         Generator {
             module,
+            module_dependencies,
             global_names,
             external_module_namespaces,
             external_named_imports,
@@ -3169,11 +3172,9 @@ impl Generator<'_> {
             .expect("invariant violated: JavaScript global has no allocated name")
     }
 
-    fn module_dependency(&self, file_id: FileId) -> &functional::tree::ModuleDependency {
-        self.module
-            .dependencies
-            .iter()
-            .find(|dependency| dependency.file_id == file_id)
+    fn module_dependency(&self, file_id: FileId) -> &ModuleDependency {
+        self.module_dependencies
+            .get(&file_id)
             .expect("invariant violated: referenced module has no dependency metadata")
     }
 

--- a/compiler-bin/src/walk.rs
+++ b/compiler-bin/src/walk.rs
@@ -49,7 +49,7 @@ pub fn walk_filtered(
 
     let globs = globs.build()?;
     let excludes = build_excludes(root, excludes)?;
-    files.retain(|path| excludes.matches(path).is_empty());
+    files.retain(|path| !excludes.is_match(path));
     let mut files_from_glob = BTreeSet::default();
 
     for root in &roots {
@@ -59,7 +59,7 @@ pub fn walk_filtered(
 
         for entry in WalkDir::new(root) {
             let path = entry?.into_path();
-            if !globs.matches(&path).is_empty() && excludes.matches(&path).is_empty() {
+            if globs.is_match(&path) && !excludes.is_match(&path) {
                 files_from_glob.insert(path);
             }
         }

--- a/compiler-core/building/src/engine.rs
+++ b/compiler-core/building/src/engine.rs
@@ -1318,7 +1318,7 @@ impl javascript::ModuleQueries for QueryEngine {
 }
 
 impl checking::PrettyQueries for QueryEngine {
-    fn lookup_type(&self, id: checking::TypeId) -> checking::Type {
+    fn lookup_type(&self, id: checking::TypeId) -> &checking::Type {
         self.interned.checking.lookup_type(id)
     }
 
@@ -1329,11 +1329,11 @@ impl checking::PrettyQueries for QueryEngine {
         self.interned.checking.lookup_forall_binder(id)
     }
 
-    fn lookup_row_type(&self, id: checking::core::RowTypeId) -> checking::core::RowType {
+    fn lookup_row_type(&self, id: checking::core::RowTypeId) -> &checking::core::RowType {
         self.interned.checking.lookup_row_type(id)
     }
 
-    fn lookup_smol_str(&self, id: checking::core::SmolStrId) -> smol_str::SmolStr {
+    fn lookup_smol_str(&self, id: checking::core::SmolStrId) -> &smol_str::SmolStr {
         self.interned.checking.lookup_smol_str(id)
     }
 }

--- a/compiler-core/building/src/lifecycle/source.rs
+++ b/compiler-core/building/src/lifecycle/source.rs
@@ -184,9 +184,9 @@ where
         let id = self.source_files.insert(Arc::clone(&unit.source), Arc::clone(&text));
         self.source_units.insert(id, SourceUnitKey::clone(unit));
         engine.set_content(id, Arc::clone(&text));
-        let lexed = lexing::lex(&text);
-        let tokens = lexing::layout(&lexed);
-        let (parsed, _) = parsing::parse(&lexed, &tokens);
+        let (parsed, _) = engine
+            .parsed(id)
+            .expect("invariant violated: source lifecycle requires exclusive engine mutation");
         if let Some(name) = parsed.module_name(&text) {
             engine.set_module_file(&name, id);
         }
@@ -204,9 +204,9 @@ where
         if previous_content == *text {
             return false;
         }
-        let previous_lexed = lexing::lex(&previous_content);
-        let previous_tokens = lexing::layout(&previous_lexed);
-        let (previous_parsed, _) = parsing::parse(&previous_lexed, &previous_tokens);
+        let (previous_parsed, _) = engine
+            .parsed(id)
+            .expect("invariant violated: source lifecycle requires exclusive engine mutation");
         let previous_name = previous_parsed.module_name(&previous_content);
 
         let path = self.source_files.path(id);
@@ -214,9 +214,9 @@ where
         debug_assert_eq!(inserted_id, id);
         engine.set_content(id, Arc::clone(text));
 
-        let current_lexed = lexing::lex(text);
-        let current_tokens = lexing::layout(&current_lexed);
-        let (current_parsed, _) = parsing::parse(&current_lexed, &current_tokens);
+        let (current_parsed, _) = engine
+            .parsed(id)
+            .expect("invariant violated: source lifecycle requires exclusive engine mutation");
         let current_name = current_parsed.module_name(text);
         if previous_name != current_name
             && let Some(previous_name) = previous_name

--- a/compiler-core/building/src/lifecycle/tests.rs
+++ b/compiler-core/building/src/lifecycle/tests.rs
@@ -248,6 +248,7 @@ fn source_updates_preserve_identity_and_module_ownership() {
     files.apply(&engine, source_disk("module Main where\n"));
     let file_id = files.source_id(unit().source()).unwrap();
     assert_eq!(engine.module_file("Main"), Some(file_id));
+    engine.parsed(file_id).unwrap();
 
     let event = LifecycleEvent::Source {
         unit: unit(),
@@ -274,6 +275,7 @@ fn source_updates_preserve_identity_and_module_ownership() {
     let change = files.apply(&engine, event);
     assert_eq!(files.source_version(file_id), Some(3));
     assert!(matches!(change.analysis(), AnalysisInvalidation::Sources(_)));
+    engine.parsed(file_id).unwrap();
 
     let event = LifecycleEvent::Source {
         unit: unit(),
@@ -282,6 +284,7 @@ fn source_updates_preserve_identity_and_module_ownership() {
     files.apply(&engine, event);
     assert_eq!(engine.module_file("Library"), None);
     assert_eq!(engine.module_file("Newer"), Some(file_id));
+    engine.parsed(file_id).unwrap();
 
     let event = LifecycleEvent::Source {
         unit: unit(),

--- a/compiler-frontend/checking/src/context.rs
+++ b/compiler-frontend/checking/src/context.rs
@@ -325,7 +325,7 @@ where
     }
 
     /// Looks up the [`Type`] for the given [`TypeId`].
-    pub fn lookup_type(&self, id: TypeId) -> Type {
+    pub fn lookup_type(&self, id: TypeId) -> &'q Type {
         self.queries.lookup_type(id)
     }
 
@@ -339,7 +339,7 @@ where
     }
 
     /// Looks up the [`RowType`] for the given [`RowTypeId`].
-    pub fn lookup_row_type(&self, id: RowTypeId) -> RowType {
+    pub fn lookup_row_type(&self, id: RowTypeId) -> &'q RowType {
         self.queries.lookup_row_type(id)
     }
 

--- a/compiler-frontend/checking/src/context.rs
+++ b/compiler-frontend/checking/src/context.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use building_types::QueryResult;
 use files::FileId;
-use indexing::{IndexedModule, TermItemId, TypeItemId};
+use indexing::{IndexedModule, InstanceSourceItemId, TermItemId, TypeItemId};
 use itertools::Itertools;
 use lowering::{GroupedModule, LoweredModule};
 use resolving::ResolvedModule;
@@ -17,6 +17,7 @@ use smol_str::SmolStr;
 use stabilizing::StabilizedModule;
 use sugar::{Bracketed, Sectioned};
 
+use crate::core::constraint::instances::InstanceCandidateOrigin;
 use crate::core::{
     CheckedSynonym, Depth, ForallBinder, ForallBinderId, Name, RowField, RowType, RowTypeId, Type,
     TypeFlags, TypeId,
@@ -44,6 +45,7 @@ where
     pub sectioned: Arc<Sectioned>,
     pub resolved: Arc<ResolvedModule>,
 
+    pub(crate) instance_positions: FxHashMap<InstanceCandidateOrigin, usize>,
     checked_dependencies: RefCell<FxHashMap<FileId, Arc<CheckedModule>>>,
     checked_synonyms: RefCell<FxHashMap<(FileId, TypeItemId), Option<CheckedSynonym>>>,
 }
@@ -73,6 +75,19 @@ where
         let sectioned = queries.sectioned(id)?;
         let resolved = queries.resolved(id)?;
 
+        let mut instance_positions = FxHashMap::default();
+        for (position, item) in indexed.items.instance_sources().iter().enumerate() {
+            let origin = match *item {
+                InstanceSourceItemId::Instance(item) => {
+                    InstanceCandidateOrigin::Instance(id, indexed.items[item].id)
+                }
+                InstanceSourceItemId::Derive(item) => {
+                    InstanceCandidateOrigin::Derive(id, indexed.items[item].id)
+                }
+            };
+            instance_positions.entry(origin).or_insert(position);
+        }
+
         Ok(CheckContext {
             queries,
             core,
@@ -84,6 +99,7 @@ where
             bracketed,
             sectioned,
             resolved,
+            instance_positions,
             checked_dependencies: RefCell::default(),
             checked_synonyms: RefCell::default(),
         })

--- a/compiler-frontend/checking/src/core/constraint.rs
+++ b/compiler-frontend/checking/src/core/constraint.rs
@@ -495,7 +495,7 @@ impl ConstraintInScope {
     where
         Q: ExternalQueries,
     {
-        let Type::Constructor(file_id, type_id) = context.lookup_type(context.prim.partial) else {
+        let Type::Constructor(file_id, type_id) = *context.lookup_type(context.prim.partial) else {
             unreachable!("critical violation: Partial is not Partial");
         };
         let constraint = &state.canonicals[self.key.wanted];

--- a/compiler-frontend/checking/src/core/constraint/canonical.rs
+++ b/compiler-frontend/checking/src/core/constraint/canonical.rs
@@ -108,7 +108,7 @@ where
 
     let class = normalise::expand(state, context, class)?;
 
-    let Type::Constructor(file_id, type_id) = context.lookup_type(class) else {
+    let Type::Constructor(file_id, type_id) = *context.lookup_type(class) else {
         return Ok(None);
     };
 

--- a/compiler-frontend/checking/src/core/constraint/compiler.rs
+++ b/compiler-frontend/checking/src/core/constraint/compiler.rs
@@ -8,6 +8,8 @@ pub mod prim_type_error;
 
 use std::sync::Arc;
 
+use lowering::StringLiteral;
+
 use crate::context::CheckContext;
 use crate::core::fold::{FoldAction, TypeFold, fold_type};
 use crate::core::unification::{CanUnify, can_unify};
@@ -64,7 +66,7 @@ pub enum RowView {
 }
 
 impl RowView {
-    fn from_row(row: RowType) -> RowView {
+    fn from_row(row: &RowType) -> RowView {
         let fields = Arc::clone(&row.fields);
         match row.tail {
             Some(tail) => RowView::Open { fields, tail },
@@ -143,17 +145,17 @@ where
     Q: ExternalQueries,
 {
     let id = recursively_normalise(state, context, id)?;
-    match context.lookup_type(id) {
+    match *context.lookup_type(id) {
         Type::Integer(value) => Ok(Some(value)),
         _ => Ok(None),
     }
 }
 
-pub fn extract_symbol<Q>(
+pub fn extract_symbol<'q, Q>(
     state: &mut CheckState,
-    context: &CheckContext<Q>,
+    context: &CheckContext<'q, Q>,
     id: TypeId,
-) -> QueryResult<Option<lowering::StringLiteral>>
+) -> QueryResult<Option<&'q lowering::StringLiteral>>
 where
     Q: ExternalQueries,
 {
@@ -170,7 +172,7 @@ where
     Q: ExternalQueries,
 {
     let id = recursively_normalise(state, context, id)?;
-    let row = if let Type::Row(id) = context.lookup_type(id) {
+    let row = if let Type::Row(id) = *context.lookup_type(id) {
         RowView::from_row(context.lookup_row_type(id))
     } else {
         RowView::from_tail(id)
@@ -388,7 +390,7 @@ where
         let symbol = extract_symbol(state, context, symbol)?.unwrap_or_else(|| {
             unreachable!("invariant violated: solved IsSymbol constraint has no symbol")
         });
-        return Ok(SynthesizedEvidence::IsSymbol(symbol));
+        return Ok(SynthesizedEvidence::IsSymbol(StringLiteral::clone(symbol)));
     }
 
     if context.known_reflectable.reflectable == Some(class) {
@@ -397,7 +399,7 @@ where
         };
         let value = recursively_normalise(state, context, value)?;
         let reflected = if let Some(symbol) = extract_symbol(state, context, value)? {
-            ReflectableEvidence::String(symbol)
+            ReflectableEvidence::String(StringLiteral::clone(symbol))
         } else if let Some(integer) = extract_integer(state, context, value)? {
             ReflectableEvidence::Integer(integer)
         } else if value == context.prim_boolean.true_ {

--- a/compiler-frontend/checking/src/core/constraint/compiler/prim_coerce.rs
+++ b/compiler-frontend/checking/src/core/constraint/compiler/prim_coerce.rs
@@ -93,7 +93,7 @@ where
 {
     safe_loop! {
         id = normalise::expand(state, context, id)?;
-        match context.lookup_type(id) {
+        match *context.lookup_type(id) {
             Type::Unification(u) => return Ok(Some(u)),
             Type::Application(function, _) | Type::KindApplication(function, _) => {
                 id = function;
@@ -270,11 +270,11 @@ where
     Q: ExternalQueries,
 {
     let id = normalise::expand(state, context, id)?;
-    match context.lookup_type(id) {
+    match *context.lookup_type(id) {
         Type::Function(argument, result) => Ok(Some((argument, result))),
         Type::Application(partial, result) => {
             let partial = normalise::expand(state, context, partial)?;
-            if let Type::Application(constructor, argument) = context.lookup_type(partial) {
+            if let Type::Application(constructor, argument) = *context.lookup_type(partial) {
                 let constructor = normalise::expand(state, context, constructor)?;
                 if constructor == context.prim.function {
                     return Ok(Some((argument, result)));
@@ -298,8 +298,8 @@ where
     let left = normalise::expand(state, context, left)?;
     let right = normalise::expand(state, context, right)?;
 
-    let Type::Row(left_row_id) = context.lookup_type(left) else { return Ok(None) };
-    let Type::Row(right_row_id) = context.lookup_type(right) else { return Ok(None) };
+    let Type::Row(left_row_id) = *context.lookup_type(left) else { return Ok(None) };
+    let Type::Row(right_row_id) = *context.lookup_type(right) else { return Ok(None) };
 
     let left_row = context.lookup_row_type(left_row_id);
     let right_row = context.lookup_row_type(right_row_id);
@@ -385,7 +385,7 @@ where
 {
     safe_loop! {
         kind_id = normalise::expand(state, context, kind_id)?;
-        match context.lookup_type(kind_id) {
+        match *context.lookup_type(kind_id) {
             Type::Forall(binder_id, inner_kind) => {
                 let binder = context.lookup_forall_binder(binder_id);
                 let fresh = state.fresh_rigid(context.queries, binder.kind);
@@ -428,25 +428,25 @@ where
             Type::KindApplication(t2_function, t2_argument),
         )
         | (Type::Kinded(t1_function, t1_argument), Type::Kinded(t2_function, t2_argument)) => {
-            Ok(try_refl(state, context, t1_function, t2_function)?
-                && try_refl(state, context, t1_argument, t2_argument)?)
+            Ok(try_refl(state, context, *t1_function, *t2_function)?
+                && try_refl(state, context, *t1_argument, *t2_argument)?)
         }
 
         (Type::Function(t1_argument, t1_result), Type::Function(t2_argument, t2_result)) => {
-            Ok(try_refl(state, context, t1_argument, t2_argument)?
-                && try_refl(state, context, t1_result, t2_result)?)
+            Ok(try_refl(state, context, *t1_argument, *t2_argument)?
+                && try_refl(state, context, *t1_result, *t2_result)?)
         }
 
         (Type::Forall(t1_binder_id, t1_inner), Type::Forall(t2_binder_id, t2_inner)) => {
-            let t1_binder = context.lookup_forall_binder(t1_binder_id);
-            let t2_binder = context.lookup_forall_binder(t2_binder_id);
+            let t1_binder = context.lookup_forall_binder(*t1_binder_id);
+            let t2_binder = context.lookup_forall_binder(*t2_binder_id);
             Ok(try_refl(state, context, t1_binder.kind, t2_binder.kind)?
-                && try_refl(state, context, t1_inner, t2_inner)?)
+                && try_refl(state, context, *t1_inner, *t2_inner)?)
         }
 
         (Type::Row(t1_row_id), Type::Row(t2_row_id)) => {
-            let t1_row = context.lookup_row_type(t1_row_id);
-            let t2_row = context.lookup_row_type(t2_row_id);
+            let t1_row = context.lookup_row_type(*t1_row_id);
+            let t2_row = context.lookup_row_type(*t2_row_id);
             if t1_row.fields.len() != t2_row.fields.len() {
                 return Ok(false);
             }
@@ -465,7 +465,7 @@ where
         }
 
         (Type::Rigid(t1_name, _, t1_kind), Type::Rigid(t2_name, _, t2_kind)) => {
-            Ok(t1_name == t2_name && try_refl(state, context, t1_kind, t2_kind)?)
+            Ok(t1_name == t2_name && try_refl(state, context, *t1_kind, *t2_kind)?)
         }
 
         _ => Ok(false),

--- a/compiler-frontend/checking/src/core/constraint/compiler/prim_reflectable.rs
+++ b/compiler-frontend/checking/src/core/constraint/compiler/prim_reflectable.rs
@@ -43,7 +43,7 @@ where
         return Ok(Some(match_expected(state, context, t, expected)?));
     }
 
-    if let Type::Unification(id) = context.lookup_type(v) {
+    if let Type::Unification(id) = *context.lookup_type(v) {
         return Ok(Some(MatchInstance::Stuck { stuck: vec![id], skolem: false }));
     }
 

--- a/compiler-frontend/checking/src/core/constraint/compiler/prim_row.rs
+++ b/compiler-frontend/checking/src/core/constraint/compiler/prim_row.rs
@@ -50,9 +50,9 @@ where
         if let Type::Application(row_constructor, row_element_kind) =
             context.lookup_type(argument_kind)
         {
-            let row_constructor = normalise::expand(state, context, row_constructor)?;
+            let row_constructor = normalise::expand(state, context, *row_constructor)?;
             if row_constructor == context.prim.row {
-                return Ok(row_element_kind);
+                return Ok(*row_element_kind);
             }
         }
     }

--- a/compiler-frontend/checking/src/core/constraint/compiler/prim_row_list.rs
+++ b/compiler-frontend/checking/src/core/constraint/compiler/prim_row_list.rs
@@ -59,7 +59,7 @@ where
     let row_kind = types::elaborate_kind(state, context, singleton_row_type)?;
 
     let row_kind = normalise::expand(state, context, row_kind)?;
-    let Type::Application(_, element_kind) = context.lookup_type(row_kind) else {
+    let Type::Application(_, element_kind) = *context.lookup_type(row_kind) else {
         return Ok(state.fresh_unification(context.queries, context.prim.t));
     };
 

--- a/compiler-frontend/checking/src/core/constraint/compiler/prim_symbol.rs
+++ b/compiler-frontend/checking/src/core/constraint/compiler/prim_symbol.rs
@@ -169,7 +169,7 @@ where
 
     let matched = if extract_symbol(state, context, symbol)?.is_some() {
         MatchInstance::empty()
-    } else if let Type::Unification(id) = context.lookup_type(symbol) {
+    } else if let Type::Unification(id) = *context.lookup_type(symbol) {
         MatchInstance::Stuck { stuck: vec![id], skolem: false }
     } else {
         MatchInstance::Apart

--- a/compiler-frontend/checking/src/core/constraint/compiler/prim_type_error.rs
+++ b/compiler-frontend/checking/src/core/constraint/compiler/prim_type_error.rs
@@ -1,5 +1,5 @@
 use building_types::QueryResult;
-use lowering::StringKind;
+use lowering::{StringKind, StringLiteral};
 use smol_str::{SmolStr, format_smolstr};
 
 use crate::ExternalQueries;
@@ -52,7 +52,7 @@ where
 {
     let id = normalise::expand(state, context, id)?;
     if let Type::String(kind, value) = context.lookup_type(id) {
-        Ok(Some((kind, value)))
+        Ok(Some((*kind, StringLiteral::clone(value))))
     } else {
         Ok(None)
     }
@@ -100,7 +100,7 @@ where
 {
     let doc = normalise::expand(state, context, doc)?;
 
-    if let Type::Unification(u) = context.lookup_type(doc) {
+    if let Type::Unification(u) = *context.lookup_type(doc) {
         return Err(RenderStuck::Blocked(u));
     }
 

--- a/compiler-frontend/checking/src/core/constraint/elaborate.rs
+++ b/compiler-frontend/checking/src/core/constraint/elaborate.rs
@@ -365,7 +365,7 @@ where
     let replacement = substitute_type(state, context, substitution, replacement)?;
     let replacement = normalise::expand(state, context, replacement)?;
 
-    match context.lookup_type(replacement) {
+    match *context.lookup_type(replacement) {
         Type::Unification(_) | Type::Unknown(_) => return Ok(false),
         Type::Rigid(replacement, _, _) if replacement == name => return Ok(false),
         _ => {}

--- a/compiler-frontend/checking/src/core/constraint/elaborate/improvements.rs
+++ b/compiler-frontend/checking/src/core/constraint/elaborate/improvements.rs
@@ -32,10 +32,10 @@ where
 
     match (context.lookup_type(left), context.lookup_type(right)) {
         (Type::Rigid(name, _, _), _) => {
-            improvements.push((name, right));
+            improvements.push((*name, right));
         }
         (_, Type::Rigid(name, _, _)) => {
-            improvements.push((name, left));
+            improvements.push((*name, left));
         }
 
         (
@@ -49,16 +49,16 @@ where
             collect_structural_improvements(
                 state,
                 context,
-                left_function,
-                right_function,
+                *left_function,
+                *right_function,
                 seen,
                 improvements,
             )?;
             collect_structural_improvements(
                 state,
                 context,
-                left_argument,
-                right_argument,
+                *left_argument,
+                *right_argument,
                 seen,
                 improvements,
             )?;
@@ -71,28 +71,28 @@ where
             collect_structural_improvements(
                 state,
                 context,
-                left_argument,
-                right_argument,
+                *left_argument,
+                *right_argument,
                 seen,
                 improvements,
             )?;
             collect_structural_improvements(
                 state,
                 context,
-                left_result,
-                right_result,
+                *left_result,
+                *right_result,
                 seen,
                 improvements,
             )?;
         }
 
         (Type::Function(left_argument, left_result), Type::Application(_, _)) => {
-            let left = context.intern_function_application(left_argument, left_result);
+            let left = context.intern_function_application(*left_argument, *left_result);
             collect_structural_improvements(state, context, left, right, seen, improvements)?;
         }
 
         (Type::Application(_, _), Type::Function(right_argument, right_result)) => {
-            let right = context.intern_function_application(right_argument, right_result);
+            let right = context.intern_function_application(*right_argument, *right_result);
             collect_structural_improvements(state, context, left, right, seen, improvements)?;
         }
 
@@ -100,16 +100,16 @@ where
             collect_structural_improvements(
                 state,
                 context,
-                left_inner,
-                right_inner,
+                *left_inner,
+                *right_inner,
                 seen,
                 improvements,
             )?;
             collect_structural_improvements(
                 state,
                 context,
-                left_kind,
-                right_kind,
+                *left_kind,
+                *right_kind,
                 seen,
                 improvements,
             )?;
@@ -119,8 +119,8 @@ where
             collect_row_improvements(
                 state,
                 context,
-                left_row_id,
-                right_row_id,
+                *left_row_id,
+                *right_row_id,
                 seen,
                 improvements,
             )?;
@@ -152,8 +152,8 @@ where
     let mut right_index = 0;
     let mut right_only = vec![];
 
-    let left_fields = left_row.fields;
-    let right_fields = right_row.fields;
+    let left_fields = &left_row.fields;
+    let right_fields = &right_row.fields;
 
     while left_index < left_fields.len() && right_index < right_fields.len() {
         let left_field = &left_fields[left_index];

--- a/compiler-frontend/checking/src/core/constraint/instances.rs
+++ b/compiler-frontend/checking/src/core/constraint/instances.rs
@@ -81,13 +81,7 @@ where
         return Ok(());
     };
 
-    let Some(current_position) = context
-        .indexed
-        .items
-        .instance_sources()
-        .iter()
-        .position(|&candidate_item_id| candidate_item_id == item_id)
-    else {
+    let Some(&current_position) = context.instance_positions.get(&origin) else {
         return Ok(());
     };
 
@@ -288,31 +282,6 @@ where
     context.indexed.pairs.instance_chain_id(instance_id).map(|chain_id| (file_id, chain_id))
 }
 
-fn instance_candidate_position<Q>(
-    context: &CheckContext<Q>,
-    origin: InstanceCandidateOrigin,
-) -> Option<usize>
-where
-    Q: ExternalQueries,
-{
-    if match origin {
-        InstanceCandidateOrigin::Instance(file_id, _)
-        | InstanceCandidateOrigin::Derive(file_id, _) => file_id != context.id,
-    } {
-        return None;
-    }
-
-    let item_id = match origin {
-        InstanceCandidateOrigin::Instance(_, id) => {
-            InstanceSourceItemId::Instance(context.indexed.pairs.instance_to_item(id)?)
-        }
-        InstanceCandidateOrigin::Derive(_, id) => {
-            InstanceSourceItemId::Derive(context.indexed.pairs.derive_to_item(id)?)
-        }
-    };
-    context.indexed.items.instance_sources().iter().position(|&id| id == item_id)
-}
-
 fn should_report_overlap<Q>(
     context: &CheckContext<Q>,
     candidate: InstanceCandidateOrigin,
@@ -326,7 +295,7 @@ where
         return false;
     }
 
-    let Some(candidate_position) = instance_candidate_position(context, candidate) else {
+    let Some(&candidate_position) = context.instance_positions.get(&candidate) else {
         return true;
     };
 

--- a/compiler-frontend/checking/src/core/constraint/matching.rs
+++ b/compiler-frontend/checking/src/core/constraint/matching.rs
@@ -80,14 +80,14 @@ where
     let right_core = context.lookup_type(right);
 
     match (left_core, right_core) {
-        (Type::Kinded(left, _), _) => types_match(state, context, pattern, left, right),
-        (_, Type::Kinded(right, _)) => types_match(state, context, pattern, left, right),
+        (Type::Kinded(left, _), _) => types_match(state, context, pattern, *left, right),
+        (_, Type::Kinded(right, _)) => types_match(state, context, pattern, left, *right),
 
         (Type::Unification(left), Type::Unification(right)) => {
             if left == right {
                 Ok(MatchType::Match { bindings: vec![] })
             } else {
-                Ok(MatchType::Stuck { stuck: vec![left, right], skolem: false })
+                Ok(MatchType::Stuck { stuck: vec![*left, *right], skolem: false })
             }
         }
 
@@ -98,11 +98,11 @@ where
         }
 
         (_, Type::Rigid(right, _, _)) if pattern.contains(&right) => {
-            Ok(MatchType::Match { bindings: vec![(right, left)] })
+            Ok(MatchType::Match { bindings: vec![(*right, left)] })
         }
 
         (Type::Unification(unification), _) | (_, Type::Unification(unification)) => {
-            Ok(MatchType::Stuck { stuck: vec![unification], skolem: false })
+            Ok(MatchType::Stuck { stuck: vec![*unification], skolem: false })
         }
 
         (Type::Rigid(name, _, _), _) | (_, Type::Rigid(name, _, _)) if !pattern.contains(&name) => {
@@ -127,18 +127,18 @@ where
             Type::Application(left_function, left_argument),
             Type::Application(right_function, right_argument),
         ) => {
-            let function = types_match(state, context, pattern, left_function, right_function)?;
-            let argument = types_match(state, context, pattern, left_argument, right_argument)?;
+            let function = types_match(state, context, pattern, *left_function, *right_function)?;
+            let argument = types_match(state, context, pattern, *left_argument, *right_argument)?;
             Ok(function.combine(argument))
         }
 
         (Type::Application(_, _), Type::Function(right_argument, right_result)) => {
-            let right = context.intern_function_application(right_argument, right_result);
+            let right = context.intern_function_application(*right_argument, *right_result);
             types_match(state, context, pattern, left, right)
         }
 
         (Type::Function(left_argument, left_result), Type::Application(_, _)) => {
-            let left = context.intern_function_application(left_argument, left_result);
+            let left = context.intern_function_application(*left_argument, *left_result);
             types_match(state, context, pattern, left, right)
         }
 
@@ -146,8 +146,8 @@ where
             Type::KindApplication(left_function, left_argument),
             Type::KindApplication(right_function, right_argument),
         ) => {
-            let function = types_match(state, context, pattern, left_function, right_function)?;
-            let argument = types_match(state, context, pattern, left_argument, right_argument)?;
+            let function = types_match(state, context, pattern, *left_function, *right_function)?;
+            let argument = types_match(state, context, pattern, *left_argument, *right_argument)?;
             Ok(function.combine(argument))
         }
 
@@ -155,16 +155,16 @@ where
             Type::Function(left_argument, left_result),
             Type::Function(right_argument, right_result),
         ) => {
-            let argument = types_match(state, context, pattern, left_argument, right_argument)?;
-            let result = types_match(state, context, pattern, left_result, right_result)?;
+            let argument = types_match(state, context, pattern, *left_argument, *right_argument)?;
+            let result = types_match(state, context, pattern, *left_result, *right_result)?;
             Ok(argument.combine(result))
         }
 
         (Type::Row(left), Type::Row(right)) => compare_row_types_with(
             state,
             context,
-            left,
-            right,
+            *left,
+            *right,
             &mut |state, context, left, right| types_match(state, context, pattern, left, right),
         ),
 
@@ -239,8 +239,8 @@ where
     if let (Type::Row(left_row), Type::Row(right_row)) =
         (context.lookup_type(left_tail), context.lookup_type(right_tail))
     {
-        let left_row = context.lookup_row_type(left_row);
-        let right_row = context.lookup_row_type(right_row);
+        let left_row = context.lookup_row_type(*left_row);
+        let right_row = context.lookup_row_type(*right_row);
 
         if left_row.fields.is_empty()
             && left_row.tail.is_none()
@@ -272,14 +272,14 @@ where
     let right_core = context.lookup_type(right);
 
     match (left_core, right_core) {
-        (Type::Kinded(left, _), _) => types_equal(state, context, left, right),
-        (_, Type::Kinded(right, _)) => types_equal(state, context, left, right),
+        (Type::Kinded(left, _), _) => types_equal(state, context, *left, right),
+        (_, Type::Kinded(right, _)) => types_equal(state, context, left, *right),
 
         (Type::Unification(left), Type::Unification(right)) => {
             if left == right {
                 Ok(MatchType::Match { bindings: vec![] })
             } else {
-                Ok(MatchType::Stuck { stuck: vec![left, right], skolem: false })
+                Ok(MatchType::Stuck { stuck: vec![*left, *right], skolem: false })
             }
         }
 
@@ -292,23 +292,23 @@ where
         }
 
         (Type::Unification(left), _) => {
-            if toolkit::contains_unification(state, context, right, left)? {
+            if toolkit::contains_unification(state, context, right, *left)? {
                 Ok(MatchType::Apart)
             } else {
-                Ok(MatchType::Stuck { stuck: vec![left], skolem: false })
+                Ok(MatchType::Stuck { stuck: vec![*left], skolem: false })
             }
         }
 
         (_, Type::Unification(right)) => {
-            if toolkit::contains_unification(state, context, left, right)? {
+            if toolkit::contains_unification(state, context, left, *right)? {
                 Ok(MatchType::Apart)
             } else {
-                Ok(MatchType::Stuck { stuck: vec![right], skolem: false })
+                Ok(MatchType::Stuck { stuck: vec![*right], skolem: false })
             }
         }
 
         (Type::Rigid(left, _, _), _) => {
-            if toolkit::contains_rigid(state, context, right, left)? {
+            if toolkit::contains_rigid(state, context, right, *left)? {
                 Ok(MatchType::Apart)
             } else {
                 Ok(MatchType::Stuck { stuck: vec![], skolem: true })
@@ -316,7 +316,7 @@ where
         }
 
         (_, Type::Rigid(right, _, _)) => {
-            if toolkit::contains_rigid(state, context, left, right)? {
+            if toolkit::contains_rigid(state, context, left, *right)? {
                 Ok(MatchType::Apart)
             } else {
                 Ok(MatchType::Stuck { stuck: vec![], skolem: true })
@@ -341,18 +341,18 @@ where
             Type::Application(left_function, left_argument),
             Type::Application(right_function, right_argument),
         ) => {
-            let function = types_equal(state, context, left_function, right_function)?;
-            let argument = types_equal(state, context, left_argument, right_argument)?;
+            let function = types_equal(state, context, *left_function, *right_function)?;
+            let argument = types_equal(state, context, *left_argument, *right_argument)?;
             Ok(function.combine(argument))
         }
 
         (Type::Application(_, _), Type::Function(right_argument, right_result)) => {
-            let right = context.intern_function_application(right_argument, right_result);
+            let right = context.intern_function_application(*right_argument, *right_result);
             types_equal(state, context, left, right)
         }
 
         (Type::Function(left_argument, left_result), Type::Application(_, _)) => {
-            let left = context.intern_function_application(left_argument, left_result);
+            let left = context.intern_function_application(*left_argument, *left_result);
             types_equal(state, context, left, right)
         }
 
@@ -360,8 +360,8 @@ where
             Type::KindApplication(left_function, left_argument),
             Type::KindApplication(right_function, right_argument),
         ) => {
-            let function = types_equal(state, context, left_function, right_function)?;
-            let argument = types_equal(state, context, left_argument, right_argument)?;
+            let function = types_equal(state, context, *left_function, *right_function)?;
+            let argument = types_equal(state, context, *left_argument, *right_argument)?;
             Ok(function.combine(argument))
         }
 
@@ -369,16 +369,16 @@ where
             Type::Function(left_argument, left_result),
             Type::Function(right_argument, right_result),
         ) => {
-            let argument = types_equal(state, context, left_argument, right_argument)?;
-            let result = types_equal(state, context, left_result, right_result)?;
+            let argument = types_equal(state, context, *left_argument, *right_argument)?;
+            let result = types_equal(state, context, *left_result, *right_result)?;
             Ok(argument.combine(result))
         }
 
         (Type::Row(left), Type::Row(right)) => compare_row_types_with(
             state,
             context,
-            left,
-            right,
+            *left,
+            *right,
             &mut |state, context, left, right| types_equal(state, context, left, right),
         ),
 
@@ -805,10 +805,10 @@ where
 
     match (left_core, right_core) {
         (Type::Kinded(left, _), _) => {
-            types_apart(state, context, left, right, comparing_kind_argument)
+            types_apart(state, context, *left, right, comparing_kind_argument)
         }
         (_, Type::Kinded(right, _)) => {
-            types_apart(state, context, left, right, comparing_kind_argument)
+            types_apart(state, context, left, *right, comparing_kind_argument)
         }
 
         (Type::Rigid(_, _, _), Type::Rigid(_, _, _))
@@ -839,36 +839,36 @@ where
         (
             Type::Application(left_function, left_argument),
             Type::Application(right_function, right_argument),
-        ) => Ok(types_apart(state, context, left_function, right_function, false)?
-            .combine(types_apart(state, context, left_argument, right_argument, false)?)),
+        ) => Ok(types_apart(state, context, *left_function, *right_function, false)?
+            .combine(types_apart(state, context, *left_argument, *right_argument, false)?)),
 
         (Type::Application(_, _), Type::Function(right_argument, right_result)) => {
-            let right = context.intern_function_application(right_argument, right_result);
+            let right = context.intern_function_application(*right_argument, *right_result);
             types_apart(state, context, left, right, comparing_kind_argument)
         }
 
         (Type::Function(left_argument, left_result), Type::Application(_, _)) => {
-            let left = context.intern_function_application(left_argument, left_result);
+            let left = context.intern_function_application(*left_argument, *left_result);
             types_apart(state, context, left, right, comparing_kind_argument)
         }
 
         (
             Type::KindApplication(left_function, left_argument),
             Type::KindApplication(right_function, right_argument),
-        ) => Ok(types_apart(state, context, left_function, right_function, false)?
-            .combine(types_apart(state, context, left_argument, right_argument, true)?)),
+        ) => Ok(types_apart(state, context, *left_function, *right_function, false)?
+            .combine(types_apart(state, context, *left_argument, *right_argument, true)?)),
 
         (
             Type::Function(left_argument, left_result),
             Type::Function(right_argument, right_result),
-        ) => Ok(types_apart(state, context, left_argument, right_argument, false)?
-            .combine(types_apart(state, context, left_result, right_result, false)?)),
+        ) => Ok(types_apart(state, context, *left_argument, *right_argument, false)?
+            .combine(types_apart(state, context, *left_result, *right_result, false)?)),
 
         (Type::Row(left), Type::Row(right)) => compare_row_types_with(
             state,
             context,
-            left,
-            right,
+            *left,
+            *right,
             &mut |state, context, left, right| types_apart(state, context, left, right, false),
         ),
 

--- a/compiler-frontend/checking/src/core/exhaustive.rs
+++ b/compiler-frontend/checking/src/core/exhaustive.rs
@@ -1135,7 +1135,7 @@ where
 
     safe_loop! {
         current_id = normalise::expand(state, context, current_id)?;
-        match context.lookup_type(current_id) {
+        match *context.lookup_type(current_id) {
             Type::Application(function, argument) => {
                 arguments.push(argument);
                 current_id = function;
@@ -1169,7 +1169,7 @@ where
 
     safe_loop! {
         type_id = normalise::expand(state, context, type_id)?;
-        match context.lookup_type(type_id) {
+        match *context.lookup_type(type_id) {
             Type::Forall(binder_id, inner) => {
                 let binder = context.lookup_forall_binder(binder_id);
                 let argument_type = if let Some(argument) = arguments_iter.next() {

--- a/compiler-frontend/checking/src/core/exhaustive/convert.rs
+++ b/compiler-frontend/checking/src/core/exhaustive/convert.rs
@@ -154,8 +154,8 @@ where
 
     let row_type_id = normalise::expand(state, context, *row_type_id)?;
 
-    let row_fields = if let Type::Row(row_type_id) = context.lookup_type(row_type_id) {
-        context.lookup_row_type(row_type_id).fields
+    let row_fields = if let Type::Row(row_type_id) = *context.lookup_type(row_type_id) {
+        Arc::clone(&context.lookup_row_type(row_type_id).fields)
     } else {
         return Ok(None);
     };
@@ -354,7 +354,7 @@ where
 
     safe_loop! {
         type_id = normalise::expand(state, context, type_id)?;
-        match context.lookup_type(type_id) {
+        match *context.lookup_type(type_id) {
             Type::Application(function, argument) => {
                 arguments.push(argument);
                 type_id = function;

--- a/compiler-frontend/checking/src/core/fold.rs
+++ b/compiler-frontend/checking/src/core/fold.rs
@@ -49,7 +49,7 @@ where
 
     let t = safe_loop! {
         let t = context.lookup_type(id);
-        match folder.transform(state, context, id, &t)? {
+        match folder.transform(state, context, id, t)? {
             FoldAction::Replace(id) => return Ok(id),
             FoldAction::ReplaceThen(then_id) => {
                 let then_id = normalise::normalise(state, context, then_id)?;
@@ -77,7 +77,7 @@ where
         }};
     }
 
-    let result = match t {
+    let result = match *t {
         Type::Application(function, argument) => {
             fold_pair!(function, argument, intern_application)
         }
@@ -161,7 +161,7 @@ where
         };
 
         let tail = normalise::normalise(state, context, tail)?;
-        let Type::Row(row_id) = context.lookup_type(tail) else {
+        let Type::Row(row_id) = *context.lookup_type(tail) else {
             break;
         };
 

--- a/compiler-frontend/checking/src/core/fold.rs
+++ b/compiler-frontend/checking/src/core/fold.rs
@@ -45,14 +45,14 @@ where
     Q: ExternalQueries,
     F: TypeFold,
 {
-    let mut id = normalise::normalise(state, context, id)?;
+    let mut id = normalise::normalise(state, context, id);
 
     let t = safe_loop! {
         let t = context.lookup_type(id);
         match folder.transform(state, context, id, t)? {
             FoldAction::Replace(id) => return Ok(id),
             FoldAction::ReplaceThen(then_id) => {
-                let then_id = normalise::normalise(state, context, then_id)?;
+                let then_id = normalise::normalise(state, context, then_id);
                 if then_id == id {
                     break context.lookup_type(id);
                 }
@@ -160,7 +160,7 @@ where
             break;
         };
 
-        let tail = normalise::normalise(state, context, tail)?;
+        let tail = normalise::normalise(state, context, tail);
         let Type::Row(row_id) = *context.lookup_type(tail) else {
             break;
         };

--- a/compiler-frontend/checking/src/core/generalise.rs
+++ b/compiler-frontend/checking/src/core/generalise.rs
@@ -54,7 +54,7 @@ where
     where
         Q: ExternalQueries,
     {
-        let id = normalise::normalise(state, context, id)?;
+        let id = normalise::normalise(state, context, id);
         let t = context.lookup_type(id);
 
         match *t {

--- a/compiler-frontend/checking/src/core/generalise.rs
+++ b/compiler-frontend/checking/src/core/generalise.rs
@@ -57,7 +57,7 @@ where
         let id = normalise::normalise(state, context, id)?;
         let t = context.lookup_type(id);
 
-        match t {
+        match *t {
             Type::Application(function, argument) | Type::KindApplication(function, argument) => {
                 aux(graph, state, context, function, dependent, visited_kinds)?;
                 aux(graph, state, context, argument, dependent, visited_kinds)?;
@@ -238,7 +238,7 @@ where
             }
             UnificationState::Solved(solution) => {
                 let solution = normalise::expand(state, context, solution)?;
-                let Type::Rigid(name, _, kind) = context.lookup_type(solution) else {
+                let Type::Rigid(name, _, kind) = *context.lookup_type(solution) else {
                     continue;
                 };
                 (solution, name, kind)

--- a/compiler-frontend/checking/src/core/normalise.rs
+++ b/compiler-frontend/checking/src/core/normalise.rs
@@ -94,16 +94,12 @@ where
 ///
 /// This function should be used in checking rules where
 /// synonyms must remain opaque such as in kind checking.
-pub fn normalise<Q>(
-    state: &mut CheckState,
-    context: &CheckContext<Q>,
-    mut id: TypeId,
-) -> QueryResult<TypeId>
+pub fn normalise<Q>(state: &mut CheckState, context: &CheckContext<Q>, mut id: TypeId) -> TypeId
 where
     Q: ExternalQueries,
 {
     if !context.lookup_type_flags(id).may_normalise() {
-        return Ok(id);
+        return id;
     }
 
     let mut reduction = ReductionContext::new(state, context);
@@ -120,7 +116,7 @@ where
         state.unifications.solve(unification_id, id);
     }
 
-    Ok(id)
+    id
 }
 
 /// Expands synonym constructor applications.
@@ -138,12 +134,12 @@ where
 {
     // Keeping the reduction head normalised avoids repeating the same
     // unification pruning while discovering synonym application spines.
-    id = normalise(state, context, id)?;
+    id = normalise(state, context, id);
 
     safe_loop! {
         let expanded = expand_synonym(state, context, id)?;
         if expanded != id {
-            id = normalise(state, context, expanded)?;
+            id = normalise(state, context, expanded);
             continue;
         }
 
@@ -151,7 +147,7 @@ where
         if expanded == id {
             return Ok(id);
         }
-        id = normalise(state, context, expanded)?;
+        id = normalise(state, context, expanded);
     }
 }
 
@@ -251,7 +247,7 @@ where
         match *context.lookup_type(current) {
             Type::Application(function, _) | Type::KindApplication(function, _) => {
                 argument_count += 1;
-                current = normalise(state, context, function)?;
+                current = normalise(state, context, function);
             }
             _ => break,
         }
@@ -273,11 +269,11 @@ where
         match *context.lookup_type(current) {
             Type::Application(function, argument) => {
                 arguments.push(ApplicationArgument::Type(argument));
-                current = normalise(state, context, function)?;
+                current = normalise(state, context, function);
             }
             Type::KindApplication(function, argument) => {
                 arguments.push(ApplicationArgument::Kind(argument));
-                current = normalise(state, context, function)?;
+                current = normalise(state, context, function);
             }
             _ => break,
         }
@@ -305,7 +301,7 @@ where
     // expansion would leave `k` rigid inside the synonym body causing
     // unification errors downstream.
     safe_loop! {
-        kind = normalise(state, context, kind)?;
+        kind = normalise(state, context, kind);
 
         let Type::Forall(binder_id, inner) = *context.lookup_type(kind) else {
             break;

--- a/compiler-frontend/checking/src/core/normalise.rs
+++ b/compiler-frontend/checking/src/core/normalise.rs
@@ -30,10 +30,10 @@ where
     fn reduce_once(&mut self, id: TypeId) -> Option<TypeId> {
         let t = self.context.lookup_type(id);
 
-        if let Some(next) = self.rule_prune_unifications(&t) {
+        if let Some(next) = self.rule_prune_unifications(t) {
             return Some(next);
         }
-        if let Some(next) = self.rule_simplify_rows(&t) {
+        if let Some(next) = self.rule_simplify_rows(t) {
             return Some(next);
         }
 
@@ -65,7 +65,7 @@ where
         let tail_id = row.tail?;
         let tail_t = self.context.lookup_type(tail_id);
 
-        let Type::Row(inner_row_id) = tail_t else {
+        let Type::Row(inner_row_id) = *tail_t else {
             return None;
         };
 
@@ -176,7 +176,7 @@ where
     let mut flattened_once = false;
 
     let row_tail = safe_loop! {
-        let Type::Row(row_id) = context.lookup_type(current_id) else {
+        let Type::Row(row_id) = *context.lookup_type(current_id) else {
             if flattened_once {
                 break Some(current_id);
             } else {
@@ -248,7 +248,7 @@ where
     // Most application heads are not synonyms. Inspect the head before
     // allocating storage for arguments, preserving normalisation along the spine.
     safe_loop! {
-        match context.lookup_type(current) {
+        match *context.lookup_type(current) {
             Type::Application(function, _) | Type::KindApplication(function, _) => {
                 argument_count += 1;
                 current = normalise(state, context, function)?;
@@ -257,7 +257,7 @@ where
         }
     }
 
-    let (file_id, type_id) = match context.lookup_type(current) {
+    let (file_id, type_id) = match *context.lookup_type(current) {
         Type::Constructor(file_id, type_id) => (file_id, type_id),
         _ => return Ok(id),
     };
@@ -270,7 +270,7 @@ where
     let mut arguments = Vec::with_capacity(argument_count);
     current = id;
     safe_loop! {
-        match context.lookup_type(current) {
+        match *context.lookup_type(current) {
             Type::Application(function, argument) => {
                 arguments.push(ApplicationArgument::Type(argument));
                 current = normalise(state, context, function)?;
@@ -307,7 +307,7 @@ where
     safe_loop! {
         kind = normalise(state, context, kind)?;
 
-        let Type::Forall(binder_id, inner) = context.lookup_type(kind) else {
+        let Type::Forall(binder_id, inner) = *context.lookup_type(kind) else {
             break;
         };
 

--- a/compiler-frontend/checking/src/core/pretty.rs
+++ b/compiler-frontend/checking/src/core/pretty.rs
@@ -35,13 +35,13 @@ pub trait PrettyQueries:
         Lowered = Arc<lowering::LoweredModule>,
     >
 {
-    fn lookup_type(&self, id: TypeId) -> Type;
+    fn lookup_type(&self, id: TypeId) -> &Type;
 
     fn lookup_forall_binder(&self, id: ForallBinderId) -> ForallBinder;
 
-    fn lookup_row_type(&self, id: RowTypeId) -> RowType;
+    fn lookup_row_type(&self, id: RowTypeId) -> &RowType;
 
-    fn lookup_smol_str(&self, id: SmolStrId) -> SmolStr;
+    fn lookup_smol_str(&self, id: SmolStrId) -> &SmolStr;
 }
 
 #[derive(Clone, Debug)]
@@ -93,7 +93,7 @@ impl PrettyNames {
 
         let display = if let Some(&id) = names.get(&name) {
             let base = queries.lookup_smol_str(id);
-            self.allocate_display_name(base)
+            self.allocate_display_name(SmolStr::clone(base))
         } else {
             let base = SmolStr::clone(&self.default_name);
             self.allocate_generated_display_name(base)
@@ -387,7 +387,7 @@ where
         }
     }
 
-    fn lookup_type(&self, id: TypeId) -> Type {
+    fn lookup_type(&self, id: TypeId) -> &Type {
         self.queries.lookup_type(id)
     }
 
@@ -395,11 +395,7 @@ where
         self.queries.lookup_forall_binder(id)
     }
 
-    fn lookup_row_type(&self, id: RowTypeId) -> RowType {
-        self.queries.lookup_row_type(id)
-    }
-
-    fn lookup_smol_str(&self, id: SmolStrId) -> smol_str::SmolStr {
+    fn lookup_smol_str(&self, id: SmolStrId) -> &smol_str::SmolStr {
         self.queries.lookup_smol_str(id)
     }
 
@@ -437,7 +433,7 @@ where
     }
 
     fn is_record_constructor(&self, id: TypeId) -> bool {
-        if let Type::Constructor(file_id, type_id) = self.lookup_type(id)
+        if let Type::Constructor(file_id, type_id) = *self.lookup_type(id)
             && file_id == self.queries.prim_id()
             && let Some(name) = self.lookup_type_name(file_id, type_id)
         {
@@ -447,7 +443,7 @@ where
     }
 
     fn is_type_kind(&self, id: TypeId) -> bool {
-        if let Type::Constructor(file_id, type_id) = self.lookup_type(id)
+        if let Type::Constructor(file_id, type_id) = *self.lookup_type(id)
             && file_id == self.queries.prim_id()
             && let Some(name) = self.lookup_type_name(file_id, type_id)
         {
@@ -467,33 +463,34 @@ where
     }
 
     fn traverse(&mut self, precedence: Precedence, id: TypeId) -> Doc<'arena> {
-        match self.lookup_type(id) {
-            Type::Application(function, argument) => {
+        let queries = self.queries;
+        match queries.lookup_type(id) {
+            &Type::Application(function, argument) => {
                 self.traverse_application(precedence, function, argument)
             }
 
-            Type::KindApplication(function, argument) => {
+            &Type::KindApplication(function, argument) => {
                 self.traverse_kind_application(precedence, function, argument)
             }
 
-            Type::Forall(binder_id, inner) => self.traverse_forall(precedence, binder_id, inner),
+            &Type::Forall(binder_id, inner) => self.traverse_forall(precedence, binder_id, inner),
 
-            Type::Constrained(constraint, inner) => {
+            &Type::Constrained(constraint, inner) => {
                 self.traverse_constrained(precedence, constraint, inner)
             }
 
-            Type::Function(argument, result) => {
+            &Type::Function(argument, result) => {
                 self.traverse_function(precedence, argument, result)
             }
 
-            Type::Kinded(inner, kind) => {
+            &Type::Kinded(inner, kind) => {
                 let inner = self.traverse(Precedence::Application, inner);
                 let kind = self.traverse(Precedence::Top, kind);
                 let kinded = inner.append(self.arena.text(" :: ")).append(kind);
                 self.parens_if(precedence > Precedence::Atom, kinded)
             }
 
-            Type::Constructor(file_id, type_id) => {
+            &Type::Constructor(file_id, type_id) => {
                 let name = self
                     .display_type_name(file_id, type_id)
                     .unwrap_or_else(|| "<InvalidName>".to_string());
@@ -506,9 +503,9 @@ where
                 self.parens_if(negative, integer)
             }
 
-            Type::String(kind, string) => match kind {
+            Type::String(kind, string) => match *kind {
                 StringKind::String => {
-                    self.arena.text(lowering::literal::encode_normal_string(&string))
+                    self.arena.text(lowering::literal::encode_normal_string(string))
                 }
                 StringKind::RawString => {
                     let string = string.to_utf8().unwrap_or_else(|_| {
@@ -518,15 +515,15 @@ where
                 }
             },
 
-            Type::Row(row_id) => {
-                let row = self.lookup_row_type(row_id);
+            &Type::Row(row_id) => {
+                let row = queries.lookup_row_type(row_id);
                 if row.fields.is_empty() && row.tail.is_none() {
                     return self.arena.text("()");
                 }
                 self.format_row(&row.fields, row.tail)
             }
 
-            Type::Rigid(name, _, kind) => {
+            &Type::Rigid(name, _, kind) => {
                 let text = self.pretty_names.display_name(self.queries, self.names, name);
                 if self.show_rigid_kinds && !self.is_type_kind(kind) {
                     let kind = self.traverse(Precedence::Top, kind);
@@ -539,14 +536,14 @@ where
                 }
             }
 
-            Type::Unification(unification_id) => self.arena.text(format!("?{unification_id}")),
+            &Type::Unification(unification_id) => self.arena.text(format!("?{unification_id}")),
 
-            Type::Free(name_id) => {
+            &Type::Free(name_id) => {
                 let name = self.lookup_smol_str(name_id);
                 self.arena.text(format!("{name}"))
             }
 
-            Type::Unknown(name_id) => {
+            &Type::Unknown(name_id) => {
                 let name = self.lookup_smol_str(name_id);
                 self.arena.text(format!("?[{name}]"))
             }
@@ -570,7 +567,7 @@ where
 
         let mut arguments = vec![argument];
 
-        while let Type::Application(inner_function, argument) = self.lookup_type(function) {
+        while let Type::Application(inner_function, argument) = *self.lookup_type(function) {
             function = inner_function;
             arguments.push(argument);
         }
@@ -589,9 +586,10 @@ where
     }
 
     fn format_record_application(&mut self, argument: TypeId) -> Doc<'arena> {
-        match self.lookup_type(argument) {
-            Type::Row(row_id) => {
-                let row = self.lookup_row_type(row_id);
+        let queries = self.queries;
+        match queries.lookup_type(argument) {
+            &Type::Row(row_id) => {
+                let row = queries.lookup_row_type(row_id);
                 self.format_record(&row.fields, row.tail)
             }
             _ => {
@@ -609,7 +607,7 @@ where
     ) -> Doc<'arena> {
         let mut arguments = vec![argument];
 
-        while let Type::KindApplication(inner_function, argument) = self.lookup_type(function) {
+        while let Type::KindApplication(inner_function, argument) = *self.lookup_type(function) {
             function = inner_function;
             arguments.push(argument);
         }
@@ -642,7 +640,7 @@ where
         let binder = self.lookup_forall_binder(binder_id);
         let mut binders = vec![binder];
 
-        while let Type::Forall(next_binder_id, next_inner) = self.lookup_type(inner) {
+        while let Type::Forall(next_binder_id, next_inner) = *self.lookup_type(inner) {
             binders.push(self.lookup_forall_binder(next_binder_id));
             inner = next_inner;
         }
@@ -689,7 +687,7 @@ where
     ) -> Doc<'arena> {
         let mut constraints = vec![constraint];
 
-        while let Type::Constrained(constraint, next_inner) = self.lookup_type(inner) {
+        while let Type::Constrained(constraint, next_inner) = *self.lookup_type(inner) {
             constraints.push(constraint);
             inner = next_inner;
         }
@@ -718,7 +716,7 @@ where
     ) -> Doc<'arena> {
         let mut arguments = vec![argument];
 
-        while let Type::Function(argument, next_result) = self.lookup_type(result) {
+        while let Type::Function(argument, next_result) = *self.lookup_type(result) {
             result = next_result;
             arguments.push(argument);
         }

--- a/compiler-frontend/checking/src/core/signature.rs
+++ b/compiler-frontend/checking/src/core/signature.rs
@@ -57,7 +57,7 @@ where
     safe_loop! {
         current = normalise::expand(state, context, current)?;
 
-        match context.lookup_type(current) {
+        match *context.lookup_type(current) {
             Type::Forall(binder_id, inner) => {
                 abstractions.push(DecomposedAbstraction::Type { binder: binder_id });
                 current = inner;
@@ -89,7 +89,7 @@ where
                 let function_argument =
                     normalise::expand(state, context, function_argument)?;
 
-                let Type::Application(function, argument) = context.lookup_type(function_argument)
+                let Type::Application(function, argument) = *context.lookup_type(function_argument)
                 else {
                     return Ok(DecomposedSignature { abstractions, arguments, result: current });
                 };
@@ -175,7 +175,7 @@ where
     while arguments.len() < required {
         let current = normalise::expand(state, context, *result_type)?;
 
-        let Type::Unification(unification_id) = context.lookup_type(current) else {
+        let Type::Unification(unification_id) = *context.lookup_type(current) else {
             break;
         };
 

--- a/compiler-frontend/checking/src/core/skolem.rs
+++ b/compiler-frontend/checking/src/core/skolem.rs
@@ -153,7 +153,7 @@ where
 
     let reported = checked.errors.iter().filter_map(|error| {
         let ErrorKind::EscapedSkolem { skolem, .. } = error.kind else { return None };
-        let Type::Rigid(name, _, _) = context.lookup_type(skolem) else { return None };
+        let Type::Rigid(name, _, _) = *context.lookup_type(skolem) else { return None };
         name.scope
     });
     let reported = reported.collect();
@@ -579,7 +579,7 @@ fn inspect_rigid_kind<Q>(
 ) where
     Q: ExternalQueries,
 {
-    if let Type::Rigid(_, _, kind) = checker.context.lookup_type(rigid) {
+    if let Type::Rigid(_, _, kind) = *checker.context.lookup_type(rigid) {
         inspect_type(checker, kind, crumb);
     }
 }
@@ -599,7 +599,7 @@ fn inspect_type<Q>(
             continue;
         }
 
-        match checker.context.lookup_type(type_id) {
+        match *checker.context.lookup_type(type_id) {
             Type::Application(function, argument)
             | Type::KindApplication(function, argument)
             | Type::Constrained(function, argument)
@@ -688,7 +688,7 @@ where
     Q: ExternalQueries,
 {
     let mut scopes = vec![];
-    while let Type::Forall(binder, inner) = context.lookup_type(type_id) {
+    while let Type::Forall(binder, inner) = *context.lookup_type(type_id) {
         let binder = context.lookup_forall_binder(binder);
         let Some(scope) = binder.scope else { break };
         scopes.push(scope);

--- a/compiler-frontend/checking/src/core/substitute.rs
+++ b/compiler-frontend/checking/src/core/substitute.rs
@@ -33,7 +33,7 @@ impl RigidRenaming {
     where
         Q: ExternalQueries,
     {
-        let Type::Rigid(name, depth, _) = context.lookup_type(replacement) else {
+        let Type::Rigid(name, depth, _) = *context.lookup_type(replacement) else {
             unreachable!("invariant violated: expected a rigid variable");
         };
         let replacement = RigidReplacement { name, depth, type_id: replacement };

--- a/compiler-frontend/checking/src/core/toolkit.rs
+++ b/compiler-frontend/checking/src/core/toolkit.rs
@@ -489,7 +489,7 @@ where
         };
 
         let binder = context.lookup_forall_binder(binder_id);
-        let binder_kind = normalise::normalise(state, context, binder.kind)?;
+        let binder_kind = normalise::normalise(state, context, binder.kind);
 
         let replacement = state.fresh_unification(context.queries, binder_kind);
         id = SubstituteName::one(state, context, binder.name, replacement, inner)?;
@@ -515,7 +515,7 @@ where
         };
 
         let binder = context.lookup_forall_binder(binder_id);
-        let binder_kind = normalise::normalise(state, context, binder.kind)?;
+        let binder_kind = normalise::normalise(state, context, binder.kind);
 
         let text = state.checked.lookup_name(binder.name);
         let rigid = state.fresh_rigid_named(context.queries, binder_kind, text);
@@ -862,7 +862,7 @@ where
         current = SubstituteName::one(state, context, binder.name, replacement, inner)?;
     }
 
-    current = normalise::normalise(state, context, current)?;
+    current = normalise::normalise(state, context, current);
 
     let InspectFunction { arguments, .. } = inspect_function(state, context, current)?;
     let [inner] = arguments[..] else { return Ok(None) };

--- a/compiler-frontend/checking/src/core/toolkit.rs
+++ b/compiler-frontend/checking/src/core/toolkit.rs
@@ -58,7 +58,7 @@ where
 
     safe_loop! {
         id = normalise::expand(state, context, id)?;
-        match context.lookup_type(id) {
+        match *context.lookup_type(id) {
             Type::Application(function, argument) => {
                 arguments.push(argument);
                 id = function;
@@ -86,7 +86,7 @@ where
 
     safe_loop! {
         id = normalise::expand(state, context, id)?;
-        match context.lookup_type(id) {
+        match *context.lookup_type(id) {
             Type::Application(function, argument) => {
                 arguments.push(crate::core::ApplicationArgument::Type(argument));
                 id = function;
@@ -326,7 +326,7 @@ where
     safe_loop! {
         current = normalise::expand(state, context, current)?;
 
-        let Type::Forall(binder_id, inner) = context.lookup_type(current) else {
+        let Type::Forall(binder_id, inner) = *context.lookup_type(current) else {
             break;
         };
 
@@ -369,7 +369,7 @@ where
             return Ok(InspectFunction { arguments, result: current });
         }
 
-        match context.lookup_type(current) {
+        match *context.lookup_type(current) {
             Type::Function(argument, result) => {
                 arguments.push(argument);
                 current = result;
@@ -377,7 +377,7 @@ where
             Type::Application(function_argument, result) => {
                 let function_argument = normalise::expand(state, context, function_argument)?;
 
-                let Type::Application(function, argument) = context.lookup_type(function_argument)
+                let Type::Application(function, argument) = *context.lookup_type(function_argument)
                 else {
                     return Ok(InspectFunction { arguments, result: current });
                 };
@@ -448,7 +448,7 @@ where
 
     safe_loop! {
         current = normalise::expand(state, context, current)?;
-        match context.lookup_type(current) {
+        match *context.lookup_type(current) {
             Type::Constrained(constraint, constrained) => {
                 constraints.push(constraint);
                 current = constrained;
@@ -484,7 +484,7 @@ where
     safe_loop! {
         id = normalise::expand(state, context, id)?;
 
-        let Type::Forall(binder_id, inner) = context.lookup_type(id) else {
+        let Type::Forall(binder_id, inner) = *context.lookup_type(id) else {
             break;
         };
 
@@ -510,7 +510,7 @@ where
     safe_loop! {
         id = normalise::expand(state, context, id)?;
 
-        let Type::Forall(binder_id, inner) = context.lookup_type(id) else {
+        let Type::Forall(binder_id, inner) = *context.lookup_type(id) else {
             break;
         };
 
@@ -536,7 +536,7 @@ where
 {
     safe_loop! {
         id = normalise::expand(state, context, id)?;
-        match context.lookup_type(id) {
+        match *context.lookup_type(id) {
             Type::Constrained(constraint, constrained) => {
                 state.push_wanted(constraint);
                 id = constrained;
@@ -557,7 +557,7 @@ where
 {
     safe_loop! {
         id = normalise::expand(state, context, id)?;
-        match context.lookup_type(id) {
+        match *context.lookup_type(id) {
             Type::Constrained(constraint, constrained) => {
                 state.push_given(constraint);
                 id = constrained;
@@ -578,7 +578,7 @@ where
 {
     safe_loop! {
         id = normalise::expand(state, context, id)?;
-        match context.lookup_type(id) {
+        match *context.lookup_type(id) {
             Type::Constrained(_, constrained) => {
                 id = constrained;
             }
@@ -673,7 +673,7 @@ where
 {
     let t = normalise::expand(state, context, t)?;
 
-    match context.lookup_type(t) {
+    match *context.lookup_type(t) {
         Type::Function(argument, result) => Ok(Some((argument, result))),
 
         Type::Unification(unification_id) => {
@@ -688,12 +688,12 @@ where
 
         Type::Application(partial, result) => {
             let partial = normalise::expand(state, context, partial)?;
-            if let Type::Application(constructor, argument) = context.lookup_type(partial) {
+            if let Type::Application(constructor, argument) = *context.lookup_type(partial) {
                 let constructor = normalise::expand(state, context, constructor)?;
                 if constructor == context.prim.function {
                     return Ok(Some((argument, result)));
                 }
-                if let Type::Unification(unification_id) = context.lookup_type(constructor) {
+                if let Type::Unification(unification_id) = *context.lookup_type(constructor) {
                     unification::solve(
                         state,
                         context,
@@ -720,7 +720,7 @@ where
     Q: ExternalQueries,
 {
     let type_id = normalise::expand(state, context, type_id)?;
-    let Type::Application(function, argument) = context.lookup_type(type_id) else {
+    let Type::Application(function, argument) = *context.lookup_type(type_id) else {
         return Ok(None);
     };
     Ok(Some((function, argument)))
@@ -773,7 +773,7 @@ where
 {
     safe_loop! {
         id = normalise::expand(state, context, id)?;
-        match context.lookup_type(id) {
+        match *context.lookup_type(id) {
             Type::Constructor(file_id, item_id) => return Ok(Some((file_id, item_id))),
             Type::Application(function, _) | Type::KindApplication(function, _) => {
                 id = function;
@@ -840,7 +840,7 @@ where
 
     safe_loop! {
         current = normalise::expand(state, context, current)?;
-        let Type::Forall(binder_id, inner) = context.lookup_type(current) else {
+        let Type::Forall(binder_id, inner) = *context.lookup_type(current) else {
             break;
         };
 

--- a/compiler-frontend/checking/src/core/unification.rs
+++ b/compiler-frontend/checking/src/core/unification.rs
@@ -148,16 +148,20 @@ where
         // ordinary subtyping handles it without collecting applications.
         (_, Type::Forall(_, _)) => subtype(state, context, t1, t2),
         (Type::Forall(binder_id, inner), _) => {
-            let binder = context.lookup_forall_binder(binder_id);
+            let binder = context.lookup_forall_binder(*binder_id);
             let argument = state.fresh_unification(context.queries, binder.kind);
-            let result = SubstituteName::one(state, context, binder.name, argument, inner)?;
+            let result = SubstituteName::one(state, context, binder.name, argument, *inner)?;
             applications.push(SubtypeApplication::Type { result });
             subtype_with_applications_core(state, context, result, t2, applications)
         }
         (Type::Constrained(constraint, result), _) => {
-            let evidence = state.push_wanted(constraint);
-            applications.push(SubtypeApplication::Evidence { evidence, constraint, result });
-            subtype_with_applications_core(state, context, result, t2, applications)
+            let evidence = state.push_wanted(*constraint);
+            applications.push(SubtypeApplication::Evidence {
+                evidence,
+                constraint: *constraint,
+                result: *result,
+            });
+            subtype_with_applications_core(state, context, *result, t2, applications)
         }
         (_, _) => subtype(state, context, t1, t2),
     }
@@ -192,8 +196,8 @@ where
             subtype_function::<Q>(
                 state,
                 context,
-                (t1_argument, t1_result),
-                (t2_argument, t2_result),
+                (*t1_argument, *t1_result),
+                (*t2_argument, *t2_result),
             )
         }
 
@@ -205,7 +209,7 @@ where
                     state,
                     context,
                     (t1_argument, t1_result),
-                    (t2_argument, t2_result),
+                    (*t2_argument, *t2_result),
                 )
             } else {
                 unify(state, context, t1, t2)
@@ -217,7 +221,7 @@ where
                 subtype_function::<Q>(
                     state,
                     context,
-                    (t1_argument, t1_result),
+                    (*t1_argument, *t1_result),
                     (t2_argument, t2_result),
                 )
             } else {
@@ -247,11 +251,11 @@ where
         // If `?a` is solved to a type containing `h`, the skolem escape
         // check is triggered because `h` was defined in a deeper scope.
         (_, Type::Forall(binder_id, inner)) => {
-            let binder = context.lookup_forall_binder(binder_id);
+            let binder = context.lookup_forall_binder(*binder_id);
             let text = state.checked.lookup_name(binder.name);
             let skolem = state.fresh_rigid_named(context.queries, binder.kind, text);
 
-            let inner = SubstituteName::one(state, context, binder.name, skolem, inner)?;
+            let inner = SubstituteName::one(state, context, binder.name, skolem, *inner)?;
             state.with_depth(|state| subtype_with::<P, Q>(state, context, t1, inner))
         }
 
@@ -272,15 +276,15 @@ where
         //
         // with the substitution [?a := b'].
         (Type::Forall(binder_id, inner), _) => {
-            let binder = context.lookup_forall_binder(binder_id);
+            let binder = context.lookup_forall_binder(*binder_id);
             let unification = state.fresh_unification(context.queries, binder.kind);
 
-            let inner = SubstituteName::one(state, context, binder.name, unification, inner)?;
+            let inner = SubstituteName::one(state, context, binder.name, unification, *inner)?;
             subtype_with::<P, Q>(state, context, inner, t2)
         }
 
         (Type::Constrained(constraint, constrained), _) => {
-            P::on_constrained(state, context, t1, constraint, constrained, t2)
+            P::on_constrained(state, context, t1, *constraint, *constrained, t2)
         }
 
         // Record subtyping is implemented through subtype_rows. Unlike
@@ -289,9 +293,9 @@ where
         (
             Type::Application(t1_function, t1_argument),
             Type::Application(t2_function, t2_argument),
-        ) if t1_function == context.prim.record && t2_function == context.prim.record => {
-            let t1_argument = normalise::expand(state, context, t1_argument)?;
-            let t2_argument = normalise::expand(state, context, t2_argument)?;
+        ) if *t1_function == context.prim.record && *t2_function == context.prim.record => {
+            let t1_argument = normalise::expand(state, context, *t1_argument)?;
+            let t2_argument = normalise::expand(state, context, *t2_argument)?;
 
             let t1_argument_core = context.lookup_type(t1_argument);
             let t2_argument_core = context.lookup_type(t2_argument);
@@ -299,7 +303,7 @@ where
             if let (Type::Row(t1_row_id), Type::Row(t2_row_id)) =
                 (t1_argument_core, t2_argument_core)
             {
-                subtype_rows::<NonElaborating, Q>(state, context, t1_row_id, t2_row_id)
+                subtype_rows::<NonElaborating, Q>(state, context, *t1_row_id, *t2_row_id)
             } else {
                 unify(state, context, t1, t2)
             }
@@ -347,23 +351,23 @@ where
         // PureScript has an impredicative type system i.e. unification
         // variables can be solved to Type::Forall. These rules must
         // be placed before the one-sided Type::Forall skolemisation.
-        (Type::Unification(id), _) => return solve(state, context, t1, id, t2),
-        (_, Type::Unification(id)) => return solve(state, context, t2, id, t1),
+        (Type::Unification(id), _) => return solve(state, context, t1, *id, t2),
+        (_, Type::Unification(id)) => return solve(state, context, t2, *id, t1),
 
         (
             Type::Application(t1_function, t1_argument),
             Type::Application(t2_function, t2_argument),
         ) => {
-            unify(state, context, t1_function, t2_function)?
-                && unify(state, context, t1_argument, t2_argument)?
+            unify(state, context, *t1_function, *t2_function)?
+                && unify(state, context, *t1_argument, *t2_argument)?
         }
 
         (
             Type::KindApplication(t1_function, t1_argument),
             Type::KindApplication(t2_function, t2_argument),
         ) => {
-            unify(state, context, t1_function, t2_function)?
-                && unify(state, context, t1_argument, t2_argument)?
+            unify(state, context, *t1_function, *t2_function)?
+                && unify(state, context, *t1_argument, *t2_argument)?
         }
 
         // Forall-Forall
@@ -376,8 +380,8 @@ where
         // types to be instantiated with the same fresh varible. It
         // does not make sense for Forall to instantiate either side.
         (Type::Forall(t1_binder_id, t1_inner), Type::Forall(t2_binder_id, t2_inner)) => {
-            let t1_binder = context.lookup_forall_binder(t1_binder_id);
-            let t2_binder = context.lookup_forall_binder(t2_binder_id);
+            let t1_binder = context.lookup_forall_binder(*t1_binder_id);
+            let t2_binder = context.lookup_forall_binder(*t2_binder_id);
 
             unify(state, context, t1_binder.kind, t2_binder.kind)?;
 
@@ -387,8 +391,8 @@ where
                 .or_else(|| state.checked.lookup_name(t2_binder.name));
             let skolem = state.fresh_rigid_named(context.queries, t1_binder.kind, text);
 
-            let t1_inner = SubstituteName::one(state, context, t1_binder.name, skolem, t1_inner)?;
-            let t2_inner = SubstituteName::one(state, context, t2_binder.name, skolem, t2_inner)?;
+            let t1_inner = SubstituteName::one(state, context, t1_binder.name, skolem, *t1_inner)?;
+            let t2_inner = SubstituteName::one(state, context, t2_binder.name, skolem, *t2_inner)?;
 
             state.with_depth(|state| unify(state, context, t1_inner, t2_inner))?
         }
@@ -408,17 +412,17 @@ where
         //
         // with the substitution [?a := 'b].
         (Type::Forall(binder_id, inner), _) => {
-            let binder = context.lookup_forall_binder(binder_id);
+            let binder = context.lookup_forall_binder(*binder_id);
             let text = state.checked.lookup_name(binder.name);
             let skolem = state.fresh_rigid_named(context.queries, binder.kind, text);
-            let inner = SubstituteName::one(state, context, binder.name, skolem, inner)?;
+            let inner = SubstituteName::one(state, context, binder.name, skolem, *inner)?;
             unify(state, context, inner, t2)?
         }
         (_, Type::Forall(binder_id, inner)) => {
-            let binder = context.lookup_forall_binder(binder_id);
+            let binder = context.lookup_forall_binder(*binder_id);
             let text = state.checked.lookup_name(binder.name);
             let skolem = state.fresh_rigid_named(context.queries, binder.kind, text);
-            let inner = SubstituteName::one(state, context, binder.name, skolem, inner)?;
+            let inner = SubstituteName::one(state, context, binder.name, skolem, *inner)?;
             unify(state, context, t1, inner)?
         }
 
@@ -426,26 +430,27 @@ where
             Type::Constrained(t1_constraint, t1_inner),
             Type::Constrained(t2_constraint, t2_inner),
         ) => {
-            unify(state, context, t1_constraint, t2_constraint)?
-                && unify(state, context, t1_inner, t2_inner)?
+            unify(state, context, *t1_constraint, *t2_constraint)?
+                && unify(state, context, *t1_inner, *t2_inner)?
         }
 
         (Type::Application(_, _), Type::Function(t2_argument, t2_result)) => {
-            let t2 = context.intern_function_application(t2_argument, t2_result);
+            let t2 = context.intern_function_application(*t2_argument, *t2_result);
             unify(state, context, t1, t2)?
         }
         (Type::Function(t1_argument, t1_result), Type::Application(_, _)) => {
-            let t1 = context.intern_function_application(t1_argument, t1_result);
+            let t1 = context.intern_function_application(*t1_argument, *t1_result);
             unify(state, context, t1, t2)?
         }
 
         (Type::Function(t1_argument, t1_result), Type::Function(t2_argument, t2_result)) => {
-            unify(state, context, t1_argument, t2_argument)?
-                && unify(state, context, t1_result, t2_result)?
+            unify(state, context, *t1_argument, *t2_argument)?
+                && unify(state, context, *t1_result, *t2_result)?
         }
 
         (Type::Kinded(t1_inner, t1_kind), Type::Kinded(t2_inner, t2_kind)) => {
-            unify(state, context, t1_inner, t2_inner)? && unify(state, context, t1_kind, t2_kind)?
+            unify(state, context, *t1_inner, *t2_inner)?
+                && unify(state, context, *t1_kind, *t2_kind)?
         }
 
         (Type::Constructor(t1_file, t1_item), Type::Constructor(t2_file, t2_item))
@@ -463,13 +468,13 @@ where
         }
 
         (Type::Row(t1_row_id), Type::Row(t2_row_id)) => {
-            unify_rows(state, context, t1_row_id, t2_row_id)?
+            unify_rows(state, context, *t1_row_id, *t2_row_id)?
         }
 
         (Type::Rigid(t1_name, _, t1_kind), Type::Rigid(t2_name, _, t2_kind))
             if t1_name == t2_name =>
         {
-            unify(state, context, t1_kind, t2_kind)?
+            unify(state, context, *t1_kind, *t2_kind)?
         }
 
         _ => false,
@@ -515,27 +520,27 @@ where
         (
             Type::Application(t1_function, t1_argument),
             Type::Application(t2_function, t2_argument),
-        ) => can_unify(state, context, t1_function, t2_function)?
-            .and_then(|| can_unify(state, context, t1_argument, t2_argument)),
+        ) => can_unify(state, context, *t1_function, *t2_function)?
+            .and_then(|| can_unify(state, context, *t1_argument, *t2_argument)),
 
         (Type::Function(t1_argument, t1_result), Type::Function(t2_argument, t2_result)) => {
-            can_unify(state, context, t1_argument, t2_argument)?
-                .and_then(|| can_unify(state, context, t1_result, t2_result))
+            can_unify(state, context, *t1_argument, *t2_argument)?
+                .and_then(|| can_unify(state, context, *t1_result, *t2_result))
         }
 
         (Type::Application(t1_function, _), Type::Function(t2_argument, t2_result)) => {
-            let t1_function = normalise::expand(state, context, t1_function)?;
+            let t1_function = normalise::expand(state, context, *t1_function)?;
             if matches!(context.lookup_type(t1_function), Type::Application(_, _)) {
-                let t2 = context.intern_function_application(t2_argument, t2_result);
+                let t2 = context.intern_function_application(*t2_argument, *t2_result);
                 can_unify(state, context, t1, t2)
             } else {
                 Ok(CanUnify::Apart)
             }
         }
         (Type::Function(t1_argument, t1_result), Type::Application(t2_function, _)) => {
-            let t2_function = normalise::expand(state, context, t2_function)?;
+            let t2_function = normalise::expand(state, context, *t2_function)?;
             if matches!(context.lookup_type(t2_function), Type::Application(_, _)) {
-                let t1 = context.intern_function_application(t1_argument, t1_result);
+                let t1 = context.intern_function_application(*t1_argument, *t1_result);
                 can_unify(state, context, t1, t2)
             } else {
                 Ok(CanUnify::Apart)
@@ -545,33 +550,33 @@ where
         (
             Type::KindApplication(t1_function, t1_argument),
             Type::KindApplication(t2_function, t2_argument),
-        ) => can_unify(state, context, t1_function, t2_function)?
-            .and_then(|| can_unify(state, context, t1_argument, t2_argument)),
+        ) => can_unify(state, context, *t1_function, *t2_function)?
+            .and_then(|| can_unify(state, context, *t1_argument, *t2_argument)),
 
         (Type::Kinded(t1_inner, t1_kind), Type::Kinded(t2_inner, t2_kind)) => {
-            can_unify(state, context, t1_inner, t2_inner)?
-                .and_then(|| can_unify(state, context, t1_kind, t2_kind))
+            can_unify(state, context, *t1_inner, *t2_inner)?
+                .and_then(|| can_unify(state, context, *t1_kind, *t2_kind))
         }
 
         (
             Type::Constrained(t1_constraint, t1_constrained),
             Type::Constrained(t2_constraint, t2_constrained),
-        ) => can_unify(state, context, t1_constraint, t2_constraint)?
-            .and_then(|| can_unify(state, context, t1_constrained, t2_constrained)),
+        ) => can_unify(state, context, *t1_constraint, *t2_constraint)?
+            .and_then(|| can_unify(state, context, *t1_constrained, *t2_constrained)),
 
         (Type::Rigid(t1_name, _, t1_kind), Type::Rigid(t2_name, _, t2_kind)) => {
             if t1_name == t2_name {
-                can_unify(state, context, t1_kind, t2_kind)
+                can_unify(state, context, *t1_kind, *t2_kind)
             } else {
                 Ok(CanUnify::Apart)
             }
         }
 
         (Type::Forall(t1_binder, t1_inner), Type::Forall(t2_binder, t2_inner)) => {
-            let t1_binder = context.lookup_forall_binder(t1_binder);
-            let t2_binder = context.lookup_forall_binder(t2_binder);
+            let t1_binder = context.lookup_forall_binder(*t1_binder);
+            let t2_binder = context.lookup_forall_binder(*t2_binder);
             can_unify(state, context, t1_binder.kind, t2_binder.kind)?
-                .and_then(|| can_unify(state, context, t1_inner, t2_inner))
+                .and_then(|| can_unify(state, context, *t1_inner, *t2_inner))
         }
 
         _ => Ok(CanUnify::Apart),
@@ -673,12 +678,12 @@ where
 
         match t {
             Type::Application(function, argument) | Type::KindApplication(function, argument) => {
-                check(promote, state, context, function)?
-                    .and_then(|| check(promote, state, context, argument))
+                check(promote, state, context, *function)?
+                    .and_then(|| check(promote, state, context, *argument))
             }
 
             Type::Forall(binder_id, inner) => {
-                let binder = context.lookup_forall_binder(binder_id);
+                let binder = context.lookup_forall_binder(*binder_id);
 
                 let on_kind = check(promote, state, context, binder.kind)?;
                 if !matches!(on_kind, PromoteResult::Ok) {
@@ -686,26 +691,26 @@ where
                 }
 
                 promote.names.push(binder.name);
-                let on_inner = check(promote, state, context, inner)?;
+                let on_inner = check(promote, state, context, *inner)?;
                 promote.names.pop();
 
                 Ok(on_inner)
             }
 
-            Type::Constrained(constraint, inner) => check(promote, state, context, constraint)?
-                .and_then(|| check(promote, state, context, inner)),
+            Type::Constrained(constraint, inner) => check(promote, state, context, *constraint)?
+                .and_then(|| check(promote, state, context, *inner)),
 
-            Type::Function(argument, result) => check(promote, state, context, argument)?
-                .and_then(|| check(promote, state, context, result)),
+            Type::Function(argument, result) => check(promote, state, context, *argument)?
+                .and_then(|| check(promote, state, context, *result)),
 
-            Type::Kinded(inner, kind) => check(promote, state, context, inner)?
-                .and_then(|| check(promote, state, context, kind)),
+            Type::Kinded(inner, kind) => check(promote, state, context, *inner)?
+                .and_then(|| check(promote, state, context, *kind)),
 
             Type::Constructor(_, _) => Ok(PromoteResult::Ok),
             Type::Integer(_) | Type::String(_, _) => Ok(PromoteResult::Ok),
 
             Type::Row(row_id) => {
-                let row = context.lookup_row_type(row_id);
+                let row = context.lookup_row_type(*row_id);
                 for field in row.fields.iter() {
                     let on_field = check(promote, state, context, field.id)?;
                     if !matches!(on_field, PromoteResult::Ok) {
@@ -721,17 +726,17 @@ where
 
             Type::Rigid(name, rigid_depth, kind) => {
                 if promote.names.contains(&name) {
-                    check(promote, state, context, kind)
-                } else if rigid_depth > promote.depth {
+                    check(promote, state, context, *kind)
+                } else if *rigid_depth > promote.depth {
                     Ok(PromoteResult::SkolemEscape)
                 } else {
-                    check(promote, state, context, kind)
+                    check(promote, state, context, *kind)
                 }
             }
 
             Type::Unification(id) => {
                 // Disallow `?t := ?t`
-                if id == promote.id {
+                if *id == promote.id {
                     return Ok(PromoteResult::OccursCheck);
                 }
                 // When solving `a` to a deeper unification variable `b`,
@@ -749,11 +754,11 @@ where
                 // This process eliminates unsolved unification variables
                 // at depth markers that are not in scope, and replaces
                 // them with unification variables that are in scope.
-                let UnificationEntry { depth, kind, .. } = *state.unifications.get(id);
+                let UnificationEntry { depth, kind, .. } = *state.unifications.get(*id);
                 if depth > promote.depth {
                     let promoted = state.unifications.fresh(promote.depth, kind);
                     let promoted = context.queries.intern_type(Type::Unification(promoted));
-                    state.unifications.solve(id, promoted);
+                    state.unifications.solve(*id, promoted);
                 }
 
                 Ok(PromoteResult::Ok)

--- a/compiler-frontend/checking/src/core/walk.rs
+++ b/compiler-frontend/checking/src/core/walk.rs
@@ -34,7 +34,7 @@ where
     Q: ExternalQueries,
     W: TypeWalker,
 {
-    let id = normalise::normalise(state, context, id)?;
+    let id = normalise::normalise(state, context, id);
     let t = context.lookup_type(id);
 
     if let WalkAction::Stop = walker.visit(state, context, id, &t)? {

--- a/compiler-frontend/checking/src/core/walk.rs
+++ b/compiler-frontend/checking/src/core/walk.rs
@@ -41,7 +41,7 @@ where
         return Ok(());
     }
 
-    match t {
+    match *t {
         Type::Application(function, argument) | Type::KindApplication(function, argument) => {
             walk_type(state, context, function, walker)?;
             walk_type(state, context, argument, walker)?;

--- a/compiler-frontend/checking/src/interners.rs
+++ b/compiler-frontend/checking/src/interners.rs
@@ -16,8 +16,8 @@ impl CoreInterners {
         self.types.intern_with_metadata(t, flags)
     }
 
-    pub fn lookup_type(&self, id: TypeId) -> Type {
-        self.types[id].clone()
+    pub fn lookup_type(&self, id: TypeId) -> &Type {
+        &self.types[id]
     }
 
     pub fn lookup_type_flags(&self, id: TypeId) -> TypeFlags {
@@ -49,16 +49,16 @@ impl CoreInterners {
         self.row_types.intern(r)
     }
 
-    pub fn lookup_row_type(&self, id: RowTypeId) -> RowType {
-        self.row_types[id].clone()
+    pub fn lookup_row_type(&self, id: RowTypeId) -> &RowType {
+        &self.row_types[id]
     }
 
     pub fn intern_smol_str(&self, s: SmolStr) -> crate::core::SmolStrId {
         self.smol_strs.intern(s)
     }
 
-    pub fn lookup_smol_str(&self, id: crate::core::SmolStrId) -> SmolStr {
-        self.smol_strs[id].clone()
+    pub fn lookup_smol_str(&self, id: crate::core::SmolStrId) -> &SmolStr {
+        &self.smol_strs[id]
     }
 }
 
@@ -70,6 +70,38 @@ mod tests {
 
     use super::CoreInterners;
     use crate::core::{RowField, RowType, Type};
+
+    #[test]
+    fn borrowed_values_remain_stable_during_concurrent_interning() {
+        let interners = CoreInterners::default();
+        let type_id = interners.intern_type(Type::Integer(-1));
+        let row_id = interners.intern_row_type(RowType::from_closed(Arc::from([])));
+        let string_id = interners.intern_smol_str(SmolStr::new("stable"));
+        let borrowed_type = interners.lookup_type(type_id);
+        let borrowed_row = interners.lookup_row_type(row_id);
+        let borrowed_string = interners.lookup_smol_str(string_id);
+
+        std::thread::scope(|scope| {
+            for _ in 0..4 {
+                let interners = &interners;
+                scope.spawn(move || {
+                    for value in 0..4096 {
+                        let id = interners.intern_type(Type::Integer(value));
+                        let fields = Arc::from([RowField { label: SmolStr::new("field"), id }]);
+                        interners.intern_row_type(RowType::from_closed(fields));
+                        interners.intern_smol_str(SmolStr::new(value.to_string()));
+                        assert_eq!(borrowed_type, &Type::Integer(-1));
+                        assert_eq!(borrowed_row, &RowType::from_closed(Arc::from([])));
+                        assert_eq!(borrowed_string, "stable");
+                    }
+                });
+            }
+        });
+
+        assert!(std::ptr::eq(borrowed_type, interners.lookup_type(type_id)));
+        assert!(std::ptr::eq(borrowed_row, interners.lookup_row_type(row_id)));
+        assert!(std::ptr::eq(borrowed_string, interners.lookup_smol_str(string_id)));
+    }
 
     #[test]
     fn normalisation_flags_describe_head_reductions() {

--- a/compiler-frontend/checking/src/source/binder.rs
+++ b/compiler-frontend/checking/src/source/binder.rs
@@ -622,16 +622,16 @@ where
     Ok((record_type, checked_fields.into()))
 }
 
-fn extract_expected_row<Q>(
+fn extract_expected_row<'q, Q>(
     state: &mut CheckState,
-    context: &CheckContext<Q>,
+    context: &CheckContext<'q, Q>,
     expected_type: TypeId,
-) -> QueryResult<Option<RowType>>
+) -> QueryResult<Option<&'q RowType>>
 where
     Q: ExternalQueries,
 {
     let expected_type = normalise::expand(state, context, expected_type)?;
-    let Type::Application(function, argument) = context.lookup_type(expected_type) else {
+    let Type::Application(function, argument) = *context.lookup_type(expected_type) else {
         return Ok(None);
     };
     let function = normalise::expand(state, context, function)?;
@@ -639,7 +639,7 @@ where
         return Ok(None);
     }
     let row = normalise::expand(state, context, argument)?;
-    let Type::Row(row_id) = context.lookup_type(row) else {
+    let Type::Row(row_id) = *context.lookup_type(row) else {
         return Ok(None);
     };
     Ok(Some(context.lookup_row_type(row_id)))
@@ -660,7 +660,7 @@ where
 
     let expected_type = normalise::expand(state, context, expected_type)?;
 
-    let expected_row = if let Type::Application(function, _) = context.lookup_type(expected_type) {
+    let expected_row = if let Type::Application(function, _) = *context.lookup_type(expected_type) {
         let function = normalise::expand(state, context, function)?;
         if function == context.prim.record {
             extract_expected_row(state, context, expected_type)?

--- a/compiler-frontend/checking/src/source/derive/field.rs
+++ b/compiler-frontend/checking/src/source/derive/field.rs
@@ -63,7 +63,7 @@ where
 
     loop {
         current = normalise::expand(state, context, current)?;
-        let Type::Forall(binder_id, inner) = context.lookup_type(current) else {
+        let Type::Forall(binder_id, inner) = *context.lookup_type(current) else {
             break;
         };
 
@@ -96,7 +96,7 @@ where
 {
     let type_id = normalise::expand(state, context, type_id)?;
 
-    match context.lookup_type(type_id) {
+    match *context.lookup_type(type_id) {
         Type::Application(function, argument) => {
             let function = normalise::expand(state, context, function)?;
             if function == context.prim.record {
@@ -137,7 +137,7 @@ where
     Q: ExternalQueries,
 {
     let type_id = normalise::expand(state, context, type_id)?;
-    let Type::Application(function, _) = context.lookup_type(type_id) else {
+    let Type::Application(function, _) = *context.lookup_type(type_id) else {
         return Ok(ComparisonStyle::Direct);
     };
     comparison_style_for_function(state, context, function)
@@ -152,7 +152,7 @@ where
     Q: ExternalQueries,
 {
     let function = normalise::expand(state, context, function)?;
-    let kind = match context.lookup_type(function) {
+    let kind = match *context.lookup_type(function) {
         Type::Rigid(_, _, kind) => kind,
         Type::Unification(unification_id) => state.unifications.get(unification_id).kind,
         _ => return Ok(ComparisonStyle::Direct),

--- a/compiler-frontend/checking/src/source/derive/generate/contravariant.rs
+++ b/compiler-frontend/checking/src/source/derive/generate/contravariant.rs
@@ -621,11 +621,11 @@ where
     }
 }
 
-fn extract_record_row<Q>(
+fn extract_record_row<'q, Q>(
     state: &mut CheckState,
-    context: &CheckContext<Q>,
+    context: &CheckContext<'q, Q>,
     type_id: TypeId,
-) -> QueryResult<Option<RowType>>
+) -> QueryResult<Option<&'q RowType>>
 where
     Q: ExternalQueries,
 {
@@ -633,7 +633,7 @@ where
         return Ok(None);
     };
     let row = normalise::expand(state, context, row)?;
-    let Type::Row(row) = context.lookup_type(row) else {
+    let Type::Row(row) = *context.lookup_type(row) else {
         return Ok(None);
     };
     Ok(Some(context.lookup_row_type(row)))

--- a/compiler-frontend/checking/src/source/derive/generate/foldable.rs
+++ b/compiler-frontend/checking/src/source/derive/generate/foldable.rs
@@ -902,11 +902,11 @@ where
     }
 }
 
-fn extract_record_row<Q>(
+fn extract_record_row<'q, Q>(
     state: &mut CheckState,
-    context: &CheckContext<Q>,
+    context: &CheckContext<'q, Q>,
     type_id: TypeId,
-) -> QueryResult<Option<RowType>>
+) -> QueryResult<Option<&'q RowType>>
 where
     Q: ExternalQueries,
 {
@@ -914,7 +914,7 @@ where
         return Ok(None);
     };
     let row = normalise::expand(state, context, row)?;
-    let Type::Row(row) = context.lookup_type(row) else {
+    let Type::Row(row) = *context.lookup_type(row) else {
         return Ok(None);
     };
     Ok(Some(context.lookup_row_type(row)))

--- a/compiler-frontend/checking/src/source/derive/generate/functor.rs
+++ b/compiler-frontend/checking/src/source/derive/generate/functor.rs
@@ -969,11 +969,11 @@ where
     }
 }
 
-fn extract_record_row<Q>(
+fn extract_record_row<'q, Q>(
     state: &mut CheckState,
-    context: &CheckContext<Q>,
+    context: &CheckContext<'q, Q>,
     type_id: TypeId,
-) -> QueryResult<Option<RowType>>
+) -> QueryResult<Option<&'q RowType>>
 where
     Q: ExternalQueries,
 {
@@ -981,6 +981,6 @@ where
         return Ok(None);
     };
     let row = normalise::expand(state, context, row)?;
-    let Type::Row(row) = context.lookup_type(row) else { return Ok(None) };
+    let Type::Row(row) = *context.lookup_type(row) else { return Ok(None) };
     Ok(Some(context.lookup_row_type(row)))
 }

--- a/compiler-frontend/checking/src/source/derive/generate/traversable.rs
+++ b/compiler-frontend/checking/src/source/derive/generate/traversable.rs
@@ -1091,11 +1091,11 @@ where
     }
 }
 
-fn extract_record_row<Q>(
+fn extract_record_row<'q, Q>(
     state: &mut CheckState,
-    context: &CheckContext<Q>,
+    context: &CheckContext<'q, Q>,
     type_id: TypeId,
-) -> QueryResult<Option<RowType>>
+) -> QueryResult<Option<&'q RowType>>
 where
     Q: ExternalQueries,
 {
@@ -1103,7 +1103,7 @@ where
         return Ok(None);
     };
     let row = normalise::expand(state, context, row)?;
-    let Type::Row(row) = context.lookup_type(row) else {
+    let Type::Row(row) = *context.lookup_type(row) else {
         return Ok(None);
     };
     Ok(Some(context.lookup_row_type(row)))

--- a/compiler-frontend/checking/src/source/derive/generic.rs
+++ b/compiler-frontend/checking/src/source/derive/generic.rs
@@ -152,7 +152,7 @@ where
     let mut arguments = vec![];
     safe_loop! {
         applied_type = normalise::expand(state, context, applied_type)?;
-        match context.lookup_type(applied_type) {
+        match *context.lookup_type(applied_type) {
             Type::Application(function, argument) | Type::KindApplication(function, argument) => {
                 arguments.push(argument);
                 applied_type = function;
@@ -178,7 +178,7 @@ where
 
     safe_loop! {
         current = normalise::expand(state, context, current)?;
-        let Type::Forall(binder_id, inner) = context.lookup_type(current) else {
+        let Type::Forall(binder_id, inner) = *context.lookup_type(current) else {
             break;
         };
 

--- a/compiler-frontend/checking/src/source/derive/newtype.rs
+++ b/compiler-frontend/checking/src/source/derive/newtype.rs
@@ -131,7 +131,7 @@ where
     for &rigid in rigids.iter().rev() {
         type_id = normalise::expand(state, context, type_id)?;
 
-        match context.lookup_type(type_id) {
+        match *context.lookup_type(type_id) {
             Type::Application(function, argument) | Type::KindApplication(function, argument) => {
                 let argument = normalise::expand(state, context, argument)?;
                 if argument != rigid {

--- a/compiler-frontend/checking/src/source/derive/newtype.rs
+++ b/compiler-frontend/checking/src/source/derive/newtype.rs
@@ -52,7 +52,7 @@ where
         return Ok(None);
     };
 
-    let inner = normalise::normalise(state, context, inner)?;
+    let inner = normalise::normalise(state, context, inner);
     let class = context.queries.intern_type(Type::Constructor(class_file, class_id));
     let class_kind = toolkit::lookup_file_type(state, context, class_file, class_id)?;
 

--- a/compiler-frontend/checking/src/source/derive/variance.rs
+++ b/compiler-frontend/checking/src/source/derive/variance.rs
@@ -194,7 +194,7 @@ where
 
     loop {
         current = normalise::expand(state, context, current)?;
-        let Type::Forall(binder_id, inner) = context.lookup_type(current) else {
+        let Type::Forall(binder_id, inner) = *context.lookup_type(current) else {
             break;
         };
 
@@ -208,7 +208,7 @@ where
             })
             .unwrap_or_else(|| {
                 let rigid = state.fresh_rigid(context.queries, binder.kind);
-                let Type::Rigid(name, _, _) = context.lookup_type(rigid) else {
+                let Type::Rigid(name, _, _) = *context.lookup_type(rigid) else {
                     unreachable!("fresh_rigid must create Type::Rigid")
                 };
                 names.push(name);
@@ -330,7 +330,7 @@ where
             return Ok(None);
         }
 
-        match self.context.lookup_type(type_id) {
+        match *self.context.lookup_type(type_id) {
             Type::Rigid(name, _, _) => {
                 if let Some(parameter) = self.rigids.get(name) {
                     *self.valid &=
@@ -798,14 +798,14 @@ where
         }
 
         match (context.lookup_type(left), context.lookup_type(right)) {
-            (Type::Constructor(left_file, left_id), Type::Constructor(right_file, right_id)) => {
+            (&Type::Constructor(left_file, left_id), &Type::Constructor(right_file, right_id)) => {
                 left_file == right_file && left_id == right_id
             }
             // Generalisation can reconstruct a rigid's kind while preserving the binder
             // name. Constructor-head availability depends on that binder identity, not
             // its kind ID.
-            (Type::Rigid(left_name, ..), Type::Rigid(right_name, ..)) => left_name == right_name,
-            (Type::Free(left_name), Type::Free(right_name)) => left_name == right_name,
+            (&Type::Rigid(left_name, ..), &Type::Rigid(right_name, ..)) => left_name == right_name,
+            (&Type::Free(left_name), &Type::Free(right_name)) => left_name == right_name,
             _ => false,
         }
     };

--- a/compiler-frontend/checking/src/source/operator.rs
+++ b/compiler-frontend/checking/src/source/operator.rs
@@ -552,7 +552,7 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::TypeId {
             operator_kind,
             &[(left_argument, left_kind), (right_argument, right_kind)],
         )? {
-            let result_kind = normalise::normalise(state, context, result_kind)?;
+            let result_kind = normalise::normalise(state, context, result_kind);
             return Ok((elaborated_type, result_kind));
         }
 
@@ -574,7 +574,7 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::TypeId {
             application::Records::Ignore,
         )?;
 
-        let result_kind = normalise::normalise(state, context, right.result_type)?;
+        let result_kind = normalise::normalise(state, context, right.result_type);
         Ok((elaborated_type, result_kind))
     }
 

--- a/compiler-frontend/checking/src/source/operator.rs
+++ b/compiler-frontend/checking/src/source/operator.rs
@@ -382,7 +382,7 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
         F: FnOnce(&mut CheckState, TypeId) -> QueryResult<(Self::Elaborated, TypeId)>,
     {
         let expected = normalise::expand(state, context, expected)?;
-        let Type::Constrained(constraint, constrained) = context.lookup_type(expected) else {
+        let Type::Constrained(constraint, constrained) = *context.lookup_type(expected) else {
             return check(state, expected);
         };
 

--- a/compiler-frontend/checking/src/source/roles.rs
+++ b/compiler-frontend/checking/src/source/roles.rs
@@ -163,7 +163,7 @@ where
 {
     let type_id = normalise::expand(inference.state, inference.context, type_id)?;
 
-    match inference.context.lookup_type(type_id) {
+    match *inference.context.lookup_type(type_id) {
         Type::Rigid(name, _, kind) => {
             if let Some(index) = inference.parameters.get(&name) {
                 let role = if mode.requires_nominal_role() {
@@ -181,7 +181,7 @@ where
             let function_id = normalise::expand(inference.state, inference.context, function)?;
 
             let is_type_variable =
-                matches!(inference.context.lookup_type(function_id), Type::Rigid(_, _, _));
+                matches!(*inference.context.lookup_type(function_id), Type::Rigid(_, _, _));
 
             infer_roles(inference, function, mode.child())?;
             infer_roles(inference, argument, mode.argument_child(is_type_variable))?;

--- a/compiler-frontend/checking/src/source/term_items.rs
+++ b/compiler-frontend/checking/src/source/term_items.rs
@@ -434,7 +434,7 @@ where
 
         if let Some(class_member_type) = class_member_type {
             let unified = state.with_implication(|state| {
-                let class_member_type = normalise::normalise(state, context, class_member_type)?;
+                let class_member_type = normalise::normalise(state, context, class_member_type);
                 let class_member_type =
                     toolkit::skolemise_forall(state, context, class_member_type)?;
                 let class_member_type = toolkit::collect_givens(state, context, class_member_type)?;
@@ -633,7 +633,7 @@ where
     }
 
     let field_type = SubstituteName::many(state, context, &bindings, member.field_type)?;
-    let field_type = normalise::normalise(state, context, field_type)?;
+    let field_type = normalise::normalise(state, context, field_type);
     Ok(Some(field_type))
 }
 

--- a/compiler-frontend/checking/src/source/term_items.rs
+++ b/compiler-frontend/checking/src/source/term_items.rs
@@ -269,7 +269,7 @@ where
         let Some(text) = toolkit::lookup_name(state, context, binder.name)? else {
             continue;
         };
-        let Type::Rigid(name, _, _) = context.lookup_type(argument) else {
+        let Type::Rigid(name, _, _) = *context.lookup_type(argument) else {
             continue;
         };
         state.checked.names.entry(name).or_insert(text);

--- a/compiler-frontend/checking/src/source/terms.rs
+++ b/compiler-frontend/checking/src/source/terms.rs
@@ -150,7 +150,7 @@ where
     F: FnOnce(&mut CheckState, TypeId) -> QueryResult<ElaboratedExpression>,
 {
     let expected = normalise::expand(state, context, expected)?;
-    match context.lookup_type(expected) {
+    match *context.lookup_type(expected) {
         Type::Forall(binder_id, inner) => {
             let binder = context.lookup_forall_binder(binder_id);
 
@@ -214,7 +214,7 @@ where
         if !parameters.is_empty() {
             let expanded = normalise::expand(state, context, current)?;
             let requires_abstraction = matches!(
-                context.lookup_type(expanded),
+                *context.lookup_type(expanded),
                 Type::Forall(_, _) | Type::Constrained(_, _)
             );
             if requires_abstraction {

--- a/compiler-frontend/checking/src/source/terms.rs
+++ b/compiler-frontend/checking/src/source/terms.rs
@@ -113,7 +113,7 @@ fn check_expression_quiet<Q>(
 where
     Q: ExternalQueries,
 {
-    let expected = normalise::normalise(state, context, expected)?;
+    let expected = normalise::normalise(state, context, expected);
     check_expected_expression(state, context, expected, |state, expected| {
         if let Some(section_result) = context.sectioned.expressions.get(&expression) {
             check_sectioned_expression(state, context, expression, section_result, expected)
@@ -132,7 +132,7 @@ pub(super) fn check_elaborated_expression<Q>(
 where
     Q: ExternalQueries,
 {
-    let expected = normalise::normalise(state, context, expected)?;
+    let expected = normalise::normalise(state, context, expected);
     let checked = check_expected_expression(state, context, expected, |state, expected| {
         check_elaborated_expression_quiet(state, context, inferred, expected)
     })?;
@@ -154,7 +154,7 @@ where
         Type::Forall(binder_id, inner) => {
             let binder = context.lookup_forall_binder(binder_id);
 
-            let kind = normalise::normalise(state, context, binder.kind)?;
+            let kind = normalise::normalise(state, context, binder.kind);
             let text = state.checked.lookup_name(binder.name);
             let (rigid, name, scope) = state.fresh_scoped_rigid_named(context.queries, kind, text);
 

--- a/compiler-frontend/checking/src/source/terms/application.rs
+++ b/compiler-frontend/checking/src/source/terms/application.rs
@@ -49,7 +49,7 @@ where
 {
     let function = normalise::expand(state, context, function)?;
 
-    match context.lookup_type(function) {
+    match *context.lookup_type(function) {
         Type::Function(argument, result) => Ok(CallableAnalysis::Function { argument, result }),
 
         Type::Unification(unification_id) => {
@@ -74,7 +74,7 @@ where
         Type::Application(function_argument, result) => {
             let function_argument = normalise::expand(state, context, function_argument)?;
 
-            let Type::Application(constructor, argument) = context.lookup_type(function_argument)
+            let Type::Application(constructor, argument) = *context.lookup_type(function_argument)
             else {
                 return Ok(CallableAnalysis::NotCallable);
             };
@@ -84,7 +84,7 @@ where
                 return Ok(CallableAnalysis::Function { argument, result });
             }
 
-            if let Type::Unification(unification_id) = context.lookup_type(constructor) {
+            if let Type::Unification(unification_id) = *context.lookup_type(constructor) {
                 unification::solve(
                     state,
                     context,
@@ -128,7 +128,7 @@ where
 {
     safe_loop! {
         let type_id = normalise::expand(state, context, expression.type_id)?;
-        match context.lookup_type(type_id) {
+        match *context.lookup_type(type_id) {
             Type::Forall(binder_id, body) => {
                 let binder = context.lookup_forall_binder(binder_id);
                 let (_, result) = instantiate_callable_forall(state, context, binder, body)?;
@@ -160,7 +160,7 @@ where
 {
     safe_loop! {
         let type_id = normalise::expand(state, context, expression.type_id)?;
-        let Type::Constrained(constraint, result) = context.lookup_type(type_id) else {
+        let Type::Constrained(constraint, result) = *context.lookup_type(type_id) else {
             break Ok(expression);
         };
         let evidence = state.push_wanted(constraint);
@@ -364,7 +364,7 @@ where
 
     safe_loop! {
         let type_id = normalise::expand(state, context, function.type_id)?;
-        match context.lookup_type(type_id) {
+        match *context.lookup_type(type_id) {
             Type::Forall(binder_id, body) => {
                 let binder = context.lookup_forall_binder(binder_id);
                 if binder.visible {

--- a/compiler-frontend/checking/src/source/terms/collections.rs
+++ b/compiler-frontend/checking/src/source/terms/collections.rs
@@ -146,7 +146,7 @@ where
     Q: ExternalQueries,
 {
     let expected = normalise::expand(state, context, expected)?;
-    let Type::Application(constructor, element) = context.lookup_type(expected) else {
+    let Type::Application(constructor, element) = *context.lookup_type(expected) else {
         return Ok(None);
     };
 
@@ -208,11 +208,11 @@ where
     Q: ExternalQueries,
 {
     let normalised = normalise::expand(state, context, expected)?;
-    if let Type::Application(constructor, row_type) = context.lookup_type(normalised) {
+    if let Type::Application(constructor, row_type) = *context.lookup_type(normalised) {
         let constructor = normalise::expand(state, context, constructor)?;
         if constructor == context.prim.record {
             let row_type = normalise::expand(state, context, row_type)?;
-            if let Type::Row(row_id) = context.lookup_type(row_type) {
+            if let Type::Row(row_id) = *context.lookup_type(row_type) {
                 let expected_fields = context.lookup_row_type(row_id);
                 let (record_type, fields, complete) = record_core(
                     state,

--- a/compiler-frontend/checking/src/source/terms/form_let.rs
+++ b/compiler-frontend/checking/src/source/terms/form_let.rs
@@ -250,7 +250,7 @@ where
             let inferred_type = inferred.type_id;
             // Keep simple let bindings e.g. `appendLocal = append` polymorphic.
             let expanded_name_type = normalise::expand(state, context, name_type)?;
-            if let Type::Unification(unification_id) = context.lookup_type(expanded_name_type) {
+            if let Type::Unification(unification_id) = *context.lookup_type(expanded_name_type) {
                 unification::solve(
                     state,
                     context,

--- a/compiler-frontend/checking/src/source/terms/forms.rs
+++ b/compiler-frontend/checking/src/source/terms/forms.rs
@@ -151,7 +151,7 @@ where
         if !arguments.is_empty() {
             let expanded = normalise::expand(state, context, remaining)?;
             let requires_abstraction = matches!(
-                context.lookup_type(expanded),
+                *context.lookup_type(expanded),
                 Type::Forall(_, _) | Type::Constrained(_, _)
             );
             if requires_abstraction {

--- a/compiler-frontend/checking/src/source/type_items.rs
+++ b/compiler-frontend/checking/src/source/type_items.rs
@@ -72,7 +72,7 @@ impl ApplyKinds {
         Q: ExternalQueries,
     {
         safe_loop! {
-            match context.lookup_type(function) {
+            match *context.lookup_type(function) {
                 Type::KindApplication(inner_function, _) => function = inner_function,
                 Type::Constructor(file_id, item_id) => return self.reference == (file_id, item_id),
                 _ => return false,

--- a/compiler-frontend/checking/src/source/types.rs
+++ b/compiler-frontend/checking/src/source/types.rs
@@ -616,7 +616,7 @@ where
             match *context.lookup_type(function_kind) {
                 Type::Forall(binder_id, inner_kind) => {
                     let binder = context.lookup_forall_binder(binder_id);
-                    let argument = normalise::normalise(state, context, argument)?;
+                    let argument = normalise::normalise(state, context, argument);
                     SubstituteName::one(state, context, binder.name, argument, inner_kind)?
                 }
                 _ => unknown,

--- a/compiler-frontend/checking/src/source/types.rs
+++ b/compiler-frontend/checking/src/source/types.rs
@@ -447,14 +447,14 @@ where
 {
     let expected_kind = normalise::expand(state, context, expected_kind)?;
 
-    if matches!(context.lookup_type(expected_kind), Type::Forall(_, _)) {
+    if matches!(*context.lookup_type(expected_kind), Type::Forall(_, _)) {
         return Ok((t, k));
     }
 
     safe_loop! {
         k = normalise::expand(state, context, k)?;
 
-        let Type::Forall(binder_id, inner_kind) = context.lookup_type(k) else {
+        let Type::Forall(binder_id, inner_kind) = *context.lookup_type(k) else {
             break;
         };
 
@@ -582,12 +582,12 @@ where
     let unknown = context.unknown("invalid kind");
     let id = normalise::expand(state, context, id)?;
 
-    let kind = match context.lookup_type(id) {
+    let kind = match *context.lookup_type(id) {
         Type::Application(function, _) => {
             let function_kind = elaborate_kind(state, context, function)?;
             let function_kind = normalise::expand(state, context, function_kind)?;
 
-            match context.lookup_type(function_kind) {
+            match *context.lookup_type(function_kind) {
                 Type::Function(_, result_kind) => result_kind,
 
                 Type::Unification(unification_id) => {
@@ -613,7 +613,7 @@ where
             let function_kind = elaborate_kind(state, context, function)?;
             let function_kind = normalise::expand(state, context, function_kind)?;
 
-            match context.lookup_type(function_kind) {
+            match *context.lookup_type(function_kind) {
                 Type::Forall(binder_id, inner_kind) => {
                     let binder = context.lookup_forall_binder(binder_id);
                     let argument = normalise::normalise(state, context, argument)?;

--- a/compiler-frontend/checking/src/source/types/application.rs
+++ b/compiler-frontend/checking/src/source/types/application.rs
@@ -57,7 +57,7 @@ impl Options {
         if self.expand {
             normalise::expand(state, context, id)
         } else {
-            normalise::normalise(state, context, id)
+            Ok(normalise::normalise(state, context, id))
         }
     }
 }

--- a/compiler-frontend/checking/src/source/types/application.rs
+++ b/compiler-frontend/checking/src/source/types/application.rs
@@ -76,7 +76,7 @@ where
     safe_loop! {
         function_kind = options.normalise(state, context, function_kind)?;
 
-        match context.lookup_type(function_kind) {
+        match *context.lookup_type(function_kind) {
             Type::Function(expected_kind, result_kind) => {
                 let argument_type = check_application_argument_kind(
                     state,

--- a/compiler-frontend/checking/src/tree/pretty.rs
+++ b/compiler-frontend/checking/src/tree/pretty.rs
@@ -473,7 +473,7 @@ where
             let mut constructor_type = result;
             for &argument_id in constructor.arguments.iter().rev() {
                 let argument = type_pretty.render(argument_id);
-                let argument = match self.queries.lookup_type(argument_id) {
+                let argument = match *self.queries.lookup_type(argument_id) {
                     Type::Forall(..)
                     | Type::Constrained(..)
                     | Type::Function(..)
@@ -717,7 +717,7 @@ where
         let mut type_pretty = self.type_pretty.state();
 
         for (rigid, display) in rigid_names {
-            if let Type::Rigid(name, _, _) = self.queries.lookup_type(*rigid) {
+            if let Type::Rigid(name, _, _) = *self.queries.lookup_type(*rigid) {
                 type_pretty.assign_display_name(name, SmolStr::clone(display));
             }
         }
@@ -734,7 +734,7 @@ where
             };
             if let Some(text) = text {
                 let text = self.queries.lookup_smol_str(text);
-                type_pretty.allocate_display_name(binder.name, text);
+                type_pretty.allocate_display_name(binder.name, SmolStr::clone(text));
             }
         }
 
@@ -766,7 +766,7 @@ where
         rigid_names: &[(crate::TypeId, SmolStr)],
     ) {
         for (rigid, display) in rigid_names {
-            if let Type::Rigid(name, _, _) = self.queries.lookup_type(*rigid) {
+            if let Type::Rigid(name, _, _) = *self.queries.lookup_type(*rigid) {
                 type_pretty.assign_display_name(name, SmolStr::clone(display));
             }
         }
@@ -781,13 +781,13 @@ where
     ) -> QueryResult<(Doc<'arena>, Vec<(crate::TypeId, SmolStr)>)> {
         let mut binders = vec![];
         let mut current = type_id;
-        while let Type::Forall(binder, inner) = self.queries.lookup_type(current) {
+        while let Type::Forall(binder, inner) = *self.queries.lookup_type(current) {
             binders.push(binder);
             current = inner;
         }
         debug_assert_eq!(binders.len(), instance.rigid_parameters.len());
 
-        while let Type::Constrained(_, inner) = self.queries.lookup_type(current) {
+        while let Type::Constrained(_, inner) = *self.queries.lookup_type(current) {
             current = inner;
         }
 
@@ -872,7 +872,7 @@ where
         let mut current = type_id;
         let mut arguments = vec![];
         loop {
-            match self.queries.lookup_type(current) {
+            match *self.queries.lookup_type(current) {
                 Type::Forall(_, inner) | Type::Constrained(_, inner) | Type::Kinded(inner, _) => {
                     current = inner;
                 }
@@ -900,7 +900,7 @@ where
         name: &mut String,
         type_id: crate::TypeId,
     ) -> QueryResult<()> {
-        match self.queries.lookup_type(type_id) {
+        match *self.queries.lookup_type(type_id) {
             Type::Application(function, argument) | Type::KindApplication(function, argument) => {
                 self.append_type_constructor_names(name, function)?;
                 self.append_type_constructor_names(name, argument)?;
@@ -2046,7 +2046,7 @@ where
 
     fn evidence_base_name(&self, mut constraint: crate::TypeId) -> QueryResult<SmolStr> {
         let class_name = loop {
-            match self.queries.lookup_type(constraint) {
+            match *self.queries.lookup_type(constraint) {
                 Type::Application(function, _)
                 | Type::KindApplication(function, _)
                 | Type::Kinded(function, _) => constraint = function,

--- a/compiler-frontend/diagnostics/src/context.rs
+++ b/compiler-frontend/diagnostics/src/context.rs
@@ -13,14 +13,14 @@ use syntax::{SyntaxElement, SyntaxKind, SyntaxNode, SyntaxNodePtr, TextRange};
 use crate::Span;
 
 pub trait ExternalQueries: checking::ExternalQueries {
-    fn lookup_checking_smol_str(&self, id: checking::core::SmolStrId) -> smol_str::SmolStr;
+    fn lookup_checking_smol_str(&self, id: checking::core::SmolStrId) -> &smol_str::SmolStr;
 }
 
 impl<T> ExternalQueries for T
 where
     T: checking::ExternalQueries + ?Sized,
 {
-    fn lookup_checking_smol_str(&self, id: checking::core::SmolStrId) -> smol_str::SmolStr {
+    fn lookup_checking_smol_str(&self, id: checking::core::SmolStrId) -> &smol_str::SmolStr {
         self.lookup_smol_str(id)
     }
 }

--- a/compiler-lsp/documentation/src/render.rs
+++ b/compiler-lsp/documentation/src/render.rs
@@ -83,7 +83,7 @@ impl<'a> TypeEncoder<'a> {
     }
 
     fn encode_type(&mut self, id: checking::TypeId) -> Result<schema::Type, Error> {
-        let expression = match self.engine.lookup_type(id) {
+        let expression = match *self.engine.lookup_type(id) {
             checking::Type::Application(function, argument) => schema::Type::Application {
                 function: self.encode_boxed_type(function)?,
                 argument: self.encode_boxed_type(argument)?,
@@ -112,7 +112,7 @@ impl<'a> TypeEncoder<'a> {
                 reference: self.resolve_type_reference(file_id, type_id)?,
             },
             checking::Type::Integer(value) => schema::Type::Integer { value },
-            checking::Type::String(kind, value) => {
+            checking::Type::String(kind, ref value) => {
                 let value = match value.to_utf8() {
                     Ok(value) => schema::StringLiteralValue::Utf8(value),
                     Err(_) => schema::StringLiteralValue::Utf16(value.as_utf16().to_vec()),

--- a/docs/src/wasm/src/engine.rs
+++ b/docs/src/wasm/src/engine.rs
@@ -401,7 +401,7 @@ impl AnalyzerHost for WasmQueryEngine {
 }
 
 impl checking::PrettyQueries for WasmQueryEngine {
-    fn lookup_type(&self, id: checking::core::TypeId) -> checking::core::Type {
+    fn lookup_type(&self, id: checking::core::TypeId) -> &checking::core::Type {
         self.interned.checking.lookup_type(id)
     }
 
@@ -412,11 +412,11 @@ impl checking::PrettyQueries for WasmQueryEngine {
         self.interned.checking.lookup_forall_binder(id)
     }
 
-    fn lookup_row_type(&self, id: checking::core::RowTypeId) -> checking::core::RowType {
+    fn lookup_row_type(&self, id: checking::core::RowTypeId) -> &checking::core::RowType {
         self.interned.checking.lookup_row_type(id)
     }
 
-    fn lookup_smol_str(&self, id: checking::core::SmolStrId) -> smol_str::SmolStr {
+    fn lookup_smol_str(&self, id: checking::core::SmolStrId) -> &smol_str::SmolStr {
         self.interned.checking.lookup_smol_str(id)
     }
 }

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -54,5 +54,9 @@ name = "lsp"
 harness = false
 
 [[test]]
+name = "lifecycle"
+harness = false
+
+[[test]]
 name = "docs"
 harness = false

--- a/tests-integration/fixtures/lifecycle/duplicate_registration/Edited.purs
+++ b/tests-integration/fixtures/lifecycle/duplicate_registration/Edited.purs
@@ -1,0 +1,3 @@
+module Main where
+
+-- A content edit must reclaim registration even when the module name is unchanged.

--- a/tests-integration/fixtures/lifecycle/duplicate_registration/Main.purs
+++ b/tests-integration/fixtures/lifecycle/duplicate_registration/Main.purs
@@ -1,0 +1,1 @@
+module Main where

--- a/tests-integration/fixtures/lifecycle/duplicate_registration/Renamed.purs
+++ b/tests-integration/fixtures/lifecycle/duplicate_registration/Renamed.purs
@@ -1,0 +1,1 @@
+module Renamed where

--- a/tests-integration/fixtures/lifecycle/missing_header/Main.purs
+++ b/tests-integration/fixtures/lifecycle/missing_header/Main.purs
@@ -1,0 +1,1 @@
+module Main where

--- a/tests-integration/fixtures/lifecycle/missing_header/Missing.purs
+++ b/tests-integration/fixtures/lifecycle/missing_header/Missing.purs
@@ -1,0 +1,1 @@
+-- The module header is temporarily absent while editing.

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -294,7 +294,7 @@ pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
             class.kind_binders.iter().chain(class.type_parameters.iter()).copied().collect_vec();
 
         let mut class_head = class.canonical;
-        while let core::Type::Forall(_, inner) = engine.lookup_type(class_head) {
+        while let core::Type::Forall(_, inner) = *engine.lookup_type(class_head) {
             class_head = inner;
         }
 

--- a/tests-integration/tests/lifecycle.rs
+++ b/tests-integration/tests/lifecycle.rs
@@ -1,0 +1,81 @@
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use building::{
+    DiskObservation, FileLifecycle, LifecycleEvent, QueryEngine, SourceEvent, SourceUnitKey,
+};
+
+fn source_disk(unit: &SourceUnitKey, content: &Arc<str>) -> LifecycleEvent<i32, ()> {
+    LifecycleEvent::Source {
+        unit: SourceUnitKey::clone(unit),
+        event: SourceEvent::DiskObserved {
+            disk: DiskObservation::Found(Arc::clone(content)),
+            metadata: (),
+        },
+    }
+}
+
+fn missing_header(path: &Path) -> datatest_stable::Result<()> {
+    let content: Arc<str> = fs::read_to_string(path)?.into();
+    let missing: Arc<str> = fs::read_to_string(path.with_file_name("Missing.purs"))?.into();
+    let unit = SourceUnitKey::new("file:///src/Main.purs", "file:///src/Main.js");
+    let engine = QueryEngine::default();
+    let mut files = FileLifecycle::default();
+    let event = LifecycleEvent::Source {
+        unit: SourceUnitKey::clone(&unit),
+        event: SourceEvent::Opened { text: Arc::clone(&missing), version: 1, metadata: () },
+    };
+    files.apply(&engine, event);
+    let file_id = files.source_id(unit.source()).unwrap();
+    assert_eq!(engine.module_file("Main"), None);
+
+    for (version, text, registered) in
+        [(2, &content, true), (3, &missing, false), (4, &content, true)]
+    {
+        engine.parsed(file_id).unwrap();
+        let event = LifecycleEvent::Source {
+            unit: SourceUnitKey::clone(&unit),
+            event: SourceEvent::Changed { text: Arc::clone(text), version },
+        };
+        files.apply(&engine, event);
+        assert_eq!(files.source_id(unit.source()), Some(file_id));
+        assert_eq!(engine.module_file("Main"), registered.then_some(file_id));
+    }
+    Ok(())
+}
+
+fn duplicate_registration(path: &Path) -> datatest_stable::Result<()> {
+    let content: Arc<str> = fs::read_to_string(path)?.into();
+    let renamed: Arc<str> = fs::read_to_string(path.with_file_name("Renamed.purs"))?.into();
+    let edited: Arc<str> = fs::read_to_string(path.with_file_name("Edited.purs"))?.into();
+    let unit = SourceUnitKey::new("file:///src/Main.purs", "file:///src/Main.js");
+    let duplicate = SourceUnitKey::new("file:///other/Main.purs", "file:///other/Main.js");
+    let engine = QueryEngine::default();
+    let mut files = FileLifecycle::default();
+    files.apply(&engine, source_disk(&unit, &content));
+    let original_id = files.source_id(unit.source()).unwrap();
+    engine.parsed(original_id).unwrap();
+
+    files.apply(&engine, source_disk(&duplicate, &content));
+    let duplicate_id = files.source_id(duplicate.source()).unwrap();
+    assert_eq!(engine.module_file("Main"), Some(duplicate_id));
+
+    files.apply(&engine, source_disk(&unit, &renamed));
+    assert_eq!(engine.module_file("Main"), Some(duplicate_id));
+    assert_eq!(engine.module_file("Renamed"), Some(original_id));
+
+    files.apply(&engine, source_disk(&unit, &content));
+    assert_eq!(engine.module_file("Renamed"), None);
+    assert_eq!(engine.module_file("Main"), Some(original_id));
+
+    engine.parsed(duplicate_id).unwrap();
+    files.apply(&engine, source_disk(&duplicate, &edited));
+    assert_eq!(engine.module_file("Main"), Some(duplicate_id));
+    Ok(())
+}
+
+datatest_stable::harness! {
+    { test = missing_header, root = "fixtures/lifecycle/missing_header", pattern = r"Main\.purs$" },
+    { test = duplicate_registration, root = "fixtures/lifecycle/duplicate_registration", pattern = r"Main\.purs$" },
+}


### PR DESCRIPTION
## Summary

Reduce redundant work in compilation and build paths without changing compiler output or diagnostics. The changes focus on repeated parsing, tree traversal, metadata lookup, and cloning of interned values.

## Changes

- Use boolean glob matching during source discovery instead of collecting matching pattern indices.
- Reuse cached parser results when registering and updating source files, preserving module ownership and invalidation behavior.
- Replace recursive functional optimization traversals with explicit worklists. Preserve depth-first ordering, shared-node mutation semantics, and occurrence counting while avoiding call-stack growth and unnecessary expression clones.
- Index JavaScript module dependencies and local instance positions instead of repeatedly scanning their source collections.
- Skip evidence-hoisting and instance-hazard graph analysis when there are no relevant candidates.
- Return borrowed interned types, rows, and strings throughout checking and its consumers. Clone only where ownership is required, with coverage for reference stability during concurrent interning.
- Make head normalization infallible and remove redundant error propagation from its callers. Synonym expansion remains fallible.

## Validation

Performance was evaluated across representative workloads. The impact varies by workload; this PR does not claim a uniform speedup.

Correctness checks included affected crate checks and unit tests, compiler and LSP integration tests, source-lifecycle fixtures, a WebAssembly check, and package-set compatibility comparisons. The compatibility corpus covered 631 packages and 7,356 PureScript sources, with no diagnostic changes. Compiler snapshots and generated JavaScript expectations remain unchanged.

The commits separate the individual optimizations from the compiler-wide borrowing migration and the normalization API change. Experimental follow-up optimizations are not included.
