### PR TITLE
[compiler-bin] Detect terminal width for CLI help

### DIFF
--- a/compiler-bin/src/bin/purescript-alexandrite.rs
+++ b/compiler-bin/src/bin/purescript-alexandrite.rs
@@ -1,3 +1,6 @@
 fn main() {
+    // SAFETY: Startup is single-threaded; no worker threads have been started.
+    unsafe { purescript_alexandrite::cli::initialize_terminal_width() };
+
     purescript_alexandrite::run();
 }

--- a/compiler-bin/src/bin/purescript-analyzer.rs
+++ b/compiler-bin/src/bin/purescript-analyzer.rs
@@ -1,4 +1,7 @@
 fn main() {
+    // SAFETY: Startup is single-threaded; no worker threads have been started.
+    unsafe { purescript_alexandrite::cli::initialize_terminal_width() };
+
     eprintln!(
         "warning: `purescript-analyzer` is deprecated; use `purescript-alexandrite` instead.",
     );

--- a/compiler-bin/src/cli.rs
+++ b/compiler-bin/src/cli.rs
@@ -6,6 +6,20 @@ use path_absolutize::Absolutize;
 use tracing::level_filters::LevelFilter;
 use usage::{Args, Subcommands, ValueEnum};
 
+/// Supply the terminal width to help rendering unless explicitly overridden.
+///
+/// # Safety
+///
+/// Call only during single-threaded startup, before starting any worker threads.
+pub unsafe fn initialize_terminal_width() {
+    if std::env::var_os("COLUMNS").is_none()
+        && let Some((_, columns)) = console::Term::stdout().size_checked()
+    {
+        // SAFETY: The caller guarantees single-threaded startup.
+        unsafe { std::env::set_var("COLUMNS", columns.to_string()) };
+    }
+}
+
 fn absolute_path(value: PathBuf) -> io::Result<PathBuf> {
     value.absolutize().map(Cow::into_owned)
 }


### PR DESCRIPTION
## Summary
- Populate COLUMNS from native stdout terminal dimensions when no explicit override exists, allowing usage-rs help to follow the terminal width.
- Share the startup logic through an unsafe CLI utility with a documented single-threaded contract, called by both executable entry points.
- Preserve redirected-output fallback and existing snapshot width overrides. Child processes inherit the detected startup width.

## Verification
- `just format`
- `cargo check -p purescript-alexandrite --tests`
- `cargo build -p purescript-alexandrite --bins` before utility extraction
- Linux pseudo-terminal checks before extraction: both binaries, root and compile help, 60/193-column native sizing, explicit override precedence, and redirected 80-column fallback
- Package check and diff checks passed after extraction; Oracle review found no blockers. macOS was not tested.

## Context
https://ampcode.com/threads/T-01a08559-1885-736b-9232-d275873c4003