### PR TITLE
[ci] Add parallel Linux and macOS Buildkite checks

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -19,6 +19,14 @@ mise ls --current
 repository_root="$PWD"
 profile_marker="# Alexandrite mise environment: $repository_root"
 if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile" 2>/dev/null; then
+  if [[ ! -e "$HOME/.bash_profile" ]]; then
+    # Creating .bash_profile must not hide the previously selected login file.
+    if [[ -r "$HOME/.bash_login" ]]; then
+      printf '%s\n' '[[ ! -r "$HOME/.bash_login" ]] || . "$HOME/.bash_login"' >> "$HOME/.bash_profile"
+    else
+      printf '%s\n' '[[ ! -r "$HOME/.profile" ]] || . "$HOME/.profile"' >> "$HOME/.bash_profile"
+    fi
+  fi
   cat >> "$HOME/.bash_profile" <<EOF
 
 $profile_marker

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,65 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-step() {
-  local label="$1" started=$SECONDS
-  shift
-  printf '\n==> %s\n' "$label"
-  "$@"
-  printf '%s completed in %ss\n' "$label" "$((SECONDS - started))"
-}
-
-export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
-
-if ! command -v rustup >/dev/null 2>&1; then
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+mise_version=2026.9.3
+export PATH="$HOME/.local/bin:$PATH"
+if [[ "$("$HOME/.local/bin/mise" version 2>/dev/null | cut -d' ' -f1 || true)" != "$mise_version" ]]; then
+  echo '--- Installing mise'
+  curl --proto '=https' --tlsv1.2 -fsSL https://mise.run \
+    | MISE_VERSION="$mise_version" sh
 fi
 
-# Keep snapshot toolchains and Cargo caches; upgrade deliberately with rustup update.
-for toolchain in stable nightly; do
-  if ! rustup run "$toolchain" rustc --version >/dev/null 2>&1; then
-    step "Installing $toolchain Rust" rustup toolchain install "$toolchain" --profile minimal
-  fi
+echo '--- Installing configured development tools'
+mise trust mise.toml
+mise install --yes
+eval "$(mise env --shell bash)"
+mise ls --current
 
-  components=(rustfmt)
-  if [[ "$toolchain" == stable ]]; then
-    components+=(clippy)
-  fi
-  installed_components=$(rustup component list --toolchain "$toolchain" --installed)
-  for component in "${components[@]}"; do
-    if ! grep -Eq "^${component}(-|$)" <<< "$installed_components"; then
-      step "Installing $toolchain $component" rustup component add --toolchain "$toolchain" "$component"
-    fi
-  done
-done
+# Amp and supervised services start in fresh non-interactive login shells.
+repository_root="$PWD"
+profile_marker="# Alexandrite mise environment: $repository_root"
+if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile" 2>/dev/null; then
+  cat >> "$HOME/.bash_profile" <<EOF
 
-installed_targets=$(rustup target list --toolchain stable --installed)
-if ! grep -Fxq wasm32-unknown-unknown <<< "$installed_targets"; then
-  step 'Installing WASM target' rustup target add --toolchain stable wasm32-unknown-unknown
+$profile_marker
+if [[ "\${ALEXANDRITE_MISE_ACTIVATING:-}" != 1 && "\$PWD/" == "$repository_root/"* ]]; then
+  export ALEXANDRITE_MISE_ACTIVATING=1
+  eval "\$("$HOME/.local/bin/mise" env --shell bash)"
+  unset ALEXANDRITE_MISE_ACTIVATING
 fi
-
-if [[ "$(rustup default 2>/dev/null || true)" != stable-* ]]; then
-  step 'Selecting stable Rust' rustup default stable
-fi
-
-missing_tools=()
-for package in just cargo-nextest cargo-insta cargo-edit cargo-bundle-licenses; do
-  executable="$package"
-  if [[ "$package" == cargo-edit ]]; then
-    executable=cargo-set-version
-  fi
-  if ! command -v "$executable" >/dev/null 2>&1; then
-    missing_tools+=("$package")
-  fi
-done
-
-if ((${#missing_tools[@]})); then
-  if ! command -v cargo-binstall >/dev/null 2>&1; then
-    curl --proto '=https' --tlsv1.2 -LsSf \
-      https://raw.githubusercontent.com/cargo-bins/cargo-binstall/aaa84a43aec4955a42c5ffc65d258961e39f276e/install-from-binstall-release.sh \
-      | BINSTALL_VERSION=1.19.1 bash
-  fi
-  step 'Installing missing development tools' cargo binstall --no-confirm "${missing_tools[@]}"
+EOF
 fi
 
 printf '\nSetup complete in %ss.\n' "$SECONDS"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,7 @@ steps:
   - label: ":rust: Linux build and unit tests"
     key: build
     commands:
+      - source .buildkite/setup.sh
       - cargo build --workspace --locked
       - cargo nextest run --locked --no-fail-fast
       - cargo nextest run -p tests-support --locked --no-fail-fast
@@ -17,12 +18,16 @@ steps:
 
   - label: ":test_tube: Integration %N/%t"
     key: integration
-    command: bash .buildkite/test.sh integration
+    commands:
+      - source .buildkite/setup.sh
+      - bash .buildkite/test.sh integration
     parallelism: 8
     timeout_in_minutes: 30
 
   - label: ":terminal: End-to-end %N/%t"
     key: e2e
-    command: bash .buildkite/test.sh e2e
+    commands:
+      - source .buildkite/setup.sh
+      - bash .buildkite/test.sh e2e
     parallelism: 4
     timeout_in_minutes: 30

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,34 +7,86 @@ env:
   INSTA_UPDATE: "no"
 
 steps:
-  - label: ":rust: Build and unit tests ({{matrix}})"
-    key: build
-    matrix: &platforms
-      - linux-medium
-      - macos-26-medium
-    agents: &platform-agents
-      queue: "{{matrix}}"
-    commands:
+  - label: ":rust: Build and unit tests (Linux)"
+    key: build-linux
+    commands: &build-commands
       - source .buildkite/setup.sh
       - cargo build --workspace --locked
       - cargo nextest run --locked --no-fail-fast
       - cargo nextest run -p tests-support --locked --no-fail-fast
+    cache:
+      name: linux-x64-build-v1
+      paths: &cache-paths
+        - "~/.local/share/mise"
+        - "~/.cache/mise"
+        # Do not persist Cargo credentials or configuration alongside dependency caches.
+        - "~/.cargo/bin"
+        - "~/.cargo/registry"
+        - "~/.cargo/git"
+        - "~/.rustup"
+        - target
     timeout_in_minutes: 30
 
-  - label: ":test_tube: Integration ({{matrix}})"
-    key: integration
-    matrix: *platforms
-    agents: *platform-agents
-    commands:
+  - label: ":rust: Build and unit tests (macOS)"
+    key: build-macos
+    agents: &macos-agents
+      queue: macos-26-medium
+    commands: *build-commands
+    cache:
+      name: macos26-arm64-build-v1
+      paths: *cache-paths
+    timeout_in_minutes: 30
+
+  - label: ":test_tube: Integration (Linux)"
+    key: integration-linux
+    commands: &integration-commands
       - source .buildkite/setup.sh
       - bash .buildkite/test.sh integration
+    cache:
+      name: linux-x64-integration-v1
+      paths: *cache-paths
     timeout_in_minutes: 30
 
-  - label: ":terminal: End-to-end ({{matrix}})"
-    key: e2e
-    matrix: *platforms
-    agents: *platform-agents
-    commands:
+  - label: ":test_tube: Integration (macOS)"
+    key: integration-macos
+    agents: *macos-agents
+    commands: *integration-commands
+    cache:
+      name: macos26-arm64-integration-v1
+      paths: *cache-paths
+    timeout_in_minutes: 30
+
+  - label: ":terminal: End-to-end (Linux)"
+    key: e2e-linux
+    commands: &e2e-commands
       - source .buildkite/setup.sh
       - bash .buildkite/test.sh e2e
+    cache:
+      name: linux-x64-e2e-v1
+      paths:
+        - "~/.local/share/mise"
+        - "~/.cache/mise"
+        - "~/.cargo/bin"
+        - "~/.cargo/registry"
+        - "~/.cargo/git"
+        - "~/.rustup"
+        - target
+        - "~/.cache/spago-nodejs"
+    timeout_in_minutes: 30
+
+  - label: ":terminal: End-to-end (macOS)"
+    key: e2e-macos
+    agents: *macos-agents
+    commands: *e2e-commands
+    cache:
+      name: macos26-arm64-e2e-v1
+      paths:
+        - "~/.local/share/mise"
+        - "~/.cache/mise"
+        - "~/.cargo/bin"
+        - "~/.cargo/registry"
+        - "~/.cargo/git"
+        - "~/.rustup"
+        - target
+        - "~/Library/Caches/spago-nodejs"
     timeout_in_minutes: 30

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,8 +7,13 @@ env:
   INSTA_UPDATE: "no"
 
 steps:
-  - label: ":rust: Linux build and unit tests"
+  - label: ":rust: Build and unit tests ({{matrix}})"
     key: build
+    matrix: &platforms
+      - linux-medium
+      - macos-26-medium
+    agents: &platform-agents
+      queue: "{{matrix}}"
     commands:
       - source .buildkite/setup.sh
       - cargo build --workspace --locked
@@ -16,18 +21,20 @@ steps:
       - cargo nextest run -p tests-support --locked --no-fail-fast
     timeout_in_minutes: 30
 
-  - label: ":test_tube: Integration %N/%t"
+  - label: ":test_tube: Integration ({{matrix}})"
     key: integration
+    matrix: *platforms
+    agents: *platform-agents
     commands:
       - source .buildkite/setup.sh
       - bash .buildkite/test.sh integration
-    parallelism: 8
     timeout_in_minutes: 30
 
-  - label: ":terminal: End-to-end %N/%t"
+  - label: ":terminal: End-to-end ({{matrix}})"
     key: e2e
+    matrix: *platforms
+    agents: *platform-agents
     commands:
       - source .buildkite/setup.sh
       - bash .buildkite/test.sh e2e
-    parallelism: 4
     timeout_in_minutes: 30

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,28 @@
+agents:
+  queue: linux-medium
+
+env:
+  CI: "true"
+  CARGO_TERM_COLOR: always
+  INSTA_UPDATE: "no"
+
+steps:
+  - label: ":rust: Linux build and unit tests"
+    key: build
+    commands:
+      - cargo build --workspace --locked
+      - cargo nextest run --locked --no-fail-fast
+      - cargo nextest run -p tests-support --locked --no-fail-fast
+    timeout_in_minutes: 30
+
+  - label: ":test_tube: Integration %N/%t"
+    key: integration
+    command: bash .buildkite/test.sh integration
+    parallelism: 8
+    timeout_in_minutes: 30
+
+  - label: ":terminal: End-to-end %N/%t"
+    key: e2e
+    command: bash .buildkite/test.sh e2e
+    parallelism: 4
+    timeout_in_minutes: 30

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,8 @@ env:
 steps:
   - label: ":rust: Build and unit tests (Linux)"
     key: build-linux
+    agents:
+      queue: linux-large
     commands: &build-commands
       - source .buildkite/setup.sh
       - cargo build --workspace --locked
@@ -39,6 +41,8 @@ steps:
 
   - label: ":test_tube: Integration (Linux)"
     key: integration-linux
+    agents:
+      queue: linux-large
     commands: &integration-commands
       - source .buildkite/setup.sh
       - bash .buildkite/test.sh integration

--- a/.buildkite/setup.sh
+++ b/.buildkite/setup.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 echo '--- Installing native build dependencies'
 case "$(uname -s)" in
   Linux)
-    node_platform=linux
-    checksum_command=(sha256sum)
     privilege=()
     if ((EUID != 0)); then
       privilege=(sudo)
@@ -15,8 +13,6 @@ case "$(uname -s)" in
       build-essential ca-certificates curl pkg-config libssl-dev xz-utils
     ;;
   Darwin)
-    node_platform=darwin
-    checksum_command=(shasum -a 256)
     xcode-select -p
     brew install pkgconf openssl@3 xz
     ;;
@@ -25,31 +21,3 @@ esac
 
 echo '--- Installing repository development tools'
 source .agents/setup
-
-echo '--- Installing Node.js and pnpm'
-case "$(uname -m)" in
-  x86_64) node_architecture=x64 ;;
-  aarch64|arm64) node_architecture=arm64 ;;
-  *) echo 'Unsupported architecture for Node.js' >&2; exit 1 ;;
-esac
-
-tools_directory="$PWD/target/buildkite-tools"
-node_archive="node-v22.23.2-${node_platform}-${node_architecture}.tar.xz"
-mkdir -p "$tools_directory"
-curl --proto '=https' --tlsv1.2 -fsSL "https://nodejs.org/dist/v22.23.2/$node_archive" \
-  -o "$tools_directory/$node_archive"
-curl --proto '=https' --tlsv1.2 -fsSL https://nodejs.org/dist/v22.23.2/SHASUMS256.txt \
-  -o "$tools_directory/SHASUMS256.txt"
-node_checksum=$(awk -v archive="$node_archive" '$2 == archive {print $1}' "$tools_directory/SHASUMS256.txt")
-printf '%s  %s\n' "$node_checksum" "$tools_directory/$node_archive" | "${checksum_command[@]}" --check -
-tar -xJf "$tools_directory/$node_archive" -C "$tools_directory" --strip-components=1
-rm "$tools_directory/$node_archive" "$tools_directory/SHASUMS256.txt"
-
-export PATH="$tools_directory/bin:$PATH"
-npm install --global --prefix "$tools_directory" --no-audit --no-fund pnpm@12
-
-cargo --version
-cargo nextest --version
-just --version
-node --version
-pnpm --version

--- a/.buildkite/setup.sh
+++ b/.buildkite/setup.sh
@@ -2,13 +2,26 @@
 set -euo pipefail
 
 echo '--- Installing native build dependencies'
-privilege=()
-if ((EUID != 0)); then
-  privilege=(sudo)
-fi
-"${privilege[@]}" apt-get update
-"${privilege[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-  build-essential ca-certificates curl pkg-config libssl-dev xz-utils
+case "$(uname -s)" in
+  Linux)
+    node_platform=linux
+    checksum_command=(sha256sum)
+    privilege=()
+    if ((EUID != 0)); then
+      privilege=(sudo)
+    fi
+    "${privilege[@]}" apt-get update
+    "${privilege[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      build-essential ca-certificates curl pkg-config libssl-dev xz-utils
+    ;;
+  Darwin)
+    node_platform=darwin
+    checksum_command=(shasum -a 256)
+    xcode-select -p
+    brew install pkgconf openssl@3 xz
+    ;;
+  *) echo 'Unsupported operating system' >&2; exit 1 ;;
+esac
 
 echo '--- Installing repository development tools'
 source .agents/setup
@@ -16,19 +29,19 @@ source .agents/setup
 echo '--- Installing Node.js and pnpm'
 case "$(uname -m)" in
   x86_64) node_architecture=x64 ;;
-  aarch64) node_architecture=arm64 ;;
-  *) echo 'Unsupported Linux architecture for Node.js' >&2; exit 1 ;;
+  aarch64|arm64) node_architecture=arm64 ;;
+  *) echo 'Unsupported architecture for Node.js' >&2; exit 1 ;;
 esac
 
 tools_directory="$PWD/target/buildkite-tools"
-node_archive="node-v22.23.2-linux-${node_architecture}.tar.xz"
+node_archive="node-v22.23.2-${node_platform}-${node_architecture}.tar.xz"
 mkdir -p "$tools_directory"
 curl --proto '=https' --tlsv1.2 -fsSL "https://nodejs.org/dist/v22.23.2/$node_archive" \
   -o "$tools_directory/$node_archive"
 curl --proto '=https' --tlsv1.2 -fsSL https://nodejs.org/dist/v22.23.2/SHASUMS256.txt \
   -o "$tools_directory/SHASUMS256.txt"
 node_checksum=$(awk -v archive="$node_archive" '$2 == archive {print $1}' "$tools_directory/SHASUMS256.txt")
-printf '%s  %s\n' "$node_checksum" "$tools_directory/$node_archive" | sha256sum --check -
+printf '%s  %s\n' "$node_checksum" "$tools_directory/$node_archive" | "${checksum_command[@]}" --check -
 tar -xJf "$tools_directory/$node_archive" -C "$tools_directory" --strip-components=1
 rm "$tools_directory/$node_archive" "$tools_directory/SHASUMS256.txt"
 

--- a/.buildkite/setup.sh
+++ b/.buildkite/setup.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo '--- Installing native build dependencies'
+privilege=()
+if ((EUID != 0)); then
+  privilege=(sudo)
+fi
+"${privilege[@]}" apt-get update
+"${privilege[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  build-essential ca-certificates curl pkg-config libssl-dev xz-utils
+
+echo '--- Installing repository development tools'
+source .agents/setup
+
+echo '--- Installing Node.js and pnpm'
+case "$(uname -m)" in
+  x86_64) node_architecture=x64 ;;
+  aarch64) node_architecture=arm64 ;;
+  *) echo 'Unsupported Linux architecture for Node.js' >&2; exit 1 ;;
+esac
+
+tools_directory="$PWD/target/buildkite-tools"
+node_archive="node-v22.23.2-linux-${node_architecture}.tar.xz"
+mkdir -p "$tools_directory"
+curl --proto '=https' --tlsv1.2 -fsSL "https://nodejs.org/dist/v22.23.2/$node_archive" \
+  -o "$tools_directory/$node_archive"
+curl --proto '=https' --tlsv1.2 -fsSL https://nodejs.org/dist/v22.23.2/SHASUMS256.txt \
+  -o "$tools_directory/SHASUMS256.txt"
+node_checksum=$(awk -v archive="$node_archive" '$2 == archive {print $1}' "$tools_directory/SHASUMS256.txt")
+printf '%s  %s\n' "$node_checksum" "$tools_directory/$node_archive" | sha256sum --check -
+tar -xJf "$tools_directory/$node_archive" -C "$tools_directory" --strip-components=1
+rm "$tools_directory/$node_archive" "$tools_directory/SHASUMS256.txt"
+
+export PATH="$tools_directory/bin:$PATH"
+npm install --global --prefix "$tools_directory" --no-audit --no-fund pnpm@12
+
+cargo --version
+cargo nextest --version
+just --version
+node --version
+pnpm --version

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Buildkite indexes jobs from zero; nextest partitions start at one.
-partition="hash:$((BUILDKITE_PARALLEL_JOB + 1))/${BUILDKITE_PARALLEL_JOB_COUNT}"
+partition="hash:$((${BUILDKITE_PARALLEL_JOB:-0} + 1))/${BUILDKITE_PARALLEL_JOB_COUNT:-1}"
 
 case "${1:-}" in
   integration)

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Buildkite indexes jobs from zero; nextest partitions start at one.
+partition="hash:$((BUILDKITE_PARALLEL_JOB + 1))/${BUILDKITE_PARALLEL_JOB_COUNT}"
+
+case "${1:-}" in
+  integration)
+    just integration --locked --no-fail-fast --partition "$partition"
+    ;;
+  e2e)
+    just e2e-prepare
+    just e2e --locked --no-fail-fast --partition "$partition"
+    ;;
+  *)
+    echo "Usage: $0 integration|e2e" >&2
+    exit 1
+    ;;
+esac

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,18 @@
 
 Thank you for taking interest in contributing to Alexandrite.
 
+## Development tools
+
+[`mise.toml`](mise.toml) pins Rust, Node.js, pnpm, and the development CLIs.
+With [mise](https://mise.jdx.dev/) installed, run `mise trust` and `mise install`
+from the repository root, then use `mise exec -- just <recipe>` or activate mise
+in your shell. `just format` uses the pinned nightly toolchain in this environment.
+
+Amp orbs and Buildkite share `.agents/setup`, which bootstraps mise and installs
+these tools. Native prerequisites remain platform-managed: a C/C++ toolchain,
+pkg-config, OpenSSL development libraries, curl, and xz. Buildkite installs them
+through apt on Linux or Homebrew on macOS (with Xcode command-line tools present).
+
 ## Integration tests
 
 Run `just t compiler` (alias `just t c`) for the unified compiler integration

--- a/justfile
+++ b/justfile
@@ -65,7 +65,7 @@ prepare-release version:
 
 [doc("Format imports with module granularity")]
 @format *args="":
-  cargo +nightly fmt {{args}} -- --config imports_granularity=Module
+  cargo +"${ALEXANDRITE_NIGHTLY_TOOLCHAIN:-nightly}" fmt {{args}} -- --config imports_granularity=Module
 
 [doc("Regenerate the language server configuration JSON Schema")]
 @configuration-schema:

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,27 @@
+min_version = "2026.9.3"
+
+[vars]
+rust_nightly = "nightly-2026-09-09"
+
+[tools]
+node = "22.23.2"
+pnpm = "12.3.4"
+just = "1.58.0"
+cargo-binstall = "1.19.1"
+cargo-insta = "1.48.0"
+"cargo:cargo-nextest" = { version = "0.9.143", depends = ["cargo-binstall", "rust"] }
+"cargo:cargo-edit" = { version = "0.13.13", depends = ["cargo-binstall", "rust"] }
+"cargo:cargo-bundle-licenses" = { version = "4.2.0", depends = ["cargo-binstall", "rust"] }
+# Keep Cargo's global bin directory after the versioned tools on PATH.
+rust = [
+  { version = "1.98.1", profile = "minimal", components = ["clippy", "rustfmt"], targets = ["wasm32-unknown-unknown"] },
+  { version = "{{vars.rust_nightly}}", profile = "minimal", components = ["rustfmt"] },
+]
+
+[settings.cargo]
+binstall_quickinstall = true
+
+[env]
+ALEXANDRITE_NIGHTLY_TOOLCHAIN = "{{vars.rust_nightly}}"
+PNPM_CONFIG_STORE_DIR = "{{config_root}}/target/pnpm-store"
+PNPM_CONFIG_CACHE_DIR = "{{config_root}}/target/pnpm-cache"

--- a/mise.toml
+++ b/mise.toml
@@ -19,6 +19,11 @@ rust = [
 ]
 
 [settings.cargo]
+# Avoid source builds when publishers do not provide binaries by trusting the
+# third-party cargo-quickinstall builds, not just publisher release artifacts.
+# QuickInstall reports crate, version, target, installer user agent, and status
+# to cargo-quickinstall-stats-server.fly.dev. Set BINSTALL_DISABLE_TELEMETRY=true
+# in the calling environment to opt out of those installation statistics.
 binstall_quickinstall = true
 
 [env]

--- a/tests-e2e/tests/package_manager/build.rs
+++ b/tests-e2e/tests/package_manager/build.rs
@@ -11,6 +11,9 @@ fn diagnostic_settings(workspace: &TestWorkspace) -> insta::Settings {
     settings.add_filter(
         concat!(
             r"(?m)^(?:Reading Spago workspace configuration\.\.\.",
+            r"|Refreshing the Registry Index\.\.\.",
+            r"|Cloning https://github\.com/purescript/registry-index\.git",
+            r"|Cloning https://github\.com/purescript/registry\.git",
             r"|✓ Selecting package to build: application",
             r#"|Adding dependency ranges to the config in "spago.yaml""#,
             r"|Downloading dependencies\.\.\.",


### PR DESCRIPTION
## Summary

Add Buildkite CI for workspace builds, unit tests, integration tests, and end-to-end tests on Linux and macOS. Split each platform into three independently scheduled jobs; use Linux Large agents for build/unit and integration work while keeping E2E and macOS on Medium. Coverage and coverage upload remain outside this pipeline.

Use mise to pin development tools and share the bootstrap through `.agents/setup`, with platform-native dependencies installed by `.buildkite/setup.sh`. Add separate per-platform, per-job cache volumes for toolchains, Cargo dependencies/build output, pnpm packages, and Spago data. Keep the existing GitHub Actions workflow intact.

Normalize Spago registry initialization progress in the E2E diagnostic snapshot filter so a cold cache does not produce an unrelated snapshot failure. Document mise usage in CONTRIBUTING.md; the local Buildkite README is intentionally excluded.

## Verification

- Clean and restored-cache Docker runs using the Buildkite Linux base image: 902 integration tests and 24 E2E tests passed in each run.
- Docker workspace build, 682 unit tests, and 11 tests-support tests passed.
- Restored pnpm cache reused 147 packages with zero downloads after checkout relocation.
- Shell syntax, Rust formatting, and strict Buildkite pipeline dry-run passed for the initial pipeline; the subsequent Large-agent routing change was verified by the hosted run.
- Latest hosted run: https://buildkite.com/justin-garcia/purescript-alexandrite/builds/9 — all six Linux/macOS jobs passed.
- Latest Linux wall time was about 1m 11s from first job start to final job completion. Both upgraded jobs had warm caches, so this is not an isolated CPU-size benchmark.

## Cache behavior

Hosted cache volumes are best-effort, not deterministic key-based storage. Reruns verified real cache reuse on both platforms, but also empty-volume misses despite unchanged names. The pipeline remains functional with cold caches; native key-based Buildkite Cache requires separate private-preview access.

## Agent thread

https://ampcode.com/threads/T-01a08642-0ffd-7445-90d4-6c8452988c67