### PR TITLE
[compiler-bin] Migrate CLI parsing from clap to usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,7 +2530,6 @@ dependencies = [
  "async-lsp",
  "building",
  "checking",
- "clap",
  "console",
  "diagnostics",
  "documentation",
@@ -2571,6 +2570,7 @@ dependencies = [
  "tracing-subscriber",
  "ts-rs",
  "url",
+ "usage-rs",
  "walkdir",
 ]
 
@@ -3890,6 +3890,33 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "usage-argv"
+version = "6.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80dcf875185d0520e1a0675f6d413749e5050fde359eede97e45d0b9690eedbd"
+
+[[package]]
+name = "usage-derive"
+version = "6.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778373c082248ae6050e96beb69c817cf109b8c8e925fbcbdf2155a12e517442"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "usage-rs"
+version = "6.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "894bcecc06869ce740fde1135ac8ee60d82bf33e88f34e4fee434a62e98e15e8"
+dependencies = [
+ "usage-argv",
+ "usage-derive",
 ]
 
 [[package]]

--- a/THIRDPARTY.toml
+++ b/THIRDPARTY.toml
@@ -77,156 +77,6 @@ license = "No license specified"
 text = "NOT FOUND"
 
 [[third_party_libraries]]
-package_name = "anstream"
-package_version = "1.0.0"
-repository = "https://github.com/rust-cli/anstyle.git"
-license = "MIT"
-
-[[third_party_libraries.licenses]]
-license = "MIT"
-text = """
-Copyright (c) Individual contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
-
-[[third_party_libraries]]
-package_name = "anstyle"
-package_version = "1.0.14"
-repository = "https://github.com/rust-cli/anstyle.git"
-license = "MIT"
-
-[[third_party_libraries.licenses]]
-license = "MIT"
-text = """
-Copyright (c) Individual contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
-
-[[third_party_libraries]]
-package_name = "anstyle-parse"
-package_version = "1.0.0"
-repository = "https://github.com/rust-cli/anstyle.git"
-license = "MIT"
-
-[[third_party_libraries.licenses]]
-license = "MIT"
-text = """
-Copyright (c) Individual contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
-
-[[third_party_libraries]]
-package_name = "anstyle-query"
-package_version = "1.1.5"
-repository = "https://github.com/rust-cli/anstyle.git"
-license = "MIT"
-
-[[third_party_libraries.licenses]]
-license = "MIT"
-text = """
-Copyright (c) Individual contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
-
-[[third_party_libraries]]
-package_name = "anstyle-wincon"
-package_version = "3.0.11"
-repository = "https://github.com/rust-cli/anstyle.git"
-license = "MIT"
-
-[[third_party_libraries.licenses]]
-license = "MIT"
-text = """
-Copyright (c) Individual contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
-
-[[third_party_libraries]]
 package_name = "anyhow"
 package_version = "1.0.104"
 repository = "https://github.com/dtolnay/anyhow"
@@ -679,156 +529,6 @@ license = "No license specified"
 [[third_party_libraries.licenses]]
 license = "No license specified"
 text = "NOT FOUND"
-
-[[third_party_libraries]]
-package_name = "clap"
-package_version = "4.6.6"
-repository = "https://github.com/clap-rs/clap"
-license = "MIT"
-
-[[third_party_libraries.licenses]]
-license = "MIT"
-text = """
-Copyright (c) Individual contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
-
-[[third_party_libraries]]
-package_name = "clap_builder"
-package_version = "4.6.6"
-repository = "https://github.com/clap-rs/clap"
-license = "MIT"
-
-[[third_party_libraries.licenses]]
-license = "MIT"
-text = """
-Copyright (c) Individual contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
-
-[[third_party_libraries]]
-package_name = "clap_derive"
-package_version = "4.6.4"
-repository = "https://github.com/clap-rs/clap"
-license = "MIT"
-
-[[third_party_libraries.licenses]]
-license = "MIT"
-text = """
-Copyright (c) Individual contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
-
-[[third_party_libraries]]
-package_name = "clap_lex"
-package_version = "1.1.0"
-repository = "https://github.com/clap-rs/clap"
-license = "MIT"
-
-[[third_party_libraries.licenses]]
-license = "MIT"
-text = """
-Copyright (c) Individual contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
-
-[[third_party_libraries]]
-package_name = "colorchoice"
-package_version = "1.0.5"
-repository = "https://github.com/rust-cli/anstyle.git"
-license = "MIT"
-
-[[third_party_libraries.licenses]]
-license = "MIT"
-text = """
-Copyright (c) Individual contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
 
 [[third_party_libraries]]
 package_name = "compact_str"
@@ -2511,42 +2211,6 @@ DEALINGS IN THE SOFTWARE.
 """
 
 [[third_party_libraries]]
-package_name = "heck"
-package_version = "0.5.0"
-repository = "https://github.com/withoutboats/heck"
-license = "MIT"
-
-[[third_party_libraries.licenses]]
-license = "MIT"
-text = """
-Copyright (c) 2015 The Rust Project Developers
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-"""
-
-[[third_party_libraries]]
 package_name = "icu_collections"
 package_version = "2.3.0"
 repository = "https://github.com/unicode-org/icu4x"
@@ -3184,36 +2848,6 @@ license = "No license specified"
 [[third_party_libraries.licenses]]
 license = "No license specified"
 text = "NOT FOUND"
-
-[[third_party_libraries]]
-package_name = "is_terminal_polyfill"
-package_version = "1.70.2"
-repository = "https://github.com/polyfill-rs/is_terminal_polyfill"
-license = "MIT"
-
-[[third_party_libraries.licenses]]
-license = "MIT"
-text = """
-Copyright (c) Individual contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
 
 [[third_party_libraries]]
 package_name = "itertools"
@@ -4533,36 +4167,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-"""
-
-[[third_party_libraries]]
-package_name = "once_cell_polyfill"
-package_version = "1.70.2"
-repository = "https://github.com/polyfill-rs/once_cell_polyfill"
-license = "MIT"
-
-[[third_party_libraries.licenses]]
-license = "MIT"
-text = """
-Copyright (c) Individual contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 """
 
 [[third_party_libraries]]
@@ -8946,6 +8550,36 @@ DEALINGS IN THE SOFTWARE.
 """
 
 [[third_party_libraries]]
+package_name = "usage-argv"
+package_version = "6.8.0"
+repository = "https://github.com/jdx/usage"
+license = "MIT"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = "NOT FOUND"
+
+[[third_party_libraries]]
+package_name = "usage-derive"
+package_version = "6.8.0"
+repository = "https://github.com/jdx/usage"
+license = "MIT"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = "NOT FOUND"
+
+[[third_party_libraries]]
+package_name = "usage-rs"
+package_version = "6.8.0"
+repository = "https://github.com/jdx/usage"
+license = "MIT"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = "NOT FOUND"
+
+[[third_party_libraries]]
 package_name = "utf8_iter"
 package_version = "1.0.4"
 repository = "https://github.com/hsivonen/utf8_iter"
@@ -8955,42 +8589,6 @@ license = "MIT"
 license = "MIT"
 text = """
 Copyright Mozilla Foundation
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-"""
-
-[[third_party_libraries]]
-package_name = "utf8parse"
-package_version = "0.2.2"
-repository = "https://github.com/alacritty/vte"
-license = "MIT"
-
-[[third_party_libraries.licenses]]
-license = "MIT"
-text = """
-Copyright (c) 2016 Joe Wilm
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/compiler-bin/Cargo.toml
+++ b/compiler-bin/Cargo.toml
@@ -28,7 +28,6 @@ analyzer = { version = "0.1.0", path = "../compiler-lsp/analyzer" }
 async-lsp = { version = "0.2.4", features = ["tokio"] }
 building = { version = "0.1.0", path = "../compiler-core/building" }
 checking = { version = "0.1.0", path = "../compiler-frontend/checking" }
-clap = { version = "4.6.6", features = ["derive"] }
 console = "0.16.4"
 documentation = { version = "0.1.0", path = "../compiler-lsp/documentation" }
 diagnostics = { version = "0.1.0", path = "../compiler-frontend/diagnostics" }
@@ -67,6 +66,7 @@ tracing = "0.1.44"
 tracing-subscriber = "0.3.23"
 ts-rs = { version = "12.0.1", default-features = false, features = ["serde-compat"] }
 url = "2.5.8"
+usage = { package = "usage-rs", version = "6.8.0" }
 walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/compiler-bin/src/cli.rs
+++ b/compiler-bin/src/cli.rs
@@ -2,240 +2,287 @@ use std::borrow::Cow;
 use std::io;
 use std::path::PathBuf;
 
-use clap::builder::{BoolishValueParser, PathBufValueParser, TypedValueParser};
-use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use path_absolutize::Absolutize;
 use tracing::level_filters::LevelFilter;
-
-use crate::compile::Resilience;
-
-const VERSION: &str = env!("CARGO_PKG_VERSION");
+use usage::{Args, Subcommands, ValueEnum};
 
 fn absolute_path(value: PathBuf) -> io::Result<PathBuf> {
     value.absolutize().map(Cow::into_owned)
 }
 
-fn absolute_path_parser() -> impl TypedValueParser<Value = PathBuf> {
-    PathBufValueParser::new().try_map(absolute_path)
-}
-
-fn resilience_parser() -> impl TypedValueParser<Value = Resilience> {
-    BoolishValueParser::new()
-        .map(|resilient| if resilient { Resilience::Resilient } else { Resilience::Strict })
-}
-
-#[derive(Debug, Parser)]
-#[command(about, version(VERSION))]
-pub struct Cli {
+#[derive(Debug, usage::Cli)]
+#[usage(
+    bin = "purescript-alexandrite",
+    about = env!("CARGO_PKG_DESCRIPTION"),
+    version,
+    unknown_flags = "error",
+    args_override_self = false
+)]
+pub struct Program {
     /// Print log path.
-    #[arg(long)]
+    #[usage(long)]
     pub log_file: bool,
-    #[command(flatten)]
+    #[usage(flatten)]
     pub lsp: LspOptions,
-    #[command(subcommand)]
+    #[usage(subcommand)]
     pub command: Option<Command>,
 }
 
-impl Cli {
-    pub fn command(self) -> Command {
-        self.command.unwrap_or(Command::Lsp(self.lsp))
+impl Program {
+    pub fn into_command(self) -> io::Result<Command> {
+        let mut command = self.command.unwrap_or(Command::Lsp(self.lsp));
+        match &mut command {
+            Command::Build(options) => options.build.normalize_paths()?,
+            Command::Watch(options) => options.normalize_paths()?,
+            Command::Run(options) => options.build.normalize_paths()?,
+            Command::Test(options) => options.build.normalize_paths()?,
+            Command::Compile(options) => {
+                options.build.output = absolute_path(std::mem::take(&mut options.build.output))?;
+                for package in &mut options.packages {
+                    *package = absolute_path(std::mem::take(package))?;
+                }
+            }
+            Command::Docs(options) => {
+                options.output = absolute_path(std::mem::take(&mut options.output))?;
+                options.spago_project =
+                    options.spago_project.take().map(absolute_path).transpose()?;
+                for package in &mut options.packages {
+                    *package = absolute_path(std::mem::take(package))?;
+                }
+                if let Some(DocsCommand::TypeScript(options)) = &mut options.command {
+                    options.output = absolute_path(std::mem::take(&mut options.output))?;
+                }
+            }
+            Command::New(_) | Command::Add(_) | Command::Lsp(_) => {}
+        }
+        Ok(command)
     }
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Subcommands)]
 pub enum Command {
-    /// Run the language server.
-    Lsp(LspOptions),
     /// Create a Spago project in the current directory.
+    #[usage(help_heading = "Project commands")]
     New(NewOptions),
-    /// Build a Spago workspace or package.
-    Build(ProjectBuildCommandOptions),
     /// Add dependencies to a Spago package.
+    #[usage(help_heading = "Project commands")]
     Add(AddOptions),
+    /// Build a Spago workspace or package.
+    #[usage(help_heading = "Project commands")]
+    Build(ProjectBuildCommandOptions),
+    /// Build a Spago workspace or package and rebuild when inputs change.
+    #[usage(help_heading = "Project commands")]
+    Watch(ProjectBuildOptions),
+    /// Run the language server.
+    #[usage(help_heading = "Project commands")]
+    Lsp(LspOptions),
     /// Build and run a Spago package with Node.js.
+    #[usage(help_heading = "Project commands")]
     Run(RunOptions),
     /// Build and test one or more Spago packages with Node.js.
+    #[usage(help_heading = "Project commands")]
     Test(TestOptions),
     /// Compile PureScript modules to JavaScript (experimental).
+    #[usage(help_heading = "Legacy commands")]
     Compile(CompileOptions),
-    /// Build a Spago workspace or package and rebuild when inputs change.
-    Watch(ProjectBuildOptions),
     /// Documentation utilities.
+    #[usage(help_heading = "Documentation commands")]
     Docs(DocsOptions),
 }
 
 #[derive(Debug, Args)]
 pub struct LoggingOptions {
     /// Log level for the query engine.
-    #[arg(long, value_name("LevelFilter"), default_value("off"))]
+    #[usage(
+        long,
+        value_name = "LevelFilter",
+        default = "off",
+        choices("off", "error", "warn", "info", "debug", "trace")
+    )]
     pub query_log: LevelFilter,
 
     /// Log level for the type checker.
-    #[arg(long, value_name("LevelFilter"), default_value("off"))]
+    #[usage(
+        long,
+        value_name = "LevelFilter",
+        default = "off",
+        choices("off", "error", "warn", "info", "debug", "trace")
+    )]
     pub checking_log: LevelFilter,
 }
 
 #[derive(Debug, Args)]
+#[usage(args_override_self = false)]
 pub struct LspOptions {
-    #[command(flatten)]
+    #[usage(flatten)]
     pub logging: LoggingOptions,
 
-    #[arg(long)]
+    #[usage(long)]
     pub stdio: bool,
 
     /// Log level for the language server.
-    #[arg(long, value_name("LevelFilter"), default_value("info"))]
+    #[usage(
+        long,
+        value_name = "LevelFilter",
+        default = "info",
+        choices("off", "error", "warn", "info", "debug", "trace")
+    )]
     pub lsp_log: LevelFilter,
 
     /// Command to use to get source files.
     ///
     /// This argument also disables the spago.lock integration.
-    #[arg(long)]
+    #[usage(long)]
     pub source_command: Option<String>,
 
     /// Publish diagnostics on textDocument/didOpen.
-    #[arg(long, value_name("bool"), action = ArgAction::Set, default_value_t = true)]
-    pub diagnostics_on_open: bool,
+    #[usage(long, value_name = "bool", default = "true")]
+    pub diagnostics_on_open: Option<bool>,
 
     /// Publish diagnostics on textDocument/didSave.
-    #[arg(long, value_name("bool"), action = ArgAction::Set, default_value_t = true)]
-    pub diagnostics_on_save: bool,
+    #[usage(long, value_name = "bool", default = "true")]
+    pub diagnostics_on_save: Option<bool>,
 
     /// Publish diagnostics on textDocument/didChange.
-    #[arg(long, default_value_t = false)]
+    #[usage(long)]
     pub diagnostics_on_change: bool,
 }
 
 #[derive(Debug, Args)]
+#[usage(args_override_self = false)]
 pub struct CompileOptions {
-    #[command(flatten)]
+    #[usage(flatten)]
     pub build: BuildOptions,
 
     /// Package folder to compile.
-    #[arg(
-        id = "package",
-        long = "package",
-        value_name("DIR"),
-        value_parser = absolute_path_parser()
-    )]
+    #[usage(name = "package", long = "package", value_name = "DIR")]
     pub packages: Vec<PathBuf>,
 
     /// PureScript source paths or glob patterns.
-    #[arg(value_name("INPUT"), required_unless_present("package"))]
+    #[usage(value_name = "INPUT", required_unless = "--package")]
     pub inputs: Vec<PathBuf>,
 
     /// Code generation targets requested by build tools.
-    #[arg(long, value_name("TARGETS"))]
+    #[usage(long, value_name = "TARGETS")]
     pub codegen: Option<String>,
 
     /// Emit a Spago-compatible JSON result.
     ///
     /// Full structured JSON diagnostics are not yet supported.
-    #[arg(long)]
+    #[usage(long)]
     pub json_errors: bool,
 }
 
 #[derive(Debug, Args)]
 pub struct BuildOptions {
-    #[command(flatten)]
+    #[usage(flatten)]
     pub logging: LoggingOptions,
 
     /// Output directory for compiled modules.
-    #[arg(short, long, value_name("DIR"), default_value("output"), value_parser = absolute_path_parser())]
+    #[usage(short, long, value_name = "DIR", default = "output")]
     pub output: PathBuf,
 
     /// Suppress build progress output.
-    #[arg(short, long)]
+    #[usage(short, long)]
     pub quiet: bool,
 
     /// When to use colors in human-readable diagnostics.
-    #[arg(long, value_enum, default_value_t = ColorChoice::Auto)]
+    #[usage(long, value_enum, default = "auto")]
     pub color: ColorChoice,
 }
 
 #[derive(Debug, Args)]
+#[usage(args_override_self = false)]
 pub struct NewOptions {
     /// Package name. Defaults to the current directory name.
-    #[arg(long, value_name("NAME"))]
+    #[usage(long, value_name = "NAME")]
     pub name: Option<String>,
 }
 
 #[derive(Debug, Args)]
+#[usage(args_override_self = false)]
 pub struct ProjectBuildOptions {
-    #[command(flatten)]
+    #[usage(flatten)]
     pub logging: LoggingOptions,
 
     /// Workspace package to build.
-    #[arg(short, long, value_name("NAME"))]
+    #[usage(short, long, value_name = "NAME")]
     pub package: Option<String>,
 
     /// Output directory for compiled modules. Defaults to output in the workspace root.
-    #[arg(short, long, value_name("DIR"), value_parser = absolute_path_parser())]
+    #[usage(short, long, value_name = "DIR")]
     pub output: Option<PathBuf>,
 
     /// Suppress build progress output.
-    #[arg(short, long)]
+    #[usage(short, long)]
     pub quiet: bool,
 
     /// When to use colors in human-readable diagnostics.
-    #[arg(long, value_enum, default_value_t = ColorChoice::Auto)]
+    #[usage(long, value_enum, default = "auto")]
     pub color: ColorChoice,
 }
 
-#[derive(Debug, Args)]
-pub struct ProjectBuildCommandOptions {
-    #[command(flatten)]
-    pub build: ProjectBuildOptions,
-
-    /// Write JavaScript output even when compilation reports errors.
-    #[arg(
-        long = "resilient",
-        action = ArgAction::SetTrue,
-        value_parser = resilience_parser()
-    )]
-    pub resilience: Resilience,
+impl ProjectBuildOptions {
+    fn normalize_paths(&mut self) -> io::Result<()> {
+        self.output = self.output.take().map(absolute_path).transpose()?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Args)]
+#[usage(args_override_self = false)]
+pub struct ProjectBuildCommandOptions {
+    #[usage(flatten)]
+    pub build: ProjectBuildOptions,
+
+    /// Write JavaScript output even when compilation reports errors.
+    #[usage(long)]
+    pub resilient: bool,
+}
+
+#[derive(Debug, Args)]
+#[usage(args_override_self = false)]
 pub struct AddOptions {
     /// Workspace package whose dependencies should change.
-    #[arg(short, long, value_name("NAME"))]
+    #[usage(short, long, value_name = "NAME")]
     pub package: Option<String>,
 
     /// Add packages as test dependencies.
-    #[arg(long)]
+    #[usage(long)]
     pub test: bool,
 
     /// Packages to add.
-    #[arg(value_name("DEPENDENCY"), required = true)]
+    #[usage(value_name = "DEPENDENCY", required = true)]
     pub dependencies: Vec<String>,
 }
 
 #[derive(Debug, Args)]
+#[usage(args_override_self = false)]
 pub struct RunOptions {
-    #[command(flatten)]
+    #[usage(flatten)]
     pub build: ProjectBuildOptions,
 
     /// Module containing the program entry point.
-    #[arg(long, value_name("MODULE"))]
+    #[usage(long, value_name = "MODULE")]
     pub main: Option<String>,
 
     /// Arguments passed to the program.
-    #[arg(last = true)]
+    #[usage(double_dash = "required")]
     pub arguments: Vec<String>,
 }
 
 #[derive(Debug, Args)]
+#[usage(args_override_self = false)]
 pub struct TestOptions {
-    #[command(flatten)]
+    #[usage(flatten)]
     pub build: ProjectBuildOptions,
 
     /// Module containing the test entry point.
-    #[arg(long, value_name("MODULE"))]
+    #[usage(long, value_name = "MODULE")]
     pub main: Option<String>,
 
     /// Arguments passed to each test program.
-    #[arg(last = true)]
+    #[usage(double_dash = "required")]
     pub arguments: Vec<String>,
 }
 
@@ -247,46 +294,51 @@ pub enum ColorChoice {
 }
 
 #[derive(Debug, Args)]
-#[command(subcommand_negates_reqs = true)]
+#[usage(subcommand_negates_reqs = true, args_override_self = false)]
 pub struct DocsOptions {
-    #[command(flatten)]
+    #[usage(flatten)]
     pub logging: LoggingOptions,
     /// Log level for the documentation tool.
-    #[arg(long, value_name("LEVEL"), default_value("info"))]
+    #[usage(
+        long,
+        value_name = "LEVEL",
+        default = "info",
+        choices("off", "error", "warn", "info", "debug", "trace")
+    )]
     pub docs_log: LevelFilter,
-    #[command(subcommand)]
+    #[usage(subcommand)]
     pub command: Option<DocsCommand>,
     /// Output directory for the generated documentation.
-    #[arg(long, value_name("DIR"), default_value("docs"), value_parser = absolute_path_parser())]
+    #[usage(long, value_name = "DIR", default = "docs")]
     pub output: PathBuf,
     /// Suppress documentation progress output.
-    #[arg(short, long)]
+    #[usage(short, long)]
     pub quiet: bool,
     /// Spago project directory containing spago.lock.
-    #[arg(long, value_name("DIR"), conflicts_with("package"), value_parser = absolute_path_parser())]
+    #[usage(long, value_name = "DIR", conflicts = "--package")]
     pub spago_project: Option<PathBuf>,
     /// Package folder to document.
-    #[arg(
-        id = "package",
+    #[usage(
+        name = "package",
         long = "package",
-        value_name("DIR"),
-        value_parser = absolute_path_parser(),
-        required_unless_present("spago_project")
+        value_name = "DIR",
+        required_unless = "--spago-project"
     )]
     pub packages: Vec<PathBuf>,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Subcommands)]
 pub enum DocsCommand {
     /// Generate TypeScript declarations for the documentation JSON schema.
-    #[command(name = "typescript")]
+    #[usage(name = "typescript")]
     TypeScript(DocsTypeScriptOptions),
 }
 
 #[derive(Debug, Args)]
+#[usage(args_override_self = false)]
 pub struct DocsTypeScriptOptions {
     /// Output directory for the generated TypeScript schema.
-    #[arg(long, value_name("DIR"), default_value("src-generated"), value_parser = absolute_path_parser())]
+    #[usage(long, value_name = "DIR", default = "src-generated")]
     pub output: PathBuf,
 }
 
@@ -303,8 +355,8 @@ impl Default for LspOptions {
             stdio: false,
             lsp_log: LevelFilter::INFO,
             source_command: None,
-            diagnostics_on_open: true,
-            diagnostics_on_save: true,
+            diagnostics_on_open: Some(true),
+            diagnostics_on_save: Some(true),
             diagnostics_on_change: false,
         }
     }
@@ -313,14 +365,26 @@ impl Default for LspOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::error::ErrorKind;
+    use std::ffi::OsStr;
     use std::path::Path;
+    use usage::diagnostic::Code;
+
+    fn parse(argv: Vec<&str>) -> Program {
+        let argv: Vec<_> = argv.into_iter().map(OsStr::new).collect();
+        Program::try_parse_from(&argv).unwrap()
+    }
+
+    fn error_kind(argv: Vec<&str>) -> Code {
+        let argv: Vec<_> = argv.into_iter().map(OsStr::new).collect();
+        let error = Program::try_parse_from(&argv).unwrap_err();
+        usage::diagnostic::report(Program::spec(), &argv[1..], &error).code
+    }
 
     fn lsp(args: &[&str]) -> LspOptions {
         let mut argv = vec!["alexandrite"];
         argv.extend(args);
-        let cli = Cli::parse_from(argv);
-        match cli.command() {
+        let program = parse(argv);
+        match program.into_command().unwrap() {
             Command::Lsp(options) => options,
             _ => unreachable!("parsed command was not `lsp`"),
         }
@@ -329,9 +393,9 @@ mod tests {
     fn docs(args: &[&str]) -> DocsOptions {
         let mut argv = vec!["alexandrite", "docs"];
         argv.extend(args);
-        let cli = Cli::parse_from(argv);
-        match cli.command {
-            Some(Command::Docs(options)) => options,
+        let program = parse(argv);
+        match program.into_command().unwrap() {
+            Command::Docs(options) => options,
             _ => unreachable!("parsed command was not `docs`"),
         }
     }
@@ -339,25 +403,25 @@ mod tests {
     fn compile(args: &[&str]) -> CompileOptions {
         let mut argv = vec!["alexandrite", "compile"];
         argv.extend(args);
-        let cli = Cli::parse_from(argv);
-        match cli.command {
-            Some(Command::Compile(options)) => options,
+        let program = parse(argv);
+        match program.into_command().unwrap() {
+            Command::Compile(options) => options,
             _ => unreachable!("parsed command was not `compile`"),
         }
     }
 
-    fn compile_error_kind(args: &[&str]) -> ErrorKind {
+    fn compile_error_kind(args: &[&str]) -> Code {
         let mut argv = vec!["alexandrite", "compile"];
         argv.extend(args);
-        Cli::try_parse_from(argv).unwrap_err().kind()
+        error_kind(argv)
     }
 
     fn build(args: &[&str]) -> ProjectBuildCommandOptions {
         let mut argv = vec!["alexandrite", "build"];
         argv.extend(args);
-        let cli = Cli::parse_from(argv);
-        match cli.command {
-            Some(Command::Build(options)) => options,
+        let program = parse(argv);
+        match program.into_command().unwrap() {
+            Command::Build(options) => options,
             _ => unreachable!("parsed command was not `build`"),
         }
     }
@@ -365,17 +429,17 @@ mod tests {
     fn watch(args: &[&str]) -> ProjectBuildOptions {
         let mut argv = vec!["alexandrite", "watch"];
         argv.extend(args);
-        let cli = Cli::parse_from(argv);
-        match cli.command {
-            Some(Command::Watch(options)) => options,
+        let program = parse(argv);
+        match program.into_command().unwrap() {
+            Command::Watch(options) => options,
             _ => unreachable!("parsed command was not `watch`"),
         }
     }
 
-    fn docs_error_kind(args: &[&str]) -> ErrorKind {
+    fn docs_error_kind(args: &[&str]) -> Code {
         let mut argv = vec!["alexandrite", "docs"];
         argv.extend(args);
-        Cli::try_parse_from(argv).unwrap_err().kind()
+        error_kind(argv)
     }
 
     fn typescript(args: &[&str]) -> DocsTypeScriptOptions {
@@ -399,6 +463,16 @@ mod tests {
 
         assert!(options.stdio);
         assert!(options.diagnostics_on_change);
+        assert_eq!(options.diagnostics_on_open, Some(true));
+        assert_eq!(options.diagnostics_on_save, Some(true));
+
+        let options = lsp(&["--diagnostics-on-open", "false", "--diagnostics-on-save", "true"]);
+        assert_eq!(options.diagnostics_on_open, Some(false));
+        assert_eq!(options.diagnostics_on_save, Some(true));
+
+        let options = lsp(&["lsp", "--diagnostics-on-open=true", "--diagnostics-on-save=false"]);
+        assert_eq!(options.diagnostics_on_open, Some(true));
+        assert_eq!(options.diagnostics_on_save, Some(false));
     }
 
     #[test]
@@ -443,8 +517,8 @@ mod tests {
     fn build_accepts_resilient_output() {
         let options = build(&["--resilient"]);
 
-        assert_eq!(options.resilience, Resilience::Resilient);
-        assert_eq!(build(&[]).resilience, Resilience::Strict);
+        assert!(options.resilient);
+        assert!(!build(&[]).resilient);
     }
 
     #[test]
@@ -465,7 +539,7 @@ mod tests {
 
     #[test]
     fn compile_requires_inputs_or_a_package() {
-        insta::assert_debug_snapshot!(compile_error_kind(&[]), @"MissingRequiredArgument");
+        insta::assert_debug_snapshot!(compile_error_kind(&[]), @"MissingRequired");
     }
 
     #[test]
@@ -501,7 +575,7 @@ mod tests {
     fn spago_project_conflicts_with_package_specs() {
         insta::assert_debug_snapshot!(
             docs_error_kind(&["--spago-project", ".", "--package", "packages/effect"]),
-            @"ArgumentConflict"
+            @"ConflictingFlags"
         );
     }
 
@@ -531,12 +605,12 @@ mod tests {
 
     #[test]
     fn missing_package_path_is_rejected() {
-        insta::assert_debug_snapshot!(docs_error_kind(&["--package"]), @"InvalidValue");
+        insta::assert_debug_snapshot!(docs_error_kind(&["--package"]), @"MissingFlagValue");
     }
 
     #[test]
     fn package_is_required() {
-        insta::assert_debug_snapshot!(docs_error_kind(&[]), @"MissingRequiredArgument");
+        insta::assert_debug_snapshot!(docs_error_kind(&[]), @"MissingRequired");
     }
 
     #[test]

--- a/compiler-bin/src/lib.rs
+++ b/compiler-bin/src/lib.rs
@@ -1,4 +1,3 @@
-use clap::Parser;
 use tracing::level_filters::LevelFilter;
 
 pub mod cli;
@@ -15,13 +14,16 @@ mod watch;
 mod workspace;
 
 pub fn run() {
-    let cli = cli::Cli::parse();
+    let program = cli::Program::parse();
 
-    if cli.log_file {
+    if program.log_file {
         eprintln!("Log file: {:?}", logging::temporary_log_file());
     }
 
-    let command = cli.command();
+    let command = program.into_command().unwrap_or_else(|error| {
+        eprintln!("error: failed to resolve command paths: {error}");
+        std::process::exit(2);
+    });
 
     match command {
         cli::Command::Lsp(options) => {
@@ -33,15 +35,20 @@ pub fn run() {
             });
             lsp::start(lsp::LspConfig {
                 source_command: options.source_command,
-                diagnostics_on_open: options.diagnostics_on_open,
-                diagnostics_on_save: options.diagnostics_on_save,
+                diagnostics_on_open: options.diagnostics_on_open.unwrap_or(true),
+                diagnostics_on_save: options.diagnostics_on_save.unwrap_or(true),
                 diagnostics_on_change: options.diagnostics_on_change,
             });
         }
         cli::Command::New(options) => project::start(project::new(options.name)),
         cli::Command::Build(options) => {
             start_project_logging(&options.build.logging);
-            project::start(project::build(project_build_config(options.build), options.resilience));
+            let resilience = if options.resilient {
+                compile::Resilience::Resilient
+            } else {
+                compile::Resilience::Strict
+            };
+            project::start(project::build(project_build_config(options.build), resilience));
         }
         cli::Command::Add(options) => {
             project::start(project::add(project::AddProjectConfig {

--- a/tests-e2e/tests/package_manager.rs
+++ b/tests-e2e/tests/package_manager.rs
@@ -2,6 +2,8 @@
 mod add;
 #[path = "package_manager/build.rs"]
 mod build;
+#[path = "package_manager/cli.rs"]
+mod cli;
 #[path = "package_manager/new.rs"]
 mod new;
 #[path = "package_manager/run.rs"]

--- a/tests-e2e/tests/package_manager/cli.rs
+++ b/tests-e2e/tests/package_manager/cli.rs
@@ -1,0 +1,163 @@
+use std::process::Output;
+
+use super::support::TestWorkspace;
+
+fn snapshot_output(name: &str, output: &Output) {
+    let status = output.status.code().map_or_else(|| "signal".to_owned(), |code| code.to_string());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    insta::with_settings!({omit_expression => true}, {
+        insta::assert_snapshot!(
+            name,
+            format!("status: {status}\n--- stdout\n{stdout}--- stderr\n{stderr}")
+        );
+    });
+}
+
+#[test]
+fn prints_help_for_every_command_path() {
+    let workspace = TestWorkspace::empty();
+    let paths: &[(&str, &[&str])] = &[
+        ("help_root", &["--help"]),
+        ("help_new", &["new", "--help"]),
+        ("help_add", &["add", "--help"]),
+        ("help_build", &["build", "--help"]),
+        ("help_watch", &["watch", "--help"]),
+        ("help_lsp", &["lsp", "--help"]),
+        ("help_run", &["run", "--help"]),
+        ("help_test", &["test", "--help"]),
+        ("help_compile", &["compile", "--help"]),
+        ("help_docs", &["docs", "--help"]),
+        ("help_docs_typescript", &["docs", "typescript", "--help"]),
+    ];
+
+    for (name, arguments) in paths {
+        let output = workspace.command(arguments);
+        assert!(output.status.success(), "{name} failed");
+        assert!(!output.stdout.is_empty(), "{name} did not write stdout");
+        assert!(output.stderr.is_empty(), "{name} wrote stderr");
+        snapshot_output(name, &output);
+    }
+}
+
+#[test]
+fn root_help_groups_commands_by_role() {
+    let workspace = TestWorkspace::empty();
+    let output = workspace.command(&["--help"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let project = stdout.find("Project commands:").unwrap();
+    let legacy = stdout.find("Legacy commands:").unwrap();
+    let documentation = stdout.find("Documentation commands:").unwrap();
+    assert!(project < legacy && legacy < documentation);
+    for command in ["new", "add", "build", "watch", "lsp", "run", "test"] {
+        assert!(stdout[project..legacy].contains(command));
+    }
+    assert!(stdout[legacy..documentation].contains("compile"));
+    assert!(stdout[documentation..].contains("docs"));
+}
+
+#[test]
+fn prints_version_to_stdout() {
+    let workspace = TestWorkspace::empty();
+    let output = workspace.command(&["--version"]);
+    assert!(output.status.success());
+    assert!(!output.stdout.is_empty());
+    assert!(output.stderr.is_empty());
+    snapshot_output("version", &output);
+}
+
+#[test]
+fn rejects_unknown_flags_and_duplicate_scalar_options() {
+    let workspace = TestWorkspace::empty();
+    let cases: &[(&str, &[&str])] = &[
+        ("unknown_root_flag", &["--unknown"]),
+        (
+            "duplicate_root_scalar",
+            &["--diagnostics-on-open", "true", "--diagnostics-on-open", "false"],
+        ),
+        ("unknown_build_flag", &["build", "--unknown"]),
+        ("duplicate_build_scalar", &["build", "--package", "one", "--package", "two"]),
+        ("unknown_compile_flag", &["compile", "--unknown", "Main.purs"]),
+        (
+            "duplicate_compile_scalar",
+            &["compile", "--output", "one", "--output", "two", "Main.purs"],
+        ),
+        ("unknown_docs_flag", &["docs", "--unknown", "--package", "."]),
+        (
+            "duplicate_docs_scalar",
+            &["docs", "--output", "one", "--output", "two", "--package", "."],
+        ),
+        ("unknown_typescript_flag", &["docs", "typescript", "--unknown"]),
+        (
+            "duplicate_typescript_scalar",
+            &["docs", "typescript", "--output", "one", "--output", "two"],
+        ),
+    ];
+
+    for (name, arguments) in cases {
+        let output = workspace.command(arguments);
+        assert!(!output.status.success(), "{name} unexpectedly succeeded");
+        assert!(output.stdout.is_empty(), "{name} wrote stdout");
+        assert!(!output.stderr.is_empty(), "{name} did not write stderr");
+        snapshot_output(name, &output);
+    }
+}
+
+#[test]
+fn rejects_missing_required_arguments() {
+    let workspace = TestWorkspace::empty();
+    let cases: &[(&str, &[&str])] = &[
+        ("add_requires_dependencies", &["add"]),
+        ("compile_requires_input_or_package", &["compile"]),
+        ("compile_package_requires_value", &["compile", "--package"]),
+        ("docs_requires_package_or_project", &["docs"]),
+        ("docs_package_requires_value", &["docs", "--package"]),
+        ("docs_project_requires_value", &["docs", "--spago-project"]),
+    ];
+
+    for (name, arguments) in cases {
+        let output = workspace.command(arguments);
+        assert!(!output.status.success(), "{name} unexpectedly succeeded");
+        snapshot_output(name, &output);
+    }
+}
+
+#[test]
+fn run_and_test_require_separator_before_trailing_arguments() {
+    let workspace = TestWorkspace::empty();
+    for (name, arguments) in [
+        ("run_requires_separator", &["run", "argument"][..]),
+        ("test_requires_separator", &["test", "argument"][..]),
+    ] {
+        let output = workspace.command(arguments);
+        assert!(!output.status.success(), "{name} unexpectedly succeeded");
+        snapshot_output(name, &output);
+    }
+}
+
+#[test]
+fn lsp_boolean_options_require_boolean_values() {
+    let workspace = TestWorkspace::empty();
+    let cases: &[(&str, &[&str])] = &[
+        ("lsp_open_requires_value", &["lsp", "--diagnostics-on-open"]),
+        ("lsp_open_rejects_invalid_value", &["lsp", "--diagnostics-on-open", "yes"]),
+        ("lsp_save_requires_value", &["lsp", "--diagnostics-on-save"]),
+        ("lsp_save_rejects_invalid_value", &["lsp", "--diagnostics-on-save", "yes"]),
+    ];
+
+    for (name, arguments) in cases {
+        let output = workspace.command(arguments);
+        assert!(!output.status.success(), "{name} unexpectedly succeeded");
+        snapshot_output(name, &output);
+    }
+}
+
+#[test]
+fn typescript_output_resolves_relative_to_the_working_directory() {
+    let workspace = TestWorkspace::empty();
+    let output =
+        workspace.command_in("project", &["docs", "typescript", "--output", "../generated"]);
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    assert!(workspace.path().join("generated/docs-schema.ts").is_file());
+}

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__add_requires_dependencies.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__add_requires_dependencies.snap
@@ -1,0 +1,12 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: the following required arguments were not provided:
+  <DEPENDENCY>…
+
+Usage: purescript-alexandrite add [-p --package <NAME>] [--test] <DEPENDENCY>…
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__compile_package_requires_value.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__compile_package_requires_value.snap
@@ -1,0 +1,9 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: a value is required for '--package <DIR>' but none was supplied
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__compile_requires_input_or_package.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__compile_requires_input_or_package.snap
@@ -1,0 +1,12 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: the following required arguments were not provided:
+  [INPUT]…
+
+Usage: purescript-alexandrite compile [FLAGS] [INPUT]…
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__docs_package_requires_value.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__docs_package_requires_value.snap
@@ -1,0 +1,9 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: a value is required for '--package <DIR>' but none was supplied
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__docs_project_requires_value.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__docs_project_requires_value.snap
@@ -1,0 +1,9 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: a value is required for '--spago-project <DIR>' but none was supplied
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__docs_requires_package_or_project.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__docs_requires_package_or_project.snap
@@ -1,0 +1,12 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: the following required arguments were not provided:
+  --package
+
+Usage: purescript-alexandrite docs [FLAGS] [SUBCOMMAND]
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__duplicate_build_scalar.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__duplicate_build_scalar.snap
@@ -1,0 +1,11 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: the argument '--package' cannot be used multiple times
+
+Usage: purescript-alexandrite build [FLAGS]
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__duplicate_compile_scalar.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__duplicate_compile_scalar.snap
@@ -1,0 +1,11 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: the argument '--output' cannot be used multiple times
+
+Usage: purescript-alexandrite compile [FLAGS] [INPUT]…
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__duplicate_docs_scalar.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__duplicate_docs_scalar.snap
@@ -1,0 +1,11 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: the argument '--output' cannot be used multiple times
+
+Usage: purescript-alexandrite docs [FLAGS] [SUBCOMMAND]
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__duplicate_root_scalar.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__duplicate_root_scalar.snap
@@ -1,0 +1,11 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: the argument '--diagnostics-on-open' cannot be used multiple times
+
+Usage: purescript-alexandrite [FLAGS] [SUBCOMMAND]
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__duplicate_typescript_scalar.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__duplicate_typescript_scalar.snap
@@ -1,0 +1,11 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: the argument '--output' cannot be used multiple times
+
+Usage: purescript-alexandrite docs typescript [--output <DIR>]
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_add.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_add.snap
@@ -1,0 +1,17 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 0
+--- stdout
+Add dependencies to a Spago package.
+
+Usage: purescript-alexandrite add [-p --package <NAME>] [--test] <DEPENDENCY>…
+
+Arguments:
+  <DEPENDENCY>…  Packages to add.
+
+Flags:
+  -p, --package <NAME>  Workspace package whose dependencies should change.
+      --test            Add packages as test dependencies.
+  -h, --help            Print help
+--- stderr

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_build.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_build.snap
@@ -1,0 +1,25 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 0
+--- stdout
+Build a Spago workspace or package.
+
+Usage: purescript-alexandrite build [FLAGS]
+
+Flags:
+      --query-log <LevelFilter>     Log level for the query engine.
+                                    [possible values: off, error, warn, info, debug, trace]
+                                    (default: off)
+      --checking-log <LevelFilter>  Log level for the type checker.
+                                    [possible values: off, error, warn, info, debug, trace]
+                                    (default: off)
+  -p, --package <NAME>              Workspace package to build.
+  -o, --output <DIR>                Output directory for compiled modules. Defaults to output in the workspace root.
+  -q, --quiet                       Suppress build progress output.
+      --color <COLOR>               When to use colors in human-readable diagnostics.
+                                    [possible values: auto, always, never]
+                                    (default: auto)
+      --resilient                   Write JavaScript output even when compilation reports errors.
+  -h, --help                        Print help
+--- stderr

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_compile.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_compile.snap
@@ -1,0 +1,32 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 0
+--- stdout
+Compile PureScript modules to JavaScript (experimental).
+
+Usage: purescript-alexandrite compile [FLAGS] [INPUT]…
+
+Arguments:
+  [INPUT]…  PureScript source paths or glob patterns.
+
+Flags:
+      --query-log <LevelFilter>     Log level for the query engine.
+                                    [possible values: off, error, warn, info, debug, trace]
+                                    (default: off)
+      --checking-log <LevelFilter>  Log level for the type checker.
+                                    [possible values: off, error, warn, info, debug, trace]
+                                    (default: off)
+  -o, --output <DIR>                Output directory for compiled modules.
+                                    (default: output)
+  -q, --quiet                       Suppress build progress output.
+      --color <COLOR>               When to use colors in human-readable diagnostics.
+                                    [possible values: auto, always, never]
+                                    (default: auto)
+      --package <DIR>               Package folder to compile.
+      --codegen <TARGETS>           Code generation targets requested by build tools.
+      --json-errors                 Emit a Spago-compatible JSON result.
+
+                                    Full structured JSON diagnostics are not yet supported.
+  -h, --help                        Print help
+--- stderr

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_docs.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_docs.snap
@@ -1,0 +1,30 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 0
+--- stdout
+Documentation utilities.
+
+Usage: purescript-alexandrite docs [FLAGS] [SUBCOMMAND]
+
+Commands:
+  typescript  Generate TypeScript declarations for the documentation JSON schema.
+  help        Print this message or the help of the given subcommand(s)
+
+Flags:
+      --query-log <LevelFilter>     Log level for the query engine.
+                                    [possible values: off, error, warn, info, debug, trace]
+                                    (default: off)
+      --checking-log <LevelFilter>  Log level for the type checker.
+                                    [possible values: off, error, warn, info, debug, trace]
+                                    (default: off)
+      --docs-log <LEVEL>            Log level for the documentation tool.
+                                    [possible values: off, error, warn, info, debug, trace]
+                                    (default: info)
+      --output <DIR>                Output directory for the generated documentation.
+                                    (default: docs)
+  -q, --quiet                       Suppress documentation progress output.
+      --spago-project <DIR>         Spago project directory containing spago.lock.
+      --package <DIR>               Package folder to document.
+  -h, --help                        Print help
+--- stderr

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_docs_typescript.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_docs_typescript.snap
@@ -1,0 +1,14 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 0
+--- stdout
+Generate TypeScript declarations for the documentation JSON schema.
+
+Usage: purescript-alexandrite docs typescript [--output <DIR>]
+
+Flags:
+      --output <DIR>  Output directory for the generated TypeScript schema.
+                      (default: src-generated)
+  -h, --help          Print help
+--- stderr

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_lsp.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_lsp.snap
@@ -1,0 +1,30 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 0
+--- stdout
+Run the language server.
+
+Usage: purescript-alexandrite lsp [FLAGS]
+
+Flags:
+      --query-log <LevelFilter>          Log level for the query engine.
+                                         [possible values: off, error, warn, info, debug, trace]
+                                         (default: off)
+      --checking-log <LevelFilter>       Log level for the type checker.
+                                         [possible values: off, error, warn, info, debug, trace]
+                                         (default: off)
+      --stdio
+      --lsp-log <LevelFilter>            Log level for the language server.
+                                         [possible values: off, error, warn, info, debug, trace]
+                                         (default: info)
+      --source-command <SOURCE_COMMAND>  Command to use to get source files.
+
+                                         This argument also disables the spago.lock integration.
+      --diagnostics-on-open <bool>       Publish diagnostics on textDocument/didOpen.
+                                         (default: true)
+      --diagnostics-on-save <bool>       Publish diagnostics on textDocument/didSave.
+                                         (default: true)
+      --diagnostics-on-change            Publish diagnostics on textDocument/didChange.
+  -h, --help                             Print help
+--- stderr

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_new.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_new.snap
@@ -1,0 +1,13 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 0
+--- stdout
+Create a Spago project in the current directory.
+
+Usage: purescript-alexandrite new [--name <NAME>]
+
+Flags:
+      --name <NAME>  Package name. Defaults to the current directory name.
+  -h, --help         Print help
+--- stderr

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_root.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_root.snap
@@ -1,0 +1,51 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 0
+--- stdout
+purescript-alexandrite 0.1.0
+Language implementation for the PureScript programming language.
+
+Usage: purescript-alexandrite [FLAGS] [SUBCOMMAND]
+
+Commands:
+  help     Print this message or the help of the given subcommand(s)
+
+Project commands:
+  add      Add dependencies to a Spago package.
+  build    Build a Spago workspace or package.
+  lsp      Run the language server.
+  new      Create a Spago project in the current directory.
+  run      Build and run a Spago package with Node.js.
+  test     Build and test one or more Spago packages with Node.js.
+  watch    Build a Spago workspace or package and rebuild when inputs change.
+
+Legacy commands:
+  compile  Compile PureScript modules to JavaScript (experimental).
+
+Documentation commands:
+  docs     Documentation utilities.
+
+Flags:
+      --log-file                         Print log path.
+      --query-log <LevelFilter>          Log level for the query engine.
+                                         [possible values: off, error, warn, info, debug, trace]
+                                         (default: off)
+      --checking-log <LevelFilter>       Log level for the type checker.
+                                         [possible values: off, error, warn, info, debug, trace]
+                                         (default: off)
+      --stdio
+      --lsp-log <LevelFilter>            Log level for the language server.
+                                         [possible values: off, error, warn, info, debug, trace]
+                                         (default: info)
+      --source-command <SOURCE_COMMAND>  Command to use to get source files.
+
+                                         This argument also disables the spago.lock integration.
+      --diagnostics-on-open <bool>       Publish diagnostics on textDocument/didOpen.
+                                         (default: true)
+      --diagnostics-on-save <bool>       Publish diagnostics on textDocument/didSave.
+                                         (default: true)
+      --diagnostics-on-change            Publish diagnostics on textDocument/didChange.
+  -h, --help                             Print help
+  -V, --version                          Print version
+--- stderr

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_run.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_run.snap
@@ -1,0 +1,28 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 0
+--- stdout
+Build and run a Spago package with Node.js.
+
+Usage: purescript-alexandrite run [FLAGS] [-- ARGUMENTS]…
+
+Arguments:
+  [-- ARGUMENTS]…  Arguments passed to the program.
+
+Flags:
+      --query-log <LevelFilter>     Log level for the query engine.
+                                    [possible values: off, error, warn, info, debug, trace]
+                                    (default: off)
+      --checking-log <LevelFilter>  Log level for the type checker.
+                                    [possible values: off, error, warn, info, debug, trace]
+                                    (default: off)
+  -p, --package <NAME>              Workspace package to build.
+  -o, --output <DIR>                Output directory for compiled modules. Defaults to output in the workspace root.
+  -q, --quiet                       Suppress build progress output.
+      --color <COLOR>               When to use colors in human-readable diagnostics.
+                                    [possible values: auto, always, never]
+                                    (default: auto)
+      --main <MODULE>               Module containing the program entry point.
+  -h, --help                        Print help
+--- stderr

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_test.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_test.snap
@@ -1,0 +1,28 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 0
+--- stdout
+Build and test one or more Spago packages with Node.js.
+
+Usage: purescript-alexandrite test [FLAGS] [-- ARGUMENTS]…
+
+Arguments:
+  [-- ARGUMENTS]…  Arguments passed to each test program.
+
+Flags:
+      --query-log <LevelFilter>     Log level for the query engine.
+                                    [possible values: off, error, warn, info, debug, trace]
+                                    (default: off)
+      --checking-log <LevelFilter>  Log level for the type checker.
+                                    [possible values: off, error, warn, info, debug, trace]
+                                    (default: off)
+  -p, --package <NAME>              Workspace package to build.
+  -o, --output <DIR>                Output directory for compiled modules. Defaults to output in the workspace root.
+  -q, --quiet                       Suppress build progress output.
+      --color <COLOR>               When to use colors in human-readable diagnostics.
+                                    [possible values: auto, always, never]
+                                    (default: auto)
+      --main <MODULE>               Module containing the test entry point.
+  -h, --help                        Print help
+--- stderr

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_watch.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_watch.snap
@@ -1,0 +1,24 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 0
+--- stdout
+Build a Spago workspace or package and rebuild when inputs change.
+
+Usage: purescript-alexandrite watch [FLAGS]
+
+Flags:
+      --query-log <LevelFilter>     Log level for the query engine.
+                                    [possible values: off, error, warn, info, debug, trace]
+                                    (default: off)
+      --checking-log <LevelFilter>  Log level for the type checker.
+                                    [possible values: off, error, warn, info, debug, trace]
+                                    (default: off)
+  -p, --package <NAME>              Workspace package to build.
+  -o, --output <DIR>                Output directory for compiled modules. Defaults to output in the workspace root.
+  -q, --quiet                       Suppress build progress output.
+      --color <COLOR>               When to use colors in human-readable diagnostics.
+                                    [possible values: auto, always, never]
+                                    (default: auto)
+  -h, --help                        Print help
+--- stderr

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__lsp_open_rejects_invalid_value.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__lsp_open_rejects_invalid_value.snap
@@ -1,0 +1,9 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: invalid value 'yes' for '--diagnostics-on-open': provided string was not `true` or `false`
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__lsp_open_requires_value.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__lsp_open_requires_value.snap
@@ -1,0 +1,9 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: a value is required for '--diagnostics-on-open <bool>' but none was supplied
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__lsp_save_rejects_invalid_value.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__lsp_save_rejects_invalid_value.snap
@@ -1,0 +1,9 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: invalid value 'yes' for '--diagnostics-on-save': provided string was not `true` or `false`
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__lsp_save_requires_value.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__lsp_save_requires_value.snap
@@ -1,0 +1,9 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: a value is required for '--diagnostics-on-save <bool>' but none was supplied
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__run_requires_separator.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__run_requires_separator.snap
@@ -1,0 +1,11 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: '[-- ARGUMENTS]…' can only be given after '--'
+
+Usage: purescript-alexandrite run [FLAGS] [-- ARGUMENTS]…
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__test_requires_separator.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__test_requires_separator.snap
@@ -1,0 +1,11 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: '[-- ARGUMENTS]…' can only be given after '--'
+
+Usage: purescript-alexandrite test [FLAGS] [-- ARGUMENTS]…
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__unknown_build_flag.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__unknown_build_flag.snap
@@ -1,0 +1,11 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: unexpected argument '--unknown' found
+
+Usage: purescript-alexandrite build [FLAGS]
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__unknown_compile_flag.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__unknown_compile_flag.snap
@@ -1,0 +1,11 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: unexpected argument '--unknown' found
+
+Usage: purescript-alexandrite compile [FLAGS] [INPUT]…
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__unknown_docs_flag.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__unknown_docs_flag.snap
@@ -1,0 +1,11 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: unexpected argument '--unknown' found
+
+Usage: purescript-alexandrite docs [FLAGS] [SUBCOMMAND]
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__unknown_root_flag.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__unknown_root_flag.snap
@@ -1,0 +1,11 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: unexpected argument '--unknown' found
+
+Usage: purescript-alexandrite [FLAGS] [SUBCOMMAND]
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__unknown_typescript_flag.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__unknown_typescript_flag.snap
@@ -1,0 +1,11 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+error: unexpected argument '--unknown' found
+
+Usage: purescript-alexandrite docs typescript [--output <DIR>]
+
+For more information, try '--help'.

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__version.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__version.snap
@@ -1,0 +1,7 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 0
+--- stdout
+purescript-alexandrite 0.1.0
+--- stderr

--- a/tests-e2e/tests/package_manager/support.rs
+++ b/tests-e2e/tests/package_manager/support.rs
@@ -73,6 +73,7 @@ impl TestWorkspace {
             .env("ALEXANDRITE_SPAGO", env!("CARGO_BIN_EXE_spago-e2e"))
             .env("ALEXANDRITE_E2E_SPAGO", spago_executable())
             .env("ALEXANDRITE_E2E_SPAGO_LOG", self.path().join("spago-calls"))
+            .env("COLUMNS", "120")
             .env("NO_COLOR", "1");
         command
     }


### PR DESCRIPTION
## Summary

Closes #485.

- Replace clap with usage-rs 6.8.0 and rename the root parser to Program.
- Preserve strict argument validation, default LSP dispatch, OS-native path normalization, and resilient build selection.
- Group help into project, legacy, and documentation commands, and declare named log-level choices.
- Add process-level CLI regression coverage. Snapshots omit expression metadata and use COLUMNS=120 only in the test harness; runtime help retains usage’s default width behavior.

## Performance

Local Linux x86-64 orb measurements using release builds:

| Parsing case | clap | usage |
| --- | ---: | ---: |
| Default LSP (--stdio) | 34.322 µs | 0.438 µs |
| Build with package and resilience | 42.469 µs | 0.812 µs |
| Compile with quiet and input glob | 44.617 µs | 1.540 µs |

Medians of five alternating runs, each parsing 100,000 times. The usage measurement includes relocated path normalization. The parser entry points differ in argument representation: clap receives string references, usage receives preconverted OsStr references. These measurements preceded the later log-choice/help review refinements.

Warm full-process latency improved approximately 8% across help, version, and missing-input invocations (300 observations per binary). This is not a compiler-throughput claim.

## Verification

- Package-scoped cargo check for purescript-alexandrite and tests-e2e, including tests, passed.
- 72 compiler-bin tests passed during migration validation.
- All 24 end-to-end tests passed on the final implementation.
- Inspected regenerated help and diagnostic snapshots; verified non-UTF-8 output paths and log-choice rejection.
- Verified the curated commits preserve the final tree exactly.

## Release caveat

The regenerated third-party inventory identifies the usage crates as MIT, but their published packages do not include license text discoverable by the generator, so those entries contain NOT FOUND. This remains unchanged by the commit curation.

## Amp thread

https://ampcode.com/threads/T-01a08447-b289-7131-9aa9-99212303a57e