### PR TITLE
[meta] Fix workspace Clippy lints

### DIFF
--- a/compiler-backend/javascript/src/convert/generator/names.rs
+++ b/compiler-backend/javascript/src/convert/generator/names.rs
@@ -141,7 +141,7 @@ mod tests {
     use super::NameAllocator;
 
     fn reserved(names: &[&str]) -> Arc<FxHashSet<SmolStr>> {
-        Arc::new(names.iter().map(|name| SmolStr::new(name)).collect())
+        Arc::new(names.iter().map(SmolStr::new).collect())
     }
 
     #[test]

--- a/compiler-bin/src/compile.rs
+++ b/compiler-bin/src/compile.rs
@@ -94,16 +94,14 @@ fn compile(config: CompileConfig) -> Result<(), CompileError> {
         source_paths.extend(package::source_files(&current_directory, package)?);
     }
 
-    compile_source_paths(
-        &current_directory,
-        &config.output,
-        source_paths,
-        config.quiet,
-        config.color,
-        Resilience::Strict,
-        started,
-        preparation_progress,
-    )
+    let build_config = BuildConfig {
+        output: &config.output,
+        current_directory: &current_directory,
+        color: use_color(config.color),
+        progress: !config.quiet,
+        resilience: Resilience::Strict,
+    };
+    compile_source_paths(&build_config, source_paths, started, preparation_progress)
 }
 
 pub(crate) fn compile_inputs(
@@ -118,25 +116,20 @@ pub(crate) fn compile_inputs(
     let preparation_progress = progress::bar(1, "Preparing", !quiet);
     let walked = walk::walk(root, inputs)?;
     let source_paths = walked.files.into_iter().collect::<BTreeSet<_>>();
-    compile_source_paths(
-        root,
+
+    let build_config = BuildConfig {
         output,
-        source_paths,
-        quiet,
-        color,
+        current_directory: root,
+        color: use_color(color),
+        progress: !quiet,
         resilience,
-        started,
-        preparation_progress,
-    )
+    };
+    compile_source_paths(&build_config, source_paths, started, preparation_progress)
 }
 
 fn compile_source_paths(
-    current_directory: &Path,
-    output: &Path,
+    config: &BuildConfig<'_>,
     source_paths: BTreeSet<PathBuf>,
-    quiet: bool,
-    color: ColorChoice,
-    resilience: Resilience,
     started: Instant,
     preparation_progress: indicatif::ProgressBar,
 ) -> Result<(), CompileError> {
@@ -153,18 +146,11 @@ fn compile_source_paths(
         return Err(io::Error::new(io::ErrorKind::NotFound, "no input files found").into());
     }
 
-    let build_config = BuildConfig {
-        output,
-        current_directory,
-        color: use_color(color),
-        progress: !quiet,
-        resilience,
-    };
-    if matches!(build(&compilation, &build_config)?, BuildOutcome::Diagnostics) {
+    if matches!(build(&compilation, config)?, BuildOutcome::Diagnostics) {
         return Err(CompileError::Diagnostics);
     }
 
-    if !quiet {
+    if config.progress {
         progress::report_completion(started.elapsed());
     }
 

--- a/compiler-frontend/checking/src/core/constraint/compiler/prim_symbol.rs
+++ b/compiler-frontend/checking/src/core/constraint/compiler/prim_symbol.rs
@@ -28,7 +28,7 @@ where
 
     let matched = match (left_symbol, right_symbol, appended_symbol) {
         (Some(left_value), Some(right_value), _) => {
-            let result = intern_symbol_literal(context, left_value.append(&right_value));
+            let result = intern_symbol_literal(context, left_value.append(right_value));
             match_equality(state, context, appended, result)?
         }
         (_, Some(right_value), Some(appended_value)) => {
@@ -82,7 +82,7 @@ where
         return Ok(Some(matching::blocking_constraint(state, context, &[right])?));
     };
 
-    let result = match left_symbol.cmp(&right_symbol) {
+    let result = match left_symbol.cmp(right_symbol) {
         Ordering::Less => context.prim_ordering.lt,
         Ordering::Equal => context.prim_ordering.eq,
         Ordering::Greater => context.prim_ordering.gt,

--- a/compiler-frontend/checking/src/core/constraint/compiler/prim_type_error.rs
+++ b/compiler-frontend/checking/src/core/constraint/compiler/prim_type_error.rs
@@ -35,7 +35,7 @@ where
     if let Type::String(_, value) = context.lookup_type(id) {
         let text = value
             .to_utf8()
-            .unwrap_or_else(|_| lowering::literal::encode_normal_string_content(&value));
+            .unwrap_or_else(|_| lowering::literal::encode_normal_string_content(value));
         Ok(Some(SmolStr::from(text)))
     } else {
         Ok(None)

--- a/compiler-frontend/checking/src/core/constraint/matching.rs
+++ b/compiler-frontend/checking/src/core/constraint/matching.rs
@@ -92,12 +92,12 @@ where
         }
 
         (Type::Rigid(left, _, _), Type::Rigid(right, _, _))
-            if !pattern.contains(&left) && !pattern.contains(&right) && left == right =>
+            if !pattern.contains(left) && !pattern.contains(right) && left == right =>
         {
             Ok(MatchType::Match { bindings: vec![] })
         }
 
-        (_, Type::Rigid(right, _, _)) if pattern.contains(&right) => {
+        (_, Type::Rigid(right, _, _)) if pattern.contains(right) => {
             Ok(MatchType::Match { bindings: vec![(*right, left)] })
         }
 
@@ -105,7 +105,7 @@ where
             Ok(MatchType::Stuck { stuck: vec![*unification], skolem: false })
         }
 
-        (Type::Rigid(name, _, _), _) | (_, Type::Rigid(name, _, _)) if !pattern.contains(&name) => {
+        (Type::Rigid(name, _, _), _) | (_, Type::Rigid(name, _, _)) if !pattern.contains(name) => {
             Ok(MatchType::Stuck { stuck: vec![], skolem: true })
         }
 

--- a/compiler-frontend/checking/src/core/unification.rs
+++ b/compiler-frontend/checking/src/core/unification.rs
@@ -725,7 +725,7 @@ where
             }
 
             Type::Rigid(name, rigid_depth, kind) => {
-                if promote.names.contains(&name) {
+                if promote.names.contains(name) {
                     check(promote, state, context, *kind)
                 } else if *rigid_depth > promote.depth {
                     Ok(PromoteResult::SkolemEscape)
@@ -794,7 +794,7 @@ where
     let t1_row = context.lookup_row_type(t1);
     let t2_row = context.lookup_row_type(t2);
 
-    let (left_only, right_only, ok) = partition_row_fields(state, context, &t1_row, &t2_row)?;
+    let (left_only, right_only, ok) = partition_row_fields(state, context, t1_row, t2_row)?;
 
     if !ok {
         return Ok(false);
@@ -846,8 +846,8 @@ where
     let (left_only, right_only, ok) = partition_row_fields_with(
         state,
         context,
-        &t1_row,
-        &t2_row,
+        t1_row,
+        t2_row,
         |state, context, left, right| subtype_with::<P, Q>(state, context, left, right),
     )?;
 

--- a/compiler-frontend/checking/src/core/walk.rs
+++ b/compiler-frontend/checking/src/core/walk.rs
@@ -37,7 +37,7 @@ where
     let id = normalise::normalise(state, context, id);
     let t = context.lookup_type(id);
 
-    if let WalkAction::Stop = walker.visit(state, context, id, &t)? {
+    if let WalkAction::Stop = walker.visit(state, context, id, t)? {
         return Ok(());
     }
 


### PR DESCRIPTION
## Purpose
Clear the 15 Clippy lints reported across workspace targets without suppressions or intended behavior changes. The CLI compile helper now receives the existing BuildConfig instead of forwarding its fields individually; the remaining fixes remove redundant borrows and a redundant closure.

## Verification
- `cargo clippy --workspace --all-targets -- -D warnings` passes (the compatibility build script still emits its existing corpus-preparation reminder).
- `cargo check -p checking -p javascript -p purescript-alexandrite --tests` passes.
- `cargo nextest run -p checking -p javascript -p purescript-alexandrite`: 121 passed.
- Targeted package-manager build/run end-to-end tests: 6 passed, including custom output paths and strict/resilient diagnostics.
- Legacy compile smoke test: quiet output, custom output directory, and all seven exported literal values verified.
- `just format --check` and `git diff --check` pass.

Amp thread: https://ampcode.com/threads/T-01a089ee-b038-735a-b96c-9e89d29cc8bd