### PR TITLE
[lsp] Define shared configuration and export JSON Schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +266,12 @@ checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "borsh"
@@ -536,6 +556,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "configuration"
+version = "0.1.0"
+dependencies = [
+ "jsonschema",
+ "schemars",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,13 +709,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "datatest-stable"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a867d7322eb69cf3a68a5426387a25b45cb3b9c5ee41023ee6cea92e2afadd82"
 dependencies = [
  "camino",
- "fancy-regex",
+ "fancy-regex 0.14.0",
  "libtest-mimic",
  "walkdir",
 ]
@@ -845,10 +881,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -889,6 +940,17 @@ name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -943,6 +1005,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +1054,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e246562084dde8ebbcc943b261c406ce4f68e5032ec28029a251a47d6a295500"
+dependencies = [
+ "num",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -1107,6 +1190,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -1114,7 +1211,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core",
  "wasm-bindgen",
 ]
@@ -1689,6 +1786,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b68339c3d874e48151d74ffe256d93a58cffa240983cb0967d3cbaea083a44fe"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex 0.19.1",
+ "fraction",
+ "getrandom 0.3.4",
+ "itoa",
+ "jsonschema-regex",
+ "jsonschema-value",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6307b5b51216ec9b941b52244c74043fa0b1d6b657b56199f57cb1416d3641c5"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0230ac05e09c6111e96c147b75c390579f5cbd45654b980c68ac60fe17b3f129"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "getrandom 0.3.4",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
+ "zmij",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +2024,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "minicov"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,6 +2119,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint 0.4.8",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,11 +2153,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint 0.4.8",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2032,6 +2248,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "oxc_allocator"
@@ -2140,7 +2362,7 @@ checksum = "1d3cb15b9e142737d38e50366be0ead824f7d16bee3ac47c79839d50deb2324b"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
- "num-bigint",
+ "num-bigint 0.5.1",
  "num-traits",
  "oxc_ast",
  "oxc_data_structures",
@@ -2173,7 +2395,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cow-utils",
  "memchr",
- "num-bigint",
+ "num-bigint 0.5.1",
  "num-traits",
  "oxc_allocator",
  "oxc_ast",
@@ -2642,6 +2864,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -2709,6 +2937,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.1",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "referencing"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a196a5b4a8a12f46b6353174df865a05d41a6055aff212ec30877492788618b6"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -2941,6 +3206,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.5",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3036,6 +3326,17 @@ name = "serde_derive"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3276,6 +3577,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "subtle"
@@ -3832,6 +4154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-id-start"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3905,6 +4233,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3921,6 +4259,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vte"
@@ -3965,6 +4309,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -4290,6 +4643,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/compiler-lsp/configuration/Cargo.toml
+++ b/compiler-lsp/configuration/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "configuration"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+schema = ["dep:schemars"]
+
+[dependencies]
+schemars = { version = "1.2.2", optional = true }
+serde = { version = "1.0.229", features = ["derive"] }
+
+[dev-dependencies]
+jsonschema = { version = "0.55.1", default-features = false }
+serde_json = "1.0.151"
+
+[[example]]
+name = "export-schema"
+required-features = ["schema"]

--- a/compiler-lsp/configuration/configuration.schema.json
+++ b/compiler-lsp/configuration/configuration.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Nullable_ConfigurationSettings",
+  "anyOf": [
+    {
+      "$ref": "#/$defs/ConfigurationSettings"
+    },
+    {
+      "type": "null"
+    }
+  ],
+  "$defs": {
+    "ConfigurationSettings": {
+      "description": "One partial configuration layer. Missing or null fields inherit from lower-priority layers.\nEach runtime snapshot replaces the preceding runtime layer, not the startup baseline.\nUnknown fields are rejected, including an embedded `$schema` property; associate this schema\nthrough editor settings instead.",
+      "type": "object",
+      "properties": {
+        "diagnostics": {
+          "description": "Override diagnostic triggers individually. Missing or null leaves lower layers unchanged.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DiagnosticSettings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sources": {
+          "description": "Replace the complete source selection. Inherits when missing or null; defaults to Spago\nwhen no layer supplies a selection.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourceDiscovery"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "DiagnosticSettings": {
+      "description": "Partial diagnostic overrides; `false` is an override, while missing or `null` inherits.",
+      "type": "object",
+      "properties": {
+        "onChange": {
+          "description": "Publish diagnostics on document change. The built-in default is false.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "onOpen": {
+          "description": "Publish diagnostics on document open. The built-in default is true.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "onSave": {
+          "description": "Publish diagnostics on document save. The built-in default is true.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SourceDiscovery": {
+      "description": "How to discover project sources. Commands name an executable and arguments, not shell text.",
+      "oneOf": [
+        {
+          "description": "Discover sources through spago.lock. Explicitly selects Spago over a lower command layer.",
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "spago"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "kind"
+          ]
+        },
+        {
+          "description": "Select a source discovery command. Only supply commands from trusted configuration.",
+          "type": "object",
+          "properties": {
+            "arguments": {
+              "description": "Individual command arguments. Omission means no arguments, not inherited arguments.",
+              "type": "array",
+              "default": [],
+              "items": {
+                "type": "string"
+              }
+            },
+            "kind": {
+              "type": "string",
+              "const": "command"
+            },
+            "program": {
+              "description": "Nonempty executable name or path, passed without shell parsing.",
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "program"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/compiler-lsp/configuration/examples/export-schema.rs
+++ b/compiler-lsp/configuration/examples/export-schema.rs
@@ -1,0 +1,10 @@
+use std::error::Error;
+use std::path::Path;
+use std::{env, fs};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let schema = serde_json::to_string_pretty(&configuration::schema())?;
+    let output = Path::new(env!("CARGO_MANIFEST_DIR")).join("configuration.schema.json");
+    fs::write(output, format!("{schema}\n"))?;
+    Ok(())
+}

--- a/compiler-lsp/configuration/src/lib.rs
+++ b/compiler-lsp/configuration/src/lib.rs
@@ -21,7 +21,11 @@
 //! just configuration-schema
 //! ```
 //!
-//! The schema describes named JSON objects, not Serde's positional-array struct representation.
+//! The schema defines the supported JSON representation exchanged with external producers and
+//! consumers. Serializing valid configuration values produces schema-compliant JSON, and
+//! deserialization accepts schema-compliant JSON produced externally. Serde may also deserialize
+//! position-encoded arrays; that permissiveness is an implementation detail, not a supported
+//! configuration format or a compatibility guarantee.
 
 use serde::{Deserialize, Deserializer, Serialize, de};
 

--- a/compiler-lsp/configuration/src/lib.rs
+++ b/compiler-lsp/configuration/src/lib.rs
@@ -1,0 +1,152 @@
+//! Editor-independent language server configuration.
+//!
+//! Deserialize each input layer as [`ConfigurationSettings`] and apply layers from lowest to
+//! highest priority to [`Configuration::default`]. Missing and `null` fields inherit from the
+//! preceding layer. Diagnostic fields inherit individually; source discovery is replaced as a
+//! whole. To restore Spago discovery over a command-based layer, supply:
+//!
+//! ```json
+//! {"sources":{"kind":"spago"}}
+//! ```
+//!
+//! A runtime settings snapshot replaces the previous runtime layer. Apply it to the startup
+//! baseline, not to the previous effective configuration, so omitted settings stop overriding
+//! that baseline. Top-level `null` represents an empty layer at the transport boundary: consumers
+//! can deserialize `Option<ConfigurationSettings>` and use `unwrap_or_default()`.
+//!
+//! This crate owns neither configuration transport nor command execution. Enable the `schema`
+//! feature to export the input contract with `schema()`. Regenerate the checked-in JSON Schema:
+//!
+//! ```sh
+//! just configuration-schema
+//! ```
+//!
+//! The schema describes named JSON objects, not Serde's positional-array struct representation.
+
+use serde::{Deserialize, Deserializer, Serialize, de};
+
+/// Effective settings after resolving all configuration layers.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Configuration {
+    pub sources: SourceDiscovery,
+    pub diagnostics: Diagnostics,
+}
+
+/// One partial configuration layer. Missing or null fields inherit from lower-priority layers.
+/// Each runtime snapshot replaces the preceding runtime layer, not the startup baseline.
+/// Unknown fields are rejected, including an embedded `$schema` property; associate this schema
+/// through editor settings instead.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConfigurationSettings {
+    /// Replace the complete source selection. Inherits when missing or null; defaults to Spago
+    /// when no layer supplies a selection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sources: Option<SourceDiscovery>,
+    /// Override diagnostic triggers individually. Missing or null leaves lower layers unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostics: Option<DiagnosticSettings>,
+}
+
+/// Generate the partial input contract, including top-level null as an empty settings layer.
+#[cfg(feature = "schema")]
+pub fn schema() -> schemars::Schema {
+    schemars::generate::SchemaSettings::draft2020_12()
+        .for_deserialize()
+        .into_generator()
+        .into_root_schema_for::<Option<ConfigurationSettings>>()
+}
+
+impl ConfigurationSettings {
+    /// Resolve this layer over a lower-priority configuration without modifying either input.
+    pub fn apply_to(&self, baseline: &Configuration) -> Configuration {
+        let mut configuration = baseline.clone();
+        if let Some(sources) = &self.sources {
+            configuration.sources = sources.clone();
+        }
+        if let Some(diagnostics) = &self.diagnostics {
+            if let Some(on_open) = diagnostics.on_open {
+                configuration.diagnostics.on_open = on_open;
+            }
+            if let Some(on_save) = diagnostics.on_save {
+                configuration.diagnostics.on_save = on_save;
+            }
+            if let Some(on_change) = diagnostics.on_change {
+                configuration.diagnostics.on_change = on_change;
+            }
+        }
+        configuration
+    }
+}
+
+/// How to discover project sources. Commands name an executable and arguments, not shell text.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(tag = "kind", rename_all = "camelCase", deny_unknown_fields)]
+pub enum SourceDiscovery {
+    /// Discover sources through spago.lock. Explicitly selects Spago over a lower command layer.
+    Spago {},
+    /// Select a source discovery command. Only supply commands from trusted configuration.
+    Command {
+        /// Nonempty executable name or path, passed without shell parsing.
+        #[serde(deserialize_with = "deserialize_program")]
+        #[cfg_attr(feature = "schema", schemars(length(min = 1)))]
+        program: String,
+        /// Individual command arguments. Omission means no arguments, not inherited arguments.
+        #[serde(default)]
+        arguments: Vec<String>,
+    },
+}
+
+impl Default for SourceDiscovery {
+    fn default() -> SourceDiscovery {
+        SourceDiscovery::Spago {}
+    }
+}
+
+fn deserialize_program<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let program = String::deserialize(deserializer)?;
+    if program.is_empty() {
+        return Err(de::Error::custom("source command program must not be empty"));
+    }
+    Ok(program)
+}
+
+/// Diagnostic triggers, not a global diagnostics enable/disable policy.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Diagnostics {
+    pub on_open: bool,
+    pub on_save: bool,
+    pub on_change: bool,
+}
+
+impl Default for Diagnostics {
+    fn default() -> Diagnostics {
+        Diagnostics { on_open: true, on_save: true, on_change: false }
+    }
+}
+
+/// Partial diagnostic overrides; `false` is an override, while missing or `null` inherits.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DiagnosticSettings {
+    /// Publish diagnostics on document open. The built-in default is true.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_open: Option<bool>,
+    /// Publish diagnostics on document save. The built-in default is true.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_save: Option<bool>,
+    /// Publish diagnostics on document change. The built-in default is false.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_change: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests;

--- a/compiler-lsp/configuration/src/tests.rs
+++ b/compiler-lsp/configuration/src/tests.rs
@@ -1,0 +1,170 @@
+use serde_json::{Value, json};
+
+use super::{Configuration, ConfigurationSettings, Diagnostics, SourceDiscovery};
+
+fn settings(value: Value) -> ConfigurationSettings {
+    #[cfg(feature = "schema")]
+    {
+        let schema = serde_json::to_value(super::schema()).unwrap();
+        let validator = jsonschema::validator_for(&schema).unwrap();
+        assert!(validator.is_valid(&value), "schema rejected {value}");
+    }
+    serde_json::from_value::<Option<ConfigurationSettings>>(value).unwrap().unwrap_or_default()
+}
+
+#[test]
+fn defaults_match_existing_diagnostic_triggers() {
+    let configuration = Configuration::default();
+    assert_eq!(configuration.sources, SourceDiscovery::Spago {});
+    assert_eq!(
+        configuration.diagnostics,
+        Diagnostics { on_open: true, on_save: true, on_change: false }
+    );
+    assert_eq!(
+        serde_json::to_value(&configuration).unwrap(),
+        json!({
+            "sources": {"kind": "spago"},
+            "diagnostics": {"onOpen": true, "onSave": true, "onChange": false}
+        })
+    );
+}
+
+#[test]
+fn layers_override_only_supplied_fields() {
+    let startup = settings(json!({
+        "sources": {"kind": "command", "program": "custom", "arguments": ["sources"]},
+        "diagnostics": {"onOpen": false, "onChange": true}
+    }));
+    let baseline = startup.apply_to(&Configuration::default());
+    let initialization = settings(json!({"diagnostics": {"onSave": false}}));
+    let baseline = initialization.apply_to(&baseline);
+    let runtime = settings(json!({"diagnostics": {"onOpen": true, "onChange": false}}));
+    let effective = runtime.apply_to(&baseline);
+
+    assert_eq!(
+        effective.sources,
+        SourceDiscovery::Command {
+            program: "custom".to_string(),
+            arguments: vec!["sources".to_string()],
+        }
+    );
+    assert_eq!(
+        effective.diagnostics,
+        Diagnostics { on_open: true, on_save: false, on_change: false }
+    );
+    assert_eq!(
+        baseline.diagnostics,
+        Diagnostics { on_open: false, on_save: false, on_change: true }
+    );
+
+    let replacement = settings(json!({"diagnostics": {"onSave": true}}));
+    assert_eq!(
+        replacement.apply_to(&baseline).diagnostics,
+        Diagnostics { on_open: false, on_save: true, on_change: true }
+    );
+}
+
+#[test]
+fn missing_and_null_inherit_instead_of_resetting_to_defaults() {
+    let baseline = Configuration {
+        sources: SourceDiscovery::Command { program: "custom".to_string(), arguments: vec![] },
+        diagnostics: Diagnostics { on_open: false, on_save: false, on_change: true },
+    };
+    for value in [
+        json!(null),
+        json!({}),
+        json!({"sources": null, "diagnostics": null}),
+        json!({"diagnostics": {}}),
+        json!({"diagnostics": {"onOpen": null, "onSave": null, "onChange": null}}),
+    ] {
+        assert_eq!(settings(value.clone()).apply_to(&baseline), baseline, "{value}");
+    }
+}
+
+#[test]
+fn source_selection_is_replaced_as_a_whole() {
+    let baseline = Configuration {
+        sources: SourceDiscovery::Command {
+            program: "old".to_string(),
+            arguments: vec!["old-argument".to_string()],
+        },
+        ..Configuration::default()
+    };
+    let command = settings(json!({"sources": {"kind": "command", "program": "new"}}));
+    assert_eq!(
+        command.apply_to(&baseline).sources,
+        SourceDiscovery::Command { program: "new".to_string(), arguments: vec![] }
+    );
+    let spago = settings(json!({"sources": {"kind": "spago"}}));
+    assert_eq!(spago.apply_to(&baseline).sources, SourceDiscovery::Spago {});
+}
+
+#[test]
+fn malformed_settings_are_rejected() {
+    #[cfg(feature = "schema")]
+    let validator =
+        jsonschema::validator_for(&serde_json::to_value(super::schema()).unwrap()).unwrap();
+
+    for value in [
+        json!(false),
+        json!("settings"),
+        json!({"$schema": "https://example.com/schema.json"}),
+        json!({"unknown": true}),
+        json!({"diagnostics": {"onOpened": true}}),
+        json!({"diagnostics": {"onOpen": "false"}}),
+        json!({"sources": {}}),
+        json!({"sources": {"kind": "unknown"}}),
+        json!({"sources": {"kind": "spago", "program": "unexpected"}}),
+        json!({"sources": {"kind": "command"}}),
+        json!({"sources": {"kind": "command", "program": ""}}),
+        json!({"sources": {"kind": "command", "program": null}}),
+        json!({"sources": {"kind": "command", "program": "custom", "arguments": null}}),
+        json!({"sources": {"kind": "command", "program": "custom", "arguments": [1]}}),
+        json!({"sources": {"kind": "command", "program": "custom", "shell": true}}),
+    ] {
+        assert!(serde_json::from_value::<ConfigurationSettings>(value.clone()).is_err(), "{value}");
+        #[cfg(feature = "schema")]
+        assert!(!validator.is_valid(&value), "schema accepted {value}");
+    }
+}
+
+#[test]
+fn serialization_preserves_overrides_and_command_arguments() {
+    let value = json!({
+        "sources": {
+            "kind": "command",
+            "program": "/path with spaces/executable",
+            "arguments": ["", "path with spaces", "--flag", "λ"]
+        },
+        "diagnostics": {"onOpen": false, "onChange": true}
+    });
+    let configuration = settings(value.clone());
+    assert_eq!(serde_json::to_value(&configuration).unwrap(), value);
+    assert_eq!(serde_json::to_value(ConfigurationSettings::default()).unwrap(), json!({}));
+
+    let effective = configuration.apply_to(&Configuration::default());
+    let exported = serde_json::to_value(&effective).unwrap();
+    assert_eq!(settings(exported).apply_to(&Configuration::default()), effective);
+}
+
+#[cfg(feature = "schema")]
+#[test]
+fn schema_excludes_serdes_positional_struct_representation() {
+    let validator =
+        jsonschema::validator_for(&serde_json::to_value(super::schema()).unwrap()).unwrap();
+    for value in [json!([]), json!({"diagnostics": []})] {
+        assert!(serde_json::from_value::<ConfigurationSettings>(value.clone()).is_ok());
+        assert!(!validator.is_valid(&value), "{value}");
+    }
+}
+
+#[cfg(feature = "schema")]
+#[test]
+fn checked_in_schema_matches_generated_schema() {
+    let generated = serde_json::to_string_pretty(&super::schema()).unwrap();
+    assert_eq!(
+        include_str!("../configuration.schema.json"),
+        format!("{generated}\n"),
+        "run just configuration-schema"
+    );
+}

--- a/justfile
+++ b/justfile
@@ -66,3 +66,7 @@ prepare-release version:
 [doc("Format imports with module granularity")]
 @format *args="":
   cargo +nightly fmt {{args}} -- --config imports_granularity=Module
+
+[doc("Regenerate the language server configuration JSON Schema")]
+@configuration-schema:
+  cargo run -q -p configuration --features schema --example export-schema


### PR DESCRIPTION
## Summary

Add an editor-independent configuration contract as the foundation for #487. Public Serde types describe source discovery and diagnostic triggers, with resolved defaults and partial-layer inheritance. Missing/null fields inherit; source selection replaces the whole selection, while diagnostic fields override individually.

Add optional Schemars support and a Cargo example that generates the checked-in Draft 2020-12 JSON Schema. Run `just configuration-schema` to regenerate it. The artifact gives external editor implementors a language-neutral contract without requiring Rust tooling.

This does not change CLI flags, LSP configuration transport, or source discovery at runtime. Those remain follow-up work for #487.

## Verification

- `cargo check -p configuration --tests` — passed.
- `cargo check -p configuration --tests --all-features` — passed.
- `cargo nextest run -p configuration` — 6 passed.
- `cargo nextest run -p configuration --all-features` — 8 passed, including schema drift and representative schema/Serde validation checks.
- `just configuration-schema` — generated and inspected the artifact.
- `just format -p configuration` and `git diff --check` — passed.
- `just licenses` — completed with license-detection warnings; THIRDPARTY.toml unchanged.

The schema deliberately describes named JSON objects rather than Serde positional-array struct representations. Tests record that distinction. Schema-specific tests require the `schema` feature; existing default-feature CI does not enable them.

## Context

https://ampcode.com/threads/T-01a08449-c75f-70da-8c05-f515d19f75ea