### PR TITLE
[lsp] Require explicit language server invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ definition, hover information, find references, workspace symbol search, and dia
 
 ## Language server configuration
 
-Run `iris lsp --stdio` (or `iris --stdio`) to start the language server.
+Run `iris lsp --stdio` to start the language server. The `lsp` subcommand is required;
+`iris` alone no longer starts the server, and language-server options must follow `lsp`.
 Supply startup settings as inline JSON or a UTF-8 JSON file:
 
 ```sh

--- a/compiler-bin/src/cli.rs
+++ b/compiler-bin/src/cli.rs
@@ -40,15 +40,13 @@ pub struct Program {
     /// Print log path.
     #[usage(long)]
     pub log_file: bool,
-    #[usage(flatten)]
-    pub lsp: LspOptions,
     #[usage(subcommand)]
-    pub command: Option<Command>,
+    pub command: Command,
 }
 
 impl Program {
     pub fn into_command(self) -> io::Result<Command> {
-        let mut command = self.command.unwrap_or(Command::Lsp(self.lsp));
+        let mut command = self.command;
         match &mut command {
             Command::Build(options) => options.build.normalize_paths()?,
             Command::Watch(options) => options.normalize_paths()?,
@@ -416,16 +414,6 @@ mod tests {
         usage::diagnostic::report(Program::spec(), &argv[1..], &error).code
     }
 
-    fn lsp(args: &[&str]) -> LspOptions {
-        let mut argv = vec!["iris"];
-        argv.extend(args);
-        let program = parse(argv);
-        match program.into_command().unwrap() {
-            Command::Lsp(options) => options,
-            _ => unreachable!("parsed command was not `lsp`"),
-        }
-    }
-
     fn docs(args: &[&str]) -> DocsOptions {
         let mut argv = vec!["iris", "docs"];
         argv.extend(args);
@@ -491,15 +479,6 @@ mod tests {
 
     fn current_directory_path(path: impl AsRef<Path>) -> PathBuf {
         current_directory().join(path)
-    }
-
-    #[test]
-    fn lsp_is_the_default_command() {
-        let options = lsp(&["--stdio"]);
-
-        assert!(options.stdio);
-        assert!(options.config.is_none());
-        assert!(options.config_file.is_none());
     }
 
     #[test]

--- a/tests-e2e/tests/package_manager/cli.rs
+++ b/tests-e2e/tests/package_manager/cli.rs
@@ -89,7 +89,7 @@ fn rejects_unknown_flags_and_duplicate_scalar_options() {
     let workspace = TestWorkspace::empty();
     let cases: &[(&str, &[&str])] = &[
         ("unknown_root_flag", &["--unknown"]),
-        ("duplicate_root_scalar", &["--config", "{}", "--config", "null"]),
+        ("duplicate_lsp_scalar", &["lsp", "--config", "{}", "--config", "null"]),
         ("unknown_build_flag", &["build", "--unknown"]),
         ("duplicate_build_scalar", &["build", "--package", "one", "--package", "two"]),
         ("unknown_compile_flag", &["compile", "--unknown", "Main.purs"]),
@@ -122,6 +122,8 @@ fn rejects_unknown_flags_and_duplicate_scalar_options() {
 fn rejects_missing_required_arguments() {
     let workspace = TestWorkspace::empty();
     let cases: &[(&str, &[&str])] = &[
+        ("root_requires_subcommand", &[]),
+        ("log_file_requires_subcommand", &["--log-file"]),
         ("add_requires_dependencies", &["add"]),
         ("compile_requires_input_or_package", &["compile"]),
         ("compile_package_requires_value", &["compile", "--package"]),
@@ -133,6 +135,27 @@ fn rejects_missing_required_arguments() {
     for (name, arguments) in cases {
         let output = workspace.command(arguments);
         assert!(!output.status.success(), "{name} unexpectedly succeeded");
+        snapshot_output(name, &output);
+    }
+}
+
+#[test]
+fn lsp_options_require_the_explicit_subcommand() {
+    let workspace = TestWorkspace::empty();
+    let cases: &[(&str, &[&str])] = &[
+        ("root_stdio", &["--stdio"]),
+        ("root_stdio_before_lsp", &["--stdio", "lsp"]),
+        ("root_lsp_log", &["--lsp-log", "off", "lsp"]),
+        ("root_query_log", &["--query-log", "off", "lsp"]),
+        ("root_checking_log", &["--checking-log", "off", "lsp"]),
+        ("root_config", &["--config", "{}", "lsp"]),
+        ("root_config_file", &["--config-file", "missing.json", "lsp"]),
+    ];
+
+    for (name, arguments) in cases {
+        let output = workspace.command(arguments);
+        assert_eq!(output.status.code(), Some(2), "{name}");
+        assert!(output.stdout.is_empty(), "{name} wrote stdout");
         snapshot_output(name, &output);
     }
 }
@@ -154,18 +177,18 @@ fn run_and_test_require_separator_before_trailing_arguments() {
 fn lsp_configuration_options_reject_invalid_arguments() {
     let workspace = TestWorkspace::empty();
     let cases: &[(&str, &[&str])] = &[
-        ("config_requires_value", &["--config"]),
+        ("config_requires_value", &["lsp", "--config"]),
         ("config_file_requires_value", &["lsp", "--config-file"]),
-        ("config_conflicts_with_file", &["--config", "{}", "--config-file", "missing.json"]),
+        ("config_conflicts_with_file", &["lsp", "--config", "{}", "--config-file", "missing.json"]),
         (
             "config_file_conflicts_with_literal",
             &["lsp", "--config-file", "missing.json", "--config", "{}"],
         ),
         ("duplicate_config_file", &["lsp", "--config-file", "one", "--config-file", "two"]),
         ("removed_source_command", &["lsp", "--source-command", "custom"]),
-        ("removed_diagnostics_on_open", &["--diagnostics-on-open", "false"]),
+        ("removed_diagnostics_on_open", &["lsp", "--diagnostics-on-open", "false"]),
         ("removed_diagnostics_on_save", &["lsp", "--diagnostics-on-save", "false"]),
-        ("removed_diagnostics_on_change", &["--diagnostics-on-change"]),
+        ("removed_diagnostics_on_change", &["lsp", "--diagnostics-on-change"]),
     ];
 
     for (name, arguments) in cases {
@@ -229,7 +252,7 @@ fn lsp_rejects_invalid_json_configuration_before_starting() {
     for (name, content) in cases {
         workspace.write("config/settings.json", content);
         for (transport, arguments) in [
-            ("inline", vec!["--config", content]),
+            ("inline", vec!["lsp", "--config", content]),
             ("file", vec!["lsp", "--config-file", "config/settings.json"]),
         ] {
             let output = workspace.command(&arguments);

--- a/tests-e2e/tests/package_manager/lsp.rs
+++ b/tests-e2e/tests/package_manager/lsp.rs
@@ -169,9 +169,9 @@ fn empty_configuration_preserves_spago_and_default_diagnostics() {
     workspace.write("config/empty.json", "{}");
 
     let cases: &[&[&str]] = &[
-        &[],
+        &["lsp"],
         &["lsp", "--config", "null"],
-        &["--config-file", "config/empty.json"],
+        &["lsp", "--config-file", "config/empty.json"],
         &[
             "lsp",
             "--config",
@@ -211,9 +211,9 @@ console.log("selected/*.purs");
     let absolute_path = workspace.path().join("settings/server config.json");
     let root = workspace.path().join("project");
     let cases: &[&[&str]] = &[
-        &["--config", &configuration],
+        &["lsp", "--config", &configuration],
         &["lsp", "--config-file", "../settings/server config.json"],
-        &["--config-file", absolute_path.to_str().unwrap()],
+        &["lsp", "--config-file", absolute_path.to_str().unwrap()],
     ];
     for arguments in cases {
         workspace.write("settings/server config.json", &configuration);

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__config_conflicts_with_file.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__config_conflicts_with_file.snap
@@ -9,10 +9,10 @@ Error! · [conflicting_flags] · command line:1:1
   │
   • the argument '--config' cannot be used with '--config-file'
   │
-  │ Usage: iris [FLAGS] [SUBCOMMAND]
+  │ Usage: iris lsp [FLAGS]
   │
   │ For more information, try '--help'.
   │
-  │   iris --config {} --config-file missing.json
-  │   ╰──────────────────────────────────────────
+  │   iris lsp --config {} --config-file missing.json
+  │   ╰──────────────────────────────────────────────
   •

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__config_requires_value.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__config_requires_value.snap
@@ -4,13 +4,13 @@ source: tests-e2e/tests/package_manager/cli.rs
 status: 2
 --- stdout
 --- stderr
-Error! · [missing_flag_value] · command line:1:6
+Error! · [missing_flag_value] · command line:1:10
   •
   │
   • a value is required for '--config <JSON>' but none was supplied
   │
   │ For more information, try '--help'.
   │
-  │   iris --config
-  │        ╰───────
+  │   iris lsp --config
+  │            ╰───────
   •

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__duplicate_lsp_scalar.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__duplicate_lsp_scalar.snap
@@ -9,10 +9,10 @@ Error! · [duplicate_flag] · command line:1:1
   │
   • the argument '--config' cannot be used multiple times
   │
-  │ Usage: iris [FLAGS] [SUBCOMMAND]
+  │ Usage: iris lsp [FLAGS]
   │
   │ For more information, try '--help'.
   │
-  │   iris --config {} --config null
-  │   ╰─────────────────────────────
+  │   iris lsp --config {} --config null
+  │   ╰─────────────────────────────────
   •

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_root.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__help_root.snap
@@ -6,7 +6,7 @@ status: 0
 iris 0.1.0
 Language implementation for the PureScript programming language.
 
-Usage: iris [FLAGS] [SUBCOMMAND]
+Usage: iris [--log-file] <SUBCOMMAND>
 
 Commands:
   help     Print this message or the help of the given subcommand(s)
@@ -27,19 +27,7 @@ Documentation commands:
   docs     Documentation utilities.
 
 Flags:
-      --log-file                    Print log path.
-      --query-log <LevelFilter>     Log level for the query engine.
-                                    [possible values: off, error, warn, info, debug, trace]
-                                    (default: off)
-      --checking-log <LevelFilter>  Log level for the type checker.
-                                    [possible values: off, error, warn, info, debug, trace]
-                                    (default: off)
-      --stdio
-      --lsp-log <LevelFilter>       Log level for the language server.
-                                    [possible values: off, error, warn, info, debug, trace]
-                                    (default: info)
-      --config <JSON>               Language server configuration as a JSON object, read once at startup.
-      --config-file <PATH>          Language server configuration file, relative to the working directory.
-  -h, --help                        Print help
-  -V, --version                     Print version
+      --log-file  Print log path.
+  -h, --help      Print help
+  -V, --version   Print version
 --- stderr

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__log_file_requires_subcommand.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__log_file_requires_subcommand.snap
@@ -1,0 +1,40 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+Error! · [missing_subcommand] · command line:1:1
+  •
+  │
+  • iris 0.1.0
+  │ Language implementation for the PureScript programming language.
+  │
+  │ Usage: iris [--log-file] <SUBCOMMAND>
+  │
+  │ Commands:
+  │   help     Print this message or the help of the given subcommand(s)
+  │
+  │ Project commands:
+  │   add      Add dependencies to a Spago package.
+  │   build    Build a Spago workspace or package.
+  │   lsp      Run the language server.
+  │   new      Create a Spago project in the current directory.
+  │   run      Build and run a Spago package with Node.js.
+  │   test     Build and test one or more Spago packages with Node.js.
+  │   watch    Build a Spago workspace or package and rebuild when inputs change.
+  │
+  │ Legacy commands:
+  │   compile  Compile PureScript modules to JavaScript (experimental).
+  │
+  │ Documentation commands:
+  │   docs     Documentation utilities.
+  │
+  │ Flags:
+  │       --log-file  Print log path.
+  │   -h, --help      Print help
+  │   -V, --version   Print version
+  │
+  │   iris --log-file
+  │   ╰──────────────
+  •

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__removed_diagnostics_on_change.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__removed_diagnostics_on_change.snap
@@ -4,15 +4,15 @@ source: tests-e2e/tests/package_manager/cli.rs
 status: 2
 --- stdout
 --- stderr
-Error! · [unknown_flag] · command line:1:6
+Error! · [unknown_flag] · command line:1:10
   •
   │
   • unexpected argument '--diagnostics-on-change' found
   │
-  │ Usage: iris [FLAGS] [SUBCOMMAND]
+  │ Usage: iris lsp [FLAGS]
   │
   │ For more information, try '--help'.
   │
-  │   iris --diagnostics-on-change
-  │        ╰──────────────────────
+  │   iris lsp --diagnostics-on-change
+  │            ╰──────────────────────
   •

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__removed_diagnostics_on_open.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__removed_diagnostics_on_open.snap
@@ -4,15 +4,15 @@ source: tests-e2e/tests/package_manager/cli.rs
 status: 2
 --- stdout
 --- stderr
-Error! · [unknown_flag] · command line:1:6
+Error! · [unknown_flag] · command line:1:10
   •
   │
   • unexpected argument '--diagnostics-on-open' found
   │
-  │ Usage: iris [FLAGS] [SUBCOMMAND]
+  │ Usage: iris lsp [FLAGS]
   │
   │ For more information, try '--help'.
   │
-  │   iris --diagnostics-on-open false
-  │        ╰────────────────────
+  │   iris lsp --diagnostics-on-open false
+  │            ╰────────────────────
   •

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_checking_log.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_checking_log.snap
@@ -7,12 +7,12 @@ status: 2
 Error! · [unknown_flag] · command line:1:6
   •
   │
-  • unexpected argument '--unknown' found
+  • unexpected argument '--checking-log' found
   │
   │ Usage: iris [--log-file] <SUBCOMMAND>
   │
   │ For more information, try '--help'.
   │
-  │   iris --unknown
-  │        ╰────────
+  │   iris --checking-log off lsp
+  │        ╰─────────────
   •

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_config.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_config.snap
@@ -7,12 +7,12 @@ status: 2
 Error! · [unknown_flag] · command line:1:6
   •
   │
-  • unexpected argument '--unknown' found
+  • unexpected argument '--config' found
   │
   │ Usage: iris [--log-file] <SUBCOMMAND>
   │
   │ For more information, try '--help'.
   │
-  │   iris --unknown
-  │        ╰────────
+  │   iris --config {} lsp
+  │        ╰───────
   •

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_config_file.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_config_file.snap
@@ -7,12 +7,14 @@ status: 2
 Error! · [unknown_flag] · command line:1:6
   •
   │
-  • unexpected argument '--unknown' found
+  • unexpected argument '--config-file' found
+  │
+  │   tip: a similar argument exists: '--log-file'
   │
   │ Usage: iris [--log-file] <SUBCOMMAND>
   │
   │ For more information, try '--help'.
   │
-  │   iris --unknown
-  │        ╰────────
+  │   iris --config-file missing.json lsp
+  │        ╰────────────
   •

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_lsp_log.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_lsp_log.snap
@@ -7,12 +7,12 @@ status: 2
 Error! · [unknown_flag] · command line:1:6
   •
   │
-  • unexpected argument '--unknown' found
+  • unexpected argument '--lsp-log' found
   │
   │ Usage: iris [--log-file] <SUBCOMMAND>
   │
   │ For more information, try '--help'.
   │
-  │   iris --unknown
+  │   iris --lsp-log off lsp
   │        ╰────────
   •

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_query_log.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_query_log.snap
@@ -7,12 +7,12 @@ status: 2
 Error! · [unknown_flag] · command line:1:6
   •
   │
-  • unexpected argument '--unknown' found
+  • unexpected argument '--query-log' found
   │
   │ Usage: iris [--log-file] <SUBCOMMAND>
   │
   │ For more information, try '--help'.
   │
-  │   iris --unknown
-  │        ╰────────
+  │   iris --query-log off lsp
+  │        ╰──────────
   •

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_requires_subcommand.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_requires_subcommand.snap
@@ -1,0 +1,40 @@
+---
+source: tests-e2e/tests/package_manager/cli.rs
+---
+status: 2
+--- stdout
+--- stderr
+Error! · [missing_subcommand] · command line:1:1
+  •
+  │
+  • iris 0.1.0
+  │ Language implementation for the PureScript programming language.
+  │
+  │ Usage: iris [--log-file] <SUBCOMMAND>
+  │
+  │ Commands:
+  │   help     Print this message or the help of the given subcommand(s)
+  │
+  │ Project commands:
+  │   add      Add dependencies to a Spago package.
+  │   build    Build a Spago workspace or package.
+  │   lsp      Run the language server.
+  │   new      Create a Spago project in the current directory.
+  │   run      Build and run a Spago package with Node.js.
+  │   test     Build and test one or more Spago packages with Node.js.
+  │   watch    Build a Spago workspace or package and rebuild when inputs change.
+  │
+  │ Legacy commands:
+  │   compile  Compile PureScript modules to JavaScript (experimental).
+  │
+  │ Documentation commands:
+  │   docs     Documentation utilities.
+  │
+  │ Flags:
+  │       --log-file  Print log path.
+  │   -h, --help      Print help
+  │   -V, --version   Print version
+  │
+  │   iris
+  │   ╰───
+  •

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_stdio.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_stdio.snap
@@ -7,12 +7,12 @@ status: 2
 Error! · [unknown_flag] · command line:1:6
   •
   │
-  • unexpected argument '--unknown' found
+  • unexpected argument '--stdio' found
   │
   │ Usage: iris [--log-file] <SUBCOMMAND>
   │
   │ For more information, try '--help'.
   │
-  │   iris --unknown
-  │        ╰────────
+  │   iris --stdio
+  │        ╰──────
   •

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_stdio_before_lsp.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__root_stdio_before_lsp.snap
@@ -7,12 +7,12 @@ status: 2
 Error! · [unknown_flag] · command line:1:6
   •
   │
-  • unexpected argument '--unknown' found
+  • unexpected argument '--stdio' found
   │
   │ Usage: iris [--log-file] <SUBCOMMAND>
   │
   │ For more information, try '--help'.
   │
-  │   iris --unknown
-  │        ╰────────
+  │   iris --stdio lsp
+  │        ╰──────
   •

--- a/tests-e2e/tests/package_manager/snapshots/package_manager__cli__unicode_unknown_flag.snap
+++ b/tests-e2e/tests/package_manager/snapshots/package_manager__cli__unicode_unknown_flag.snap
@@ -9,7 +9,7 @@ Error! · [unknown_flag] · command line:1:6
   │
   • unexpected argument '--λ' found
   │
-  │ Usage: iris [FLAGS] [SUBCOMMAND]
+  │ Usage: iris [--log-file] <SUBCOMMAND>
   │
   │ For more information, try '--help'.
   │


### PR DESCRIPTION
## Purpose

Require `iris lsp` to start the language server, implementing the Iris CLI portion of #486. Clients that currently invoke `iris` or `iris --stdio` must include the `lsp` subcommand.

## Behavior

- Make the parsed command mandatory and remove the implicit LSP fallback.
- Keep language-server options under `lsp`; reject them at the root, including before an explicit subcommand.
- Preserve existing project and documentation commands, help, and version output.
- Update the documented invocation and process-level tests for startup, configuration, and diagnostics.

The separate VS Code extension update tracked in #486 is not included.

## Verification

- `cargo check -p purescript-iris -p tests-e2e --tests` — passed.
- `mise exec -- cargo nextest run -p purescript-iris` — 73 passed.
- `mise exec -- just e2e` — 31 passed, including real LSP initialization, diagnostics, and shutdown.
- `mise exec -- just format --check` and `git diff --check` — passed.
- Regenerated diagnostic snapshots reviewed; no pending snapshots.

## Amp thread

https://ampcode.com/threads/T-01a08c2f-99d8-76cd-b448-fcad840c7030